### PR TITLE
Fix: revert rogue landing page CSS changes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,7 @@
 :root {
   /* Core */
   --color-navy: #0F2544;
-  --color-accent: #3b703a;
+  --color-accent: #60A1E2;
   --color-white: #FFFFFF;
 
   /* Neutrals */
@@ -16,7 +16,7 @@
   --color-dark-gray: #3B4251;
 
   /* Accent Variations */
-  --color-accent-hover: #2d5a2c;
+  --color-accent-hover: #4e93d8;
 
   /* Borders */
   --border-subtle: rgba(15, 37, 68, 0.06);
@@ -70,7 +70,6 @@ body {
   font-family: var(--font-inter), system-ui, -apple-system, sans-serif;
   color: var(--color-dark-gray);
   background: var(--color-navy); /* prevents white flash during auth loading transition */
-  overflow-x: hidden;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -129,15 +128,18 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .navbar--default {
-  background: rgba(254, 254, 254, 0.85);
+  background: rgba(255, 255, 255, 0.85);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--border-light);
 }
 
 .navbar--transparent {
-  background: rgba(254, 254, 254, 0.85);
+  background: transparent;
+}
+
+.navbar--transparent.navbar--scrolled {
+  background: var(--navy-overlay-85);
   backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--border-light);
 }
 
 .navbar__inner {
@@ -167,28 +169,26 @@ h1, h2, h3, h4, h5, h6 {
   gap: 12px;
 }
 
-.navbar__signin-img-btn {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  transition: opacity var(--transition-fast), transform var(--transition-fast);
-}
-
-.navbar__signin-img-btn:hover {
-  opacity: 0.85;
-  transform: translateY(-1px);
-}
-
-.navbar__signin-img-btn:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
+.navbar__signin {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 18px;
   border-radius: var(--radius);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-white);
+  background: var(--color-navy);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
 }
 
-.navbar__signin-img {
-  height: 34px;
-  display: block;
+.navbar__signin:hover {
+  border-color: rgba(255, 255, 255, 0.45);
+  box-shadow: 0 0 12px rgba(96, 161, 226, 0.2);
+  transform: translateY(-1px);
 }
 
 .navbar__signin:focus-visible {
@@ -211,33 +211,60 @@ h1, h2, h3, h4, h5, h6 {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: #f9f9f9;
-  overflow: visible;
+  background: var(--color-navy);
+  overflow: hidden;
   text-align: center;
-  padding: calc(var(--navbar-height) + 80px) 24px calc(var(--navbar-height) + 80px);
+  padding: calc(var(--navbar-height) + 48px) 24px 48px;
+}
+
+.hero__bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background:
+    radial-gradient(ellipse 80% 50% at 20% 40%, rgba(96,161,226,0.15) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 80% at 80% 20%, rgba(26,58,107,0.2) 0%, transparent 60%),
+    radial-gradient(ellipse 50% 60% at 50% 80%, rgba(96,161,226,0.08) 0%, transparent 50%);
+  background-size: 200% 200%, 200% 200%, 200% 200%;
+  animation: meshShift 20s ease-in-out infinite;
+}
+
+@keyframes meshShift {
+  0%   { background-position: 0% 0%, 100% 0%, 50% 100%; }
+  33%  { background-position: 10% 20%, 90% 10%, 40% 90%; }
+  66%  { background-position: 5% 10%, 95% 20%, 55% 80%; }
+  100% { background-position: 0% 0%, 100% 0%, 50% 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero__bg {
+    animation: none;
+  }
 }
 
 .hero__inner {
+  position: relative;
+  z-index: 1;
   max-width: 800px;
   margin: 0 auto;
 }
 
 .hero__title {
-  color: #111111;
-  font-size: clamp(3rem, 8vw + 1rem, 6rem);
+  color: var(--color-white);
+  font-size: clamp(2.5rem, 6vw + 1rem, 5rem);
   font-weight: 700;
   line-height: 1.05;
   letter-spacing: -0.04em;
-  margin-bottom: 28px;
+  margin-bottom: 24px;
 }
 
 .hero__subtitle {
-  color: var(--color-dark-gray);
-  font-size: clamp(1.125rem, 2vw + 0.5rem, 1.5rem);
+  color: var(--color-mid-gray);
+  font-size: clamp(1rem, 1.5vw + 0.5rem, 1.25rem);
   line-height: 1.5;
   font-weight: 400;
-  max-width: 580px;
-  margin: 0 auto 56px;
+  max-width: 520px;
+  margin: 0 auto 48px;
 }
 
 .hero__actions {
@@ -262,60 +289,23 @@ h1, h2, h3, h4, h5, h6 {
   border-radius: var(--radius);
   font-size: 1rem;
   font-weight: 500;
-  color: #111111;
-  background: rgba(0, 0, 0, 0.04);
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  color: var(--color-white);
+  background: rgba(96, 161, 226, 0.1);
+  border: 1px solid rgba(96, 161, 226, 0.2);
   cursor: pointer;
   transition: all var(--transition-fast);
   text-decoration: none;
 }
 
 .hero__btn-primary:hover {
-  background: rgba(0, 0, 0, 0.07);
-  border-color: rgba(0, 0, 0, 0.2);
-  color: #111111;
-}
-
-/* Dark-section override for CTA button */
-.landing-section--dark .hero__btn-primary {
-  color: var(--color-white);
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-}
-
-.landing-section--dark .hero__btn-primary:hover {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.3);
+  background: rgba(96, 161, 226, 0.15);
+  border-color: rgba(96, 161, 226, 0.35);
   color: var(--color-white);
 }
 
 .hero__btn-primary:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
-}
-
-.hero__btn-signin {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  transition: opacity var(--transition-fast), transform var(--transition-fast);
-}
-
-.hero__btn-signin:hover {
-  opacity: 0.85;
-  transform: translateY(-1px);
-}
-
-.hero__btn-signin:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 4px;
-  border-radius: var(--radius);
-}
-
-.hero__btn-signin-img {
-  height: 56px;
-  display: block;
 }
 
 .hero__btn-secondary {
@@ -373,18 +363,6 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 
-/* Hero guilloche decoration */
-.hero__guilloche {
-  position: absolute;
-  top: -30%;
-  right: -40%;
-  width: 90%;
-  max-width: 1050px;
-  opacity: 0.5;
-  pointer-events: none;
-  user-select: none;
-}
-
 /* Hero landing modifier — full-viewport */
 .hero--landing {
   min-height: 100vh;
@@ -392,9 +370,9 @@ h1, h2, h3, h4, h5, h6 {
 
 /* ========== Landing Footer ========== */
 .landing-footer {
-  background: #f3f4f6;
+  background: var(--color-navy);
   padding: 24px 0;
-  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .landing-footer__inner {
@@ -411,7 +389,7 @@ h1, h2, h3, h4, h5, h6 {
 .landing-footer p,
 .landing-footer__links a {
   font-size: 0.75rem;
-  color: rgba(0, 0, 0, 0.5);
+  color: rgba(255, 255, 255, 0.6);
   text-decoration: none;
   transition: color var(--transition-fast);
 }
@@ -422,7 +400,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .landing-footer__links a:hover {
-  color: rgba(0, 0, 0, 0.8);
+  color: rgba(255, 255, 255, 0.85);
 }
 
 @media (max-width: 768px) {
@@ -535,7 +513,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .signin-modal__input:focus {
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 3px rgba(59, 112, 58, 0.15);
+  box-shadow: 0 0 0 3px rgba(96, 161, 226, 0.15);
 }
 
 .signin-modal__input:disabled {
@@ -708,15 +686,12 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .landing-cta h2 {
-  font-size: clamp(2.75rem, 6vw + 1rem, 5rem);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  margin-bottom: 20px;
+  margin-bottom: 12px;
 }
 
 .landing-cta p {
   font-size: 1rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 0.5);
   margin-bottom: 32px;
 }
 
@@ -817,7 +792,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .landing-section--dark {
-  background: #111111;
+  background: var(--color-navy);
   color: var(--color-white);
 }
 
@@ -983,7 +958,7 @@ h1, h2, h3, h4, h5, h6 {
 .landing-step {
   text-align: center;
   padding: 32px 20px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius);
 }
 
@@ -994,8 +969,8 @@ h1, h2, h3, h4, h5, h6 {
   width: 40px;
   height: 40px;
   border-radius: var(--radius);
-  background: rgba(59, 112, 58, 0.1);
-  border: 1px solid rgba(59, 112, 58, 0.2);
+  background: rgba(96, 161, 226, 0.1);
+  border: 1px solid rgba(96, 161, 226, 0.2);
   color: var(--color-accent);
   font-size: 1rem;
   font-weight: 700;
@@ -1005,21 +980,21 @@ h1, h2, h3, h4, h5, h6 {
 .landing-step h3 {
   font-size: 1rem;
   font-weight: 600;
-  color: #111111;
+  color: var(--color-white);
   margin-bottom: 8px;
 }
 
 .landing-step p {
   font-size: 0.875rem;
   line-height: 1.6;
-  color: var(--color-mid-gray);
+  color: rgba(255, 255, 255, 0.5);
   margin: 0;
 }
 
 .landing-reassurance {
   text-align: center;
   font-size: 0.875rem;
-  color: var(--color-mid-gray);
+  color: rgba(255, 255, 255, 0.4);
 }
 
 /* ========== Built for Trust Section ========== */
@@ -1035,7 +1010,7 @@ h1, h2, h3, h4, h5, h6 {
 .landing-trust-list li {
   font-size: 1rem;
   line-height: 1.6;
-  color: var(--color-dark-gray);
+  color: rgba(255, 255, 255, 0.6);
   padding-left: 28px;
   position: relative;
 }
@@ -1050,14 +1025,14 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .landing-trust-sub {
-  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
   padding-top: 24px;
 }
 
 .landing-trust-sub h3 {
   font-size: 0.875rem;
   font-weight: 600;
-  color: #111111;
+  color: var(--color-white);
   margin-bottom: 12px;
 }
 
@@ -1073,13 +1048,13 @@ h1, h2, h3, h4, h5, h6 {
 .landing-trust-sub li {
   font-size: 0.875rem;
   line-height: 1.5;
-  color: var(--color-mid-gray);
+  color: rgba(255, 255, 255, 0.5);
 }
 
 .landing-trust-sub a {
   color: var(--color-accent);
   text-decoration: none;
-  border-bottom: 1px solid rgba(59, 112, 58, 0.3);
+  border-bottom: 1px solid rgba(96, 161, 226, 0.3);
   transition: border-color var(--transition-fast);
 }
 
@@ -1277,7 +1252,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .username-card__domain-btn:hover {
-  background: rgba(59, 112, 58, 0.06);
+  background: rgba(96, 161, 226, 0.06);
   border-color: var(--color-accent);
 }
 
@@ -1316,7 +1291,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .username-card__subdomain-input:focus {
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 3px rgba(59, 112, 58, 0.15);
+  box-shadow: 0 0 0 3px rgba(96, 161, 226, 0.15);
   z-index: 1;
 }
 
@@ -1644,7 +1619,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .domain-modal__input:focus {
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 3px rgba(59, 112, 58, 0.15);
+  box-shadow: 0 0 0 3px rgba(96, 161, 226, 0.15);
 }
 
 .domain-modal__hint {
@@ -1724,7 +1699,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .domain-modal__copy-btn:hover {
   color: var(--color-accent);
-  background: rgba(59, 112, 58, 0.1);
+  background: rgba(96, 161, 226, 0.1);
 }
 
 /* Info box */


### PR DESCRIPTION
## Summary

- Revert unauthorized CSS changes introduced by a worker in commit `91d602e` (batch 1)
- The worker was tasked with adding email-section CSS only, but also changed accent colors, hero background, navbar, footer, and landing section styles
- This restores the original blue accent (`#60A1E2`), dark navy hero with animated mesh gradient, transparent navbar, and all landing page styling

## What was reverted

| Property | Rogue value | Restored value |
|----------|-------------|----------------|
| `--color-accent` | `#3b703a` (green) | `#60A1E2` (blue) |
| Hero background | `#f9f9f9` (light) | Navy + animated mesh gradient |
| Navbar transparent | White with border | Transparent (dark on scroll) |
| Landing dark sections | `#111111` | `var(--color-navy)` |
| Footer | Light gray | Dark navy |
| Sign-in button | Image button | Text button |

## What was kept

- ✅ Email-section CSS classes (`.email-section__*`) — the legitimate addition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated accent color theme from green to blue throughout the interface
  * Enhanced navbar with improved transparency handling and dynamic scroll effects
  * Redesigned hero section with new animated gradient background
  * Refactored sign-in button with improved visual styling
  * Refreshed dark section styling for better contrast and visual hierarchy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->