### PR TITLE
Fix DSA page: use legal@hypercerts.org for EU representative

### DIFF
--- a/src/app/dsa/page.tsx
+++ b/src/app/dsa/page.tsx
@@ -54,10 +54,10 @@ export default function DsaPage() {
               Holzmarktstraße 25, 10243 Berlin, Germany
               <br />
               <a
-                href="mailto:holke@hypercerts.org"
+                href="mailto:legal@hypercerts.org"
                 className="text-blue-600 underline hover:text-blue-800"
               >
-                holke@hypercerts.org
+                legal@hypercerts.org
               </a>
             </p>
           </section>


### PR DESCRIPTION
## Summary
- Replace `holke@hypercerts.org` with `legal@hypercerts.org` for the EU representative contact on the DSA compliance page

## Test plan
- [ ] Verify `/dsa` section 3 shows `legal@hypercerts.org` as the EU representative email

🤖 Generated with [Claude Code](https://claude.com/claude-code)