### PR TITLE
Remove UsernameCard from profile page

### DIFF
--- a/src/components/landing/home-client.tsx
+++ b/src/components/landing/home-client.tsx
@@ -14,7 +14,6 @@ import Button from "@/components/ui/button";
 
 // Dashboard components — only loaded for authenticated users
 const SignInPreviewCard = dynamic(() => import("@/components/dashboard/sign-in-preview-card"));
-const UsernameCard = dynamic(() => import("@/components/dashboard/username-card"));
 // Landing sections — only loaded for unauthenticated users
 const WhatYouGet = dynamic(() => import("@/components/landing/sections/what-you-get"));
 const HowItWorks = dynamic(() => import("@/components/landing/sections/how-it-works"));
@@ -24,7 +23,7 @@ const Faq = dynamic(() => import("@/components/landing/sections/faq"));
 const ReadyCta = dynamic(() => import("@/components/landing/sections/ready-cta"));
 
 export default function HomeClient() {
-  const { isLoading, isAuthenticated, did, pdsUrl, openSignIn } = useAuth();
+  const { isLoading, isAuthenticated, did, openSignIn } = useAuth();
   const { profile, avatarUrl, bannerUrl, isFallback } = useProfile();
   const { setVariant } = useNavbarVariant();
   const { handle } = useSession();
@@ -91,9 +90,6 @@ export default function HomeClient() {
                 <dd className="personal-info__hint">Your stable decentralized identifier (DID) — this never changes, even if you update your username.</dd>
               </dl>
             </div>
-
-            {/* Username card */}
-            <UsernameCard handle={handle} pdsUrl={pdsUrl || undefined} did={did || undefined} />
 
             {/* Account Details card */}
             <div className="dash-card mt-4">


### PR DESCRIPTION
## Summary

- Removes the `UsernameCard` component from the dashboard profile page
- Removes the unused `pdsUrl` destructure from `useAuth()` and the `UsernameCard` dynamic import

One file changed, 4 lines removed.