### PR TITLE
fix(security): allowlist schemes for user-controlled URL hrefs

### DIFF
--- a/src/app/groups/[groupDid]/page.tsx
+++ b/src/app/groups/[groupDid]/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/lib/auth/auth-context"
 import { useOrg } from "@/lib/groups/org-context"
 import { getOrgProfile } from "@/lib/groups/api"
 import type { OrgProfile } from "@/lib/groups/types"
+import { safeExternalUrl } from "@/lib/utils/url"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import Button from "@/components/ui/button"
 import Avatar from "@/components/ui/avatar"
@@ -87,18 +88,25 @@ export default function OrgProfilePage() {
                     {profile?.description && (
                       <p className="profile-card__bio">{profile.description}</p>
                     )}
-                    {profile?.website && (
-                      <p className="profile-card__bio">
-                        <a
-                          href={profile.website}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="personal-info__field--link"
-                        >
-                          {profile.website}
-                        </a>
-                      </p>
-                    )}
+                    {profile?.website && (() => {
+                      const safe = safeExternalUrl(profile.website)
+                      return (
+                        <p className="profile-card__bio">
+                          {safe ? (
+                            <a
+                              href={safe}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="personal-info__field--link"
+                            >
+                              {profile.website}
+                            </a>
+                          ) : (
+                            profile.website
+                          )}
+                        </p>
+                      )
+                    })()}
                   </div>
                 </div>
                 {canEdit && (

--- a/src/components/profile/profile-client.tsx
+++ b/src/components/profile/profile-client.tsx
@@ -11,6 +11,7 @@ import { resolveHandle, resolvePdsUrl } from "@/lib/atproto/did";
 import { getAvatarUrl, getBannerUrl } from "@/lib/atproto/profile";
 import type { OrgProfile, GroupMetadata } from "@/lib/groups/types";
 import type { CertifiedProfile } from "@/lib/atproto/types";
+import { safeExternalUrl } from "@/lib/utils/url";
 import Avatar from "@/components/ui/avatar";
 import Button from "@/components/ui/button";
 import LoadingSpinner from "@/components/ui/loading-spinner";
@@ -193,18 +194,22 @@ export default function ProfileClient() {
               <div className="personal-info__full-width">
                 <dt className="personal-info__label">Website</dt>
                 <dd className="personal-info__field">
-                  {profile?.website ? (
-                    <a
-                      href={profile.website}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="personal-info__field--link"
-                    >
-                      {profile.website}
-                    </a>
-                  ) : (
-                    "—"
-                  )}
+                  {(() => {
+                    const safe = safeExternalUrl(profile?.website);
+                    if (safe) {
+                      return (
+                        <a
+                          href={safe}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="personal-info__field--link"
+                        >
+                          {profile!.website}
+                        </a>
+                      );
+                    }
+                    return profile?.website || "—";
+                  })()}
                 </dd>
               </div>
               {isOrg && (
@@ -230,26 +235,32 @@ export default function ProfileClient() {
                     </dd>
                   </div>
                 )}
-              {isOrg && metadata?.urls && metadata.urls.length > 0 && (
-                <div className="personal-info__full-width">
-                  <dt className="personal-info__label">Links</dt>
-                  <dd className="personal-info__field">
-                    {metadata.urls.map((u, i) => (
-                      <span key={i}>
-                        {i > 0 && " · "}
-                        <a
-                          href={u.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="personal-info__field--link"
-                        >
-                          {u.label || u.url}
-                        </a>
-                      </span>
-                    ))}
-                  </dd>
-                </div>
-              )}
+              {isOrg && metadata?.urls && metadata.urls.length > 0 && (() => {
+                const safeLinks = metadata.urls
+                  .map((u) => ({ ...u, safeHref: safeExternalUrl(u.url) }))
+                  .filter((u) => !!u.safeHref);
+                if (safeLinks.length === 0) return null;
+                return (
+                  <div className="personal-info__full-width">
+                    <dt className="personal-info__label">Links</dt>
+                    <dd className="personal-info__field">
+                      {safeLinks.map((u, i) => (
+                        <span key={i}>
+                          {i > 0 && " · "}
+                          <a
+                            href={u.safeHref!}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="personal-info__field--link"
+                          >
+                            {u.label || u.url}
+                          </a>
+                        </span>
+                      ))}
+                    </dd>
+                  </div>
+                );
+              })()}
             </dl>
           </div>
         </div>

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -1,0 +1,22 @@
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+/**
+ * Returns the input URL unchanged if it parses as an absolute URL with an
+ * allowlisted scheme (http, https, mailto, tel). Returns null otherwise —
+ * e.g. for `javascript:`, `data:`, `vbscript:`, relative URLs, or malformed
+ * input.
+ *
+ * Use before rendering user-controlled URLs as anchor `href` attributes,
+ * since `href="javascript:..."` executes JavaScript when clicked.
+ */
+export function safeExternalUrl(input: string | undefined | null): string | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed);
+    return ALLOWED_PROTOCOLS.has(parsed.protocol) ? trimmed : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Profile website and group link URLs were rendered directly into anchor hrefs. A malicious user could save a javascript: URL on their own profile or (as a group admin) on a group's links array, executing script in any viewer's browser.

Adds safeExternalUrl helper that returns the URL unchanged only for http, https, mailto, or tel schemes; everything else (including javascript:, data:, vbscript:, relative paths, malformed input) returns null and the component falls back to plain text.

Applied at every user-controlled render site:
- ProfileClient: profile.website and metadata.urls
- groups/[groupDid]/page.tsx: profile.website

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of external links in user and organization profiles with enhanced URL validation and normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->