### PR TITLE
feat(groups): add beta notice banner on groups page

### DIFF
--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -162,6 +162,20 @@ export default function GroupsPage() {
 
       <div className="dashboard__body dashboard__body--single">
         <div className="dashboard__main">
+          <div
+            style={{
+              padding: "10px 14px",
+              marginBottom: 16,
+              borderRadius: 8,
+              background: "var(--color-warning-bg)",
+              border: "1px solid var(--color-warning-border)",
+              color: "var(--color-warning-text)",
+              fontSize: 13,
+              lineHeight: 1.5,
+            }}
+          >
+            <strong>Heads up:</strong> Groups are in beta and currently run on a test server. Data may be reset or removed without notice — please don't rely on it for anything important yet.
+          </div>
           {isLoading ? (
             <div className="org-list__loading">
               <LoadingSpinner size="md" />


### PR DESCRIPTION
## Summary
- Adds a warning-styled banner at the top of the Groups page letting users know groups are in beta and currently run on a test server, so data may be reset or removed without notice.

## Test plan
- [ ] Visit `/groups` and confirm the banner renders above the groups list / empty state
- [ ] Confirm the banner uses the warning color tokens and is readable in light/dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning banner on the Groups page to inform users that the groups feature is in beta, operates on a test server, and that data may be reset or removed without notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->