### PR TITLE
docs(privacy): clarify Vercel Analytics basis, add complaint right

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -23,7 +23,7 @@ export default function PrivacyPage() {
           Privacy Policy — Certified
         </h1>
 
-        <p className="text-sm text-gray-500 mb-8">Last updated: May 6, 2026</p>
+        <p className="text-sm text-gray-500 mb-8">Last updated: May 11, 2026</p>
 
         <div className="prose prose-navy max-w-none space-y-8">
           <section>
@@ -317,11 +317,22 @@ export default function PrivacyPage() {
               that track individual users across websites.
             </p>
             <p className="mt-4">
-              We use Vercel Web Analytics to collect anonymous, aggregated usage data such as page
-              views, referrer information, and general device or browser type. Vercel Web Analytics
-              does not use cookies and does not collect personal data or track individual users.
-              This data is processed by Vercel Inc. (US) under Standard Contractual Clauses (SCCs)
-              as the legal mechanism for international data transfers.
+              We use Vercel Web Analytics to collect aggregated usage data such as page views,
+              referrer information, and general device or browser type. Vercel Web Analytics does
+              not use cookies and does not store persistent identifiers in your browser. Instead,
+              it derives an ephemeral session identifier by hashing request metadata (including the
+              IP address and user agent). These hashes are retained for no longer than 24 hours and
+              are not used to track individuals across sessions, websites, or applications.
+            </p>
+            <p className="mt-4">
+              The legal basis for this processing is our legitimate interest under Article 6(1)(f)
+              GDPR in understanding aggregate usage of the service to maintain, secure, and improve
+              it. You have the right to object to this processing on grounds relating to your
+              particular situation (see Section 13).
+            </p>
+            <p className="mt-4">
+              This data is processed by Vercel Inc. (United States) under Standard Contractual
+              Clauses (SCCs) as the legal mechanism for international data transfers.
             </p>
             <p className="mt-4">
               If our use of cookies or analytics changes in the future, we will update this policy
@@ -404,7 +415,23 @@ export default function PrivacyPage() {
               <li>restrict or object to certain types of processing</li>
               <li>request portability of data they have provided</li>
               <li>withdraw consent, where processing is based on consent</li>
+              <li>lodge a complaint with a data protection supervisory authority</li>
             </ul>
+            <p className="mt-4">
+              You may lodge a complaint with the supervisory authority in the EU Member State of
+              your habitual residence, place of work, or the place of the alleged infringement.
+              Where our EU representative is established (Berlin, Germany), the competent authority
+              is the Berliner Beauftragte für Datenschutz und Informationsfreiheit (BlnBDI),{" "}
+              <a
+                href="https://www.datenschutz-berlin.de"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                https://www.datenschutz-berlin.de
+              </a>
+              .
+            </p>
             <p className="mt-4">Requests may be submitted to:</p>
             <p className="mt-2">
               <a


### PR DESCRIPTION
## Summary
- **Section 9 — Vercel Web Analytics.** Replaces the "anonymous, aggregated" wording with a more accurate description: Vercel derives an ephemeral session identifier by hashing request metadata (IP + user agent), retained ≤ 24 h, not used for cross-session/cross-site tracking. Adds the explicit Art. 6(1)(f) GDPR legitimate-interest basis with a cross-reference to the Section 13 right to object.
- **Section 13 — Your rights.** Adds the Art. 13(2)(d) / Art. 77 GDPR right to lodge a complaint with a supervisory authority, and points users to the Berliner Beauftragte für Datenschutz und Informationsfreiheit (BlnBDI) as the competent authority where our EU representative is established.
- **"Last updated"** bumped to May 11, 2026.

## Out of scope
No other sections of the privacy policy modified. No routing or dependency changes.

## Test plan
- [ ] `/privacy` renders with the updated date and three Vercel Analytics paragraphs
- [ ] Section 13 shows the new bullet and the Berlin (BlnBDI) supervisory-authority paragraph above "Requests may be submitted to:"
- [ ] External link to https://www.datenschutz-berlin.de opens in a new tab (existing convention)
- [ ] `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated privacy policy with current effective date
  * Enhanced cookies and analytics disclosures with more comprehensive technical details regarding data handling and retention practices
  * Expanded user rights section to include information on lodging complaints with data protection supervisory authorities

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypercerts-org/certified-app/pull/59)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->