### PR TITLE
feat(profile): add /profile/[did] route

### DIFF
--- a/src/app/profile/[did]/page.tsx
+++ b/src/app/profile/[did]/page.tsx
@@ -1,12 +1,12 @@
 import { Metadata } from "next";
-import HomeClient from "@/components/landing/home-client";
+import ProfileClient from "@/components/profile/profile-client";
 
 export const metadata: Metadata = {
   title: "Profile",
-  description: "Certified profile and account overview.",
+  description: "Certified profile.",
   robots: { index: false, follow: false },
 };
 
 export default function ProfilePage() {
-  return <HomeClient />;
+  return <ProfileClient />;
 }

--- a/src/app/profile/[did]/page.tsx
+++ b/src/app/profile/[did]/page.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next";
+import HomeClient from "@/components/landing/home-client";
+
+export const metadata: Metadata = {
+  title: "Profile",
+  description: "Certified profile and account overview.",
+  robots: { index: false, follow: false },
+};
+
+export default function ProfilePage() {
+  return <HomeClient />;
+}

--- a/src/components/landing/home-client.tsx
+++ b/src/components/landing/home-client.tsx
@@ -1,192 +1,42 @@
 "use client";
 
 import { useEffect } from "react";
-import { usePathname, useRouter } from "next/navigation";
-import Link from "next/link";
-import { Pencil } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth/auth-context";
-import { useProfile } from "@/hooks/use-profile";
-import { useOrgProfile } from "@/hooks/use-org-profile";
 import { useOrg } from "@/lib/groups/org-context";
-import { useSession } from "@/hooks/use-session";
-import Avatar from "@/components/ui/avatar";
-import { getInitials } from "@/lib/utils/initials";
-import Button from "@/components/ui/button";
 
+/**
+ * Root `/` redirector. Sends unauthenticated users to `/welcome` and
+ * authenticated users to their canonical profile URL `/profile/{did}`.
+ * The profile itself is rendered by ProfileClient at `/profile/[did]`.
+ */
 export default function HomeClient() {
   const router = useRouter();
-  const pathname = usePathname();
   const { isLoading, isAuthenticated, did } = useAuth();
-  const { profile, avatarUrl, bannerUrl, isFallback } = useProfile();
   const { activeOrg, isLoading: orgsLoading } = useOrg();
-  const { orgProfile, orgMetadata, orgAvatarUrl, orgBannerUrl } = useOrgProfile();
-  const { handle } = useSession();
 
-  // Redirect to /welcome if not authenticated (handles expired sessions, sign-out)
   useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
+    if (isLoading) return;
+    if (!isAuthenticated) {
       router.replace("/welcome");
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- router is stable, omitting to prevent re-renders
-  }, [isLoading, isAuthenticated]);
-
-  // Canonicalize URL: `/` → `/profile/{did}`. Wait for orgs so we don't
-  // redirect to a stale activeOrg persisted in localStorage.
-  useEffect(() => {
-    if (isLoading || orgsLoading || !isAuthenticated || !did) return;
-    if (pathname !== "/") return;
+    if (orgsLoading || !did) return;
     const targetDid = activeOrg?.groupDid || did;
     router.replace(`/profile/${encodeURIComponent(targetDid)}`);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is stable
-  }, [isLoading, orgsLoading, isAuthenticated, did, pathname, activeOrg?.groupDid]);
+  }, [isLoading, isAuthenticated, orgsLoading, did, activeOrg?.groupDid]);
 
-  const initials = getInitials(profile?.displayName, did);
-
-  // Show loading while redirecting from `/`
-  if (isLoading || (isAuthenticated && pathname === "/")) {
-    return (
-      <div className="loading-screen">
-        <div className="loading-screen__inner">
-          <img
-            src="/assets/certified_brandmark_black.svg"
-            alt=""
-            aria-hidden="true"
-            className="loading-screen__logo"
-          />
-        </div>
+  return (
+    <div className="loading-screen">
+      <div className="loading-screen__inner">
+        <img
+          src="/assets/certified_brandmark_black.svg"
+          alt=""
+          aria-hidden="true"
+          className="loading-screen__logo"
+        />
       </div>
-    );
-  }
-
-  if (isAuthenticated) {
-    // When acting as a group, show the org profile
-    const isOrgMode = !!activeOrg;
-    const displayProfile = isOrgMode ? orgProfile : profile;
-    const displayAvatar = isOrgMode ? (orgAvatarUrl || undefined) : (avatarUrl || undefined);
-    const displayBanner = isOrgMode ? orgBannerUrl : bannerUrl;
-    const displayInitials = isOrgMode
-      ? (activeOrg.displayName || activeOrg.handle || "O").slice(0, 2).toUpperCase()
-      : initials;
-    const displayHandle = isOrgMode ? activeOrg.handle : handle;
-    const displayDid = isOrgMode ? activeOrg.groupDid : did;
-    const editHref = isOrgMode
-      ? `/groups/${encodeURIComponent(activeOrg.groupDid)}/edit-profile`
-      : "/settings/edit-profile";
-
-    return (
-      <div className="dashboard">
-        {/* Top bar */}
-        <div className="dashboard__topbar">
-          <h1 className="dashboard__page-title">Profile</h1>
-        </div>
-
-        {/* Main content area */}
-        <div className="dashboard__body">
-          <div className="dashboard__main">
-            {/* Profile header card */}
-            <div className="dash-card">
-              <div className="profile-card__banner">
-                {displayBanner ? (
-                  <img src={displayBanner} alt="" />
-                ) : null}
-              </div>
-              <div className="profile-card">
-                <Avatar size="lg" src={displayAvatar} fallbackInitials={displayInitials} bordered />
-                <div className="profile-card__info">
-                  <h2 className="profile-card__name">{displayProfile?.displayName || (isOrgMode ? activeOrg.displayName : "Anonymous")}</h2>
-                  <p className="profile-card__handle">@{displayHandle}</p>
-                </div>
-                <Link href={editHref}>
-                  <Button variant="ghost" size="sm">
-                    <Pencil size={14} />
-                    Edit
-                  </Button>
-                </Link>
-              </div>
-              <dl className="profile-card__did">
-                <dt className="personal-info__label">Identifier</dt>
-                <dd className="personal-info__field personal-info__field--mono">{displayDid}</dd>
-                <dd className="personal-info__hint">
-                  {isOrgMode
-                    ? "The group's decentralized identifier (DID) — this never changes, even if you update the handle."
-                    : "Your stable decentralized identifier (DID) — this never changes, even if you update your username."}
-                </dd>
-              </dl>
-            </div>
-
-            {/* Account Details card */}
-            <div className="dash-card">
-              <h2 className="dash-card__title">
-                {isOrgMode ? "Group Details" : "Account Details"}
-              </h2>
-              {!isOrgMode && isFallback && (
-                <div className="profile-fallback-note">
-                  <p>This information was imported from your Bluesky profile. Edit your Certified profile to customize it.</p>
-                </div>
-              )}
-              <dl className="personal-info__grid">
-                {!isOrgMode && (
-                  <div>
-                    <dt className="personal-info__label">Display Name</dt>
-                    <dd className="personal-info__field">{displayProfile?.displayName || "—"}</dd>
-                  </div>
-                )}
-                <div className="personal-info__full-width">
-                  <dt className="personal-info__label">About</dt>
-                  <dd className="personal-info__field">{displayProfile?.description || "—"}</dd>
-                </div>
-                <div className="personal-info__full-width">
-                  <dt className="personal-info__label">Website</dt>
-                  <dd className="personal-info__field">
-                    {displayProfile?.website ? (
-                      <a href={displayProfile.website} target="_blank" rel="noopener noreferrer" className="personal-info__field--link">
-                        {displayProfile.website}
-                      </a>
-                    ) : "—"}
-                  </dd>
-                </div>
-                {isOrgMode && (
-                  <div>
-                    <dt className="personal-info__label">Founded</dt>
-                    <dd className="personal-info__field">
-                      {orgMetadata?.foundedDate
-                        ? new Date(orgMetadata.foundedDate).toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" })
-                        : "—"}
-                    </dd>
-                  </div>
-                )}
-                {isOrgMode && orgMetadata?.organizationType && orgMetadata.organizationType.length > 0 && (
-                  <div>
-                    <dt className="personal-info__label">Type</dt>
-                    <dd className="personal-info__field">
-                      {orgMetadata.organizationType.join(", ")}
-                    </dd>
-                  </div>
-                )}
-                {isOrgMode && orgMetadata?.urls && orgMetadata.urls.length > 0 && (
-                  <div className="personal-info__full-width">
-                    <dt className="personal-info__label">Links</dt>
-                    <dd className="personal-info__field">
-                      {orgMetadata.urls.map((u, i) => (
-                        <span key={i}>
-                          {i > 0 && " · "}
-                          <a href={u.url} target="_blank" rel="noopener noreferrer" className="personal-info__field--link">
-                            {u.label || u.url}
-                          </a>
-                        </span>
-                      ))}
-                    </dd>
-                  </div>
-                )}
-              </dl>
-            </div>
-
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Not authenticated — useEffect above will redirect to /welcome
-  return null;
+    </div>
+  );
 }

--- a/src/components/landing/home-client.tsx
+++ b/src/components/landing/home-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useParams, usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
 import { Pencil } from "lucide-react";
 import { useAuth } from "@/lib/auth/auth-context";
@@ -15,9 +15,12 @@ import Button from "@/components/ui/button";
 
 export default function HomeClient() {
   const router = useRouter();
+  const pathname = usePathname();
+  const params = useParams();
+  const urlDid = typeof params?.did === "string" ? decodeURIComponent(params.did) : null;
   const { isLoading, isAuthenticated, did } = useAuth();
   const { profile, avatarUrl, bannerUrl, isFallback } = useProfile();
-  const { activeOrg } = useOrg();
+  const { activeOrg, groups, isLoading: orgsLoading, switchOrg } = useOrg();
   const { orgProfile, orgMetadata, orgAvatarUrl, orgBannerUrl } = useOrgProfile();
   const { handle } = useSession();
 
@@ -29,9 +32,42 @@ export default function HomeClient() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is stable, omitting to prevent re-renders
   }, [isLoading, isAuthenticated]);
 
+  // Canonicalize URL: `/` → `/profile/{did}` (of user or active org)
+  useEffect(() => {
+    if (isLoading || !isAuthenticated || !did) return;
+    if (pathname !== "/") return;
+    const targetDid = activeOrg?.groupDid || did;
+    router.replace(`/profile/${encodeURIComponent(targetDid)}`);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- router is stable
+  }, [isLoading, isAuthenticated, did, pathname, activeOrg?.groupDid]);
+
+  // Sync active org with URL DID when on `/profile/[did]`
+  useEffect(() => {
+    if (isLoading || orgsLoading || !isAuthenticated || !did || !urlDid) return;
+
+    if (urlDid === did) {
+      if (activeOrg !== null) switchOrg(null);
+      return;
+    }
+
+    const matchingGroup = groups.find((g) => g.groupDid === urlDid);
+    if (matchingGroup) {
+      if (activeOrg?.groupDid !== matchingGroup.groupDid) switchOrg(matchingGroup);
+      return;
+    }
+
+    // URL DID doesn't match user or any of their groups — redirect to self.
+    const selfDid = activeOrg?.groupDid || did;
+    if (urlDid !== selfDid) {
+      router.replace(`/profile/${encodeURIComponent(selfDid)}`);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- router is stable
+  }, [isLoading, orgsLoading, isAuthenticated, did, urlDid, groups, activeOrg?.groupDid]);
+
   const initials = getInitials(profile?.displayName, did);
 
-  if (isLoading) {
+  // Show loading screen while loading, or while on `/` (redirecting to /profile/{did})
+  if (isLoading || (isAuthenticated && pathname === "/")) {
     return (
       <div className="loading-screen">
         <div className="loading-screen__inner">

--- a/src/components/landing/home-client.tsx
+++ b/src/components/landing/home-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useParams, usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
 import { Pencil } from "lucide-react";
 import { useAuth } from "@/lib/auth/auth-context";
@@ -16,11 +16,9 @@ import Button from "@/components/ui/button";
 export default function HomeClient() {
   const router = useRouter();
   const pathname = usePathname();
-  const params = useParams();
-  const urlDid = typeof params?.did === "string" ? decodeURIComponent(params.did) : null;
   const { isLoading, isAuthenticated, did } = useAuth();
   const { profile, avatarUrl, bannerUrl, isFallback } = useProfile();
-  const { activeOrg, groups, isLoading: orgsLoading, switchOrg } = useOrg();
+  const { activeOrg, isLoading: orgsLoading } = useOrg();
   const { orgProfile, orgMetadata, orgAvatarUrl, orgBannerUrl } = useOrgProfile();
   const { handle } = useSession();
 
@@ -32,47 +30,20 @@ export default function HomeClient() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is stable, omitting to prevent re-renders
   }, [isLoading, isAuthenticated]);
 
-  // Canonicalize URL: `/` → `/profile/{did}` (of user or active org)
+  // Canonicalize URL: `/` → `/profile/{did}`. Wait for orgs so we don't
+  // redirect to a stale activeOrg persisted in localStorage.
   useEffect(() => {
-    if (isLoading || !isAuthenticated || !did) return;
+    if (isLoading || orgsLoading || !isAuthenticated || !did) return;
     if (pathname !== "/") return;
     const targetDid = activeOrg?.groupDid || did;
     router.replace(`/profile/${encodeURIComponent(targetDid)}`);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is stable
-  }, [isLoading, isAuthenticated, did, pathname, activeOrg?.groupDid]);
-
-  // Sync active org with URL DID when on `/profile/[did]`
-  useEffect(() => {
-    if (isLoading || orgsLoading || !isAuthenticated || !did || !urlDid) return;
-
-    if (urlDid === did) {
-      if (activeOrg !== null) switchOrg(null);
-      return;
-    }
-
-    const matchingGroup = groups.find((g) => g.groupDid === urlDid);
-    if (matchingGroup) {
-      if (activeOrg?.groupDid !== matchingGroup.groupDid) switchOrg(matchingGroup);
-      return;
-    }
-
-    // URL DID doesn't match user or any of their groups — redirect to self.
-    const selfDid = activeOrg?.groupDid || did;
-    if (urlDid !== selfDid) {
-      router.replace(`/profile/${encodeURIComponent(selfDid)}`);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- router is stable
-  }, [isLoading, orgsLoading, isAuthenticated, did, urlDid, groups, activeOrg?.groupDid]);
+  }, [isLoading, orgsLoading, isAuthenticated, did, pathname, activeOrg?.groupDid]);
 
   const initials = getInitials(profile?.displayName, did);
 
-  // Stay in loading state when the URL DID hasn't been reconciled with
-  // activeOrg yet — prevents a flash of the wrong profile before the sync
-  // effect can switchOrg or redirect.
-  const displayedDid = activeOrg?.groupDid || did;
-  const urlOutOfSync = Boolean(urlDid) && urlDid !== displayedDid;
-
-  if (isLoading || (isAuthenticated && pathname === "/") || urlOutOfSync) {
+  // Show loading while redirecting from `/`
+  if (isLoading || (isAuthenticated && pathname === "/")) {
     return (
       <div className="loading-screen">
         <div className="loading-screen__inner">

--- a/src/components/landing/home-client.tsx
+++ b/src/components/landing/home-client.tsx
@@ -66,8 +66,13 @@ export default function HomeClient() {
 
   const initials = getInitials(profile?.displayName, did);
 
-  // Show loading screen while loading, or while on `/` (redirecting to /profile/{did})
-  if (isLoading || (isAuthenticated && pathname === "/")) {
+  // Stay in loading state when the URL DID hasn't been reconciled with
+  // activeOrg yet — prevents a flash of the wrong profile before the sync
+  // effect can switchOrg or redirect.
+  const displayedDid = activeOrg?.groupDid || did;
+  const urlOutOfSync = Boolean(urlDid) && urlDid !== displayedDid;
+
+  if (isLoading || (isAuthenticated && pathname === "/") || urlOutOfSync) {
     return (
       <div className="loading-screen">
         <div className="loading-screen__inner">

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -14,15 +14,15 @@ import { useOrg } from "@/lib/groups/org-context";
 import { useOrgProfile } from "@/hooks/use-org-profile";
 import { Menu, X, ChevronDown, LogOut } from "lucide-react";
 
-const PERSONAL_NAV_LINKS = [
-  { href: "/", label: "Profile" },
+const PERSONAL_NAV_LINKS = (profileHref: string) => [
+  { href: profileHref, label: "Profile" },
   { href: "/groups", label: "Groups" },
   { href: "/connected-apps", label: "Apps" },
   { href: "/settings", label: "Settings" },
 ];
 
-const ORG_NAV_LINKS = [
-  { href: "/", label: "Profile" },
+const ORG_NAV_LINKS = (profileHref: string) => [
+  { href: profileHref, label: "Profile" },
   { href: "/connected-apps", label: "Apps" },
   { href: "/settings", label: "Settings" },
 ];
@@ -145,7 +145,10 @@ const Navbar: React.FC = () => {
   }, [sheetExpanded]);
 
   // Derive display state from org context
-  const navLinks = activeOrg ? ORG_NAV_LINKS : PERSONAL_NAV_LINKS;
+  const profileDid = activeOrg?.groupDid || did;
+  const profileHref = profileDid ? `/profile/${encodeURIComponent(profileDid)}` : "/";
+  const selfProfileHref = did ? `/profile/${encodeURIComponent(did)}` : "/";
+  const navLinks = activeOrg ? ORG_NAV_LINKS(profileHref) : PERSONAL_NAV_LINKS(profileHref);
   const displayName = activeOrg
     ? (activeOrg.displayName || activeOrg.handle)
     : profile?.displayName;
@@ -169,6 +172,9 @@ const Navbar: React.FC = () => {
 
   const isActive = (href: string) => {
     if (href === "/") return pathname === "/" || pathname === "/settings/edit-profile";
+    if (href.startsWith("/profile/")) {
+      return pathname === "/" || pathname.startsWith("/profile/") || pathname === "/settings/edit-profile";
+    }
     return pathname.startsWith(href);
   };
 
@@ -216,7 +222,7 @@ const Navbar: React.FC = () => {
                       <button
                         role="menuitem"
                         className={`account-switcher__item ${!activeOrg ? "account-switcher__item--active" : ""}`}
-                        onClick={() => { switchOrg(null); setSwitcherOpen(false); router.push("/"); }}
+                        onClick={() => { switchOrg(null); setSwitcherOpen(false); router.push(selfProfileHref); }}
                       >
                         <Avatar
                           src={avatarUrl || undefined}
@@ -253,7 +259,7 @@ const Navbar: React.FC = () => {
                             onClick={() => {
                               switchOrg(org);
                               setSwitcherOpen(false);
-                              router.push("/");
+                              router.push(`/profile/${encodeURIComponent(org.groupDid)}`);
                             }}
                           >
                             <Avatar
@@ -306,7 +312,7 @@ const Navbar: React.FC = () => {
                         <button
                           role="menuitem"
                           className={`account-switcher__item ${!activeOrg ? "account-switcher__item--active" : ""}`}
-                          onClick={() => { switchOrg(null); setSwitcherOpen(false); router.push("/"); }}
+                          onClick={() => { switchOrg(null); setSwitcherOpen(false); router.push(selfProfileHref); }}
                         >
                           <Avatar
                             src={avatarUrl || undefined}
@@ -343,7 +349,7 @@ const Navbar: React.FC = () => {
                               onClick={() => {
                                 switchOrg(org);
                                 setSwitcherOpen(false);
-                                router.push("/");
+                                router.push(`/profile/${encodeURIComponent(org.groupDid)}`);
                               }}
                             >
                               <Avatar

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -18,12 +18,18 @@ interface SidebarProps {
 }
 
 export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
-  const { signOut } = useAuth();
+  const { signOut, did } = useAuth();
   const { profile, avatarUrl } = useProfile();
   const { handle } = useSession();
   const { activeOrg } = useOrg();
   const { orgAvatarUrl } = useOrgProfile();
   const pathname = usePathname();
+  const profileDid = activeOrg?.groupDid || did;
+  const profileHref = profileDid ? `/profile/${encodeURIComponent(profileDid)}` : "/";
+  const isProfileActive =
+    pathname === "/" ||
+    pathname.startsWith("/profile/") ||
+    pathname === "/settings/edit-profile";
 
   // Close sidebar on navigation (mobile)
   useEffect(() => {
@@ -60,8 +66,8 @@ export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
         <ul className="sidebar__menu">
           <li>
             <Link
-              href="/"
-              className={`sidebar__item ${pathname === "/" || pathname === "/settings/edit-profile" ? "sidebar__item--active" : ""}`}
+              href={profileHref}
+              className={`sidebar__item ${isProfileActive ? "sidebar__item--active" : ""}`}
             >
               <User size={18} />
               Profile

--- a/src/components/profile/profile-client.tsx
+++ b/src/components/profile/profile-client.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { Pencil } from "lucide-react";
+import { useAuth } from "@/lib/auth/auth-context";
+import { useOrg } from "@/lib/groups/org-context";
+import { getOrgProfile, getOrgMetadata } from "@/lib/groups/api";
+import { resolveHandle, resolvePdsUrl } from "@/lib/atproto/did";
+import { getAvatarUrl, getBannerUrl } from "@/lib/atproto/profile";
+import type { OrgProfile, GroupMetadata } from "@/lib/groups/types";
+import type { CertifiedProfile } from "@/lib/atproto/types";
+import Avatar from "@/components/ui/avatar";
+import Button from "@/components/ui/button";
+import LoadingSpinner from "@/components/ui/loading-spinner";
+
+export default function ProfileClient() {
+  const params = useParams();
+  const did = typeof params?.did === "string" ? decodeURIComponent(params.did) : "";
+  const { did: currentUserDid } = useAuth();
+  const { groups } = useOrg();
+
+  const [profile, setProfile] = useState<OrgProfile | null>(null);
+  const [metadata, setMetadata] = useState<GroupMetadata | null>(null);
+  const [handle, setHandle] = useState<string | null>(null);
+  const [pdsUrl, setPdsUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!did) {
+        setError("No identifier provided");
+        setIsLoading(false);
+        return;
+      }
+      setIsLoading(true);
+      setError(null);
+      try {
+        const [p, m, h, pds] = await Promise.all([
+          getOrgProfile(did, signal).catch(() => null),
+          getOrgMetadata(did, signal).catch(() => null),
+          resolveHandle(did).catch(() => null),
+          resolvePdsUrl(did).catch(() => null),
+        ]);
+        if (signal?.aborted) return;
+        setProfile(p);
+        setMetadata(m);
+        setHandle(h);
+        setPdsUrl(pds);
+      } catch (err) {
+        if (signal?.aborted) return;
+        console.error("Failed to fetch profile:", err);
+        setError(err instanceof Error ? err.message : "Failed to fetch profile");
+      } finally {
+        if (!signal?.aborted) setIsLoading(false);
+      }
+    },
+    [did]
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchData(controller.signal);
+    return () => controller.abort();
+  }, [fetchData]);
+
+  const effectivePdsUrl = pdsUrl || "https://certified.one";
+  const avatarUrl = profile
+    ? getAvatarUrl(profile as CertifiedProfile, did, effectivePdsUrl)
+    : null;
+  const bannerUrl = profile
+    ? getBannerUrl(profile as CertifiedProfile, did, effectivePdsUrl)
+    : null;
+
+  // Presence of an organization metadata record = this DID is a group
+  const isOrg = !!metadata;
+  const isOwnProfile = !!currentUserDid && currentUserDid === did;
+  const membership = groups.find((g) => g.groupDid === did);
+  const canEditGroup =
+    !!membership && (membership.role === "owner" || membership.role === "admin");
+
+  const editHref = isOwnProfile
+    ? "/settings/edit-profile"
+    : canEditGroup
+      ? `/groups/${encodeURIComponent(did)}/edit-profile`
+      : null;
+
+  const initials = (profile?.displayName || handle || did)
+    .slice(0, 2)
+    .toUpperCase();
+
+  if (isLoading) {
+    return (
+      <div className="dashboard">
+        <div className="dashboard__body dashboard__body--single">
+          <div className="dashboard__main">
+            <div className="auth-guard-loading" aria-busy="true">
+              <LoadingSpinner size="md" />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Hard error: DID couldn't be resolved at all
+  if (error && !pdsUrl) {
+    return (
+      <div className="dashboard">
+        <div className="dashboard__topbar">
+          <h1 className="dashboard__page-title">Profile unavailable</h1>
+        </div>
+        <div className="dashboard__body dashboard__body--single">
+          <div className="dashboard__main">
+            <div className="dash-card">
+              <p className="dash-card__desc">{error}</p>
+              <p className="personal-info__field--mono">{did}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dashboard">
+      <div className="dashboard__topbar">
+        <h1 className="dashboard__page-title">Profile</h1>
+      </div>
+
+      <div className="dashboard__body">
+        <div className="dashboard__main">
+          {/* Profile header card */}
+          <div className="dash-card">
+            <div className="profile-card__banner">
+              {bannerUrl ? <img src={bannerUrl} alt="" /> : null}
+            </div>
+            <div className="profile-card">
+              <Avatar
+                size="lg"
+                src={avatarUrl || undefined}
+                fallbackInitials={initials}
+                bordered
+              />
+              <div className="profile-card__info">
+                <h2 className="profile-card__name">
+                  {profile?.displayName || (isOrg ? "Unnamed group" : "Anonymous")}
+                </h2>
+                {handle && <p className="profile-card__handle">@{handle}</p>}
+              </div>
+              {editHref && (
+                <Link href={editHref}>
+                  <Button variant="ghost" size="sm">
+                    <Pencil size={14} />
+                    Edit
+                  </Button>
+                </Link>
+              )}
+            </div>
+            <dl className="profile-card__did">
+              <dt className="personal-info__label">Identifier</dt>
+              <dd className="personal-info__field personal-info__field--mono">{did}</dd>
+              <dd className="personal-info__hint">
+                {isOrg
+                  ? "The group's decentralized identifier (DID) — this never changes, even if the handle is updated."
+                  : "Stable decentralized identifier (DID) — this never changes, even if the username is updated."}
+              </dd>
+            </dl>
+          </div>
+
+          {/* Details card */}
+          <div className="dash-card">
+            <h2 className="dash-card__title">
+              {isOrg ? "Group Details" : "Account Details"}
+            </h2>
+            <dl className="personal-info__grid">
+              {!isOrg && (
+                <div>
+                  <dt className="personal-info__label">Display Name</dt>
+                  <dd className="personal-info__field">
+                    {profile?.displayName || "—"}
+                  </dd>
+                </div>
+              )}
+              <div className="personal-info__full-width">
+                <dt className="personal-info__label">About</dt>
+                <dd className="personal-info__field">
+                  {profile?.description || "—"}
+                </dd>
+              </div>
+              <div className="personal-info__full-width">
+                <dt className="personal-info__label">Website</dt>
+                <dd className="personal-info__field">
+                  {profile?.website ? (
+                    <a
+                      href={profile.website}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="personal-info__field--link"
+                    >
+                      {profile.website}
+                    </a>
+                  ) : (
+                    "—"
+                  )}
+                </dd>
+              </div>
+              {isOrg && (
+                <div>
+                  <dt className="personal-info__label">Founded</dt>
+                  <dd className="personal-info__field">
+                    {metadata?.foundedDate
+                      ? new Date(metadata.foundedDate).toLocaleDateString(
+                          undefined,
+                          { year: "numeric", month: "long", day: "numeric" }
+                        )
+                      : "—"}
+                  </dd>
+                </div>
+              )}
+              {isOrg &&
+                metadata?.organizationType &&
+                metadata.organizationType.length > 0 && (
+                  <div>
+                    <dt className="personal-info__label">Type</dt>
+                    <dd className="personal-info__field">
+                      {metadata.organizationType.join(", ")}
+                    </dd>
+                  </div>
+                )}
+              {isOrg && metadata?.urls && metadata.urls.length > 0 && (
+                <div className="personal-info__full-width">
+                  <dt className="personal-info__label">Links</dt>
+                  <dd className="personal-info__field">
+                    {metadata.urls.map((u, i) => (
+                      <span key={i}>
+                        {i > 0 && " · "}
+                        <a
+                          href={u.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="personal-info__field--link"
+                        >
+                          {u.label || u.url}
+                        </a>
+                      </span>
+                    ))}
+                  </dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a canonical profile URL at `/profile/{did}` so viewing a profile reflects its DID in the address bar. The root `/` redirects to `/profile/{did}` (user's DID or active org's) and the URL DID is kept in sync with the active-org context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated profile pages with no-index metadata for personal and org profiles.
  * Homepage shows a loading screen and redirects signed-in users to their active profile (personal or org).
  * Navigation and sidebar now recognize and highlight profile and settings routes.
  * Account switcher routes directly to the selected profile (personal or org).

* **Bug Fixes**
  * Improved loading/redirect behavior to avoid premature content flashes while profile context syncs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->