### PR TITLE
feat(endorsements): single indexer query replaces PDS fan-out scan

### DIFF
--- a/docs/endorsements-indexer-filter/plan.md
+++ b/docs/endorsements-indexer-filter/plan.md
@@ -1,0 +1,98 @@
+# Replace PDS fan-out with indexer subject filter
+
+## Problem
+
+`useReceivedEndorsements` (profile page + `/endorsements`) takes
+several seconds to load on a cold cache. Diagnosis:
+
+1. Indexer GraphQL query: `appCertifiedActorProfile` listing every
+   certified user (~14 today, growing linearly).
+2. **PDS fan-out**: `listAwards(issuerDid)` for EVERY certified user.
+   That's the bulk of the latency.
+3. For each issuer with a candidate match: `listDefinitions(issuerDid)`
+   to verify the badge is endorsement-typed.
+4. PDS listResponses on the profile owner for the response-state
+   filter.
+
+Steps 2–3 fan out across the universe of certified users. With the
+indexer now exposing `subject: DIDFilterInput` on
+`AppCertifiedBadgeAwardWhereInput` (magic-indexer PR #75 + the #78
+fix for the `{did}` object shape), the entire scan collapses to a
+single GraphQL query that returns only the awards-targeting-me.
+
+## Approach
+
+Replace `scanReceivedEndorsements` with `fetchReceivedAwardsFromIndexer`:
+
+```graphql
+query ReceivedEndorsements($did: String!, $first: Int!, $after: String) {
+  appCertifiedBadgeAward(
+    where: { subject: { eq: $did } }
+    first: $first
+    after: $after
+  ) {
+    edges { cursor node { uri cid did createdAt note badge } }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+```
+
+This collapses N PDS-listAwards round-trips into one indexer query.
+The per-issuer definition lookup (`listDefinitions`) stays — it's
+the cheapest path to verify badge type, runs only over K unique
+issuers (typically 0–2 for a real profile), and is already cached
+within a single scan.
+
+### Why keep PDS for definitions?
+
+The indexer's `badge` field is currently exposed as a stringified Go
+`map[cid:... uri:...]` literal, which is awkward to parse client-side.
+The cleanest mitigation is to leave definition resolution on the
+issuer's PDS for now — a separate indexer fix can come later. K is
+small, so the win from eliminating the awards fan-out is the
+dominant gain.
+
+## Files
+
+### Modified
+
+- `src/hooks/use-received-endorsements.ts` — replace
+  `scanReceivedEndorsements` with `fetchReceivedAwardsFromIndexer`.
+  Module cache, stale time, focus-revalidate, response-state filter
+  all unchanged.
+- `src/lib/atproto/badges.ts` — `BadgeAwardValue.subject` typing
+  unchanged (still `string | StrongRef`) since we no longer match on
+  it client-side. Remove `awardSubjectMatchesDid` — no remaining
+  consumers.
+
+### Out of scope
+
+- Indexer's `badge` field serialization fix (separate concern).
+- Server-side response-state join. Today we still fetch the owner's
+  responses from their PDS and filter client-side; that's the right
+  shape (responses on the owner's repo, only owner is authorised
+  to read them efficiently).
+
+## Acceptance criteria
+
+1. Loading endorsements on profile + `/endorsements` finishes in one
+   indexer round-trip + K issuer PDS round-trips (K = unique issuers
+   among matches).
+2. Endorsements written in the `defs#did` `{did: "..."}` subject shape
+   appear (previously dropped by both `awardSubjectMatchesDid` AND
+   the not-yet-fixed indexer filter).
+3. Endorsements written in the strongRef shape continue to appear.
+4. Response-state filter (rejected awards hidden) continues to work.
+5. Module cache + focus-revalidate behaviour unchanged.
+
+## Gating
+
+Open as Draft. Cannot merge until magic-indexer PR #78 is deployed —
+without #78, the indexer's subject filter misses 70% of records (the
+`{did}` shape), and this PR would return strictly fewer results than
+the current PDS scan.
+
+## Rollback
+
+Single revert restores the PDS fan-out scan. The replaced function is
+self-contained; module cache / hook contract are unchanged.

--- a/src/hooks/use-received-endorsements.ts
+++ b/src/hooks/use-received-endorsements.ts
@@ -2,12 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
-  awardSubjectMatchesDid,
-  listAwards,
   listDefinitions,
   resolveResponseState,
   ENDORSEMENT_BADGE_TYPE,
-  type BadgeAwardRecord,
 } from "@/lib/atproto/badges"
 import { useProfileResponses } from "@/hooks/use-profile-responses"
 
@@ -31,18 +28,24 @@ export interface ReceivedEndorsement {
 }
 
 /**
- * Indexer query — list every DID with an `app.certified.actor.profile`
- * record. We use it as the universe of "issuers we should ask" during
- * the PDS scan below.
+ * Indexer query — pull every badge.award whose `subject` resolves to
+ * the given DID across both lexicon refs of the subject union
+ * (app.certified.defs#did `{did: "..."}` AND
+ * com.atproto.repo.strongRef `{uri: "at://<did>/..."}`). Subject
+ * filter lives in the indexer (see hb-agent/magic-indexer#65 + the
+ * #78 follow-up that added the defs#did object branch).
  *
- * This is the workaround until the indexer adds a `subjectDid` filter
- * on `appCertifiedBadgeAward` (see hb-agent/magic-indexer#65). Once
- * that lands, this whole hook collapses to a single GraphQL query.
+ * This collapses what used to be a PDS fan-out across every certified
+ * user (N round-trips) into one query.
  */
-const PROFILES_QUERY = `
-query ProfileDids($first: Int!, $after: String) {
-  appCertifiedActorProfile(first: $first, after: $after) {
-    edges { node { did } }
+const RECEIVED_AWARDS_QUERY = `
+query ReceivedEndorsements($did: String!, $first: Int!, $after: String) {
+  appCertifiedBadgeAward(
+    where: { subject: { eq: $did } }
+    first: $first
+    after: $after
+  ) {
+    edges { node { uri cid did createdAt note badge } }
     pageInfo { hasNextPage endCursor }
   }
 }
@@ -50,34 +53,70 @@ query ProfileDids($first: Int!, $after: String) {
 
 const INDEXER_PROXY_URL = "/api/indexer"
 
-async function fetchAllProfileDids(signal?: AbortSignal): Promise<string[]> {
+/**
+ * The indexer currently serializes the `badge` strongRef as a
+ * stringified Go map literal (`"map[cid:bafy... uri:at://...]"`)
+ * rather than as structured JSON. Pull the URI out with a regex
+ * so we can match awards to their issuer's endorsement definitions.
+ *
+ * If the indexer fix ships and `badge` becomes structured JSON,
+ * this helper becomes a no-op for that shape but stays for backwards
+ * compatibility.
+ */
+function extractBadgeDefinitionUri(badge: unknown): string | null {
+  if (!badge) return null
+  if (typeof badge === "string") {
+    // Go map literal: "map[cid:... uri:at://.../app.certified.badge.definition/...]"
+    const m = badge.match(/uri:(at:\/\/\S+)/)
+    return m?.[1] ?? null
+  }
+  if (typeof badge === "object" && "uri" in badge) {
+    const uri = (badge as { uri?: unknown }).uri
+    return typeof uri === "string" ? uri : null
+  }
+  return null
+}
+
+interface IndexerAwardNode {
+  uri: string
+  cid: string
+  did: string
+  createdAt: string
+  note?: string
+  badge: unknown
+}
+
+async function fetchReceivedAwardsFromIndexer(
+  profileDid: string,
+  signal?: AbortSignal,
+): Promise<IndexerAwardNode[]> {
   const PAGE_SIZE = 100
-  const SAFETY_CAP = 5_000
-  const out: string[] = []
+  const SAFETY_CAP = 10_000
+  const out: IndexerAwardNode[] = []
   let cursor: string | null = null
   while (out.length < SAFETY_CAP) {
     const res = await fetch(INDEXER_PROXY_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        query: PROFILES_QUERY,
-        variables: { first: PAGE_SIZE, after: cursor },
+        query: RECEIVED_AWARDS_QUERY,
+        variables: { did: profileDid, first: PAGE_SIZE, after: cursor },
       }),
       signal,
     })
     if (!res.ok) throw new Error(`Indexer query failed: ${res.status}`)
     const json = (await res.json()) as {
       data?: {
-        appCertifiedActorProfile?: {
-          edges: { node: { did: string } | null }[]
+        appCertifiedBadgeAward?: {
+          edges: { node: IndexerAwardNode | null }[]
           pageInfo: { hasNextPage: boolean; endCursor: string | null }
         } | null
       } | null
     }
-    const conn = json.data?.appCertifiedActorProfile
+    const conn = json.data?.appCertifiedBadgeAward
     if (!conn) break
     for (const edge of conn.edges) {
-      if (edge.node?.did) out.push(edge.node.did)
+      if (edge.node) out.push(edge.node)
     }
     if (!conn.pageInfo.hasNextPage || !conn.pageInfo.endCursor) break
     cursor = conn.pageInfo.endCursor
@@ -86,27 +125,10 @@ async function fetchAllProfileDids(signal?: AbortSignal): Promise<string[]> {
 }
 
 /**
- * For a single (issuer) DID, list every award and return those that
- * target `subjectDid`. We DELIBERATELY skip the per-issuer definition
- * lookup at this stage — many issuers will have no matching awards
- * and we save round-trips by deferring the badge-type filter until
- * after candidates are narrowed down.
- */
-async function listMatchingAwards(
-  issuerDid: string,
-  subjectDid: string,
-  signal?: AbortSignal,
-): Promise<BadgeAwardRecord[]> {
-  const awards = await listAwards(issuerDid, signal).catch(
-    () => [] as BadgeAwardRecord[],
-  )
-  return awards.filter((a) => awardSubjectMatchesDid(a.value, subjectDid))
-}
-
-/**
- * Resolve which of the issuer's definitions are endorsement
- * definitions. Cached for the duration of the scan so an issuer with
- * many matching awards only triggers one definition fetch.
+ * For each unique issuer that endorsed `profileDid`, ask the issuer's
+ * PDS which of their definitions are endorsement-typed. Cached so an
+ * issuer with multiple awards on this profile only triggers one
+ * definition fetch.
  */
 async function getEndorsementDefUris(
   issuerDid: string,
@@ -126,53 +148,32 @@ async function getEndorsementDefUris(
 }
 
 /**
- * Run the scan: for every known certified user, list their awards,
- * keep those that target `profileDid`, then filter to awards whose
- * badge ref points at an endorsement-typed definition.
- *
- * Concurrency: we fan out awards-listings 20 issuers at a time so we
- * stay polite to certified.one and the xrpc proxy.
+ * Run the scan: one indexer query for awards-targeting-me, then per
+ * unique issuer load their definitions and keep awards whose badge
+ * ref points at an endorsement-typed one.
  */
 async function scanReceivedEndorsements(
   profileDid: string,
   signal?: AbortSignal,
 ): Promise<ReceivedEndorsement[]> {
-  const allDids = await fetchAllProfileDids(signal)
+  const awards = await fetchReceivedAwardsFromIndexer(profileDid, signal)
   if (signal?.aborted) return []
 
-  const CONCURRENCY = 20
-  const matchesByIssuer = new Map<string, BadgeAwardRecord[]>()
-
-  for (let i = 0; i < allDids.length; i += CONCURRENCY) {
-    if (signal?.aborted) return []
-    const slice = allDids.slice(i, i + CONCURRENCY)
-    const results = await Promise.all(
-      slice.map((d) => listMatchingAwards(d, profileDid, signal)),
-    )
-    for (let j = 0; j < slice.length; j++) {
-      const issuer = slice[j]
-      const matches = results[j]
-      if (matches.length > 0) matchesByIssuer.set(issuer, matches)
-    }
-  }
-
-  // For issuers with at least one candidate, fetch their definitions
-  // and keep only awards that reference an endorsement-typed one.
   const defCache = new Map<string, Set<string>>()
   const out: ReceivedEndorsement[] = []
-  for (const [issuer, awards] of matchesByIssuer) {
+  for (const a of awards) {
     if (signal?.aborted) return []
-    const endorsementDefUris = await getEndorsementDefUris(issuer, defCache, signal)
-    for (const a of awards) {
-      if (!endorsementDefUris.has(a.value.badge?.uri ?? "")) continue
-      out.push({
-        uri: a.uri,
-        cid: a.cid,
-        issuerDid: issuer,
-        createdAt: a.value.createdAt,
-        note: a.value.note,
-      })
-    }
+    const defUri = extractBadgeDefinitionUri(a.badge)
+    if (!defUri) continue
+    const endorsementDefUris = await getEndorsementDefUris(a.did, defCache, signal)
+    if (!endorsementDefUris.has(defUri)) continue
+    out.push({
+      uri: a.uri,
+      cid: a.cid,
+      issuerDid: a.did,
+      createdAt: a.createdAt,
+      note: a.note,
+    })
   }
 
   // Newest first.
@@ -214,17 +215,24 @@ export function peekCachedReceivedEndorsements(
 }
 
 /**
- * Fetch every public endorsement award targeting `profileDid` from
- * every known certified user, AND filter out awards whose latest
- * response (on the profile owner's PDS) is `"rejected"`. Scoped to
- * the badge.{definition,award,response} lexicons — the legacy
- * `app.certified.temp.graph.endorsement` collection is NOT
- * consulted (hard cutover per the migration plan).
+ * Fetch every public endorsement award targeting `profileDid`, AND
+ * filter out awards whose latest response (on the profile owner's
+ * PDS) is `"rejected"`. Scoped to the badge.{definition,award,response}
+ * lexicons — the legacy `app.certified.temp.graph.endorsement`
+ * collection is NOT consulted (hard cutover per the migration plan).
  *
- * The response join is a SINGLE listRecords against the
- * `profileDid`'s PDS — never per-issuer. This was the most likely
- * implementation foot-gun flagged in plan review (R1+R3 critical
- * C1); the contract enforces "one extra listRecords, not 386."
+ * Fetch shape:
+ *   1. One indexer GraphQL query for awards-targeting-me (subject
+ *      filter on `appCertifiedBadgeAward`).
+ *   2. Per unique issuer in the result: one PDS `listDefinitions`
+ *      call to verify their badge is endorsement-typed.
+ *   3. One PDS `listResponses` on the profile owner for the
+ *      response-state filter.
+ *
+ * Previously this fanned out `listAwards` across every certified
+ * user (~14 round-trips today, growing linearly). With the indexer's
+ * `subject: DIDFilterInput` (magic-indexer #65 + #78) the awards
+ * fan-out collapses to a single query.
  *
  * Returns the **visible** awards only. Per-award response state is
  * deliberately not returned to non-owner viewers (privacy: R2 C7).

--- a/src/lib/atproto/badges.ts
+++ b/src/lib/atproto/badges.ts
@@ -316,32 +316,6 @@ export async function deleteEndorsementAward(
 }
 
 /**
- * Convenience predicate: does this award's `subject` resolve to the
- * given DID? Handles both subject shapes (bare DID string and
- * strongRef). For endorsements we always write the bare-string form,
- * but read paths should accept either since other apps may write
- * either.
- */
-export function awardSubjectMatchesDid(
-  award: BadgeAwardValue,
-  did: string,
-): boolean {
-  const subject = award.subject
-  if (typeof subject === "string") return subject === did
-  if (subject && typeof subject === "object" && "uri" in subject) {
-    // strongRef to a record on a DID's repo — DID is the first
-    // segment after `at://`.
-    const uri = subject.uri
-    if (typeof uri !== "string" || !uri.startsWith("at://")) return false
-    const tail = uri.slice("at://".length)
-    const slash = tail.indexOf("/")
-    const repoDid = slash >= 0 ? tail.slice(0, slash) : tail
-    return repoDid === did
-  }
-  return false
-}
-
-/**
  * Extract the issuer DID from an award URI. Used by read paths that
  * fan out across users and need to attribute each award to its
  * author.


### PR DESCRIPTION
## Summary

Collapses `useReceivedEndorsements` (profile page + `/endorsements`) from an N-round-trip PDS fan-out to one indexer GraphQL query. Resolves the slow-load complaint on both surfaces.

**Blocking dependency**: do not merge until magic-indexer [PR #78](https://github.com/hb-agent/magic-indexer/pull/78) is merged and deployed. Without #78, the indexer's `subject` filter misses 70% of records (the `{did: "..."}` object shape), and this PR would return strictly fewer results than the current scan.

## Before / after

**Before** (current):
1. Indexer: `appCertifiedActorProfile` to list every certified user.
2. PDS: `listAwards(issuerDid)` for **every** certified user (~14 today, growing linearly). Bulk of the latency.
3. PDS: `listDefinitions(issuerDid)` for each issuer with a candidate match.
4. PDS: `listResponses(profileDid)` on the profile owner for response-state filter.

**After**:
1. Indexer: `appCertifiedBadgeAward(where: { subject: { eq: profileDid } })`.
2. PDS: `listDefinitions(issuerDid)` for each **unique** issuer in the result (K = 0-2 for a typical profile).
3. PDS: `listResponses(profileDid)` — unchanged.

The indexer fan-out (step 1) goes from N round-trips to 1.

## Wrinkle: stringified `badge` field

The indexer currently returns the `badge` strongRef as a stringified Go map literal: `"map[cid:bafy... uri:at://.../app.certified.badge.definition/...]"`. A tiny `extractBadgeDefinitionUri` helper uses a regex to pull out the URI for the definition lookup. If the indexer's serialization is fixed later, the helper transparently handles the structured JSON case too. Out-of-scope to fix the indexer's `badge` serialization in this PR.

## Removed

`awardSubjectMatchesDid` — no remaining consumers after this PR. It had its own bug anyway: it only recognised bare-string + strongRef subject shapes, not the `defs#did` `{did: "..."}` object shape that 70% of production records use. Better gone than wrong.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` — no new errors (28 pre-existing warnings unchanged).
- [ ] CI green.
- [ ] **After #78 deploys**, manual smoke on staging:
  - Visit `/endorsements` on a profile with known endorsements. Load completes in <1s (vs ~3-10s today).
  - Visit a public profile that received an endorsement written in the `defs#did` shape. Endorsement appears (today it's silently dropped by `awardSubjectMatchesDid`).
  - Visit a profile that received a strongRef-shape endorsement. Still appears.
  - Hide an endorsement, then refresh. Stays hidden (response-state filter still works).

## Out of scope

- Indexer's `badge` field serialization fix (separate concern; PR-able when the indexer team prioritises it).
- Server-side response-state join. Today we still fetch the owner's responses from their PDS and filter client-side; that's the right shape (responses on the owner's repo, only owner is authorised to read them efficiently).

## Rollback

Single revert restores the PDS fan-out scan. The replaced function is self-contained; module cache, stale time, focus-revalidate, hook contract are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)