### PR TITLE
docs(legal): update privacy, terms, and DSA for new sub-processors

### DIFF
--- a/src/app/dsa/page.tsx
+++ b/src/app/dsa/page.tsx
@@ -23,7 +23,7 @@ export default function DsaPage() {
           Digital Services Act — Compliance Information
         </h1>
 
-        <p className="text-sm text-gray-500 mb-8">Last updated: March 15, 2026</p>
+        <p className="text-sm text-gray-500 mb-8">Last updated: May 6, 2026</p>
 
         <div className="prose prose-navy max-w-none space-y-8">
           <section>
@@ -44,9 +44,18 @@ export default function DsaPage() {
             <h2 className="font-mono text-xl text-navy mb-4">2. Service provider</h2>
             <p>
               <strong>Hypercerts Foundation</strong>
-              <br />A Delaware nonstock corporation
+              <br />
+              A Delaware nonstock corporation
+              <br />
+              1209 Orange St.
+              <br />
+              Wilmington, DE 19801
+              <br />
+              United States
             </p>
             <p className="mt-4">
+              Phone: +1 302 658 7581
+              <br />
               Contact:{" "}
               <a
                 href="mailto:legal@hypercerts.org"

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -23,7 +23,7 @@ export default function PrivacyPage() {
           Privacy Policy — Certified
         </h1>
 
-        <p className="text-sm text-gray-500 mb-8">Last updated: April 1, 2026</p>
+        <p className="text-sm text-gray-500 mb-8">Last updated: May 6, 2026</p>
 
         <div className="prose prose-navy max-w-none space-y-8">
           <section>
@@ -182,6 +182,10 @@ export default function PrivacyPage() {
             <ul className="list-disc pl-6 mt-2 space-y-2">
               <li>operate and maintain certified.app and certified.one</li>
               <li>authenticate users and manage accounts</li>
+              <li>
+                send service-related notifications such as authentication, account, and security
+                communications
+              </li>
               <li>operate AT Protocol Personal Data Servers</li>
               <li>ensure the stability and security of the infrastructure</li>
               <li>detect and prevent abuse or malicious activity</li>
@@ -233,9 +237,12 @@ export default function PrivacyPage() {
               <strong>European Union</strong>.
             </p>
             <p className="mt-4">
-              Operational service providers may process limited data outside the European Union.
-              Where this occurs, appropriate safeguards are implemented in accordance with
-              applicable data protection laws.
+              Some operational service providers process limited data outside the European Union.
+              Specifically, transactional email delivery is handled by a US-based provider (see
+              Section 8), and certain corporate operations of our hosting providers may take place
+              in the United States. Where personal data is transferred outside the European Union,
+              transfers are protected by Standard Contractual Clauses (SCCs) approved by the
+              European Commission, in accordance with Article 46 GDPR.
             </p>
           </section>
 
@@ -261,8 +268,10 @@ export default function PrivacyPage() {
             </p>
             <p className="mt-4">
               Once data is shared through the federated network, the Hypercerts Foundation cannot
-              control how third-party services process or store that information. Those services act
-              as <strong>independent data controllers</strong> for any processing they perform.
+              control how third-party services process or store that information. The legal status
+              of those operators under data protection law depends on their specific activities; in
+              many cases they will themselves be <strong>data controllers</strong> for their own
+              processing.
             </p>
           </section>
 
@@ -275,7 +284,15 @@ export default function PrivacyPage() {
             <ul className="list-disc pl-6 mt-2 space-y-2">
               <li>
                 with service providers that support the operation of the services and process data
-                on our behalf, including Vercel Inc. (hosting and anonymous web analytics)
+                on our behalf, including:
+                <ul className="list-disc pl-6 mt-2 space-y-2">
+                  <li>Vercel Inc. (web application hosting and anonymous web analytics)</li>
+                  <li>Railway Corporation (application and database hosting infrastructure)</li>
+                  <li>
+                    Plus Five Five, Inc. (d/b/a Resend) (transactional email delivery for account,
+                    security, and operational notifications)
+                  </li>
+                </ul>
               </li>
               <li>
                 with third-party services that users choose to connect to their accounts

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -23,7 +23,7 @@ export default function TermsPage() {
           Terms of Service — Certified
         </h1>
 
-        <p className="text-sm text-gray-500 mb-8">Last updated: April 1, 2026</p>
+        <p className="text-sm text-gray-500 mb-8">Last updated: May 6, 2026</p>
 
         <div className="prose prose-navy max-w-none space-y-8">
           <section>
@@ -222,8 +222,9 @@ export default function TermsPage() {
               operational tasks such as:
             </p>
             <ul className="list-disc pl-6 mt-2 space-y-2">
+              <li>application and database hosting</li>
               <li>system monitoring</li>
-              <li>communications</li>
+              <li>transactional email delivery</li>
               <li>analytics</li>
               <li>technical support</li>
             </ul>
@@ -427,9 +428,9 @@ export default function TermsPage() {
 
             <h3 className="font-mono text-lg text-navy mt-6 mb-3">Survival</h3>
             <p>
-              Sections 5 (intellectual property), 12 (data persistence), 15 (feedback), 16
-              (disclaimer of warranties), 17 (limitation of liability), 18 (indemnification), 19
-              (consumer protections), and 23 (governing law) survive termination of these Terms.
+              Sections 6 (intellectual property), 13 (data persistence), 16 (feedback), 17
+              (disclaimer of warranties), 18 (limitation of liability), 19 (indemnification), 20
+              (consumer protections), and 24 (governing law) survive termination of these Terms.
             </p>
           </section>
 


### PR DESCRIPTION
## Summary
- Disclose Railway and Resend as sub-processors (Privacy §8) and add the email-notifications processing purpose (Privacy §4) so the policy matches the DPA.
- Tighten Privacy §6 to name US transfers explicitly and cite SCCs / Art. 46 GDPR; soften Privacy §7's federated-relay framing away from a blanket "independent data controllers" claim.
- Sync the Terms operational-tasks list with the new sub-processors (§8), fix the off-by-one section numbering in the §15 survival clause, and bring the DSA §2 service-provider block to parity with the Privacy/Terms address blocks.
- Bump "Last updated" to May 6, 2026 across all three pages.

## Test plan
- [ ] Visit `/privacy`, `/terms`, `/dsa` locally and confirm the sections render correctly (nested list in Privacy §8 in particular).
- [ ] Re-read the §15 Survival clause in Terms and confirm each section number now matches the named topic.
- [ ] Spot-check the cross-references (Privacy §14 → §6, Terms §11 → DSA, DSA §6 → Terms) still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Data Subject Access page with expanded service provider contact information
  * Updated Privacy Policy with data handling, cross-border transfer, and service provider details
  * Updated Terms of Service with infrastructure and service operation information
  * All policy documents now reflect May 6, 2026

<!-- end of auto-generated comment: release notes by coderabbit.ai -->