### PR TITLE
feat(imprint): add § 5 DDG Impressum page

### DIFF
--- a/src/app/imprint/page.tsx
+++ b/src/app/imprint/page.tsx
@@ -20,7 +20,7 @@ export default function ImprintPage() {
     <div className="app-page">
       <div className="app-page__inner max-w-3xl">
         <h1 className="font-mono text-h1 text-navy tracking-tight mb-8">
-          Impressum / Imprint
+          Imprint
         </h1>
 
         <p className="text-sm text-gray-500 mb-8">Last updated: May 11, 2026</p>

--- a/src/app/imprint/page.tsx
+++ b/src/app/imprint/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Imprint",
+  description:
+    "Imprint (Impressum) for Certified, the identity platform operated by the Hypercerts Foundation. Service operator details, authorized representatives, EU representative, and legal contact under § 5 DDG.",
+  alternates: { canonical: "https://certified.app/imprint" },
+  openGraph: {
+    title: "Imprint — Certified",
+    description:
+      "Imprint (Impressum) for Certified, the identity platform operated by the Hypercerts Foundation.",
+    url: "https://certified.app/imprint",
+    type: "website",
+    images: [{ url: "/assets/certified-hero-1200x630.png", width: 1200, height: 630, alt: "Certified — One account, any app" }],
+  },
+};
+
+export default function ImprintPage() {
+  return (
+    <div className="app-page">
+      <div className="app-page__inner max-w-3xl">
+        <h1 className="font-mono text-h1 text-navy tracking-tight mb-8">
+          Impressum / Imprint
+        </h1>
+
+        <p className="text-sm text-gray-500 mb-8">Last updated: May 11, 2026</p>
+
+        <div className="prose prose-navy max-w-none space-y-8">
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">Service operator</h2>
+            <p>
+              <strong>Hypercerts Foundation</strong>
+              <br />
+              1209 Orange St.
+              <br />
+              Wilmington, DE 19801
+              <br />
+              United States
+            </p>
+            <p className="mt-4">Legal form: Delaware nonstock corporation (US nonprofit)</p>
+            <p className="mt-4">
+              Phone: +1 302 658 7581
+              <br />
+              Email:{" "}
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">Authorized representatives</h2>
+            <p>Holke Brammer</p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              Representative in the European Union
+            </h2>
+            <p>In accordance with Article 27 GDPR:</p>
+            <p className="mt-4">
+              Holke Brammer
+              <br />
+              Holzmarktstraße 25
+              <br />
+              10243 Berlin
+              <br />
+              Germany
+            </p>
+            <p className="mt-4">
+              Email:{" "}
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">
+              Contact for legal notices and Digital Services Act communications
+            </h2>
+            <p>
+              Email:{" "}
+              <a
+                href="mailto:legal@hypercerts.org"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                legal@hypercerts.org
+              </a>
+            </p>
+            <p className="mt-4">
+              Notice-and-action procedures for content reports are described on the{" "}
+              <a href="/dsa" className="text-blue-600 underline hover:text-blue-800">
+                DSA Compliance Page
+              </a>
+              .
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-mono text-xl text-navy mb-4">Online dispute resolution</h2>
+            <p>
+              The European Commission provides a platform for online dispute resolution (ODR):{" "}
+              <a
+                href="https://ec.europa.eu/consumers/odr"
+                className="text-blue-600 underline hover:text-blue-800"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                https://ec.europa.eu/consumers/odr
+              </a>
+            </p>
+            <p className="mt-4">
+              The Hypercerts Foundation is not obligated and not willing to participate in dispute
+              resolution proceedings before a consumer arbitration board.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/imprint/page.tsx
+++ b/src/app/imprint/page.tsx
@@ -37,7 +37,7 @@ export default function ImprintPage() {
               <br />
               United States
             </p>
-            <p className="mt-4">Legal form: Delaware nonstock corporation (US nonprofit)</p>
+            <p className="mt-4">Legal form: Delaware nonstock corporation</p>
             <p className="mt-4">
               Phone: +1 302 658 7581
               <br />

--- a/src/app/imprint/page.tsx
+++ b/src/app/imprint/page.tsx
@@ -20,7 +20,7 @@ export default function ImprintPage() {
     <div className="app-page">
       <div className="app-page__inner max-w-3xl">
         <h1 className="font-mono text-h1 text-navy tracking-tight mb-8">
-          Imprint
+          Imprint — Certified
         </h1>
 
         <p className="text-sm text-gray-500 mb-8">Last updated: May 11, 2026</p>

--- a/src/app/imprint/page.tsx
+++ b/src/app/imprint/page.tsx
@@ -53,7 +53,7 @@ export default function ImprintPage() {
 
           <section>
             <h2 className="font-mono text-xl text-navy mb-4">Authorized representatives</h2>
-            <p>Holke Brammer</p>
+            <p>Holke Brammer (Director)</p>
           </section>
 
           <section>

--- a/src/app/imprint/page.tsx
+++ b/src/app/imprint/page.tsx
@@ -103,24 +103,6 @@ export default function ImprintPage() {
             </p>
           </section>
 
-          <section>
-            <h2 className="font-mono text-xl text-navy mb-4">Online dispute resolution</h2>
-            <p>
-              The European Commission provides a platform for online dispute resolution (ODR):{" "}
-              <a
-                href="https://ec.europa.eu/consumers/odr"
-                className="text-blue-600 underline hover:text-blue-800"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                https://ec.europa.eu/consumers/odr
-              </a>
-            </p>
-            <p className="mt-4">
-              The Hypercerts Foundation is not obligated and not willing to participate in dispute
-              resolution proceedings before a consumer arbitration board.
-            </p>
-          </section>
         </div>
       </div>
     </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -32,5 +32,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.3,
     },
+    {
+      url: "https://certified.app/imprint",
+      lastModified: new Date("2026-05-11"),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
   ];
 }

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -14,6 +14,7 @@ export default function Footer() {
           <Link href="/about">About</Link>
           <Link href="/terms">Terms</Link>
           <Link href="/privacy">Privacy</Link>
+          <Link href="/imprint">Imprint</Link>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- Adds `/imprint` page satisfying § 5 DDG (Digitale-Dienste-Gesetz) for the German market: service operator, authorized representatives, EU Art. 27 GDPR representative, legal-notice / DSA contact. Layout, typography, metadata, and "Last updated" pattern mirror `/terms` and `/privacy`.
- Links **Imprint** from the persistent footer (`src/components/layout/footer.tsx`), which renders globally via `src/app/layout.tsx`, so the link is reachable in one click from `/welcome`, the sign-in flow, partner-branded sign-ins, `/terms`, `/privacy`, and `/dsa`.
- Registers `/imprint` in `sitemap.ts`.

## Content decisions
- Heading: **"Imprint — Certified"** (matches Terms/Privacy convention).
- Authorized representatives: **Holke Brammer (Director)**.
- § 18 (2) MStV content-responsibility section: **omitted** — Certified is identity/data hosting, not journalistic-editorial content.
- Online dispute resolution section: omitted.
- No Handelsregister entry, no German VAT ID, no "N/A" placeholders for fields that legally do not apply to a Delaware nonstock corporation.

## Out of scope
- Sign-in screen inline copy referencing the Imprint — the global footer link satisfies the "reachable in one click" requirement; no separate inline copy added.

## Test plan
- [ ] `/imprint` renders and matches `/terms` / `/privacy` styling
- [ ] Footer on every page (including `/welcome`, sign-in, `/terms`, `/privacy`, `/dsa`, partner sign-ins) shows the **Imprint** link
- [ ] `next build` succeeds; `/imprint` is prerendered
- [ ] Sitemap includes `/imprint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Imprint page with legal information and contact details
  * Imprint link now appears in the footer navigation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypercerts-org/certified-app/pull/58)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->