### PR TITLE
feat(navbar): atproto user search

### DIFF
--- a/src/app/api/search-actors/route.ts
+++ b/src/app/api/search-actors/route.ts
@@ -1,44 +1,78 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getAuthenticatedAgent } from "@/lib/groups/proxy-agent"
+
+const PUBLIC_BSKY_APPVIEW = "https://public.api.bsky.app"
+
+interface BskyActor {
+  did?: string
+  handle?: string
+  displayName?: string
+  avatar?: string
+}
+
+interface BskySearchResponse {
+  actors?: BskyActor[]
+}
 
 /**
  * GET /api/search-actors?q=<query>&limit=<n>
- * Search Bluesky actors by handle/name using typeahead.
+ *
+ * Searches atproto identities via the public Bluesky AppView. The endpoint is
+ * deliberately unauthenticated — `app.bsky.actor.searchActors` is a public read
+ * on the AppView, and we want the navbar typeahead to work for signed-out
+ * visitors too.
+ *
  * Returns: { actors: [{ did, handle, displayName, avatar }] }
  */
 export async function GET(request: NextRequest) {
+  const q = (request.nextUrl.searchParams.get("q") || "").trim()
+  const rawLimit = Number(request.nextUrl.searchParams.get("limit") || "8")
+  const limit = Math.min(Math.max(Number.isFinite(rawLimit) ? rawLimit : 8, 1), 25)
+
+  if (!q) {
+    return NextResponse.json({ actors: [] })
+  }
+
   try {
-    const auth = await getAuthenticatedAgent()
-    if (!auth)
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+    const url = new URL("/xrpc/app.bsky.actor.searchActors", PUBLIC_BSKY_APPVIEW)
+    url.searchParams.set("q", q)
+    url.searchParams.set("limit", String(limit))
 
-    const q = request.nextUrl.searchParams.get("q") || ""
-    const limit = Math.min(Number(request.nextUrl.searchParams.get("limit") || "8"), 25)
-
-    if (!q.trim()) {
-      return NextResponse.json({ actors: [] })
-    }
-
-    // Use searchActors for comprehensive results (includes full profiles)
-    const result = await auth.agent.app.bsky.actor.searchActors({
-      q: q.trim(),
-      limit,
+    const res = await fetch(url.toString(), {
+      headers: { Accept: "application/json" },
+      // Reasonable upstream timeout — the AppView is normally fast.
+      signal: AbortSignal.timeout(5000),
     })
 
-    const actors = (result.data.actors || []).map((a) => ({
-      did: a.did,
-      handle: a.handle,
-      displayName: a.displayName || "",
-      avatar: a.avatar || null,
-    }))
+    if (!res.ok) {
+      // Sanitize 5xx upstream messages per AGENTS.md §17.
+      if (res.status >= 500) {
+        return NextResponse.json(
+          { error: "Search backend unavailable" },
+          { status: 502 }
+        )
+      }
+      const text = await res.text().catch(() => "")
+      return NextResponse.json(
+        { error: text || "Search failed" },
+        { status: res.status }
+      )
+    }
+
+    const data = (await res.json()) as BskySearchResponse
+    const actors = (data.actors ?? [])
+      .filter((a): a is BskyActor & { did: string; handle: string } =>
+        typeof a.did === "string" && typeof a.handle === "string"
+      )
+      .map((a) => ({
+        did: a.did,
+        handle: a.handle,
+        displayName: a.displayName || "",
+        avatar: a.avatar || null,
+      }))
 
     return NextResponse.json({ actors })
   } catch (err: unknown) {
-    console.error("Search actors error:", err)
-    const error = err as { message?: string }
-    return NextResponse.json(
-      { error: error?.message || "Search failed" },
-      { status: 500 }
-    )
+    console.error("[search-actors]", err)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3978,6 +3978,190 @@ h1, h2, h3, h4, h5, h6 {
   white-space: nowrap;
 }
 
+/* ========== Navbar Search (top-bar typeahead) ========== */
+.navbar-search {
+  position: relative;
+  flex: 1 1 auto;
+  max-width: 420px;
+  min-width: 0;
+  margin: 0 24px;
+}
+
+.navbar-search__field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 38px;
+  padding: 0 12px;
+  /* Whisper-soft warm white — only a hair off the page surface (#fefefe),
+     so the fill barely registers and the hairline border carries the
+     shape. Reads like a pill of unbleached paper rather than a control. */
+  background: #fdfcf9;
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  transition: background var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.navbar-search__field:hover {
+  border-color: var(--border-default);
+}
+
+.navbar-search__field:focus-within {
+  background: #ffffff;
+  border-color: var(--border-medium);
+  box-shadow: 0 0 0 3px rgba(50, 35, 20, 0.05);
+}
+
+.navbar-search__icon {
+  flex: 0 0 auto;
+  color: var(--color-mid-gray);
+  margin-right: 8px;
+}
+
+.navbar-search__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 100%;
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: 0.875rem;
+  color: var(--color-primary);
+  padding: 0;
+}
+
+.navbar-search__input::placeholder {
+  color: var(--color-mid-gray);
+}
+
+.navbar-search__clear {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  margin-left: 4px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-mid-gray);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.navbar-search__clear:hover {
+  background: var(--color-gray-100);
+  color: var(--color-primary);
+}
+
+.navbar-search__clear:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.navbar-search__dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  background: var(--color-white, #ffffff);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.10);
+  z-index: 60;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.navbar-search__empty {
+  padding: 14px 12px;
+  font-size: 0.8125rem;
+  color: var(--color-mid-gray);
+  text-align: left;
+}
+
+.navbar-search__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition-fast), box-shadow var(--transition-fast);
+  user-select: none;
+  box-shadow: inset 2px 0 0 transparent;
+}
+
+.navbar-search__item:hover {
+  background: var(--color-gray-100);
+}
+
+.navbar-search__item--highlighted {
+  background: var(--color-gray-100);
+  box-shadow: inset 2px 0 0 var(--color-primary);
+}
+
+.navbar-search__item-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.navbar-search__item-name {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.navbar-search__item-handle {
+  font-size: 0.6875rem;
+  color: var(--color-mid-gray);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 900px) {
+  .navbar-search { max-width: 320px; margin: 0 16px; }
+}
+
+@media (max-width: 768px) {
+  /* On tablet/mobile the app-links / public-links / desktop user cluster all
+     hide — letting the search expand into the freed middle space keeps it
+     usable next to the logo and the mobile actions (avatar + hamburger,
+     or sign-in / get-started). */
+  .navbar-search {
+    max-width: none;
+    margin: 0 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .navbar-search { margin: 0 8px; }
+  .navbar-search__field { padding: 0 10px; height: 36px; }
+  .navbar-search__icon { margin-right: 6px; }
+  .navbar-search__input { font-size: 0.8125rem; }
+  /* Drop the placeholder text on very narrow screens — the icon is enough
+     visual cue and the few extra pixels matter when the navbar is tight. */
+  .navbar-search__input::placeholder { color: transparent; }
+}
+
+@media (max-width: 380px) {
+  .navbar-search { margin: 0 6px; }
+  .navbar-search__field { padding: 0 8px; }
+}
+
 /* ========== Organizations ========== */
 
 /* Organization list page */

--- a/src/components/layout/navbar-search.tsx
+++ b/src/components/layout/navbar-search.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Search, X } from "lucide-react";
+import Avatar from "@/components/ui/avatar";
+import { getInitials } from "@/lib/utils/initials";
+
+interface Actor {
+  did: string;
+  handle: string;
+  displayName: string;
+  avatar: string | null;
+}
+
+interface NavbarSearchProps {
+  /** Optional className passed to the wrapping element. */
+  className?: string;
+  /** Override placeholder text. */
+  placeholder?: string;
+}
+
+/**
+ * Top-of-page user search.
+ *
+ * Behaviour:
+ * - Calls /api/search-actors (debounced, 250ms) to suggest matching atproto identities.
+ * - Up/Down arrows move the highlight through the dropdown (with wrap-around).
+ * - Enter selects the highlighted result; if nothing is highlighted, falls back to
+ *   the first result. Esc clears + closes the dropdown.
+ * - Cmd/Ctrl+K from anywhere on the page focuses the search input.
+ * - Selecting a result navigates to /profile/<did>.
+ */
+export default function NavbarSearch({
+  className = "",
+  placeholder = "Search people on atproto",
+}: NavbarSearchProps) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Actor[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
+  const [highlight, setHighlight] = useState<number>(-1);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Lets us drop stale responses when the user keeps typing.
+  const requestSeq = useRef(0);
+
+  // Debounced fetch.
+  const search = useCallback(async (q: string, seq: number) => {
+    const trimmed = q.trim();
+    if (trimmed.length < 1) {
+      setResults([]);
+      setIsOpen(false);
+      setIsSearching(false);
+      return;
+    }
+    setIsSearching(true);
+    try {
+      // Plain fetch (not authFetch) — the route is unauthenticated, and we don't
+      // want a transient 5xx to trip the global 401 → sign-in interceptor.
+      const res = await fetch(
+        `/api/search-actors?q=${encodeURIComponent(trimmed)}&limit=8`,
+        { headers: { Accept: "application/json" } }
+      );
+      // If a newer request started while this one was in flight, drop the result.
+      if (seq !== requestSeq.current) return;
+      if (res.ok) {
+        const data = (await res.json()) as { actors?: Actor[] };
+        const next = data.actors ?? [];
+        setResults(next);
+        setHighlight(next.length > 0 ? 0 : -1);
+        setIsOpen(true);
+      } else {
+        setResults([]);
+        setHighlight(-1);
+        setIsOpen(true);
+      }
+    } catch {
+      // ignore — keep the previous results visible to avoid flicker
+    } finally {
+      if (seq === requestSeq.current) setIsSearching(false);
+    }
+  }, []);
+
+  // Run the debounced search whenever `query` changes.
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!query.trim()) {
+      setResults([]);
+      setIsOpen(false);
+      setIsSearching(false);
+      setHighlight(-1);
+      return;
+    }
+    const seq = ++requestSeq.current;
+    debounceRef.current = setTimeout(() => search(query, seq), 250);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, search]);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [isOpen]);
+
+  // Cmd/Ctrl+K focus shortcut, scoped to keyboard events outside other inputs.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Keep the highlighted row visible when navigating with the keyboard.
+  useEffect(() => {
+    if (highlight < 0 || !listRef.current) return;
+    const el = listRef.current.querySelectorAll<HTMLLIElement>("[data-result-row]")[highlight];
+    el?.scrollIntoView({ block: "nearest" });
+  }, [highlight]);
+
+  const select = useCallback(
+    (actor: Actor) => {
+      setQuery("");
+      setResults([]);
+      setIsOpen(false);
+      setHighlight(-1);
+      // Blur so the dropdown doesn't reappear on the destination page.
+      inputRef.current?.blur();
+      router.push(`/profile/${encodeURIComponent(actor.did)}`);
+    },
+    [router]
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Open the dropdown on first arrow-down even before any results have loaded.
+    if (e.key === "ArrowDown") {
+      if (results.length === 0) return;
+      e.preventDefault();
+      setIsOpen(true);
+      setHighlight((h) => (h + 1) % results.length);
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      if (results.length === 0) return;
+      e.preventDefault();
+      setIsOpen(true);
+      setHighlight((h) => (h <= 0 ? results.length - 1 : h - 1));
+      return;
+    }
+    if (e.key === "Enter") {
+      if (results.length === 0) return;
+      e.preventDefault();
+      const target = highlight >= 0 ? results[highlight] : results[0];
+      if (target) select(target);
+      return;
+    }
+    if (e.key === "Escape") {
+      e.preventDefault();
+      if (query) {
+        setQuery("");
+      } else {
+        setIsOpen(false);
+        inputRef.current?.blur();
+      }
+      return;
+    }
+    if (e.key === "Home") {
+      if (results.length === 0) return;
+      e.preventDefault();
+      setHighlight(0);
+      return;
+    }
+    if (e.key === "End") {
+      if (results.length === 0) return;
+      e.preventDefault();
+      setHighlight(results.length - 1);
+    }
+  };
+
+  const handleClear = () => {
+    setQuery("");
+    setResults([]);
+    setIsOpen(false);
+    setHighlight(-1);
+    inputRef.current?.focus();
+  };
+
+  const showDropdown =
+    isOpen && (isSearching || results.length > 0 || query.trim().length > 0);
+
+  // ARIA: tie input to listbox + active row for screen readers.
+  const listboxId = "navbar-search-listbox";
+  const activeId = highlight >= 0 ? `navbar-search-option-${highlight}` : undefined;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`navbar-search ${className}`}
+      role="search"
+    >
+      <div className="navbar-search__field">
+        <Search size={16} className="navbar-search__icon" aria-hidden="true" />
+        <input
+          ref={inputRef}
+          type="text"
+          className="navbar-search__input"
+          value={query}
+          placeholder={placeholder}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onFocus={() => {
+            if (results.length > 0 || query.trim().length > 0) setIsOpen(true);
+          }}
+          role="combobox"
+          aria-label="Search people on atproto"
+          aria-autocomplete="list"
+          aria-expanded={showDropdown}
+          aria-controls={showDropdown ? listboxId : undefined}
+          aria-activedescendant={activeId}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        {query ? (
+          <button
+            type="button"
+            className="navbar-search__clear"
+            onClick={handleClear}
+            aria-label="Clear search"
+          >
+            <X size={14} aria-hidden="true" />
+          </button>
+        ) : null}
+      </div>
+
+      {showDropdown && (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          className="navbar-search__dropdown"
+        >
+          {isSearching && results.length === 0 && (
+            <li className="navbar-search__empty" role="presentation">
+              Searching…
+            </li>
+          )}
+          {!isSearching && results.length === 0 && query.trim() && (
+            <li className="navbar-search__empty" role="presentation">
+              No people found for &ldquo;{query.trim()}&rdquo;.
+            </li>
+          )}
+          {results.map((actor, i) => {
+            const name = actor.displayName || actor.handle;
+            const isHighlighted = i === highlight;
+            return (
+              <li
+                key={actor.did}
+                id={`navbar-search-option-${i}`}
+                role="option"
+                aria-selected={isHighlighted}
+                data-result-row
+                className={`navbar-search__item ${
+                  isHighlighted ? "navbar-search__item--highlighted" : ""
+                }`}
+                onMouseEnter={() => setHighlight(i)}
+                // mouseDown (not click) — fires before the input's blur and avoids
+                // the dropdown disappearing before the navigation happens.
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  select(actor);
+                }}
+              >
+                <Avatar
+                  size="sm"
+                  src={actor.avatar || undefined}
+                  fallbackInitials={getInitials(name, actor.did)}
+                />
+                <div className="navbar-search__item-info">
+                  <span className="navbar-search__item-name">{name}</span>
+                  <span className="navbar-search__item-handle">@{actor.handle}</span>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/navbar-search.tsx
+++ b/src/components/layout/navbar-search.tsx
@@ -48,6 +48,10 @@ export default function NavbarSearch({
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Lets us drop stale responses when the user keeps typing.
   const requestSeq = useRef(0);
+  // Set when we update `query` programmatically after a selection so the
+  // debounced search effect skips the auto-fire for that one update — without
+  // this we'd immediately re-search for the selected user's display name.
+  const suppressNextSearchRef = useRef(false);
 
   // Debounced fetch.
   const search = useCallback(async (q: string, seq: number) => {
@@ -89,6 +93,12 @@ export default function NavbarSearch({
   // Run the debounced search whenever `query` changes.
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
+    // Skip the search once when we set `query` programmatically after a
+    // selection — the user already picked someone, no need to re-query.
+    if (suppressNextSearchRef.current) {
+      suppressNextSearchRef.current = false;
+      return;
+    }
     if (!query.trim()) {
       setResults([]);
       setIsOpen(false);
@@ -137,9 +147,15 @@ export default function NavbarSearch({
 
   const select = useCallback(
     (actor: Actor) => {
-      setQuery("");
+      // Keep the selected user visible in the search bar instead of clearing
+      // it — confirms the selection and matches what the user navigated to.
+      // Suppress the next debounced search so we don't immediately re-fire a
+      // request for the display name we just set.
+      suppressNextSearchRef.current = true;
+      setQuery(actor.displayName || actor.handle);
       setResults([]);
       setIsOpen(false);
+      setIsSearching(false);
       setHighlight(-1);
       // Blur so the dropdown doesn't reappear on the destination page.
       inputRef.current?.blur();
@@ -226,7 +242,11 @@ export default function NavbarSearch({
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
           onFocus={() => {
-            if (results.length > 0 || query.trim().length > 0) setIsOpen(true);
+            // Only reopen if there are actual results to show. After a
+            // selection results is empty but the input still holds the picked
+            // user's name — refocusing in that state shouldn't pop a stale or
+            // empty dropdown.
+            if (results.length > 0) setIsOpen(true);
           }}
           role="combobox"
           aria-label="Search people on atproto"

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -13,6 +13,7 @@ import { getInitials } from "@/lib/utils/initials";
 import { useOrg } from "@/lib/groups/org-context";
 import { useOrgProfile } from "@/hooks/use-org-profile";
 import { Menu, X, ChevronDown, LogOut } from "lucide-react";
+import NavbarSearch from "./navbar-search";
 
 const PERSONAL_NAV_LINKS = (profileHref: string) => [
   { href: profileHref, label: "Profile" },
@@ -188,6 +189,9 @@ const Navbar: React.FC = () => {
 
         {isAuthenticated ? (
           <>
+            {/* Desktop: search bar */}
+            <NavbarSearch className="navbar__search" />
+
             {/* Desktop: nav links */}
             <div className="navbar__app-links">
               {navLinks.map((link) => (
@@ -403,14 +407,19 @@ const Navbar: React.FC = () => {
             </div>
           </>
         ) : (
-          <div className="navbar__right">
-            <button
-              onClick={openSignIn}
-              className="navbar__signin"
-            >
-              <img src="/assets/certified_signin_black.svg" alt="Sign in" className="navbar__signin-img" />
-            </button>
-          </div>
+          <>
+            {/* Desktop: search bar (works without auth via public Bluesky AppView) */}
+            <NavbarSearch className="navbar__search" />
+
+            <div className="navbar__right">
+              <button
+                onClick={openSignIn}
+                className="navbar__signin"
+              >
+                <img src="/assets/certified_signin_black.svg" alt="Sign in" className="navbar__signin-img" />
+              </button>
+            </div>
+          </>
         )}
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- Adds a typeahead navbar search for atproto identities, mounted in both authenticated and unauthenticated nav branches.
- Routes `/api/search-actors` through the public Bluesky AppView so unauthenticated visitors can search.
- Selecting a result keeps the chosen user's display name in the input (no flicker back to query).

Split out of #49 so the auth/profile fixes can ship without exposing the search bar yet. Hold this PR until ready to enable the search UI.

## Commits
- `feat(api)`: allow unauthenticated user search via public Bluesky AppView
- `feat(navbar)`: add atproto user search with keyboard nav (debounce, ARIA combobox, responsive layout)
- `fix(navbar-search)`: keep selected user's name in the search input

## Test plan
- [ ] Type a handle in the navbar search; results appear from Bluesky AppView
- [ ] Keyboard nav: ArrowDown/Up, Home/End, Enter, Esc all behave per the commit message
- [ ] Selecting a result navigates to `/profile/<did>` and the input shows the chosen name
- [ ] Works while signed out (no 401 → sign-in modal trip)
- [ ] Responsive: <=900px / <=768px / <=480px / <=380px breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)