### PR TITLE
Update legal pages: account deletion contact + date

### DIFF
--- a/src/app/dsa/page.tsx
+++ b/src/app/dsa/page.tsx
@@ -6,7 +6,7 @@ export default function DsaPage() {
           Digital Services Act — Compliance Information
         </h1>
 
-        <p className="text-sm text-gray-500 mb-8">Last updated: March 14, 2026</p>
+        <p className="text-sm text-gray-500 mb-8">Last updated: March 15, 2026</p>
 
         <div className="prose prose-navy max-w-none space-y-8">
           <section>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -6,7 +6,7 @@ export default function PrivacyPage() {
           Privacy Policy — Certified
         </h1>
 
-        <p className="text-sm text-gray-500 mb-8">Last updated: March 14, 2026</p>
+        <p className="text-sm text-gray-500 mb-8">Last updated: March 15, 2026</p>
 
         <div className="prose prose-navy max-w-none space-y-8">
           <section>
@@ -299,7 +299,14 @@ export default function PrivacyPage() {
               obligations.
             </p>
             <p className="mt-4">
-              If you close your account, we will delete account-related data from our infrastructure
+              To delete your account, contact us at{" "}
+              <a
+                href="mailto:support@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                support@hypercerts.org
+              </a>
+              . We will delete account-related data from our infrastructure
               within a reasonable period, subject to:
             </p>
             <ul className="list-disc pl-6 mt-2 space-y-2">

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -6,7 +6,7 @@ export default function TermsPage() {
           Terms of Service — Certified
         </h1>
 
-        <p className="text-sm text-gray-500 mb-8">Last updated: March 14, 2026</p>
+        <p className="text-sm text-gray-500 mb-8">Last updated: March 15, 2026</p>
 
         <div className="prose prose-navy max-w-none space-y-8">
           <section>
@@ -344,13 +344,12 @@ export default function TermsPage() {
 
             <h3 className="font-mono text-lg text-navy mt-6 mb-3">Termination by you</h3>
             <p>
-              You may close your account at any time by using the account closure functionality
-              provided through certified.app, or by contacting us at{" "}
+              To delete your account, contact us at{" "}
               <a
-                href="mailto:legal@hypercerts.org"
+                href="mailto:support@hypercerts.org"
                 className="text-blue-600 underline hover:text-blue-800"
               >
-                legal@hypercerts.org
+                support@hypercerts.org
               </a>
               .
             </p>


### PR DESCRIPTION
## Summary
- Account deletion now directs users to contact `support@hypercerts.org` (no in-app deletion yet)
- Updated on Terms (`/terms`) and Privacy Policy (`/privacy`)
- Updated "last updated" date to March 15, 2026 on all three legal pages

## Test plan
- [ ] Verify `/terms` section 14 shows `support@hypercerts.org` for account deletion
- [ ] Verify `/privacy` section 10 shows `support@hypercerts.org` for account deletion
- [ ] Verify all three pages show "Last updated: March 15, 2026"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated legal documentation (Privacy Policy, Terms of Service, DSA) with current dates
* Clarified account deletion process—users are now directed to contact support directly
* Updated support contact information across policy pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->