### PR TITLE
chore(groups): remove beta test-server warning banner

### DIFF
--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -162,20 +162,6 @@ export default function GroupsPage() {
 
       <div className="dashboard__body dashboard__body--single">
         <div className="dashboard__main">
-          <div
-            style={{
-              padding: "10px 14px",
-              marginBottom: 16,
-              borderRadius: 8,
-              background: "var(--color-warning-bg)",
-              border: "1px solid var(--color-warning-border)",
-              color: "var(--color-warning-text)",
-              fontSize: 13,
-              lineHeight: 1.5,
-            }}
-          >
-            <strong>Heads up:</strong> Groups are in beta and currently run on a test server. Data may be reset or removed without notice — please don't rely on it for anything important yet.
-          </div>
           {isLoading ? (
             <div className="org-list__loading">
               <LoadingSpinner size="md" />


### PR DESCRIPTION
## Summary
- Removes the warning banner on `/groups` that read: *"Heads up: Groups are in beta and currently run on a test server. Data may be reset or removed without notice — please don't rely on it for anything important yet."*

## Test plan
- [ ] Visit `/groups` — no warning banner renders above the group list
- [ ] Loading and empty states still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the beta warning banner from the Groups page.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypercerts-org/certified-app/pull/52)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->