### PR TITLE
Add Terms of Service, Privacy Policy, and DSA compliance pages

### DIFF
--- a/src/app/dsa/page.tsx
+++ b/src/app/dsa/page.tsx
@@ -1,0 +1,291 @@
+export default function DsaPage() {
+  return (
+    <div className="app-page">
+      <div className="app-page__inner max-w-3xl">
+        <h1 className="font-mono text-h1 text-navy tracking-tight mb-8">
+          Digital Services Act — Compliance Information
+        </h1>
+
+        <p className="text-sm text-gray-500 mb-8">Last updated: March 14, 2026</p>
+
+        <div className="prose prose-navy max-w-none space-y-8">
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">1. About this page</h2>
+            <p>
+              This page provides information required under the Digital Services Act (Regulation
+              (EU) 2022/2065) (&quot;DSA&quot;) regarding the hosting services operated by the
+              Hypercerts Foundation in connection with Certified.
+            </p>
+            <p className="mt-4">
+              Certified operates AT Protocol Personal Data Servers (PDS) that store and serve
+              identity records and associated user data. Under the DSA, this qualifies as a{" "}
+              <strong>hosting service</strong> as defined in Article 3(g)(iii).
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">2. Service provider</h2>
+            <p>
+              <strong>Hypercerts Foundation</strong>
+              <br />A Delaware nonstock corporation
+            </p>
+            <p className="mt-4">
+              Contact:{" "}
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              3. Legal representative in the European Union
+            </h2>
+            <p>
+              In accordance with Article 13 of the DSA, the Hypercerts Foundation has designated
+              the following legal representative in the European Union:
+            </p>
+            <p className="mt-4">
+              Holke Brammer
+              <br />
+              Holzmarktstraße 25, 10243 Berlin, Germany
+              <br />
+              <a
+                href="mailto:holke@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                holke@hypercerts.org
+              </a>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">4. Point of contact</h2>
+            <p>
+              In accordance with Article 11 of the DSA, the single point of contact for
+              communications with EU member state authorities, the European Commission, and the
+              European Board for Digital Services is:
+            </p>
+            <p className="mt-4">
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+            <p className="mt-4">Communications may be submitted in English.</p>
+            <p className="mt-4">
+              The same address serves as the point of contact for recipients of the service in
+              accordance with Article 12 of the DSA.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              5. Notice-and-action procedure
+            </h2>
+            <p>
+              Any individual or entity may notify the Hypercerts Foundation of the presence of
+              specific items of information that the notifier considers to be illegal content, in
+              accordance with Article 16 of the DSA.
+            </p>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">
+              How to submit a notice
+            </h3>
+            <p>Notices should be sent to:</p>
+            <p className="mt-2">
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+            <p className="mt-4">
+              To enable effective processing, a notice should include:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>
+                a sufficiently substantiated explanation of why the content is considered illegal
+              </li>
+              <li>
+                a clear indication of the exact electronic location of the content (for example
+                URL, DID, or record identifier)
+              </li>
+              <li>the name and email address of the notifier</li>
+              <li>
+                a statement confirming the notifier&apos;s good-faith belief that the information
+                and allegations contained in the notice are accurate and complete
+              </li>
+            </ul>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">
+              How we process notices
+            </h3>
+            <p>Upon receipt of a notice, the Hypercerts Foundation will:</p>
+            <ol className="list-decimal pl-6 mt-2 space-y-2">
+              <li>
+                Send an acknowledgment of receipt to the notifier without undue delay.
+              </li>
+              <li>
+                Process the notice in a timely, diligent, non-arbitrary, and objective manner.
+              </li>
+              <li>
+                Where the notice contains sufficient information to allow identification of the
+                content and an assessment of its illegality, take appropriate action. This may
+                include restricting access to specific data or suspending an account.
+              </li>
+              <li>
+                Notify the affected user of any action taken, including the reasons for the
+                decision and available remedies.
+              </li>
+              <li>Inform the notifier of the outcome of the notice.</li>
+            </ol>
+            <p className="mt-4">Decisions are made on the basis of applicable law.</p>
+            <p className="mt-4">
+              The Hypercerts Foundation does not routinely monitor the information stored on
+              Personal Data Servers and has{" "}
+              <strong>no general obligation to monitor information</strong> stored through the
+              services in accordance with Article 8 of the Digital Services Act.
+            </p>
+            <p className="mt-4">
+              The Hypercerts Foundation may take appropriate measures to address{" "}
+              <strong>
+                manifestly unfounded notices or repeated abusive submissions
+              </strong>
+              , including limiting the ability of the notifier to submit future notices where
+              permitted by applicable law.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              6. Content restrictions
+            </h2>
+            <p>
+              As described in the{" "}
+              <a href="/terms" className="text-blue-600 underline hover:text-blue-800">
+                Terms of Service
+              </a>
+              , the Hypercerts Foundation may restrict access to content or suspend accounts in
+              the following circumstances:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>
+                to comply with legal obligations or respond to valid legal orders
+              </li>
+              <li>to protect the stability or security of the infrastructure</li>
+              <li>to address clearly unlawful content when required by law</li>
+              <li>
+                in response to a valid notice submitted under this procedure
+              </li>
+            </ul>
+            <p className="mt-4">
+              Certified operates as infrastructure within a federated network architecture.
+              Content stored through Personal Data Servers may be replicated, cached, indexed, or
+              displayed by independent servers or applications outside the control of the
+              Hypercerts Foundation.
+            </p>
+            <p className="mt-4">
+              The Hypercerts Foundation does not apply editorial content policies, operate
+              recommendation systems, or curate user content. Certified is infrastructure, not a
+              social media platform.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              7. Statement of reasons
+            </h2>
+            <p>
+              In accordance with Article 17 of the DSA, when the Hypercerts Foundation restricts
+              access to content or suspends an account, it will provide the affected user with a
+              clear and specific statement of reasons, including:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>
+                the facts and circumstances relied on in making the decision
+              </li>
+              <li>the legal or contractual basis for the decision</li>
+              <li>
+                information about the notice, if the decision was based on one
+              </li>
+              <li>
+                information about the right to seek redress, including any available internal
+                complaint mechanism
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              8. Internal complaint-handling
+            </h2>
+            <p>
+              In accordance with Article 20 of the DSA, users who are affected by a content
+              restriction or account suspension decision may submit a complaint to:
+            </p>
+            <p className="mt-4">
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+            <p className="mt-4">
+              Complaints will be processed in a timely and non-discriminatory manner. Users will
+              be informed of the outcome and the reasoning behind the decision.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              9. Trusted flaggers
+            </h2>
+            <p>
+              Where the Hypercerts Foundation receives notices from entities designated as{" "}
+              <strong>trusted flaggers</strong> under Article 22 of the Digital Services Act, such
+              notices will be prioritized and processed without undue delay.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">10. Transparency</h2>
+            <p>
+              The Hypercerts Foundation will publish{" "}
+              <strong>annual transparency reports</strong> in accordance with Article 15 of the
+              DSA, including information on:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>
+                the number of orders received from EU member state authorities
+              </li>
+              <li>the number of notices received and actions taken</li>
+              <li>
+                any content moderation activity undertaken on its own initiative
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">11. Limitation</h2>
+            <p>
+              The Hypercerts Foundation is not responsible for content moderation decisions made by
+              third-party applications that access data through the AT Protocol.
+            </p>
+            <p className="mt-4">
+              Moderation policies applied by other services are outside our control and do not
+              reflect actions taken by the Hypercerts Foundation.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,8 +1,435 @@
 export default function PrivacyPage() {
   return (
     <div className="app-page">
-      <div className="app-page__inner">
-        <h1 className="font-mono text-h1 text-navy tracking-tight mb-8">Privacy Policy</h1>
+      <div className="app-page__inner max-w-3xl">
+        <h1 className="font-mono text-h1 text-navy tracking-tight mb-8">
+          Privacy Policy — Certified
+        </h1>
+
+        <p className="text-sm text-gray-500 mb-8">Last updated: March 14, 2026</p>
+
+        <div className="prose prose-navy max-w-none space-y-8">
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">1. Introduction</h2>
+            <p>
+              This Privacy Policy explains how the Hypercerts Foundation (&quot;Hypercerts
+              Foundation&quot;, &quot;we&quot;, &quot;our&quot;, or &quot;us&quot;) processes
+              personal data in connection with the Certified services.
+            </p>
+            <p className="mt-4">Certified consists of:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>
+                <strong>certified.app</strong> – a web application used to create and manage AT
+                Protocol identities and configure related services
+              </li>
+              <li>
+                <strong>certified.one</strong> – infrastructure operating AT Protocol Personal Data
+                Servers (PDS)
+              </li>
+            </ul>
+            <p className="mt-4">
+              The Hypercerts Foundation operates these services as identity and data hosting
+              infrastructure for the AT Protocol ecosystem.
+            </p>
+            <p className="mt-4">This Privacy Policy explains:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>what personal data we process</li>
+              <li>how we use that data</li>
+              <li>how data is stored and shared</li>
+              <li>your rights under applicable data protection laws</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">2. Data controller</h2>
+            <p>
+              For the purposes of the EU General Data Protection Regulation (GDPR), the data
+              controller is:
+            </p>
+            <p className="mt-4">
+              <strong>Hypercerts Foundation</strong>
+              <br />
+              1209 Orange St.
+              <br />
+              Wilmington, DE 19801
+              <br />
+              United States
+            </p>
+            <p className="mt-4">
+              Phone: +1 302 658 7581
+              <br />
+              Contact:{" "}
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+            <p className="mt-4">
+              For data stored on Personal Data Servers, the Hypercerts Foundation acts as an{" "}
+              <strong>
+                infrastructure provider operating the server environment in which user-controlled
+                data is stored
+              </strong>
+              .
+            </p>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">EU representative</h3>
+            <p>
+              In accordance with Article 27 of the GDPR, the Hypercerts Foundation has designated
+              the following representative in the European Union:
+            </p>
+            <p className="mt-4">
+              Holke Brammer
+              <br />
+              Holzmarktstraße 25
+              <br />
+              10243 Berlin
+              <br />
+              Germany
+            </p>
+            <p className="mt-4">
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              3. Personal data we process
+            </h2>
+            <p>
+              The personal data processed by Certified depends on how you use the services.
+            </p>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">Account information</h3>
+            <p>
+              When you create or manage an account using certified.app, we may process:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>email address</li>
+              <li>account identifiers</li>
+              <li>authentication information</li>
+              <li>configuration settings for your AT Protocol identity</li>
+            </ul>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">
+              Data stored on Personal Data Servers
+            </h3>
+            <p>
+              certified.one operates Personal Data Servers that store records associated with AT
+              Protocol identities.
+            </p>
+            <p className="mt-4">These records may include:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>profile information</li>
+              <li>user-generated content</li>
+              <li>references to external resources</li>
+              <li>metadata associated with AT Protocol records</li>
+            </ul>
+            <p className="mt-4">
+              This data is stored at the direction of users and may contain personal data depending
+              on how the user uses the service.
+            </p>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">
+              Technical and operational data
+            </h3>
+            <p>To operate the services, we may process:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>IP addresses</li>
+              <li>system logs</li>
+              <li>device or browser information</li>
+              <li>timestamps of service interactions</li>
+              <li>security and abuse-prevention signals</li>
+            </ul>
+            <p className="mt-4">
+              System logs and security-related operational data may be retained for limited periods
+              necessary to detect abuse, investigate incidents, and maintain service reliability.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              4. How we use personal data
+            </h2>
+            <p>
+              We process personal data only where necessary for the operation of the services.
+            </p>
+            <p className="mt-4">This may include processing necessary to:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>operate and maintain certified.app and certified.one</li>
+              <li>authenticate users and manage accounts</li>
+              <li>operate AT Protocol Personal Data Servers</li>
+              <li>ensure the stability and security of the infrastructure</li>
+              <li>detect and prevent abuse or malicious activity</li>
+              <li>comply with legal obligations</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              5. Legal basis for processing
+            </h2>
+            <p>
+              Where the GDPR applies, personal data is processed on the following legal bases:
+            </p>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">Contractual necessity</h3>
+            <p>Processing necessary to provide the services requested by the user.</p>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">Legitimate interests</h3>
+            <p>Processing necessary to:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>maintain service security</li>
+              <li>prevent abuse</li>
+              <li>operate and improve infrastructure</li>
+              <li>ensure reliable system performance</li>
+            </ul>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">Legal obligations</h3>
+            <p>
+              Processing required to comply with applicable laws or regulatory requirements.
+            </p>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">Consent</h3>
+            <p>
+              Where applicable, certain processing may be based on your consent. Where consent is
+              the legal basis, you have the right to withdraw consent at any time. Withdrawal of
+              consent does not affect the lawfulness of processing carried out before the
+              withdrawal.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              6. Data storage and infrastructure
+            </h2>
+            <p>
+              The infrastructure supporting certified.one Personal Data Servers is currently hosted
+              on cloud infrastructure located within the{" "}
+              <strong>European Union</strong>.
+            </p>
+            <p className="mt-4">
+              Operational service providers may process limited data outside the European Union.
+              Where this occurs, appropriate safeguards are implemented in accordance with
+              applicable data protection laws.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              7. Federated network architecture
+            </h2>
+            <p>
+              Certified operates within the <strong>AT Protocol</strong>, a federated network
+              architecture.
+            </p>
+            <p className="mt-4">
+              When users publish records through their Personal Data Server, those records may be:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>replicated</li>
+              <li>cached</li>
+              <li>indexed</li>
+              <li>displayed</li>
+            </ul>
+            <p className="mt-4">
+              by independent servers or applications participating in the network.
+            </p>
+            <p className="mt-4">
+              Once data is shared through the federated network, the Hypercerts Foundation cannot
+              control how third-party services process or store that information. Those services act
+              as <strong>independent data controllers</strong> for any processing they perform.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">8. Data sharing</h2>
+            <p>We do not sell personal data.</p>
+            <p className="mt-4">
+              Personal data may be shared only in limited circumstances, including:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>
+                with service providers that support the operation of the services and process data
+                on our behalf
+              </li>
+              <li>
+                with third-party services that users choose to connect to their accounts
+              </li>
+              <li>where required by law or legal process</li>
+              <li>
+                where necessary to protect the security or integrity of the services
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              9. Cookies and tracking technologies
+            </h2>
+            <p>
+              certified.app uses only cookies that are strictly necessary for the operation of the
+              service, such as session management and authentication.
+            </p>
+            <p className="mt-4">
+              We do not use advertising cookies, third-party tracking pixels, or analytics cookies
+              that track individual users across websites.
+            </p>
+            <p className="mt-4">
+              If our use of cookies changes in the future, we will update this policy and provide
+              appropriate notice and controls.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">10. Data retention</h2>
+            <p>
+              We retain personal data only for as long as necessary to operate the services and
+              fulfill legal obligations.
+            </p>
+            <p className="mt-4">
+              Retention periods may vary depending on the type of data and applicable legal
+              obligations.
+            </p>
+            <p className="mt-4">
+              If you close your account, we will delete account-related data from our infrastructure
+              within a reasonable period, subject to:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>legal retention requirements</li>
+              <li>system backups</li>
+              <li>technical limitations related to federated data replication</li>
+            </ul>
+            <p className="mt-4">
+              As described above, data previously shared through the AT Protocol network may
+              continue to exist on third-party systems.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">11. Security</h2>
+            <p>
+              We implement reasonable technical and organizational measures to protect the security
+              of the services and the data stored on them.
+            </p>
+            <p className="mt-4">
+              However, no system can guarantee complete security. Users are responsible for
+              protecting their account credentials and cryptographic keys associated with their AT
+              Protocol identities.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              12. Children&apos;s data
+            </h2>
+            <p>
+              The services are not directed at individuals under the age of 16. The Hypercerts
+              Foundation does not knowingly collect personal data from individuals under 16 years of
+              age, or under the minimum age required to consent to data processing under applicable
+              law in the user&apos;s jurisdiction.
+            </p>
+            <p className="mt-4">
+              If we become aware that personal data has been collected from an individual under the
+              applicable minimum age without appropriate authorization, we will take steps to delete
+              that data.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">13. Your rights</h2>
+            <p>
+              Where applicable under data protection laws such as the GDPR, individuals may have
+              the right to:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>access their personal data</li>
+              <li>request correction of inaccurate data</li>
+              <li>request deletion of personal data</li>
+              <li>restrict or object to certain types of processing</li>
+              <li>request portability of data they have provided</li>
+              <li>withdraw consent, where processing is based on consent</li>
+            </ul>
+            <p className="mt-4">Requests may be submitted to:</p>
+            <p className="mt-2">
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+            <p className="mt-4">
+              We will respond to requests within one month, or inform you if an extension is
+              necessary in accordance with applicable law.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              14. International users
+            </h2>
+            <p>
+              Certified is operated from infrastructure located primarily within the European Union
+              but may be accessed globally.
+            </p>
+            <p className="mt-4">
+              If you access the services from outside the European Union, your data may be processed
+              in jurisdictions outside your country of residence, subject to the safeguards
+              described in Section 6.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              15. Changes to this policy
+            </h2>
+            <p>We may update this Privacy Policy from time to time.</p>
+            <p className="mt-4">
+              When changes are material, we will provide notice through certified.app or other
+              appropriate communication channels.
+            </p>
+            <p className="mt-4">
+              The most recent version of this policy will always be available on the Certified
+              website.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">16. Contact</h2>
+            <p>
+              For privacy inquiries, data protection requests, or questions about this policy,
+              contact:
+            </p>
+            <p className="mt-4">
+              <strong>Hypercerts Foundation</strong>
+              <br />
+              1209 Orange St.
+              <br />
+              Wilmington, DE 19801
+              <br />
+              United States
+            </p>
+            <p className="mt-4">
+              Phone: +1 302 658 7581
+              <br />
+              Email:{" "}
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+          </section>
+        </div>
       </div>
     </div>
   );

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,8 +1,584 @@
 export default function TermsPage() {
   return (
     <div className="app-page">
-      <div className="app-page__inner">
-        <h1 className="font-mono text-h1 text-navy tracking-tight mb-8">Terms of Service</h1>
+      <div className="app-page__inner max-w-3xl">
+        <h1 className="font-mono text-h1 text-navy tracking-tight mb-8">
+          Terms of Service — Certified
+        </h1>
+
+        <p className="text-sm text-gray-500 mb-8">Last updated: March 14, 2026</p>
+
+        <div className="prose prose-navy max-w-none space-y-8">
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">1. About Certified</h2>
+            <p>
+              Certified is operated by the Hypercerts Foundation (&quot;Hypercerts
+              Foundation&quot;, &quot;we&quot;, &quot;our&quot;, or &quot;us&quot;), a Delaware
+              nonstock corporation that develops and maintains open infrastructure for the
+              hypercerts ecosystem.
+            </p>
+            <p className="mt-4">The Certified services consist of two components:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>
+                <strong>certified.app</strong> – a web application used to create and manage AT
+                Protocol identities and configure related services.
+              </li>
+              <li>
+                <strong>certified.one</strong> – infrastructure that operates AT Protocol Personal
+                Data Servers (PDS) that store and serve identity records and associated user data.
+              </li>
+            </ul>
+            <p className="mt-4">
+              These services provide identity and data hosting infrastructure for the AT Protocol
+              ecosystem.
+            </p>
+            <p className="mt-4">
+              Certified is not a social media platform. We do not operate feeds, rank content,
+              recommend posts, or curate speech. Applications that display or process user data are
+              operated independently by third parties.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              2. Nature of the services
+            </h2>
+            <p>
+              Certified is part of an evolving technical ecosystem built on the AT Protocol, an
+              open and developing standard.
+            </p>
+            <p className="mt-4">
+              Features, interoperability, and functionality may change as the protocol evolves. The
+              Hypercerts Foundation does not guarantee that the services will remain compatible with
+              all future versions or implementations of the protocol.
+            </p>
+            <p className="mt-4">
+              The services are provided as technical infrastructure for identity and data hosting,
+              not as a platform for transactions or agreements between users.
+            </p>
+            <p className="mt-4">
+              The Hypercerts Foundation is not a party to any agreements, interactions, or
+              transactions between users or between users and third-party applications.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              3. Agreement to these Terms
+            </h2>
+            <p>
+              By creating an account, accessing certified.app, or using certified.one, you agree to
+              be bound by these Terms of Service and the Certified Privacy Policy (together, the
+              &quot;Agreement&quot;).
+            </p>
+            <p className="mt-4">
+              If you do not agree to these Terms, you may not use the services.
+            </p>
+            <p className="mt-4">
+              You must be at least 16 years old, or the minimum age required to consent to data
+              processing under applicable law in your jurisdiction.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              4. AT Protocol identity and user responsibility
+            </h2>
+            <p>
+              Certified provides tools and infrastructure that allow users to operate an AT Protocol
+              identity.
+            </p>
+            <p className="mt-4">
+              You retain ownership of the content, records, and data associated with your account.
+              The Hypercerts Foundation does not claim ownership of user content.
+            </p>
+            <p className="mt-4">Users are solely responsible for:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>all data stored through their Personal Data Server</li>
+              <li>any records published under their identity</li>
+              <li>ensuring their use of the services complies with applicable laws</li>
+            </ul>
+            <p className="mt-4">
+              You determine which applications or services may access your data.
+            </p>
+            <p className="mt-4">
+              Because the AT Protocol operates as a federated network, data published through your
+              Personal Data Server <strong>may be made available</strong> to other servers and
+              applications as part of normal protocol operation. This includes replication, caching,
+              indexing, and display by third-party services you interact with.
+            </p>
+            <p className="mt-4">
+              The Hypercerts Foundation is not responsible for how third-party services process,
+              display, or use such data.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              5. Intellectual property
+            </h2>
+            <p>
+              The Hypercerts Foundation retains all rights, title, and interest in the services,
+              including all software, interfaces, trademarks, and other intellectual property
+              associated with Certified.
+            </p>
+            <p className="mt-4">
+              Nothing in these Terms grants you any right, title, or interest in the Hypercerts
+              Foundation&apos;s intellectual property, except the{" "}
+              <strong>
+                limited, non-exclusive, non-transferable right to use the services in accordance
+                with these Terms
+              </strong>
+              .
+            </p>
+            <p className="mt-4">
+              User content remains the property of the user, as described in Section 4.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">6. Acceptable use</h2>
+            <p>
+              You may use Certified only for lawful purposes and in a manner that does not
+              interfere with the operation or stability of the services.
+            </p>
+            <p className="mt-4">You agree not to:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>use the services in violation of applicable laws or regulations</li>
+              <li>attempt unauthorized access to accounts, infrastructure, or systems</li>
+              <li>introduce malware or otherwise disrupt network functionality</li>
+              <li>store or distribute material that is illegal to possess or transmit</li>
+              <li>infringe intellectual property or privacy rights of others</li>
+              <li>
+                generate excessive automated traffic that disrupts or degrades the services
+              </li>
+              <li>conduct denial-of-service attacks or similar infrastructure abuse</li>
+              <li>
+                scrape, crawl, or access infrastructure in a manner that interferes with system
+                performance or stability
+              </li>
+            </ul>
+            <p className="mt-4">
+              The Hypercerts Foundation may implement technical measures such as rate limiting,
+              automated abuse detection, traffic filtering, or temporary access restrictions in
+              order to protect the stability and security of the services.
+            </p>
+            <p className="mt-4">
+              Where necessary to comply with law or protect infrastructure integrity, the Hypercerts
+              Foundation may restrict access to certain data, limit functionality, or suspend
+              accounts.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              7. Infrastructure and service operation
+            </h2>
+            <p>
+              certified.one hosts Personal Data Servers that store AT Protocol identity records and
+              related user data.
+            </p>
+            <p className="mt-4">
+              The infrastructure supporting these servers is{" "}
+              <strong>currently hosted</strong> on cloud infrastructure located within the European
+              Union.
+            </p>
+            <p className="mt-4">
+              To operate the services, we may rely on specialized third-party providers for
+              operational tasks such as:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>system monitoring</li>
+              <li>communications</li>
+              <li>analytics</li>
+              <li>technical support</li>
+            </ul>
+            <p className="mt-4">
+              Some of these providers may process limited data outside the European Union. Such
+              processing occurs in accordance with applicable data protection laws and appropriate
+              safeguards.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              8. Third-party services
+            </h2>
+            <p>
+              The services may interact with or reference third-party applications, websites, or
+              services.
+            </p>
+            <p className="mt-4">
+              These services are operated independently and governed by their own terms and
+              policies. The Hypercerts Foundation does not control and is not responsible for the
+              operation or content of third-party services.
+            </p>
+            <p className="mt-4">Your use of such services is at your own discretion.</p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              9. Privacy and data protection
+            </h2>
+            <p>
+              Personal data is processed in accordance with applicable data protection laws,
+              including the EU General Data Protection Regulation (GDPR) where applicable.
+            </p>
+            <p className="mt-4">Our Privacy Policy explains:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>what personal data we process</li>
+              <li>the purposes for processing</li>
+              <li>where data is stored</li>
+              <li>how long it is retained</li>
+              <li>the rights available to individuals</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              10. Handling unlawful data and legal orders
+            </h2>
+            <p>
+              The Hypercerts Foundation does not routinely monitor all information stored on Personal
+              Data Servers.
+            </p>
+            <p className="mt-4">However, we may take action where necessary to:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>comply with legal obligations</li>
+              <li>respond to orders from competent authorities</li>
+              <li>protect the stability or security of the infrastructure</li>
+              <li>address clearly unlawful data when required by law</li>
+            </ul>
+            <p className="mt-4">
+              Such actions may include restricting access to specific records or suspending accounts.
+            </p>
+            <p className="mt-4">
+              The Hypercerts Foundation may rely on{" "}
+              <strong>automated systems or third-party services</strong> to assist in identifying or
+              responding to unlawful content, infrastructure abuse, or security threats.
+            </p>
+            <p className="mt-4">
+              The Hypercerts Foundation is not responsible for content moderation decisions made by
+              third-party applications that access data through the AT Protocol. Moderation policies
+              applied by other services are outside our control and do not reflect actions taken by
+              the Hypercerts Foundation.
+            </p>
+            <p className="mt-4">
+              Reports of illegal content may be submitted in accordance with the notice-and-action
+              procedure described in our{" "}
+              <a href="/dsa" className="text-blue-600 underline hover:text-blue-800">
+                DSA Compliance Page
+              </a>
+              .
+            </p>
+            <p className="mt-4">
+              Reports and legal notices may also be sent to:{" "}
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              11. Availability, modification, and discontinuation
+            </h2>
+            <p>Certified services are provided on a best-effort basis.</p>
+            <p className="mt-4">
+              Maintenance, system updates, or security work may result in temporary interruptions.
+            </p>
+            <p className="mt-4">
+              The Hypercerts Foundation may modify, suspend, or discontinue all or part of the
+              services at any time. Where reasonably possible, we will provide advance notice of
+              material changes or service discontinuation.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              12. Data persistence in federated systems
+            </h2>
+            <p>
+              Because the AT Protocol operates as a federated network, data published through the
+              services may be copied, cached, or stored by other servers or applications.
+            </p>
+            <p className="mt-4">
+              The Hypercerts Foundation cannot guarantee that data removed from its infrastructure
+              will also be removed from third-party systems.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              13. Account security
+            </h2>
+            <p>
+              You are responsible for protecting your account credentials and authentication
+              information.
+            </p>
+            <p className="mt-4">
+              If you believe your account has been compromised, you must notify us promptly at{" "}
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+              .
+            </p>
+            <p className="mt-4">
+              Access to accounts may be temporarily restricted while security investigations are
+              conducted.
+            </p>
+            <p className="mt-4">
+              Because AT Protocol identities rely on cryptographic credentials, recovery of accounts
+              may not be possible if credentials are permanently lost.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">14. Termination</h2>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">Termination by you</h3>
+            <p>
+              You may close your account at any time by using the account closure functionality
+              provided through certified.app, or by contacting us at{" "}
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+              .
+            </p>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">
+              Termination by the Hypercerts Foundation
+            </h3>
+            <p>
+              The Hypercerts Foundation may suspend or terminate your account if:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>you breach these Terms of Service</li>
+              <li>
+                your use of the services poses a risk to the stability, security, or integrity of
+                the infrastructure
+              </li>
+              <li>
+                we are required to do so by law or in response to a valid legal order
+              </li>
+              <li>the services are discontinued in accordance with Section 11</li>
+            </ul>
+            <p className="mt-4">
+              Where reasonably possible, we will provide notice before terminating an account. In
+              cases involving security threats, legal obligations, or infrastructure abuse, immediate
+              action may be taken without prior notice.
+            </p>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">
+              Effect of termination
+            </h3>
+            <p>
+              Upon termination, your access to the services will cease. The Hypercerts Foundation
+              will delete your account data from its infrastructure within a reasonable period,
+              subject to any legal retention obligations.
+            </p>
+            <p className="mt-4">
+              As described in Section 12, data previously published through the AT Protocol may
+              continue to exist on third-party servers or applications. The Hypercerts Foundation
+              cannot ensure deletion of such data from federated systems.
+            </p>
+
+            <h3 className="font-mono text-lg text-navy mt-6 mb-3">Survival</h3>
+            <p>
+              Sections 5 (intellectual property), 12 (data persistence), 15 (feedback), 16
+              (disclaimer of warranties), 17 (limitation of liability), 18 (indemnification), 19
+              (consumer protections), and 23 (governing law) survive termination of these Terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">15. Feedback</h2>
+            <p>
+              If you provide suggestions, ideas, or feedback regarding the services, the Hypercerts
+              Foundation may use such feedback{" "}
+              <strong>for any purpose, without restriction or compensation</strong>.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              16. Disclaimer of warranties
+            </h2>
+            <p>
+              The services are provided &quot;as is&quot; and &quot;as available.&quot;
+            </p>
+            <p className="mt-4">
+              The Hypercerts Foundation makes no representations or warranties regarding the
+              reliability, availability, or accuracy of the services.
+            </p>
+            <p className="mt-4">
+              To the maximum extent permitted by law, we disclaim all warranties, express or
+              implied, including warranties of merchantability, fitness for a particular purpose, and
+              non-infringement.
+            </p>
+            <p className="mt-4">
+              You understand that your use of the services is at your own discretion and risk.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              17. Limitation of liability
+            </h2>
+            <p>
+              Nothing in these Terms limits liability where such limitation is prohibited by law.
+            </p>
+            <p className="mt-4">
+              To the maximum extent permitted by law, the Hypercerts Foundation is not liable for
+              indirect, incidental, or consequential damages arising from the use of the services.
+            </p>
+            <p className="mt-4">
+              Where liability cannot be excluded, the Hypercerts Foundation&apos;s total liability{" "}
+              <strong>arising out of or relating to the services</strong> is limited to:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>
+                the amount paid by you for the services during the 12 months preceding the claim, or
+              </li>
+              <li>USD 100, if the services were used free of charge.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              18. Indemnification
+            </h2>
+            <p>
+              To the extent permitted by applicable law, you agree to indemnify and hold harmless
+              the Hypercerts Foundation from claims, damages, losses, and expenses (including
+              reasonable legal fees) arising from:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>your use of the services in violation of these Terms</li>
+              <li>data you store or publish through the services</li>
+              <li>your violation of applicable laws or the rights of third parties</li>
+            </ul>
+            <p className="mt-4">
+              This indemnification obligation does not apply to consumers where prohibited by
+              applicable consumer protection law.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              19. Consumer protections
+            </h2>
+            <p>
+              If you use the services as a consumer, you may have mandatory rights under applicable
+              consumer protection laws. Nothing in these Terms limits those rights.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              20. Validity and waiver
+            </h2>
+            <p>
+              If any provision of these Terms is found unenforceable by a court of competent
+              jurisdiction, the remaining provisions will continue to apply.
+            </p>
+            <p className="mt-4">
+              The failure of the Hypercerts Foundation to enforce any provision of these Terms does
+              not constitute a waiver of that provision or any other provision.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              21. Changes to these Terms
+            </h2>
+            <p>
+              The Hypercerts Foundation may update these Terms from time to time. We will notify
+              users of material changes by posting a notice on certified.app and, where practicable,
+              by email or other direct communication at least 30 days before the changes take
+              effect.
+            </p>
+            <p className="mt-4">
+              The updated Terms will indicate the date of the most recent revision. Your continued
+              use of the services after the effective date of the updated Terms constitutes
+              acceptance of the changes,{" "}
+              <strong>to the extent permitted by applicable law</strong>.
+            </p>
+            <p className="mt-4">
+              If you do not agree with the updated Terms, you may close your account in accordance
+              with Section 14.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              22. Transfer of rights
+            </h2>
+            <p>
+              Users may not transfer their rights or obligations under these Terms without the prior
+              written consent of the Hypercerts Foundation.
+            </p>
+            <p className="mt-4">
+              The Hypercerts Foundation may assign or transfer its rights or obligations as part of
+              organizational restructuring or transfer of the services.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">23. Governing law</h2>
+            <p>
+              These Terms are governed by the laws of the State of California, regardless of
+              conflict of laws rules.
+            </p>
+            <p className="mt-4">
+              Any disputes arising out of or relating to these Terms will be resolved exclusively in
+              the federal or state courts located in San Francisco County, California, and you
+              consent to the personal jurisdiction of those courts.
+            </p>
+            <p className="mt-4">
+              If you are a consumer in the European Union, this section does not affect any mandatory
+              consumer protections or jurisdictional rights available to you under the laws of your
+              country of residence.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              24. Entire agreement
+            </h2>
+            <p>
+              These Terms of Service and the Certified Privacy Policy constitute the entire
+              agreement between you and the Hypercerts Foundation regarding the services and
+              supersede all prior understandings, communications, or agreements relating to the
+              subject matter.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">25. Contact</h2>
+            <p>
+              For all inquiries — including support, legal notices, Digital Services Act
+              communications, and privacy matters:
+            </p>
+            <p className="mt-4">
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+          </section>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Populated `/terms` with full 25-section Terms of Service content
- Populated `/privacy` with full 16-section Privacy Policy content
- Created new `/dsa` page with 11-section Digital Services Act compliance information
- All pages follow the existing app styling pattern (font-mono headings, navy color scheme, app-page layout)
- Cross-links between pages (Terms ↔ DSA, Privacy references)

## Test plan
- [ ] Verify `/terms` renders correctly with all 25 sections
- [ ] Verify `/privacy` renders correctly with all 16 sections
- [ ] Verify `/dsa` renders correctly with all 11 sections
- [ ] Check all `mailto:` links work
- [ ] Check internal links between `/terms` ↔ `/dsa` work
- [ ] Verify responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)