### PR TITLE
release: bsky-PDS write fix + groups list overhaul + UX/observability fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Certified is a passwordless identity platform built on **AT Protocol** (atproto)
 | React | 19.x |
 | Language | TypeScript 5 (strict, `paths: { "@/*": ["./src/*"] }`) |
 | Styling | Tailwind CSS 3.4 (utilities only) + custom CSS in `globals.css` (BEM-like) |
-| Atproto SDK | `@atproto/api` 0.13, `@atproto/oauth-client-node` 0.3, `@atproto/jwk-jose` 0.1 |
+| Atproto SDK | `@atproto/api` 0.19, `@atproto/oauth-client-node` 0.3, `@atproto/jwk-jose` 0.1 (`@atproto/oauth-client` 0.6 pulled in transitively) |
 | Session/State store | Upstash Redis (`@upstash/redis`) — REST-based, serverless-safe |
 | Server actions | None — all server work is in route handlers (`src/app/api/**`) |
 | Wallets | `wagmi` 2.x + `viem` 2.x + `@tanstack/react-query` (mounted only on `/settings/wallet`) |

--- a/docs/groups-list-improvements/review-round-1.md
+++ b/docs/groups-list-improvements/review-round-1.md
@@ -1,0 +1,30 @@
+# Review round 1 — feat/groups-list-improvements
+
+Three reviewers (code quality, security, functional/UX) ran in parallel against PR #53. All three returned a `ship` or `ship-then-fix-nits` verdict — no critical findings. Items below are tracked as accepted (acted on this round) or rejected (with rationale).
+
+## Accepted
+
+| # | Source | Item | Action |
+|---|---|---|---|
+| A1 | Code quality #2 | Sort comparator redundantly lowercases before `localeCompare` | Drop `.toLowerCase()`, pass `{ sensitivity: "base" }` to `localeCompare` |
+| A2 | Code quality #3 | `new Date(joinedAt).getTime()` runs O(n log n) times during sort | Decorate-sort-undecorate: pre-compute timestamps once |
+| A3 | Code quality #4 | Bare `aria-hidden` is inconsistent with `aria-hidden="true"` elsewhere | Use the explicit form |
+| A4 | Code quality #5 | `e.target.value as SortMode` is an unchecked cast | Validate against `SORT_OPTIONS` before setting state |
+| A5 | Code quality #10 + Functional #1 | Tooltip on wrapper div is invisible to keyboard/AT users; current sort mode not announced | Move `title` onto the `<select>` and include the current mode in `aria-label` |
+| A6 | Functional #2 | Owners' Leave-button tooltip is a dead-end ("Owners can't leave the group") | Add actionable guidance: "Owners can't leave — transfer ownership in group settings first" |
+| A7 | Code quality #7 | `org.displayName \|\| org.handle` is repeated 6x | Extract a local `displayLabel` const inside `renderOrgItem` |
+
+## Rejected
+
+| # | Source | Item | Rationale |
+|---|---|---|---|
+| R1 | Code quality #1 | Persist `sortMode` to `localStorage` | Out of scope. User explicitly said "by default order them from oldest to newest" — persistence is a separate product decision. The PR body lists this in "Out of scope". |
+| R2 | Code quality #6 | Inline `renderOrgItem` JSX in `.map()` instead of extracting | Style preference; helper improves the JSX-block readability. No perf signal. |
+| R3 | Code quality #8 + #9 + Functional #3 | Prune `accepted` tie-break from `navbar.tsx`; mark `Group.accepted` optional | Out of scope. PR body explicitly leaves the navbar untouched. `accepted` is still set by `groups/create/page.tsx` and `add-org-modal.tsx`; deeper cleanup belongs in a follow-up. |
+| R4 | Security nit | Wrap `console.error("Failed to leave group:", err)` to avoid logging full Error objects | Reviewer rated "Acceptable" — no token/cookie/secret in scope. Pre-existing pattern in the file. |
+| R5 | Security important | Removing UserCheck/UserX is a privacy-UX regression (no in-app way to make a previously-public membership private) | User explicitly asked to remove these buttons. Already noted in PR "Out of scope". Flag is for product, not code. |
+| R6 | Functional #5 | Safari/Firefox quirks of the transparent-select pattern | Reviewer said "not worth fixing pre-merge". Will be caught by manual smoke before staging→main if it surfaces. |
+
+## Round 2?
+
+Per workflow rule: "Run a follow-up round only if round 1 surfaced ≥5 substantive items." Substantive items here (Important): 2 (A5/A6, the AT/keyboard improvements). The rest are nits or perf polish. **Skipping round 2.**

--- a/docs/groups-list-improvements/review-round-2.md
+++ b/docs/groups-list-improvements/review-round-2.md
@@ -1,0 +1,22 @@
+# Review round 2 — feat/groups-list-improvements
+
+Two reviewers (code quality, functional/UX) ran against the round-1 fix commit. Both verdicts: `ship`. One **Important** item flagged independently by both reviewers; the rest are nits.
+
+## Accepted
+
+| # | Source | Item | Action |
+|---|---|---|---|
+| B1 | Functional Important + Code quality nit | `aria-label="Sort groups, current: <label>"` is redundant — native `<select>` already announces the selected `<option>` after the role | Revert to `aria-label="Sort groups"`. Keep the `title` attribute (different audience: sighted keyboard/mouse). |
+| B2 | Both reviewers (nit) | Stale comment "reuse the lowercased label" — the label is no longer lowercased | Update comment + add a note that ES2019 `Array.prototype.sort` is stable so equal keys don't need an explicit tiebreak |
+| B3 | Code quality nit | Two `as SortMode` casts inside the `onChange` validator | Extract a `isSortMode(v): v is SortMode` type predicate; `SORT_VALUES` widened to `ReadonlySet<string>` so the predicate's input doesn't need a cast |
+
+## Rejected
+
+| # | Source | Item | Rationale |
+|---|---|---|---|
+| C1 | Functional nit | Restructure the NaN sentinel: `const d = …; ts = d && !Number.isNaN(d.getTime()) ? d.getTime() : null` | Equivalent behavior, style preference. Current form is two lines and self-documents via `Number.isNaN(t) ? null : t`. |
+| C2 | Code quality nit | Trim the `?? ""` defensive fallback on `currentSortLabel` | `?? ""` is harmless and keeps the type as `string` rather than `string \| undefined`, simplifying interpolation. Defensive but cheap. |
+
+## Round 3?
+
+Substantive items in round 2: 1 (B1). Below the ≥5 threshold for a follow-up round per the workflow rule. Both reviewers explicitly returned `ship` verdicts. **Stopping here.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -227,7 +227,9 @@
       }
     },
     "node_modules/@atproto/oauth-client": {
-      "version": "0.6.0",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@atproto/oauth-client/-/oauth-client-0.6.1.tgz",
+      "integrity": "sha512-QTLbEFyv7EJuwJf4A8IZnsylK5wwrzrSsxy0INcZf9zktPVQvgckWhSvbfK8alp60M+rwWfQQAlodcCF4WB78A==",
       "license": "MIT",
       "dependencies": {
         "@atproto-labs/did-resolver": "^0.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "certified-app",
       "version": "0.1.0",
       "dependencies": {
-        "@atproto/api": "^0.13.20",
+        "@atproto/api": "^0.19.16",
         "@atproto/jwk-jose": "^0.1.11",
         "@atproto/oauth-client-node": "^0.3.17",
         "@tanstack/react-query": "^5.90.21",
@@ -128,13 +128,15 @@
       }
     },
     "node_modules/@atproto/api": {
-      "version": "0.13.35",
+      "version": "0.19.16",
+      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.19.16.tgz",
+      "integrity": "sha512-OAnY0+JDucUjPuPIrRVNT3h1PMi8txHd+lOdzenCcDAhtEsMRrUEWv4/IpEHRMclUAnX4ekfJDLlYleaOCQcng==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "^0.4.0",
-        "@atproto/lexicon": "^0.4.6",
-        "@atproto/syntax": "^0.3.2",
-        "@atproto/xrpc": "^0.6.8",
+        "@atproto/common-web": "^0.4.21",
+        "@atproto/lexicon": "^0.6.2",
+        "@atproto/syntax": "^0.5.4",
+        "@atproto/xrpc": "^0.7.7",
         "await-lock": "^2.2.2",
         "multiformats": "^9.9.0",
         "tlds": "^1.234.0",
@@ -142,20 +144,15 @@
       }
     },
     "node_modules/@atproto/common-web": {
-      "version": "0.4.17",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.21.tgz",
+      "integrity": "sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.0.12",
-        "@atproto/lex-json": "^0.0.12",
-        "@atproto/syntax": "^0.4.3",
+        "@atproto/lex-data": "^0.0.15",
+        "@atproto/lex-json": "^0.0.16",
+        "@atproto/syntax": "^0.5.4",
         "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@atproto/common-web/node_modules/@atproto/syntax": {
-      "version": "0.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
       }
     },
     "node_modules/@atproto/did": {
@@ -191,7 +188,9 @@
       }
     },
     "node_modules/@atproto/lex-data": {
-      "version": "0.0.12",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.0.15.tgz",
+      "integrity": "sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw==",
       "license": "MIT",
       "dependencies": {
         "multiformats": "^9.9.0",
@@ -201,29 +200,26 @@
       }
     },
     "node_modules/@atproto/lex-json": {
-      "version": "0.0.12",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.0.16.tgz",
+      "integrity": "sha512-IgLgQ0krshVlrIYZ+heTBDbCnM3LmAgWvsaYn5MxvKA3LcBot3PG3ptdO8VOweVZ+WgCLuo39cz9EbUmIbqdtg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.0.12",
+        "@atproto/lex-data": "^0.0.15",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@atproto/lexicon": {
-      "version": "0.4.14",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.6.2.tgz",
+      "integrity": "sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "^0.4.2",
-        "@atproto/syntax": "^0.4.0",
+        "@atproto/common-web": "^0.4.18",
+        "@atproto/syntax": "^0.5.0",
         "iso-datestring-validator": "^2.2.2",
         "multiformats": "^9.9.0",
         "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@atproto/lexicon/node_modules/@atproto/syntax": {
-      "version": "0.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
       }
     },
     "node_modules/@atproto/oauth-client": {
@@ -265,32 +261,6 @@
         "node": ">=18.7.0"
       }
     },
-    "node_modules/@atproto/oauth-client/node_modules/@atproto/lexicon": {
-      "version": "0.6.1",
-      "license": "MIT",
-      "dependencies": {
-        "@atproto/common-web": "^0.4.13",
-        "@atproto/syntax": "^0.4.3",
-        "iso-datestring-validator": "^2.2.2",
-        "multiformats": "^9.9.0",
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@atproto/oauth-client/node_modules/@atproto/syntax": {
-      "version": "0.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@atproto/oauth-client/node_modules/@atproto/xrpc": {
-      "version": "0.7.7",
-      "license": "MIT",
-      "dependencies": {
-        "@atproto/lexicon": "^0.6.0",
-        "zod": "^3.23.8"
-      }
-    },
     "node_modules/@atproto/oauth-types": {
       "version": "0.6.3",
       "license": "MIT",
@@ -301,14 +271,21 @@
       }
     },
     "node_modules/@atproto/syntax": {
-      "version": "0.3.4",
-      "license": "MIT"
-    },
-    "node_modules/@atproto/xrpc": {
-      "version": "0.6.12",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.5.4.tgz",
+      "integrity": "sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lexicon": "^0.4.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/xrpc": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.7.7.tgz",
+      "integrity": "sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lexicon": "^0.6.0",
         "zod": "^3.23.8"
       }
     },
@@ -10301,6 +10278,8 @@
     },
     "node_modules/unicode-segmenter": {
       "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/unicode-segmenter/-/unicode-segmenter-0.14.5.tgz",
+      "integrity": "sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==",
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint src/ --ext .ts,.tsx"
   },
   "dependencies": {
-    "@atproto/api": "^0.13.20",
+    "@atproto/api": "^0.19.16",
     "@atproto/jwk-jose": "^0.1.11",
     "@atproto/oauth-client-node": "^0.3.17",
     "@tanstack/react-query": "^5.90.21",

--- a/src/app/api/xrpc/[...method]/route.ts
+++ b/src/app/api/xrpc/[...method]/route.ts
@@ -33,12 +33,28 @@ const MAX_BLOB_SIZE = 4 * 1024 * 1024 // 4MB — Vercel serverless functions hav
 
 /** Extract a usable HTTP status + message from an unknown XRPC error. */
 function xrpcError(err: unknown): { status: number; message: string } {
-  const error = err as { status?: number; statusCode?: number; message?: string }
+  const error = err as {
+    status?: number
+    statusCode?: number
+    message?: string
+    error?: string
+    cause?: unknown
+  }
   const status = error?.status ?? error?.statusCode ?? 500
   const message =
     status >= 500
       ? "Internal server error"
       : (error?.message ?? "Internal server error")
+  // Server-side log so the masked-to-client message can still be diagnosed
+  // from Vercel logs. Client never sees the original PDS error body.
+  console.error("[xrpc] upstream error", {
+    name: (err as Error)?.name,
+    status,
+    error: error?.error,
+    message: error?.message,
+    cause: error?.cause,
+    stack: (err as Error)?.stack,
+  })
   return { status, message }
 }
 
@@ -66,7 +82,8 @@ export async function GET(
     let oauthSession
     try {
       oauthSession = await client.restore(did)
-    } catch {
+    } catch (err) {
+      console.error("[xrpc] oauth restore failed", err)
       await deleteSession()
       return NextResponse.json({ error: "Session expired" }, { status: 401 })
     }
@@ -153,7 +170,8 @@ export async function POST(
     let oauthSession
     try {
       oauthSession = await client.restore(did)
-    } catch {
+    } catch (err) {
+      console.error("[xrpc] oauth restore failed", err)
       await deleteSession()
       return NextResponse.json({ error: "Session expired" }, { status: 401 })
     }

--- a/src/app/api/xrpc/[...method]/route.ts
+++ b/src/app/api/xrpc/[...method]/route.ts
@@ -31,6 +31,20 @@ const ALLOWED_BLOB_CONTENT_TYPES = [
 
 const MAX_BLOB_SIZE = 4 * 1024 * 1024 // 4MB — Vercel serverless functions have a ~4.5MB request body limit
 
+/**
+ * Strip secrets out of strings before they hit logs. Targets the things we've
+ * actually seen leak from atproto SDK error messages — JWTs (DPoP proofs and
+ * bearer tokens both match), the `Authorization`/`DPoP`/`Cookie` header lines
+ * that show up in serialized Request inspections, and email addresses.
+ */
+function redactSecrets(s: string): string {
+  return s
+    .replace(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, "<jwt>")
+    .replace(/(Authorization|DPoP|Cookie|Set-Cookie):\s*\S+/gi, "$1: <redacted>")
+    .replace(/(access_token|refresh_token|id_token)=[A-Za-z0-9._~+/-]+=*/gi, "$1=<redacted>")
+    .replace(/[\w.+-]+@[\w-]+\.[\w.-]+/g, "<email>")
+}
+
 /** Extract a usable HTTP status + message from an unknown XRPC error. */
 function xrpcError(err: unknown): { status: number; message: string } {
   const error = err as {
@@ -38,7 +52,6 @@ function xrpcError(err: unknown): { status: number; message: string } {
     statusCode?: number
     message?: string
     error?: string
-    cause?: unknown
   }
   const status = error?.status ?? error?.statusCode ?? 500
   const message =
@@ -47,15 +60,25 @@ function xrpcError(err: unknown): { status: number; message: string } {
       : (error?.message ?? "Internal server error")
   // Server-side log so the masked-to-client message can still be diagnosed
   // from Vercel logs. Client never sees the original PDS error body.
+  // We deliberately drop `err.cause` and `err.stack` because the atproto SDK
+  // attaches the upstream Request (with DPoP proofs and Bearer tokens) on
+  // `cause`, and stack traces include the same Request via util.inspect.
   console.error("[xrpc] upstream error", {
     name: (err as Error)?.name,
     status,
     error: error?.error,
-    message: error?.message,
-    cause: error?.cause,
-    stack: (err as Error)?.stack,
+    message: typeof error?.message === "string" ? redactSecrets(error.message) : undefined,
   })
   return { status, message }
+}
+
+/** Log an unknown error safely — name + redacted message only, no cause/stack. */
+function logSafe(prefix: string, err: unknown): void {
+  const e = err as { name?: string; message?: string }
+  console.error(prefix, {
+    name: e?.name,
+    message: typeof e?.message === "string" ? redactSecrets(e.message) : undefined,
+  })
 }
 
 /** Clamp and validate a limit query param. */
@@ -83,7 +106,7 @@ export async function GET(
     try {
       oauthSession = await client.restore(did)
     } catch (err) {
-      console.error("[xrpc] oauth restore failed", err)
+      logSafe("[xrpc] oauth restore failed", err)
       await deleteSession()
       return NextResponse.json({ error: "Session expired" }, { status: 401 })
     }
@@ -169,7 +192,7 @@ export async function POST(
     try {
       oauthSession = await client.restore(did)
     } catch (err) {
-      console.error("[xrpc] oauth restore failed", err)
+      logSafe("[xrpc] oauth restore failed", err)
       await deleteSession()
       return NextResponse.json({ error: "Session expired" }, { status: 401 })
     }

--- a/src/app/api/xrpc/[...method]/route.ts
+++ b/src/app/api/xrpc/[...method]/route.ts
@@ -106,7 +106,7 @@ export async function GET(
         return NextResponse.json(result.data)
       }
       case "com.atproto.repo.listRecords": {
-        const { repo, collection, cursor, reverse, rkeyEnd, rkeyStart } = queryParams
+        const { repo, collection, cursor, reverse } = queryParams
         if (!repo || !collection) {
           return NextResponse.json({ error: "repo and collection are required" }, { status: 400 })
         }
@@ -116,8 +116,6 @@ export async function GET(
           limit: parseLimit(queryParams.limit),
           cursor,
           reverse: reverse === "true" ? true : undefined,
-          rkeyEnd,
-          rkeyStart,
         })
         return NextResponse.json(result.data)
       }
@@ -207,19 +205,19 @@ export async function POST(
     switch (methodName) {
       case "com.atproto.repo.createRecord": {
         const result = await agent.com.atproto.repo.createRecord(
-          body as ComAtprotoRepoCreateRecord.InputSchema
+          body as unknown as ComAtprotoRepoCreateRecord.InputSchema
         )
         return NextResponse.json(result.data)
       }
       case "com.atproto.repo.putRecord": {
         const result = await agent.com.atproto.repo.putRecord(
-          body as ComAtprotoRepoPutRecord.InputSchema
+          body as unknown as ComAtprotoRepoPutRecord.InputSchema
         )
         return NextResponse.json(result.data)
       }
       case "com.atproto.repo.deleteRecord": {
         const result = await agent.com.atproto.repo.deleteRecord(
-          body as ComAtprotoRepoDeleteRecord.InputSchema
+          body as unknown as ComAtprotoRepoDeleteRecord.InputSchema
         )
         return NextResponse.json(result.data)
       }
@@ -257,20 +255,20 @@ export async function POST(
       }
       case "com.atproto.identity.updateHandle": {
         await agent.com.atproto.identity.updateHandle(
-          body as ComAtprotoIdentityUpdateHandle.InputSchema
+          body as unknown as ComAtprotoIdentityUpdateHandle.InputSchema
         )
         // Void operation — no data to return
         return NextResponse.json({})
       }
       case "com.atproto.server.requestPasswordReset": {
         await agent.com.atproto.server.requestPasswordReset(
-          body as ComAtprotoServerRequestPasswordReset.InputSchema
+          body as unknown as ComAtprotoServerRequestPasswordReset.InputSchema
         )
         return NextResponse.json({})
       }
       case "com.atproto.server.resetPassword": {
         await agent.com.atproto.server.resetPassword(
-          body as ComAtprotoServerResetPassword.InputSchema
+          body as unknown as ComAtprotoServerResetPassword.InputSchema
         )
         return NextResponse.json({})
       }
@@ -280,7 +278,7 @@ export async function POST(
       }
       case "com.atproto.server.updateEmail": {
         await agent.com.atproto.server.updateEmail(
-          body as ComAtprotoServerUpdateEmail.InputSchema
+          body as unknown as ComAtprotoServerUpdateEmail.InputSchema
         )
         return NextResponse.json({})
       }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4062,54 +4062,45 @@ h1, h2, h3, h4, h5, h6 {
   border-radius: var(--radius);
 }
 
-.org-list__sort {
+.org-list__header-right {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
   gap: 8px;
-  margin: 12px 0 4px;
 }
 
-.org-list__sort-label {
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-mid-gray);
-}
-
-.org-list__sort-select {
+.org-list__sort-icon-btn {
   position: relative;
-  flex-shrink: 0;
-}
-
-.org-list__sort-dropdown {
-  appearance: none;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: var(--color-primary);
-  background: var(--color-off-white);
-  border: 1px solid var(--border-default);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
   border-radius: var(--radius);
-  padding: 6px 28px 6px 10px;
+  color: var(--color-mid-gray);
   cursor: pointer;
-  transition: border-color var(--transition-fast);
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
-.org-list__sort-dropdown:hover {
-  border-color: var(--border-hover);
+.org-list__sort-icon-btn:hover {
+  background: var(--color-off-white);
+  color: var(--color-primary);
 }
 
-.org-list__sort-dropdown:focus-visible {
+.org-list__sort-icon-btn:focus-within {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
-.org-list__sort-icon {
+.org-list__sort-icon-select {
   position: absolute;
-  right: 8px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--color-mid-gray);
-  pointer-events: none;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+  appearance: none;
+  border: none;
+  background: transparent;
 }
 
 .org-list__items {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4062,6 +4062,56 @@ h1, h2, h3, h4, h5, h6 {
   border-radius: var(--radius);
 }
 
+.org-list__sort {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin: 12px 0 4px;
+}
+
+.org-list__sort-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-mid-gray);
+}
+
+.org-list__sort-select {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.org-list__sort-dropdown {
+  appearance: none;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-primary);
+  background: var(--color-off-white);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 6px 28px 6px 10px;
+  cursor: pointer;
+  transition: border-color var(--transition-fast);
+}
+
+.org-list__sort-dropdown:hover {
+  border-color: var(--border-hover);
+}
+
+.org-list__sort-dropdown:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.org-list__sort-icon {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-mid-gray);
+  pointer-events: none;
+}
+
 .org-list__items {
   display: flex;
   flex-direction: column;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4111,6 +4111,12 @@ h1, h2, h3, h4, h5, h6 {
   white-space: nowrap;
 }
 
+.org-list__item-meta {
+  font-size: 0.6875rem;
+  color: var(--color-mid-gray);
+  margin-top: 2px;
+}
+
 .org-list__item-role {
   font-size: 0.6875rem;
   font-weight: 500;
@@ -4133,81 +4139,6 @@ h1, h2, h3, h4, h5, h6 {
   padding: 24px 0;
   display: flex;
   justify-content: center;
-}
-
-.org-list__divider {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 16px 0 8px;
-  margin-top: 4px;
-}
-
-.org-list__divider::before,
-.org-list__divider::after {
-  content: "";
-  flex: 1;
-  height: 1px;
-  background: var(--border-subtle);
-}
-
-.org-list__divider-text {
-  font-size: 0.75rem;
-  color: var(--color-mid-gray);
-  white-space: nowrap;
-}
-
-.org-list__accept-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: 1px solid var(--color-success-text);
-  border-radius: var(--radius);
-  background: transparent;
-  color: var(--color-success-text);
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-
-.org-list__accept-btn:hover {
-  background: var(--color-success-text);
-  color: #fff;
-}
-
-.org-list__accept-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.org-list__accept-btn:disabled:hover {
-  background: transparent;
-  color: var(--color-success-text);
-}
-
-.org-list__remove-public-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius);
-  background: transparent;
-  color: var(--color-mid-gray);
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
-}
-
-.org-list__remove-public-btn:hover {
-  border-color: var(--color-warning-text, #b45309);
-  color: var(--color-warning-text, #b45309);
-}
-
-.org-list__remove-public-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 .org-list__leave-btn {

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo } from "react"
 import Link from "next/link"
-import { Building2, Plus, LogOut, ChevronDown } from "lucide-react"
+import { Building2, Plus, LogOut, ArrowUpDown } from "lucide-react"
 import { useOrg } from "@/lib/groups/org-context"
 import { useAuth } from "@/lib/auth/auth-context"
 import { deleteMembership, removeOrgMember } from "@/lib/groups/api"
@@ -165,33 +165,33 @@ export default function GroupsPage() {
             <div className="dash-card">
               <div className="org-list__header">
                 <h2 className="dash-card__title">Your groups</h2>
-                <span className="org-list__count">{groups.length}</span>
+                <div className="org-list__header-right">
+                  <span className="org-list__count">{groups.length}</span>
+                  {groups.length > 1 && (
+                    <div
+                      className="org-list__sort-icon-btn"
+                      title={`Sort: ${SORT_OPTIONS.find((o) => o.value === sortMode)?.label}`}
+                    >
+                      <ArrowUpDown size={14} aria-hidden />
+                      <select
+                        aria-label="Sort groups"
+                        value={sortMode}
+                        onChange={(e) => setSortMode(e.target.value as SortMode)}
+                        className="org-list__sort-icon-select"
+                      >
+                        {SORT_OPTIONS.map((opt) => (
+                          <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
+                </div>
               </div>
               <p className="dash-card__desc">
                 Groups you belong to. Switch your profile in the top right to act as a group.
               </p>
-              {groups.length > 1 && (
-                <div className="org-list__sort">
-                  <label className="org-list__sort-label" htmlFor="org-sort">
-                    Sort
-                  </label>
-                  <div className="org-list__sort-select">
-                    <select
-                      id="org-sort"
-                      value={sortMode}
-                      onChange={(e) => setSortMode(e.target.value as SortMode)}
-                      className="org-list__sort-dropdown"
-                    >
-                      {SORT_OPTIONS.map((opt) => (
-                        <option key={opt.value} value={opt.value}>
-                          {opt.label}
-                        </option>
-                      ))}
-                    </select>
-                    <ChevronDown size={14} className="org-list__sort-icon" />
-                  </div>
-                </div>
-              )}
               <div className="org-list__items">
                 {sortedOrgs.map(renderOrgItem)}
               </div>

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo } from "react"
 import Link from "next/link"
-import { Building2, Plus, LogOut } from "lucide-react"
+import { Building2, Plus, LogOut, ChevronDown } from "lucide-react"
 import { useOrg } from "@/lib/groups/org-context"
 import { useAuth } from "@/lib/auth/auth-context"
 import { deleteMembership, removeOrgMember } from "@/lib/groups/api"
@@ -23,24 +23,41 @@ function formatJoinedDate(iso?: string): string | null {
   return date.toLocaleDateString("en-US", JOINED_DATE_FORMAT)
 }
 
+type SortMode = "joined-asc" | "joined-desc" | "name-asc" | "name-desc"
+
+const SORT_OPTIONS: ReadonlyArray<{ value: SortMode; label: string }> = [
+  { value: "joined-asc", label: "Joined (oldest first)" },
+  { value: "joined-desc", label: "Joined (newest first)" },
+  { value: "name-asc", label: "Name (A → Z)" },
+  { value: "name-desc", label: "Name (Z → A)" },
+]
+
 export default function GroupsPage() {
   const { groups, isLoading, refetchOrgs } = useOrg()
   const { did } = useAuth()
   const [leaveOrg, setLeaveOrg] = useState<{ groupDid: string; name: string } | null>(null)
   const [isLeaving, setIsLeaving] = useState(false)
-
-  const ROLE_ORDER: Record<string, number> = { owner: 0, admin: 1, member: 2 }
+  const [sortMode, setSortMode] = useState<SortMode>("joined-asc")
 
   const sortedOrgs = useMemo(() => {
-    return [...groups].sort((a, b) => {
-      const roleA = ROLE_ORDER[a.role] ?? 3
-      const roleB = ROLE_ORDER[b.role] ?? 3
-      if (roleA !== roleB) return roleA - roleB
+    const arr = [...groups]
+    arr.sort((a, b) => {
+      if (sortMode === "joined-asc" || sortMode === "joined-desc") {
+        // Missing joinedAt always sorts to the end, regardless of direction.
+        const ta = a.joinedAt ? new Date(a.joinedAt).getTime() : null
+        const tb = b.joinedAt ? new Date(b.joinedAt).getTime() : null
+        if (ta === null && tb === null) return 0
+        if (ta === null) return 1
+        if (tb === null) return -1
+        return sortMode === "joined-asc" ? ta - tb : tb - ta
+      }
       const nameA = (a.displayName || a.handle).toLowerCase()
       const nameB = (b.displayName || b.handle).toLowerCase()
-      return nameA.localeCompare(nameB)
+      const diff = nameA.localeCompare(nameB)
+      return sortMode === "name-asc" ? diff : -diff
     })
-  }, [groups])
+    return arr
+  }, [groups, sortMode])
 
   // Owners can never leave — grey out the button. Non-owners can always leave.
   const canLeaveMap = useMemo(() => {
@@ -153,6 +170,28 @@ export default function GroupsPage() {
               <p className="dash-card__desc">
                 Groups you belong to. Switch your profile in the top right to act as a group.
               </p>
+              {groups.length > 1 && (
+                <div className="org-list__sort">
+                  <label className="org-list__sort-label" htmlFor="org-sort">
+                    Sort
+                  </label>
+                  <div className="org-list__sort-select">
+                    <select
+                      id="org-sort"
+                      value={sortMode}
+                      onChange={(e) => setSortMode(e.target.value as SortMode)}
+                      className="org-list__sort-dropdown"
+                    >
+                      {SORT_OPTIONS.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                    <ChevronDown size={14} className="org-list__sort-icon" />
+                  </div>
+                </div>
+              )}
               <div className="org-list__items">
                 {sortedOrgs.map(renderOrgItem)}
               </div>

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -2,46 +2,45 @@
 
 import React, { useState, useMemo } from "react"
 import Link from "next/link"
-import { Building2, Plus, LogOut, UserCheck, UserX } from "lucide-react"
+import { Building2, Plus, LogOut } from "lucide-react"
 import { useOrg } from "@/lib/groups/org-context"
 import { useAuth } from "@/lib/auth/auth-context"
-import {
-  putMembership,
-  deleteMembership,
-  removeOrgMember,
-} from "@/lib/groups/api"
-import type { OrgRole } from "@/lib/groups/types"
+import { deleteMembership, removeOrgMember } from "@/lib/groups/api"
 import Avatar from "@/components/ui/avatar"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import Button from "@/components/ui/button"
+
+const JOINED_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+}
+
+function formatJoinedDate(iso?: string): string | null {
+  if (!iso) return null
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleDateString("en-US", JOINED_DATE_FORMAT)
+}
 
 export default function GroupsPage() {
   const { groups, isLoading, refetchOrgs } = useOrg()
   const { did } = useAuth()
   const [leaveOrg, setLeaveOrg] = useState<{ groupDid: string; name: string } | null>(null)
   const [isLeaving, setIsLeaving] = useState(false)
-  const [acceptingOrg, setAcceptingOrg] = useState<string | null>(null)
-  const [removingPublic, setRemovingPublic] = useState<string | null>(null)
 
   const ROLE_ORDER: Record<string, number> = { owner: 0, admin: 1, member: 2 }
 
   const sortedOrgs = useMemo(() => {
     return [...groups].sort((a, b) => {
-      // Accepted first
-      if (a.accepted !== b.accepted) return a.accepted ? -1 : 1
-      // Then by role
       const roleA = ROLE_ORDER[a.role] ?? 3
       const roleB = ROLE_ORDER[b.role] ?? 3
       if (roleA !== roleB) return roleA - roleB
-      // Then by name
       const nameA = (a.displayName || a.handle).toLowerCase()
       const nameB = (b.displayName || b.handle).toLowerCase()
       return nameA.localeCompare(nameB)
     })
   }, [groups])
-
-  const acceptedOrgs = sortedOrgs.filter((o) => o.accepted)
-  const pendingOrgs = sortedOrgs.filter((o) => !o.accepted)
 
   // Owners can never leave — grey out the button. Non-owners can always leave.
   const canLeaveMap = useMemo(() => {
@@ -52,68 +51,44 @@ export default function GroupsPage() {
     return map
   }, [groups])
 
-  const renderOrgItem = (org: (typeof sortedOrgs)[number]) => (
-    <div key={org.groupDid} className="org-list__item">
-      <div className="org-list__item-avatar">
-        <Avatar
-          src={org.avatarUrl}
-          alt={org.displayName || org.handle}
-          size="sm"
-          fallbackInitials={(org.displayName || org.handle).slice(0, 2)}
-        />
-      </div>
-      <div className="org-list__item-info">
-        <p className="org-list__item-name">
-          {org.displayName || org.handle}
-        </p>
-        <p className="org-list__item-handle">
-          {org.handle}
-        </p>
-      </div>
-      <span className="org-list__item-role">{org.role}</span>
-      <div className="org-list__item-actions">
-        {org.accepted ? (
+  const renderOrgItem = (org: (typeof sortedOrgs)[number]) => {
+    const joinedLabel = formatJoinedDate(org.joinedAt)
+    return (
+      <div key={org.groupDid} className="org-list__item">
+        <div className="org-list__item-avatar">
+          <Avatar
+            src={org.avatarUrl}
+            alt={org.displayName || org.handle}
+            size="sm"
+            fallbackInitials={(org.displayName || org.handle).slice(0, 2)}
+          />
+        </div>
+        <div className="org-list__item-info">
+          <p className="org-list__item-name">
+            {org.displayName || org.handle}
+          </p>
+          <p className="org-list__item-handle">
+            {org.handle}
+          </p>
+          {joinedLabel && (
+            <p className="org-list__item-meta">
+              Joined {joinedLabel}
+            </p>
+          )}
+        </div>
+        <span className="org-list__item-role">{org.role}</span>
+        <div className="org-list__item-actions">
           <button
-            className="org-list__remove-public-btn"
-            onClick={() => handleRemovePublicMembership(org.groupDid)}
-            disabled={removingPublic === org.groupDid}
-            title="Remove public membership"
+            className="org-list__leave-btn"
+            onClick={() => setLeaveOrg({ groupDid: org.groupDid, name: org.displayName || org.handle })}
+            disabled={!canLeaveMap[org.groupDid]}
+            title={!canLeaveMap[org.groupDid] ? "Owners can't leave the group" : "Leave group"}
           >
-            <UserX size={14} />
+            <LogOut size={14} />
           </button>
-        ) : (
-          <button
-            className="org-list__accept-btn"
-            onClick={() => handleAcceptMembership(org.groupDid, org.role)}
-            disabled={acceptingOrg === org.groupDid}
-            title="Accept membership publicly"
-          >
-            <UserCheck size={14} />
-          </button>
-        )}
-        <button
-          className="org-list__leave-btn"
-          onClick={() => setLeaveOrg({ groupDid: org.groupDid, name: org.displayName || org.handle })}
-          disabled={!canLeaveMap[org.groupDid]}
-          title={!canLeaveMap[org.groupDid] ? "Owners can't leave the group" : "Leave group"}
-        >
-          <LogOut size={14} />
-        </button>
+        </div>
       </div>
-    </div>
-  )
-
-  const handleRemovePublicMembership = async (groupDid: string) => {
-    if (!did) return
-    setRemovingPublic(groupDid)
-    try {
-      await deleteMembership(did, groupDid)
-      await refetchOrgs()
-    } catch (err) {
-      console.error("Failed to remove public membership:", err)
-    } finally {
-      setRemovingPublic(null)
-    }
+    )
   }
 
   const handleLeaveOrg = async () => {
@@ -130,19 +105,6 @@ export default function GroupsPage() {
       console.error("Failed to leave group:", err)
     } finally {
       setIsLeaving(false)
-    }
-  }
-
-  const handleAcceptMembership = async (groupDid: string, role: OrgRole) => {
-    if (!did) return
-    setAcceptingOrg(groupDid)
-    try {
-      await putMembership(did, groupDid, role)
-      await refetchOrgs()
-    } catch (err) {
-      console.error("Failed to accept membership:", err)
-    } finally {
-      setAcceptingOrg(null)
     }
   }
 
@@ -192,15 +154,7 @@ export default function GroupsPage() {
                 Groups you belong to. Switch your profile in the top right to act as a group.
               </p>
               <div className="org-list__items">
-                {acceptedOrgs.map(renderOrgItem)}
-                {pendingOrgs.length > 0 && (
-                  <div className="org-list__divider">
-                    <span className="org-list__divider-text">
-                      Groups where your membership is private. You can still act on behalf of these groups.
-                    </span>
-                  </div>
-                )}
-                {pendingOrgs.map(renderOrgItem)}
+                {sortedOrgs.map(renderOrgItem)}
               </div>
             </div>
           )}

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -32,7 +32,11 @@ const SORT_OPTIONS: ReadonlyArray<{ value: SortMode; label: string }> = [
   { value: "name-desc", label: "Name (Z → A)" },
 ]
 
-const SORT_VALUES: ReadonlySet<SortMode> = new Set(SORT_OPTIONS.map((o) => o.value))
+const SORT_VALUES: ReadonlySet<string> = new Set(SORT_OPTIONS.map((o) => o.value))
+
+function isSortMode(v: string): v is SortMode {
+  return SORT_VALUES.has(v)
+}
 
 export default function GroupsPage() {
   const { groups, isLoading, refetchOrgs } = useOrg()
@@ -43,7 +47,9 @@ export default function GroupsPage() {
 
   const sortedOrgs = useMemo(() => {
     // Decorate-sort-undecorate: parse joinedAt once per group rather than per
-    // comparison, and reuse the lowercased label for name comparisons.
+    // comparison, and cache the display label for case/accent-insensitive
+    // name comparisons. Array.prototype.sort is stable as of ES2019, so equal
+    // keys preserve input order without needing an explicit tiebreak.
     type Decorated = {
       org: (typeof groups)[number]
       ts: number | null
@@ -71,7 +77,8 @@ export default function GroupsPage() {
     return decorated.map((d) => d.org)
   }, [groups, sortMode])
 
-  const currentSortLabel = SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? ""
+  const currentSortLabel =
+    SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? ""
 
   // Owners can never leave — grey out the button. Non-owners can always leave.
   const canLeaveMap = useMemo(() => {
@@ -187,14 +194,12 @@ export default function GroupsPage() {
                     <div className="org-list__sort-icon-btn">
                       <ArrowUpDown size={14} aria-hidden="true" />
                       <select
-                        aria-label={`Sort groups, current: ${currentSortLabel}`}
+                        aria-label="Sort groups"
                         title={`Sort: ${currentSortLabel}`}
                         value={sortMode}
                         onChange={(e) => {
                           const next = e.target.value
-                          if (SORT_VALUES.has(next as SortMode)) {
-                            setSortMode(next as SortMode)
-                          }
+                          if (isSortMode(next)) setSortMode(next)
                         }}
                         className="org-list__sort-icon-select"
                       >

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -32,6 +32,8 @@ const SORT_OPTIONS: ReadonlyArray<{ value: SortMode; label: string }> = [
   { value: "name-desc", label: "Name (Z → A)" },
 ]
 
+const SORT_VALUES: ReadonlySet<SortMode> = new Set(SORT_OPTIONS.map((o) => o.value))
+
 export default function GroupsPage() {
   const { groups, isLoading, refetchOrgs } = useOrg()
   const { did } = useAuth()
@@ -40,24 +42,36 @@ export default function GroupsPage() {
   const [sortMode, setSortMode] = useState<SortMode>("joined-asc")
 
   const sortedOrgs = useMemo(() => {
-    const arr = [...groups]
-    arr.sort((a, b) => {
+    // Decorate-sort-undecorate: parse joinedAt once per group rather than per
+    // comparison, and reuse the lowercased label for name comparisons.
+    type Decorated = {
+      org: (typeof groups)[number]
+      ts: number | null
+      label: string
+    }
+    const decorated: Decorated[] = groups.map((org) => {
+      const t = org.joinedAt ? new Date(org.joinedAt).getTime() : NaN
+      return {
+        org,
+        ts: Number.isNaN(t) ? null : t,
+        label: org.displayName || org.handle,
+      }
+    })
+    decorated.sort((a, b) => {
       if (sortMode === "joined-asc" || sortMode === "joined-desc") {
         // Missing joinedAt always sorts to the end, regardless of direction.
-        const ta = a.joinedAt ? new Date(a.joinedAt).getTime() : null
-        const tb = b.joinedAt ? new Date(b.joinedAt).getTime() : null
-        if (ta === null && tb === null) return 0
-        if (ta === null) return 1
-        if (tb === null) return -1
-        return sortMode === "joined-asc" ? ta - tb : tb - ta
+        if (a.ts === null && b.ts === null) return 0
+        if (a.ts === null) return 1
+        if (b.ts === null) return -1
+        return sortMode === "joined-asc" ? a.ts - b.ts : b.ts - a.ts
       }
-      const nameA = (a.displayName || a.handle).toLowerCase()
-      const nameB = (b.displayName || b.handle).toLowerCase()
-      const diff = nameA.localeCompare(nameB)
+      const diff = a.label.localeCompare(b.label, undefined, { sensitivity: "base" })
       return sortMode === "name-asc" ? diff : -diff
     })
-    return arr
+    return decorated.map((d) => d.org)
   }, [groups, sortMode])
+
+  const currentSortLabel = SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? ""
 
   // Owners can never leave — grey out the button. Non-owners can always leave.
   const canLeaveMap = useMemo(() => {
@@ -69,24 +83,22 @@ export default function GroupsPage() {
   }, [groups])
 
   const renderOrgItem = (org: (typeof sortedOrgs)[number]) => {
+    const displayLabel = org.displayName || org.handle
     const joinedLabel = formatJoinedDate(org.joinedAt)
+    const canLeave = canLeaveMap[org.groupDid]
     return (
       <div key={org.groupDid} className="org-list__item">
         <div className="org-list__item-avatar">
           <Avatar
             src={org.avatarUrl}
-            alt={org.displayName || org.handle}
+            alt={displayLabel}
             size="sm"
-            fallbackInitials={(org.displayName || org.handle).slice(0, 2)}
+            fallbackInitials={displayLabel.slice(0, 2)}
           />
         </div>
         <div className="org-list__item-info">
-          <p className="org-list__item-name">
-            {org.displayName || org.handle}
-          </p>
-          <p className="org-list__item-handle">
-            {org.handle}
-          </p>
+          <p className="org-list__item-name">{displayLabel}</p>
+          <p className="org-list__item-handle">{org.handle}</p>
           {joinedLabel && (
             <p className="org-list__item-meta">
               Joined {joinedLabel}
@@ -97,9 +109,13 @@ export default function GroupsPage() {
         <div className="org-list__item-actions">
           <button
             className="org-list__leave-btn"
-            onClick={() => setLeaveOrg({ groupDid: org.groupDid, name: org.displayName || org.handle })}
-            disabled={!canLeaveMap[org.groupDid]}
-            title={!canLeaveMap[org.groupDid] ? "Owners can't leave the group" : "Leave group"}
+            onClick={() => setLeaveOrg({ groupDid: org.groupDid, name: displayLabel })}
+            disabled={!canLeave}
+            title={
+              canLeave
+                ? "Leave group"
+                : "Owners can't leave — transfer ownership in group settings first"
+            }
           >
             <LogOut size={14} />
           </button>
@@ -168,15 +184,18 @@ export default function GroupsPage() {
                 <div className="org-list__header-right">
                   <span className="org-list__count">{groups.length}</span>
                   {groups.length > 1 && (
-                    <div
-                      className="org-list__sort-icon-btn"
-                      title={`Sort: ${SORT_OPTIONS.find((o) => o.value === sortMode)?.label}`}
-                    >
-                      <ArrowUpDown size={14} aria-hidden />
+                    <div className="org-list__sort-icon-btn">
+                      <ArrowUpDown size={14} aria-hidden="true" />
                       <select
-                        aria-label="Sort groups"
+                        aria-label={`Sort groups, current: ${currentSortLabel}`}
+                        title={`Sort: ${currentSortLabel}`}
                         value={sortMode}
-                        onChange={(e) => setSortMode(e.target.value as SortMode)}
+                        onChange={(e) => {
+                          const next = e.target.value
+                          if (SORT_VALUES.has(next as SortMode)) {
+                            setSortMode(next as SortMode)
+                          }
+                        }}
                         className="org-list__sort-icon-select"
                       >
                         {SORT_OPTIONS.map((opt) => (

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -20,7 +20,7 @@ function formatJoinedDate(iso?: string): string | null {
   if (!iso) return null
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) return null
-  return date.toLocaleDateString("en-US", JOINED_DATE_FORMAT)
+  return date.toLocaleDateString(undefined, JOINED_DATE_FORMAT)
 }
 
 type SortMode = "joined-asc" | "joined-desc" | "name-asc" | "name-desc"

--- a/src/components/profile/profile-client.tsx
+++ b/src/components/profile/profile-client.tsx
@@ -136,7 +136,7 @@ export default function ProfileClient() {
           <div className="dash-card">
             {bannerUrl && (
               <div className="profile-card__banner">
-                <img src={bannerUrl} alt="" />
+                <img src={bannerUrl} alt="" aria-hidden="true" />
               </div>
             )}
             <div className="profile-card">

--- a/src/components/profile/profile-client.tsx
+++ b/src/components/profile/profile-client.tsx
@@ -134,9 +134,11 @@ export default function ProfileClient() {
         <div className="dashboard__main">
           {/* Profile header card */}
           <div className="dash-card">
-            <div className="profile-card__banner">
-              {bannerUrl ? <img src={bannerUrl} alt="" /> : null}
-            </div>
+            {bannerUrl && (
+              <div className="profile-card__banner">
+                <img src={bannerUrl} alt="" />
+              </div>
+            )}
             <div className="profile-card">
               <Avatar
                 size="lg"

--- a/src/lib/auth/oauth-client.ts
+++ b/src/lib/auth/oauth-client.ts
@@ -147,18 +147,29 @@ export async function getOAuthClient(): Promise<NodeOAuthClient> {
 // wrapper passes a Request to fetch, and bsky's PDS reliably returns 401 +
 // DPoP-Nonce on the first hit, triggering the bug. Buffer the body once and
 // re-issue with (url, init) form so Next.js's wrapper never sees a Request.
+//
+// Note on uploadBlob: the route handler in `src/app/api/xrpc/[...method]`
+// already buffers the upload to an ArrayBuffer, and the atproto Agent then
+// constructs a Request whose body we buffer again here. The transient ~8MB
+// double-buffer is acceptable on Vercel's 1GB function memory.
 const safeFetch: typeof fetch = async (input, init) => {
   if (input instanceof Request) {
+    // Preserve "had a body" — sending `undefined` for a 0-byte POST/PUT would
+    // strip Content-Length: 0 and the server would see a missing body.
     const buffer = input.body ? await input.arrayBuffer() : undefined
+    // The dpop wrapper always invokes us as `fetch.call(this, request)` with
+    // no second argument, so `init` is null in practice. Don't spread it here
+    // — if a future caller did pass `init.body`, the spread would overwrite
+    // our buffered body and re-introduce the very bug this fix prevents.
+    void init
     return globalThis.fetch(input.url, {
       method: input.method,
       headers: input.headers,
-      body: buffer && buffer.byteLength > 0 ? buffer : undefined,
+      body: input.body ? buffer : undefined,
       signal: input.signal,
       redirect: input.redirect,
       credentials: input.credentials,
       cache: input.cache,
-      ...init,
     })
   }
   return globalThis.fetch(input, init)

--- a/src/lib/auth/oauth-client.ts
+++ b/src/lib/auth/oauth-client.ts
@@ -134,8 +134,32 @@ export async function getOAuthClient(): Promise<NodeOAuthClient> {
     clientMetadata,
     stateStore: new RedisStateStore(),
     sessionStore: new RedisSessionStore(),
+    fetch: safeFetch,
     ...(keyset ? { keyset } : {}),
   })
 
   return clientInstance
+}
+
+// Workaround for vercel/next.js#90826: on Node ≥ 24.14, Next.js's patched
+// fetch throws `expected non-null body source` when given a Request whose
+// body has been consumed and the response is an error. The atproto DPoP
+// wrapper passes a Request to fetch, and bsky's PDS reliably returns 401 +
+// DPoP-Nonce on the first hit, triggering the bug. Buffer the body once and
+// re-issue with (url, init) form so Next.js's wrapper never sees a Request.
+const safeFetch: typeof fetch = async (input, init) => {
+  if (input instanceof Request) {
+    const buffer = input.body ? await input.arrayBuffer() : undefined
+    return globalThis.fetch(input.url, {
+      method: input.method,
+      headers: input.headers,
+      body: buffer && buffer.byteLength > 0 ? buffer : undefined,
+      signal: input.signal,
+      redirect: input.redirect,
+      credentials: input.credentials,
+      cache: input.cache,
+      ...init,
+    })
+  }
+  return globalThis.fetch(input, init)
 }

--- a/src/lib/groups/api.ts
+++ b/src/lib/groups/api.ts
@@ -465,6 +465,7 @@ export async function resolveGroups(
         accepted: acceptedSet.has(rm.groupDid),
         avatarUrl,
         rkey: localRecord?.rkey,
+        joinedAt: rm.joinedAt,
       } satisfies Group
     })
   )

--- a/src/lib/groups/types.ts
+++ b/src/lib/groups/types.ts
@@ -6,6 +6,8 @@ export interface Group {
   accepted: boolean
   avatarUrl?: string
   rkey?: string
+  /** ISO timestamp from the group service indicating when the user joined. */
+  joinedAt?: string
 }
 
 export interface RemoteMembership {


### PR DESCRIPTION
## Summary

Brings 11 commits from `staging` into `main`. Three themes:

- **Auth — bsky-PDS write fix.** Saves to repos hosted on `*.host.bsky.network` (i.e. any Bluesky-hosted handle) were 500ing with `expected non-null body source`. Root cause is [vercel/next.js#90826](https://github.com/vercel/next.js/issues/90826) (Node ≥ 24.14): Next.js's patched fetch re-reads a Request body for tracing on error responses, but undici has tightened stream locking. The atproto OAuth DPoP wrapper passes a Request to fetch, and bsky's PDS reliably returns 401 + DPoP-Nonce on the first hit, so every authenticated write to a bsky-side PDS triggered the bug. Fixed by wrapping the `fetch` passed to `NodeOAuthClient` so any incoming Request is deconstructed to (url, init) before reaching Next.js's wrapper. Also bumped `@atproto/api` 0.13 → 0.19 and `@atproto/oauth-client` to 0.6.1 (and dropped the now-deprecated `rkeyEnd`/`rkeyStart` from the listRecords proxy).
- **Groups — list overhaul.** Unified group list with join dates, a sort control (collapses to an icon), and removal of the beta test-server warning banner. Came in via merged PR #53.
- **Profile + observability.** Hide the banner area on profiles with no banner image; log upstream xrpc errors server-side before masking them as `Internal server error` (this is what made the bsky-PDS bug above debuggable in the first place).

A sibling-repo issue tracking the same bsky-PDS bug for `certs-social` is filed at [hypercerts-org/certs-social#86](https://github.com/hypercerts-org/certs-social/issues/86) — the recommended fix there is the identical `safeFetch` wrapper validated here.

## Test plan

- [x] Sign in with a Bluesky-hosted handle (`holke.xyz`, DID resolves to `amanita.us-east.host.bsky.network`) on `staging.certified.app`; edit profile and save → `POST /api/xrpc/com/atproto/repo/putRecord` returns 200, redirect to `/profile/[did]`, saved values render. Verified end-to-end before this PR was opened.
- [x] Sign in with a Certified-hosted handle (email-OTP flow); profile save still works as before. Verified.
- [x] Staging deploy builds clean on Node 24.x with the bumped @atproto packages. TypeScript passes (`npx tsc --noEmit`).
- [ ] Smoke-test groups list page: sort control, join dates, no banner-warning banner.
- [ ] Smoke-test a profile with no banner image: no empty banner area shows.
- [ ] After merge: ensure production env on `main` has all the same env vars staging has (COOKIE_SECRET, PUBLIC_URL, UPSTASH_*, etc.) — production is on a separate Vercel environment and won't inherit from staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sorting options for groups (by joined date or name, ascending/descending).
  * Groups now display when you joined each one.

* **Bug Fixes**
  * Fixed profile banner rendering logic.
  * Improved error handling and logging in API requests.
  * Enhanced OAuth session restoration flow.

* **Chores**
  * Updated dependencies.
  * Added review documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypercerts-org/certified-app/pull/54)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->