### PR TITLE
style: center hero text and increase eyebrow size

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -259,11 +259,12 @@ h1, h2, h3, h4, h5, h6 {
   max-width: 1536px;
   margin: 0 auto;
   width: 100%;
+  text-align: center;
 }
 
 .hero__label {
   display: block;
-  font-size: 0.6875rem;
+  font-size: 0.875rem;
   font-weight: 500;
   letter-spacing: 0.2em;
   text-transform: uppercase;
@@ -293,6 +294,8 @@ h1, h2, h3, h4, h5, h6 {
   line-height: 1.6;
   font-weight: 400;
   max-width: 640px;
+  margin-left: auto;
+  margin-right: auto;
   margin-bottom: 48px;
 }
 
@@ -300,6 +303,7 @@ h1, h2, h3, h4, h5, h6 {
   display: flex;
   gap: 24px;
   flex-wrap: wrap;
+  justify-content: center;
 }
 
 .hero__btn-primary {


### PR DESCRIPTION
## Summary
- Center hero text, subtitle, and action buttons horizontally
- Increase eyebrow label font size from 11px to 14px

## Test plan
- [ ] Verify hero section text is centered on desktop
- [ ] Verify hero section text is centered on mobile
- [ ] Verify eyebrow label is visually larger

🤖 Generated with [Claude Code](https://claude.com/claude-code)