### PR TITLE
feat(groups): unify list, show join date, add sort control

### DIFF
--- a/docs/groups-list-improvements/review-round-1.md
+++ b/docs/groups-list-improvements/review-round-1.md
@@ -1,0 +1,30 @@
+# Review round 1 — feat/groups-list-improvements
+
+Three reviewers (code quality, security, functional/UX) ran in parallel against PR #53. All three returned a `ship` or `ship-then-fix-nits` verdict — no critical findings. Items below are tracked as accepted (acted on this round) or rejected (with rationale).
+
+## Accepted
+
+| # | Source | Item | Action |
+|---|---|---|---|
+| A1 | Code quality #2 | Sort comparator redundantly lowercases before `localeCompare` | Drop `.toLowerCase()`, pass `{ sensitivity: "base" }` to `localeCompare` |
+| A2 | Code quality #3 | `new Date(joinedAt).getTime()` runs O(n log n) times during sort | Decorate-sort-undecorate: pre-compute timestamps once |
+| A3 | Code quality #4 | Bare `aria-hidden` is inconsistent with `aria-hidden="true"` elsewhere | Use the explicit form |
+| A4 | Code quality #5 | `e.target.value as SortMode` is an unchecked cast | Validate against `SORT_OPTIONS` before setting state |
+| A5 | Code quality #10 + Functional #1 | Tooltip on wrapper div is invisible to keyboard/AT users; current sort mode not announced | Move `title` onto the `<select>` and include the current mode in `aria-label` |
+| A6 | Functional #2 | Owners' Leave-button tooltip is a dead-end ("Owners can't leave the group") | Add actionable guidance: "Owners can't leave — transfer ownership in group settings first" |
+| A7 | Code quality #7 | `org.displayName \|\| org.handle` is repeated 6x | Extract a local `displayLabel` const inside `renderOrgItem` |
+
+## Rejected
+
+| # | Source | Item | Rationale |
+|---|---|---|---|
+| R1 | Code quality #1 | Persist `sortMode` to `localStorage` | Out of scope. User explicitly said "by default order them from oldest to newest" — persistence is a separate product decision. The PR body lists this in "Out of scope". |
+| R2 | Code quality #6 | Inline `renderOrgItem` JSX in `.map()` instead of extracting | Style preference; helper improves the JSX-block readability. No perf signal. |
+| R3 | Code quality #8 + #9 + Functional #3 | Prune `accepted` tie-break from `navbar.tsx`; mark `Group.accepted` optional | Out of scope. PR body explicitly leaves the navbar untouched. `accepted` is still set by `groups/create/page.tsx` and `add-org-modal.tsx`; deeper cleanup belongs in a follow-up. |
+| R4 | Security nit | Wrap `console.error("Failed to leave group:", err)` to avoid logging full Error objects | Reviewer rated "Acceptable" — no token/cookie/secret in scope. Pre-existing pattern in the file. |
+| R5 | Security important | Removing UserCheck/UserX is a privacy-UX regression (no in-app way to make a previously-public membership private) | User explicitly asked to remove these buttons. Already noted in PR "Out of scope". Flag is for product, not code. |
+| R6 | Functional #5 | Safari/Firefox quirks of the transparent-select pattern | Reviewer said "not worth fixing pre-merge". Will be caught by manual smoke before staging→main if it surfaces. |
+
+## Round 2?
+
+Per workflow rule: "Run a follow-up round only if round 1 surfaced ≥5 substantive items." Substantive items here (Important): 2 (A5/A6, the AT/keyboard improvements). The rest are nits or perf polish. **Skipping round 2.**

--- a/docs/groups-list-improvements/review-round-2.md
+++ b/docs/groups-list-improvements/review-round-2.md
@@ -1,0 +1,22 @@
+# Review round 2 — feat/groups-list-improvements
+
+Two reviewers (code quality, functional/UX) ran against the round-1 fix commit. Both verdicts: `ship`. One **Important** item flagged independently by both reviewers; the rest are nits.
+
+## Accepted
+
+| # | Source | Item | Action |
+|---|---|---|---|
+| B1 | Functional Important + Code quality nit | `aria-label="Sort groups, current: <label>"` is redundant — native `<select>` already announces the selected `<option>` after the role | Revert to `aria-label="Sort groups"`. Keep the `title` attribute (different audience: sighted keyboard/mouse). |
+| B2 | Both reviewers (nit) | Stale comment "reuse the lowercased label" — the label is no longer lowercased | Update comment + add a note that ES2019 `Array.prototype.sort` is stable so equal keys don't need an explicit tiebreak |
+| B3 | Code quality nit | Two `as SortMode` casts inside the `onChange` validator | Extract a `isSortMode(v): v is SortMode` type predicate; `SORT_VALUES` widened to `ReadonlySet<string>` so the predicate's input doesn't need a cast |
+
+## Rejected
+
+| # | Source | Item | Rationale |
+|---|---|---|---|
+| C1 | Functional nit | Restructure the NaN sentinel: `const d = …; ts = d && !Number.isNaN(d.getTime()) ? d.getTime() : null` | Equivalent behavior, style preference. Current form is two lines and self-documents via `Number.isNaN(t) ? null : t`. |
+| C2 | Code quality nit | Trim the `?? ""` defensive fallback on `currentSortLabel` | `?? ""` is harmless and keeps the type as `string` rather than `string \| undefined`, simplifying interpolation. Defensive but cheap. |
+
+## Round 3?
+
+Substantive items in round 2: 1 (B1). Below the ≥5 threshold for a follow-up round per the workflow rule. Both reviewers explicitly returned `ship` verdicts. **Stopping here.**

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4062,54 +4062,45 @@ h1, h2, h3, h4, h5, h6 {
   border-radius: var(--radius);
 }
 
-.org-list__sort {
+.org-list__header-right {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
   gap: 8px;
-  margin: 12px 0 4px;
 }
 
-.org-list__sort-label {
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-mid-gray);
-}
-
-.org-list__sort-select {
+.org-list__sort-icon-btn {
   position: relative;
-  flex-shrink: 0;
-}
-
-.org-list__sort-dropdown {
-  appearance: none;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: var(--color-primary);
-  background: var(--color-off-white);
-  border: 1px solid var(--border-default);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
   border-radius: var(--radius);
-  padding: 6px 28px 6px 10px;
+  color: var(--color-mid-gray);
   cursor: pointer;
-  transition: border-color var(--transition-fast);
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
-.org-list__sort-dropdown:hover {
-  border-color: var(--border-hover);
+.org-list__sort-icon-btn:hover {
+  background: var(--color-off-white);
+  color: var(--color-primary);
 }
 
-.org-list__sort-dropdown:focus-visible {
+.org-list__sort-icon-btn:focus-within {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
-.org-list__sort-icon {
+.org-list__sort-icon-select {
   position: absolute;
-  right: 8px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--color-mid-gray);
-  pointer-events: none;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+  appearance: none;
+  border: none;
+  background: transparent;
 }
 
 .org-list__items {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4062,6 +4062,56 @@ h1, h2, h3, h4, h5, h6 {
   border-radius: var(--radius);
 }
 
+.org-list__sort {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin: 12px 0 4px;
+}
+
+.org-list__sort-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-mid-gray);
+}
+
+.org-list__sort-select {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.org-list__sort-dropdown {
+  appearance: none;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-primary);
+  background: var(--color-off-white);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 6px 28px 6px 10px;
+  cursor: pointer;
+  transition: border-color var(--transition-fast);
+}
+
+.org-list__sort-dropdown:hover {
+  border-color: var(--border-hover);
+}
+
+.org-list__sort-dropdown:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.org-list__sort-icon {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-mid-gray);
+  pointer-events: none;
+}
+
 .org-list__items {
   display: flex;
   flex-direction: column;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4111,6 +4111,12 @@ h1, h2, h3, h4, h5, h6 {
   white-space: nowrap;
 }
 
+.org-list__item-meta {
+  font-size: 0.6875rem;
+  color: var(--color-mid-gray);
+  margin-top: 2px;
+}
+
 .org-list__item-role {
   font-size: 0.6875rem;
   font-weight: 500;
@@ -4133,81 +4139,6 @@ h1, h2, h3, h4, h5, h6 {
   padding: 24px 0;
   display: flex;
   justify-content: center;
-}
-
-.org-list__divider {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 16px 0 8px;
-  margin-top: 4px;
-}
-
-.org-list__divider::before,
-.org-list__divider::after {
-  content: "";
-  flex: 1;
-  height: 1px;
-  background: var(--border-subtle);
-}
-
-.org-list__divider-text {
-  font-size: 0.75rem;
-  color: var(--color-mid-gray);
-  white-space: nowrap;
-}
-
-.org-list__accept-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: 1px solid var(--color-success-text);
-  border-radius: var(--radius);
-  background: transparent;
-  color: var(--color-success-text);
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-
-.org-list__accept-btn:hover {
-  background: var(--color-success-text);
-  color: #fff;
-}
-
-.org-list__accept-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.org-list__accept-btn:disabled:hover {
-  background: transparent;
-  color: var(--color-success-text);
-}
-
-.org-list__remove-public-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius);
-  background: transparent;
-  color: var(--color-mid-gray);
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
-}
-
-.org-list__remove-public-btn:hover {
-  border-color: var(--color-warning-text, #b45309);
-  color: var(--color-warning-text, #b45309);
-}
-
-.org-list__remove-public-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 .org-list__leave-btn {

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo } from "react"
 import Link from "next/link"
-import { Building2, Plus, LogOut, ChevronDown } from "lucide-react"
+import { Building2, Plus, LogOut, ArrowUpDown } from "lucide-react"
 import { useOrg } from "@/lib/groups/org-context"
 import { useAuth } from "@/lib/auth/auth-context"
 import { deleteMembership, removeOrgMember } from "@/lib/groups/api"
@@ -165,33 +165,33 @@ export default function GroupsPage() {
             <div className="dash-card">
               <div className="org-list__header">
                 <h2 className="dash-card__title">Your groups</h2>
-                <span className="org-list__count">{groups.length}</span>
+                <div className="org-list__header-right">
+                  <span className="org-list__count">{groups.length}</span>
+                  {groups.length > 1 && (
+                    <div
+                      className="org-list__sort-icon-btn"
+                      title={`Sort: ${SORT_OPTIONS.find((o) => o.value === sortMode)?.label}`}
+                    >
+                      <ArrowUpDown size={14} aria-hidden />
+                      <select
+                        aria-label="Sort groups"
+                        value={sortMode}
+                        onChange={(e) => setSortMode(e.target.value as SortMode)}
+                        className="org-list__sort-icon-select"
+                      >
+                        {SORT_OPTIONS.map((opt) => (
+                          <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
+                </div>
               </div>
               <p className="dash-card__desc">
                 Groups you belong to. Switch your profile in the top right to act as a group.
               </p>
-              {groups.length > 1 && (
-                <div className="org-list__sort">
-                  <label className="org-list__sort-label" htmlFor="org-sort">
-                    Sort
-                  </label>
-                  <div className="org-list__sort-select">
-                    <select
-                      id="org-sort"
-                      value={sortMode}
-                      onChange={(e) => setSortMode(e.target.value as SortMode)}
-                      className="org-list__sort-dropdown"
-                    >
-                      {SORT_OPTIONS.map((opt) => (
-                        <option key={opt.value} value={opt.value}>
-                          {opt.label}
-                        </option>
-                      ))}
-                    </select>
-                    <ChevronDown size={14} className="org-list__sort-icon" />
-                  </div>
-                </div>
-              )}
               <div className="org-list__items">
                 {sortedOrgs.map(renderOrgItem)}
               </div>

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo } from "react"
 import Link from "next/link"
-import { Building2, Plus, LogOut } from "lucide-react"
+import { Building2, Plus, LogOut, ChevronDown } from "lucide-react"
 import { useOrg } from "@/lib/groups/org-context"
 import { useAuth } from "@/lib/auth/auth-context"
 import { deleteMembership, removeOrgMember } from "@/lib/groups/api"
@@ -23,24 +23,41 @@ function formatJoinedDate(iso?: string): string | null {
   return date.toLocaleDateString("en-US", JOINED_DATE_FORMAT)
 }
 
+type SortMode = "joined-asc" | "joined-desc" | "name-asc" | "name-desc"
+
+const SORT_OPTIONS: ReadonlyArray<{ value: SortMode; label: string }> = [
+  { value: "joined-asc", label: "Joined (oldest first)" },
+  { value: "joined-desc", label: "Joined (newest first)" },
+  { value: "name-asc", label: "Name (A → Z)" },
+  { value: "name-desc", label: "Name (Z → A)" },
+]
+
 export default function GroupsPage() {
   const { groups, isLoading, refetchOrgs } = useOrg()
   const { did } = useAuth()
   const [leaveOrg, setLeaveOrg] = useState<{ groupDid: string; name: string } | null>(null)
   const [isLeaving, setIsLeaving] = useState(false)
-
-  const ROLE_ORDER: Record<string, number> = { owner: 0, admin: 1, member: 2 }
+  const [sortMode, setSortMode] = useState<SortMode>("joined-asc")
 
   const sortedOrgs = useMemo(() => {
-    return [...groups].sort((a, b) => {
-      const roleA = ROLE_ORDER[a.role] ?? 3
-      const roleB = ROLE_ORDER[b.role] ?? 3
-      if (roleA !== roleB) return roleA - roleB
+    const arr = [...groups]
+    arr.sort((a, b) => {
+      if (sortMode === "joined-asc" || sortMode === "joined-desc") {
+        // Missing joinedAt always sorts to the end, regardless of direction.
+        const ta = a.joinedAt ? new Date(a.joinedAt).getTime() : null
+        const tb = b.joinedAt ? new Date(b.joinedAt).getTime() : null
+        if (ta === null && tb === null) return 0
+        if (ta === null) return 1
+        if (tb === null) return -1
+        return sortMode === "joined-asc" ? ta - tb : tb - ta
+      }
       const nameA = (a.displayName || a.handle).toLowerCase()
       const nameB = (b.displayName || b.handle).toLowerCase()
-      return nameA.localeCompare(nameB)
+      const diff = nameA.localeCompare(nameB)
+      return sortMode === "name-asc" ? diff : -diff
     })
-  }, [groups])
+    return arr
+  }, [groups, sortMode])
 
   // Owners can never leave — grey out the button. Non-owners can always leave.
   const canLeaveMap = useMemo(() => {
@@ -153,6 +170,28 @@ export default function GroupsPage() {
               <p className="dash-card__desc">
                 Groups you belong to. Switch your profile in the top right to act as a group.
               </p>
+              {groups.length > 1 && (
+                <div className="org-list__sort">
+                  <label className="org-list__sort-label" htmlFor="org-sort">
+                    Sort
+                  </label>
+                  <div className="org-list__sort-select">
+                    <select
+                      id="org-sort"
+                      value={sortMode}
+                      onChange={(e) => setSortMode(e.target.value as SortMode)}
+                      className="org-list__sort-dropdown"
+                    >
+                      {SORT_OPTIONS.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                    <ChevronDown size={14} className="org-list__sort-icon" />
+                  </div>
+                </div>
+              )}
               <div className="org-list__items">
                 {sortedOrgs.map(renderOrgItem)}
               </div>

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -2,46 +2,45 @@
 
 import React, { useState, useMemo } from "react"
 import Link from "next/link"
-import { Building2, Plus, LogOut, UserCheck, UserX } from "lucide-react"
+import { Building2, Plus, LogOut } from "lucide-react"
 import { useOrg } from "@/lib/groups/org-context"
 import { useAuth } from "@/lib/auth/auth-context"
-import {
-  putMembership,
-  deleteMembership,
-  removeOrgMember,
-} from "@/lib/groups/api"
-import type { OrgRole } from "@/lib/groups/types"
+import { deleteMembership, removeOrgMember } from "@/lib/groups/api"
 import Avatar from "@/components/ui/avatar"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import Button from "@/components/ui/button"
+
+const JOINED_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+}
+
+function formatJoinedDate(iso?: string): string | null {
+  if (!iso) return null
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleDateString("en-US", JOINED_DATE_FORMAT)
+}
 
 export default function GroupsPage() {
   const { groups, isLoading, refetchOrgs } = useOrg()
   const { did } = useAuth()
   const [leaveOrg, setLeaveOrg] = useState<{ groupDid: string; name: string } | null>(null)
   const [isLeaving, setIsLeaving] = useState(false)
-  const [acceptingOrg, setAcceptingOrg] = useState<string | null>(null)
-  const [removingPublic, setRemovingPublic] = useState<string | null>(null)
 
   const ROLE_ORDER: Record<string, number> = { owner: 0, admin: 1, member: 2 }
 
   const sortedOrgs = useMemo(() => {
     return [...groups].sort((a, b) => {
-      // Accepted first
-      if (a.accepted !== b.accepted) return a.accepted ? -1 : 1
-      // Then by role
       const roleA = ROLE_ORDER[a.role] ?? 3
       const roleB = ROLE_ORDER[b.role] ?? 3
       if (roleA !== roleB) return roleA - roleB
-      // Then by name
       const nameA = (a.displayName || a.handle).toLowerCase()
       const nameB = (b.displayName || b.handle).toLowerCase()
       return nameA.localeCompare(nameB)
     })
   }, [groups])
-
-  const acceptedOrgs = sortedOrgs.filter((o) => o.accepted)
-  const pendingOrgs = sortedOrgs.filter((o) => !o.accepted)
 
   // Owners can never leave — grey out the button. Non-owners can always leave.
   const canLeaveMap = useMemo(() => {
@@ -52,68 +51,44 @@ export default function GroupsPage() {
     return map
   }, [groups])
 
-  const renderOrgItem = (org: (typeof sortedOrgs)[number]) => (
-    <div key={org.groupDid} className="org-list__item">
-      <div className="org-list__item-avatar">
-        <Avatar
-          src={org.avatarUrl}
-          alt={org.displayName || org.handle}
-          size="sm"
-          fallbackInitials={(org.displayName || org.handle).slice(0, 2)}
-        />
-      </div>
-      <div className="org-list__item-info">
-        <p className="org-list__item-name">
-          {org.displayName || org.handle}
-        </p>
-        <p className="org-list__item-handle">
-          {org.handle}
-        </p>
-      </div>
-      <span className="org-list__item-role">{org.role}</span>
-      <div className="org-list__item-actions">
-        {org.accepted ? (
+  const renderOrgItem = (org: (typeof sortedOrgs)[number]) => {
+    const joinedLabel = formatJoinedDate(org.joinedAt)
+    return (
+      <div key={org.groupDid} className="org-list__item">
+        <div className="org-list__item-avatar">
+          <Avatar
+            src={org.avatarUrl}
+            alt={org.displayName || org.handle}
+            size="sm"
+            fallbackInitials={(org.displayName || org.handle).slice(0, 2)}
+          />
+        </div>
+        <div className="org-list__item-info">
+          <p className="org-list__item-name">
+            {org.displayName || org.handle}
+          </p>
+          <p className="org-list__item-handle">
+            {org.handle}
+          </p>
+          {joinedLabel && (
+            <p className="org-list__item-meta">
+              Joined {joinedLabel}
+            </p>
+          )}
+        </div>
+        <span className="org-list__item-role">{org.role}</span>
+        <div className="org-list__item-actions">
           <button
-            className="org-list__remove-public-btn"
-            onClick={() => handleRemovePublicMembership(org.groupDid)}
-            disabled={removingPublic === org.groupDid}
-            title="Remove public membership"
+            className="org-list__leave-btn"
+            onClick={() => setLeaveOrg({ groupDid: org.groupDid, name: org.displayName || org.handle })}
+            disabled={!canLeaveMap[org.groupDid]}
+            title={!canLeaveMap[org.groupDid] ? "Owners can't leave the group" : "Leave group"}
           >
-            <UserX size={14} />
+            <LogOut size={14} />
           </button>
-        ) : (
-          <button
-            className="org-list__accept-btn"
-            onClick={() => handleAcceptMembership(org.groupDid, org.role)}
-            disabled={acceptingOrg === org.groupDid}
-            title="Accept membership publicly"
-          >
-            <UserCheck size={14} />
-          </button>
-        )}
-        <button
-          className="org-list__leave-btn"
-          onClick={() => setLeaveOrg({ groupDid: org.groupDid, name: org.displayName || org.handle })}
-          disabled={!canLeaveMap[org.groupDid]}
-          title={!canLeaveMap[org.groupDid] ? "Owners can't leave the group" : "Leave group"}
-        >
-          <LogOut size={14} />
-        </button>
+        </div>
       </div>
-    </div>
-  )
-
-  const handleRemovePublicMembership = async (groupDid: string) => {
-    if (!did) return
-    setRemovingPublic(groupDid)
-    try {
-      await deleteMembership(did, groupDid)
-      await refetchOrgs()
-    } catch (err) {
-      console.error("Failed to remove public membership:", err)
-    } finally {
-      setRemovingPublic(null)
-    }
+    )
   }
 
   const handleLeaveOrg = async () => {
@@ -130,19 +105,6 @@ export default function GroupsPage() {
       console.error("Failed to leave group:", err)
     } finally {
       setIsLeaving(false)
-    }
-  }
-
-  const handleAcceptMembership = async (groupDid: string, role: OrgRole) => {
-    if (!did) return
-    setAcceptingOrg(groupDid)
-    try {
-      await putMembership(did, groupDid, role)
-      await refetchOrgs()
-    } catch (err) {
-      console.error("Failed to accept membership:", err)
-    } finally {
-      setAcceptingOrg(null)
     }
   }
 
@@ -192,15 +154,7 @@ export default function GroupsPage() {
                 Groups you belong to. Switch your profile in the top right to act as a group.
               </p>
               <div className="org-list__items">
-                {acceptedOrgs.map(renderOrgItem)}
-                {pendingOrgs.length > 0 && (
-                  <div className="org-list__divider">
-                    <span className="org-list__divider-text">
-                      Groups where your membership is private. You can still act on behalf of these groups.
-                    </span>
-                  </div>
-                )}
-                {pendingOrgs.map(renderOrgItem)}
+                {sortedOrgs.map(renderOrgItem)}
               </div>
             </div>
           )}

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -32,7 +32,11 @@ const SORT_OPTIONS: ReadonlyArray<{ value: SortMode; label: string }> = [
   { value: "name-desc", label: "Name (Z → A)" },
 ]
 
-const SORT_VALUES: ReadonlySet<SortMode> = new Set(SORT_OPTIONS.map((o) => o.value))
+const SORT_VALUES: ReadonlySet<string> = new Set(SORT_OPTIONS.map((o) => o.value))
+
+function isSortMode(v: string): v is SortMode {
+  return SORT_VALUES.has(v)
+}
 
 export default function GroupsPage() {
   const { groups, isLoading, refetchOrgs } = useOrg()
@@ -43,7 +47,9 @@ export default function GroupsPage() {
 
   const sortedOrgs = useMemo(() => {
     // Decorate-sort-undecorate: parse joinedAt once per group rather than per
-    // comparison, and reuse the lowercased label for name comparisons.
+    // comparison, and cache the display label for case/accent-insensitive
+    // name comparisons. Array.prototype.sort is stable as of ES2019, so equal
+    // keys preserve input order without needing an explicit tiebreak.
     type Decorated = {
       org: (typeof groups)[number]
       ts: number | null
@@ -71,7 +77,8 @@ export default function GroupsPage() {
     return decorated.map((d) => d.org)
   }, [groups, sortMode])
 
-  const currentSortLabel = SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? ""
+  const currentSortLabel =
+    SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? ""
 
   // Owners can never leave — grey out the button. Non-owners can always leave.
   const canLeaveMap = useMemo(() => {
@@ -187,14 +194,12 @@ export default function GroupsPage() {
                     <div className="org-list__sort-icon-btn">
                       <ArrowUpDown size={14} aria-hidden="true" />
                       <select
-                        aria-label={`Sort groups, current: ${currentSortLabel}`}
+                        aria-label="Sort groups"
                         title={`Sort: ${currentSortLabel}`}
                         value={sortMode}
                         onChange={(e) => {
                           const next = e.target.value
-                          if (SORT_VALUES.has(next as SortMode)) {
-                            setSortMode(next as SortMode)
-                          }
+                          if (isSortMode(next)) setSortMode(next)
                         }}
                         className="org-list__sort-icon-select"
                       >

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -32,6 +32,8 @@ const SORT_OPTIONS: ReadonlyArray<{ value: SortMode; label: string }> = [
   { value: "name-desc", label: "Name (Z → A)" },
 ]
 
+const SORT_VALUES: ReadonlySet<SortMode> = new Set(SORT_OPTIONS.map((o) => o.value))
+
 export default function GroupsPage() {
   const { groups, isLoading, refetchOrgs } = useOrg()
   const { did } = useAuth()
@@ -40,24 +42,36 @@ export default function GroupsPage() {
   const [sortMode, setSortMode] = useState<SortMode>("joined-asc")
 
   const sortedOrgs = useMemo(() => {
-    const arr = [...groups]
-    arr.sort((a, b) => {
+    // Decorate-sort-undecorate: parse joinedAt once per group rather than per
+    // comparison, and reuse the lowercased label for name comparisons.
+    type Decorated = {
+      org: (typeof groups)[number]
+      ts: number | null
+      label: string
+    }
+    const decorated: Decorated[] = groups.map((org) => {
+      const t = org.joinedAt ? new Date(org.joinedAt).getTime() : NaN
+      return {
+        org,
+        ts: Number.isNaN(t) ? null : t,
+        label: org.displayName || org.handle,
+      }
+    })
+    decorated.sort((a, b) => {
       if (sortMode === "joined-asc" || sortMode === "joined-desc") {
         // Missing joinedAt always sorts to the end, regardless of direction.
-        const ta = a.joinedAt ? new Date(a.joinedAt).getTime() : null
-        const tb = b.joinedAt ? new Date(b.joinedAt).getTime() : null
-        if (ta === null && tb === null) return 0
-        if (ta === null) return 1
-        if (tb === null) return -1
-        return sortMode === "joined-asc" ? ta - tb : tb - ta
+        if (a.ts === null && b.ts === null) return 0
+        if (a.ts === null) return 1
+        if (b.ts === null) return -1
+        return sortMode === "joined-asc" ? a.ts - b.ts : b.ts - a.ts
       }
-      const nameA = (a.displayName || a.handle).toLowerCase()
-      const nameB = (b.displayName || b.handle).toLowerCase()
-      const diff = nameA.localeCompare(nameB)
+      const diff = a.label.localeCompare(b.label, undefined, { sensitivity: "base" })
       return sortMode === "name-asc" ? diff : -diff
     })
-    return arr
+    return decorated.map((d) => d.org)
   }, [groups, sortMode])
+
+  const currentSortLabel = SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? ""
 
   // Owners can never leave — grey out the button. Non-owners can always leave.
   const canLeaveMap = useMemo(() => {
@@ -69,24 +83,22 @@ export default function GroupsPage() {
   }, [groups])
 
   const renderOrgItem = (org: (typeof sortedOrgs)[number]) => {
+    const displayLabel = org.displayName || org.handle
     const joinedLabel = formatJoinedDate(org.joinedAt)
+    const canLeave = canLeaveMap[org.groupDid]
     return (
       <div key={org.groupDid} className="org-list__item">
         <div className="org-list__item-avatar">
           <Avatar
             src={org.avatarUrl}
-            alt={org.displayName || org.handle}
+            alt={displayLabel}
             size="sm"
-            fallbackInitials={(org.displayName || org.handle).slice(0, 2)}
+            fallbackInitials={displayLabel.slice(0, 2)}
           />
         </div>
         <div className="org-list__item-info">
-          <p className="org-list__item-name">
-            {org.displayName || org.handle}
-          </p>
-          <p className="org-list__item-handle">
-            {org.handle}
-          </p>
+          <p className="org-list__item-name">{displayLabel}</p>
+          <p className="org-list__item-handle">{org.handle}</p>
           {joinedLabel && (
             <p className="org-list__item-meta">
               Joined {joinedLabel}
@@ -97,9 +109,13 @@ export default function GroupsPage() {
         <div className="org-list__item-actions">
           <button
             className="org-list__leave-btn"
-            onClick={() => setLeaveOrg({ groupDid: org.groupDid, name: org.displayName || org.handle })}
-            disabled={!canLeaveMap[org.groupDid]}
-            title={!canLeaveMap[org.groupDid] ? "Owners can't leave the group" : "Leave group"}
+            onClick={() => setLeaveOrg({ groupDid: org.groupDid, name: displayLabel })}
+            disabled={!canLeave}
+            title={
+              canLeave
+                ? "Leave group"
+                : "Owners can't leave — transfer ownership in group settings first"
+            }
           >
             <LogOut size={14} />
           </button>
@@ -168,15 +184,18 @@ export default function GroupsPage() {
                 <div className="org-list__header-right">
                   <span className="org-list__count">{groups.length}</span>
                   {groups.length > 1 && (
-                    <div
-                      className="org-list__sort-icon-btn"
-                      title={`Sort: ${SORT_OPTIONS.find((o) => o.value === sortMode)?.label}`}
-                    >
-                      <ArrowUpDown size={14} aria-hidden />
+                    <div className="org-list__sort-icon-btn">
+                      <ArrowUpDown size={14} aria-hidden="true" />
                       <select
-                        aria-label="Sort groups"
+                        aria-label={`Sort groups, current: ${currentSortLabel}`}
+                        title={`Sort: ${currentSortLabel}`}
                         value={sortMode}
-                        onChange={(e) => setSortMode(e.target.value as SortMode)}
+                        onChange={(e) => {
+                          const next = e.target.value
+                          if (SORT_VALUES.has(next as SortMode)) {
+                            setSortMode(next as SortMode)
+                          }
+                        }}
                         className="org-list__sort-icon-select"
                       >
                         {SORT_OPTIONS.map((opt) => (

--- a/src/lib/groups/api.ts
+++ b/src/lib/groups/api.ts
@@ -465,6 +465,7 @@ export async function resolveGroups(
         accepted: acceptedSet.has(rm.groupDid),
         avatarUrl,
         rkey: localRecord?.rkey,
+        joinedAt: rm.joinedAt,
       } satisfies Group
     })
   )

--- a/src/lib/groups/types.ts
+++ b/src/lib/groups/types.ts
@@ -6,6 +6,8 @@ export interface Group {
   accepted: boolean
   avatarUrl?: string
   rkey?: string
+  /** ISO timestamp from the group service indicating when the user joined. */
+  joinedAt?: string
 }
 
 export interface RemoteMembership {


### PR DESCRIPTION
## Summary
- Drop the public/private membership split on `/groups`: a single sorted list now shows every group the user belongs to
- Surface `joinedAt` from the group service on each row ("Joined Mon DD, YYYY")
- Add a sort control (single ArrowUpDown icon next to the group count) with four modes: joined oldest first (default), joined newest first, name A→Z, name Z→A
- Plumb `joinedAt` through `Group` type + `resolveGroups`
- Remove now-unused CSS (`.org-list__divider*`, `.org-list__accept-btn*`, `.org-list__remove-public-btn*`) and add `.org-list__item-meta`, `.org-list__header-right`, `.org-list__sort-icon-*`

## Out of scope
- The navbar org switcher still sorts accepted-first; not touched here
- Group create / add-member flows still write `accepted=true` PDS membership records
- Sort preference is not persisted across page loads

## Test plan
- [ ] `/groups` renders one list with role-irrelevant ordering driven by the sort control
- [ ] Default load shows oldest-joined first
- [ ] All four sort modes reorder correctly
- [ ] Rows with no `joinedAt` (legacy data) sort to the bottom of joined-* views
- [ ] Sort icon hidden when `groups.length <= 1`
- [ ] Owner row's leave button stays disabled
- [ ] Native select menu opens on icon click and via keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)