### PR TITLE
feat(endorsements): lists are org.hypercerts.collection records

### DIFF
--- a/docs/lists-as-collections/discovery.md
+++ b/docs/lists-as-collections/discovery.md
@@ -1,0 +1,82 @@
+# Lists-as-collections — discovery
+
+Snapshot of how endorsement lists are implemented today, what `org.hypercerts.collection` already does in this repo, and what the migration touches. Speculative architecture lives in `plan.md`; this file is just observations.
+
+## Current model (Option A)
+
+A "list" is an `app.certified.badge.definition` record on the owner's PDS with:
+
+- `badgeType === "endorsement"`
+- `title !== "Endorsement"` (the reserved default — that's the auto-created shell behind the Received/Given panels)
+- optional `description`
+
+An "endorsement in list X" is an `app.certified.badge.award` record on the same PDS whose `badge` strongRef points at list X's definition URI.
+
+Three coupled lexicons:
+
+| Collection | Role |
+| --- | --- |
+| `app.certified.badge.definition` | Defines a badge type. One per user is the default endorsement def; additional ones are lists. |
+| `app.certified.badge.award` | An award from issuer → subject, referencing a definition via `badge.{uri, cid}`. |
+| `app.certified.badge.response` | Recipient accept/reject lever, references the award via `badgeAward.{uri, cid}`. Unchanged in scope of this migration. |
+
+### Code map
+
+**Service layer** (`src/lib/atproto/badges.ts`, 940 lines)
+
+- Constants: `BADGE_DEFINITION_COLLECTION`, `BADGE_AWARD_COLLECTION`, `BADGE_RESPONSE_COLLECTION`, `ENDORSEMENT_BADGE_TYPE = "endorsement"`, `ENDORSEMENT_BADGE_TITLE = "Endorsement"`.
+- `listDefinitions(did)` — PDS `listRecords` over `badge.definition`.
+- `ensureEndorsementDefinition(did)` — idempotent find-or-create of the default endorsement def. Web-Lock + dedupe-on-read against same-account double-create.
+- `createListDefinition(title, description)` — write a custom def with `badgeType: "endorsement"` and the given title; rejects the reserved `"Endorsement"` title.
+- `updateListDefinition(rkey, createdAt, title, description)` — round-trip overwrite preserving rkey + createdAt.
+- `deleteListAndAwards(listRkey, awardRkeys[])` — sequential delete of awards then the def. Awards first so an interrupted run never orphans them under a missing def.
+- `createEndorsementAward(subjectDid, note)` — default-def award.
+- `createListAward(subjectDid, badgeRef)` — list-def award. No `note` accepted (the list itself is the reason).
+- `listAwards(did)`, `listResponses(did)`, `resolveResponseState(...)` — read paths.
+
+**Hooks**
+
+- `src/hooks/use-endorsement-lists.ts` — owner/visitor view of every list on a DID. Fetches `listDefinitions` + `listAwards` in parallel, filters defs to the `endorsement` badgeType & non-reserved title, groups awards by `badge.uri`. Exposes `createList`, `updateList`, `deleteList` (owner-only). 5-minute in-memory cache keyed by DID.
+- `src/hooks/use-endorsements.ts` (Given panel) — fetches the viewer's awards, joins each award's `badge.uri` to a definition title, decorates with `listTitle` when the def is a non-default list.
+- `src/hooks/use-received-endorsements.ts` — magic-indexer GraphQL backed; pulls `appCertifiedBadgeAward` rows targeting `profileDid` and resolves definitions via `appCertifiedBadgeDefinition` to filter on `badgeType === "endorsement"`.
+
+**UI**
+
+- `src/components/profile/endorsement-lists.tsx` — master/detail UI for owner lists; create/edit/delete modals; "Add people" entry to the modal below.
+- `src/components/profile/endorse-people-modal.tsx` — reused for default endorsements (`createEndorsementAward`) and per-list adds (`createListAward`).
+- `src/components/profile/profile-endorsements.tsx` — tab orchestrator. Lists section is owner-only.
+- `src/components/profile/profile-overview.tsx`, `profile-sidebar.tsx` — touch the Given/Received hooks but don't see list metadata directly.
+
+**Server**
+
+- `src/app/api/xrpc/[...method]/route.ts` — `ALLOWED_WRITE_COLLECTIONS` includes `badge.definition`, `badge.award`, `badge.response`. Rate-limit scope `endorsement-issue` maps to `badge.award`.
+- `src/app/api/indexer/route.ts` — server-held GraphQL queries:
+  - `ReceivedEndorsements` — `appCertifiedBadgeAward` filtered by `subject == profileDid`.
+  - `EndorsementDefs` — `appCertifiedBadgeDefinition` batched by issuer DID, filtered to `badgeType == "endorsement"`. Used to resolve award → list title.
+  - Variants for counts.
+- `src/lib/auth/rate-limit.ts` — `RATE_LIMITED_WRITE_COLLECTIONS: { "app.certified.badge.award": "endorsement-issue" }`.
+
+## What `org.hypercerts.collection` already does
+
+Used in production today for **projects**.
+
+- `src/lib/atproto/collection.ts` exposes a loose `CollectionValue` and `fetchCollections(did)` (PDS-side `listRecords`).
+- `src/lib/atproto/project.ts` writes/updates a project record (dual-path: own-DID via XRPC, group-owned via BFF).
+- The BFF route `src/app/api/groups/[groupDid]/project/route.ts` defines the field allowlist, server-pins `createdAt` and `type`, and validates `items` as `{itemIdentifier: {uri, cid}, ...}[]`.
+- Discriminator: project records have `type === "project"`. The Projects tab filters on that.
+- `items[i].itemIdentifier` is a strongRef. Other fields per item are allowed and passed through.
+- `org.hypercerts.collection` is already in `ALLOWED_WRITE_COLLECTIONS` (implicitly — actually the proxy currently does NOT list it; see "Open questions").
+
+## Open questions
+
+1. **Is `org.hypercerts.collection` in `ALLOWED_WRITE_COLLECTIONS`?** A grep on the route file shows badge collections but not the hypercerts one. The project flow uses a separate BFF route for group-owned writes; for own-DID project writes the proxy must allowlist it. Verify or add in implementation.
+2. **`items` shape for lists.** Projects use `{itemIdentifier: {uri, cid}}`. Awards live on the issuer's own PDS, so all award URIs are well-formed strongRefs — the same shape fits. Need to confirm with the canonical lexicon whether `org.hypercerts.collection` accepts a heterogeneous mix of items or imposes an item-type constraint.
+3. **`type` value for lists.** Has to disambiguate from `"project"`. Candidate: `"endorsement-list"`. Confirm in plan review.
+4. **Migration of existing data.** No backfill is the simplest stance; the magic-indexer + UI need to keep reading the old shape during a transition window, OR we drop legacy lists on the floor. Decided in plan, not here.
+5. **`items` ordering.** PDS preserves array order on round-trip; that gives us "newest at the top" semantics by client convention. Same as projects.
+
+## Out of scope (this discovery only)
+
+- `badge.response` flow.
+- `temp.graph.endorsement` lexicon (placeholder, not in the write path).
+- Indexer schema changes — the indexer already speaks `orgHypercertsCollection` (it's the source of the `projects` tab), so list reads can land without a coordinated indexer ship.

--- a/docs/lists-as-collections/plan.md
+++ b/docs/lists-as-collections/plan.md
@@ -1,0 +1,185 @@
+# Lists-as-collections — plan
+
+Migrate endorsement lists from "one `app.certified.badge.definition` per list" to "one `org.hypercerts.collection` record per list, owning a curated `items` array of award strongRefs." All awards continue to point at a single per-issuer default `badge.definition`; lists become a curation overlay rather than a badge sub-type.
+
+Branch: `feat/lists-as-collections` off `feat/positioning-redesign`. Draft PR opens into `feat/positioning-redesign`.
+
+## Why
+
+See `discovery.md` and the user-facing pros/cons summary in the chat session — short version:
+
+- Schema proliferation: every new list is a published lexicon-shaped record today; moving to a generic collection means one schema for all lists.
+- Cross-list queries become trivial — the indexer already speaks `orgHypercertsCollection` (Projects tab uses it).
+- Lists become composable curation, decoupled from badge identity. Deleting a list does not delete endorsements.
+- The user has explicitly asked for Option B: lists as `org.hypercerts.collection` records, all endorsements sharing one badge definition.
+
+## Target architecture
+
+### Three actors, three records
+
+1. **One `app.certified.badge.definition` per issuer.** The existing default (auto-created via `ensureEndorsementDefinition`) with `badgeType: "endorsement"` and `title: "Endorsement"`. No more user-created list-defs.
+2. **`app.certified.badge.award` for every endorsement.** Subject DID + `note` unchanged. The `badge` strongRef always points at the issuer's single default def.
+3. **`org.hypercerts.collection` per list.** New record shape:
+    ```jsonc
+    {
+      "$type": "org.hypercerts.collection",
+      "type": "endorsement-list",
+      "title": "Frontend mentors",
+      "description": "...optional...",
+      "createdAt": "2026-05-20T...",
+      "items": [
+        {
+          "itemIdentifier": {
+            "uri": "at://did:plc:.../app.certified.badge.award/<rkey>",
+            "cid": "..."
+          },
+          "addedAt": "2026-05-20T..."
+        }
+      ]
+    }
+    ```
+   - `type: "endorsement-list"` disambiguates from projects (`type: "project"`).
+   - `items[i].itemIdentifier` is a strongRef to an award (same shape as project items strongRef to certs).
+   - `items[i].addedAt` is optional metadata; client preserves on round-trip.
+   - All awards on a list are owned by the same issuer, so all item URIs share the issuer's DID — same PDS as the collection record.
+
+### Lifecycle
+
+- **Create list:** write a new `org.hypercerts.collection` with `type: "endorsement-list"`, `title`, `description`, empty `items`.
+- **Add subject to list:** ensure-default-def → ensure award exists for subject (create if absent) → read collection → append item → write collection.
+- **Remove subject from list:** read collection → drop item → write collection. Award is not deleted.
+- **Edit list metadata:** read collection → splice title/description → write back (server-pins `createdAt`, `type`).
+- **Delete list:** delete collection record. Awards survive.
+- **Default endorsements panel:** unchanged — the existing default-def + award flow already works without lists.
+
+## Files
+
+### Service layer
+
+- `src/lib/atproto/collection.ts` — extend with:
+  - `LIST_TYPE = "endorsement-list"` constant.
+  - `EndorsementListCollectionValue` type narrowing `CollectionValue` to the list shape.
+  - `listEndorsementListCollections(did, signal?, opts?)` — fetch `org.hypercerts.collection` records, filter `type === "endorsement-list"`. Reuses the existing `fetchCollections` helper.
+  - `createEndorsementListCollection(ownDid, {title, description})`, `updateEndorsementListCollection(ownDid, rkey, {title, description, items, existingCreatedAt})`, `deleteEndorsementListCollection(ownDid, rkey)`, `appendItemToList(ownDid, rkey, existing, awardRef)`, `removeItemFromList(ownDid, rkey, existing, awardUri)`. All go through `/api/xrpc/com/atproto/repo/createRecord`, `putRecord`, `deleteRecord` (own-DID path only; lists are personal, no group flow for v1).
+  - `purgeAwardFromLists(ownDid, awardUri)` — iterates the owner's lists and removes items whose `itemIdentifier.uri === awardUri`. Called from `deleteEndorsementAward` to keep lists consistent.
+- `src/lib/atproto/badges.ts` — remove the list-via-definition surface area:
+  - Remove `createListDefinition`, `updateListDefinition`, `deleteListAndAwards`, `createListAward`.
+  - `ensureEndorsementDefinition` stays — it's the one definition every award still points at.
+  - `createEndorsementAward` stays unchanged.
+  - `deleteEndorsementAward` extended to call `purgeAwardFromLists` (in `collection.ts`) before the actual award delete, so a revoke from the Given panel doesn't leave ghost rows on the issuer's lists.
+  - Keep response helpers untouched.
+- `src/app/api/xrpc/[...method]/route.ts` — **no change.** `"org.hypercerts.collection"` is already in `ALLOWED_WRITE_COLLECTIONS` (used by the projects flow). Verified during review-round-1.
+- `src/lib/auth/rate-limit.ts` — `RATE_LIMITED_WRITE_COLLECTIONS`:
+  - Keep `"app.certified.badge.award" → "endorsement-issue"`.
+  - Add `"org.hypercerts.collection" → "endorsement-list-write"` (new scope, conservative limit: 30/hour, 100/day). Reason: prevents abuse via mass list creation.
+
+### Hooks
+
+- `src/hooks/use-endorsement-lists.ts` — full refactor:
+  - Replace `listDefinitions`/`listAwards` parallel call with `listEndorsementListCollections` + `listAwards`.
+  - Group: for each list collection, resolve `items[i].itemIdentifier.uri` to an award record (lookup in the fetched awards array by URI). **Items that don't resolve are dropped silently — orphan items render nothing and re-fetches don't carry them forward.** (Possible causes: an award was revoked elsewhere, or a foreign-PDS race.)
+  - `createList(title, description)` calls `createEndorsementListCollection`.
+  - `updateList(rkey, title, description)` calls `updateEndorsementListCollection`.
+  - `deleteList(rkey)` calls `deleteEndorsementListCollection`. Returns `void` (awards survive; old `{deletedAwards}` shape is dropped — only consumer is `endorsement-lists.tsx:217` which discards the value).
+  - Add `addSubjectToList(rkey, subjectDid)`: dedupe (skip if already in the list) → ensure-award (`createEndorsementAward`, which is idempotent at the def level and creates a fresh award even if one exists already — that's existing behaviour, do not change in this PR) → read collection → append item → put. Optimistic UI.
+  - Add `removeSubjectFromList(rkey, awardUri)`: read collection → drop item by `itemIdentifier.uri` match → put. Optimistic UI. Does NOT delete the underlying award.
+  - 5-minute cache preserved.
+
+- `src/hooks/use-endorsements.ts` — Given panel:
+  - Drop the per-award `listTitle` POPULATION (awards no longer belong to one list). The `listTitle?: string` field on `GivenEndorsement` stays for prop-shape continuity with `PersonCard.listTitle?` (avoids touching `profile-endorsements.tsx`), but is always `undefined` after this PR.
+  - Multi-list chip rendering on Given panel is deliberately deferred — see "Out of scope." `profile-endorsements.tsx` is NOT touched.
+
+- `src/hooks/use-received-endorsements.ts` — Received panel:
+  - Unchanged in scope. The indexer query for awards targeting `profileDid` doesn't need the def-title join anymore — every award is the canonical endorsement def. The `EndorsementDefs` join can become a no-op (drop in a follow-up; for v1 keep the join but treat the def as decorative).
+
+### UI
+
+- `src/components/profile/endorsement-lists.tsx` — minimal change:
+  - Field names and the renderer largely unchanged (still `lists[i].title`, `description`, `items`).
+  - "Add people" still routes through `endorse-people-modal`, but on `onEndorse(subjectDid)` calls `addSubjectToList(rkey, subjectDid)` instead of `createListAward(subjectDid, badgeRef)`.
+  - **Copy fix — list delete confirm:** "Delete this list? Your endorsements are not removed." (today the copy implies awards get removed too).
+  - **Copy fix — `RevokeListItemButton` (lines 822-823 today):** today asserts award deletion. Replace with "Remove from list? Their endorsement from you stays — only the list membership is removed."
+  - Empty-state copy unchanged.
+- `src/components/profile/endorse-people-modal.tsx` — minimal change:
+  - The shared modal already takes an `onEndorse` callback; lists pass `addSubjectToList`. No structural change.
+  - Add an optional `subtitle` prop (or context-aware copy) so that when the modal is opened from a list it reads "They'll be endorsed (if not already) and added to '<list-title>'." Default flow (not from a list) keeps existing copy.
+- `src/components/profile/profile-endorsements.tsx` — no change.
+- `src/components/profile/profile-overview.tsx`, `profile-sidebar.tsx` — no change.
+
+### Indexer / API routes
+
+- `src/app/api/indexer/route.ts` — `EndorsementDefs` query stays for the Received panel decoration (or, optionally, drop it as a follow-up — out of scope here). No new server-held query in v1; lists are read from PDS only.
+
+### Tests
+
+- `tests/atproto/collection.test.ts` (new) — unit-test the collection helpers (build the record, append item, remove item).
+- `tests/atproto/badges.test.ts` (if a useful seam) — touch only the removed-function call sites to confirm imports compile.
+- No e2e tests are added in v1.
+
+## Acceptance criteria
+
+1. **Owner can create a list.** Title + optional description → record appears on PDS as `org.hypercerts.collection` with `type: "endorsement-list"` and empty `items`. Lists tab shows the new list immediately.
+2. **Owner can add a subject to a list.** The subject receives an award (if not already endorsed) AND the collection's items grows by 1. Refresh shows persisted state. Re-adding the same subject is a no-op (no double-award, no double-item).
+3. **Owner can remove a subject from a list.** Items shrinks by 1; the award is NOT deleted (verified by reloading the Given panel).
+4. **Owner can edit a list's title / description.** Round-trip persists.
+5. **Owner can delete a list.** Collection record gone; awards survive.
+6. **Visitor can view someone's lists.** Public read works without auth (PDS `listRecords` is public).
+7. **`type: "project"` collections are not surfaced in the Lists tab.** And `type: "endorsement-list"` collections are not surfaced in the Projects tab.
+8. **No regression** on default endorsements (Received / Given panels still work, Endorse button on profile-sidebar still issues an award against the default def).
+9. **Type-check** clean (no new tsc errors above baseline). **Lint** clean. **Build** succeeds.
+
+## Migration / backward compat
+
+V1 stance: **no backfill, no legacy reads.**
+
+Existing test/staging PDSes may have old per-list `badge.definition` records. After this PR ships:
+
+- The Lists tab will not surface them (the read path queries `org.hypercerts.collection` only).
+- They become invisible orphans on the PDS. Awards that referenced them stay valid as awards (subject + note + createdAt all intact), and the Given panel still renders them as "endorsement of <subject>" without a list label.
+- A follow-up PR can run a one-shot migration if real users have non-trivial list data. Out of scope for this PR.
+
+Documented in PR body and DESIGN.md (one-paragraph note).
+
+## Out of scope
+
+- Indexer schema changes — no new GraphQL ops in v1. Lists are PDS-read only. The existing `orgHypercertsCollection` GraphQL surface only powers the Projects counts query and is not extended here.
+- Group-owned endorsement lists (mirror of the project group-write path).
+- Backfill of legacy `badge.definition`-shaped lists. After this PR, old lists become invisible on the Lists tab; the underlying awards continue to render in Given/Received unchanged.
+- Dropping the `EndorsementDefs` indexer join.
+- Changing the `badge.response` accept/reject flow.
+- Renaming or restyling list UI past the two confirm-copy fixes and the modal-subtitle hint.
+- Multi-list chip rendering on the Given panel. `listTitle` is no longer populated; multi-list display is a follow-up once chip-row UX is designed.
+- Additional "to unendorse, use the Given panel" affordance — the corrected `RevokeListItemButton` copy already disambiguates; revisit only if user confusion surfaces.
+- Removing the `app.certified.badge.definition` collection from the XRPC allowlist (still needed for the default def).
+- Cleaning up the `temp.graph.endorsement` lexicon shell (unrelated).
+- Cross-issuer "follow this list" semantics.
+
+## Rollback
+
+- Single PR, reverts cleanly if needed — the new collection-based code path is additive at the service layer; the legacy badge-def list code is removed but recoverable from the diff.
+- If a regression ships to staging, revert the PR. Production data: any `org.hypercerts.collection` records written under `type: "endorsement-list"` are orphaned but harmless (the Projects tab filters on `type === "project"`, not `!= "endorsement-list"`).
+- Awards written between rollout and rollback survive — they're still default-def endorsements.
+
+## Implementation tracks (disjoint file ownership)
+
+Single-author work (this is a tightly coupled refactor; parallel tracks risk merge conflicts). Sequence:
+
+1. Service layer: extend `collection.ts`; trim `badges.ts`; update `xrpc/[...method]/route.ts` and `rate-limit.ts`.
+2. Hook layer: rewrite `use-endorsement-lists.ts`; touch `use-endorsements.ts`.
+3. UI layer: rewire `endorsement-lists.tsx`'s create/add/delete callbacks; update delete-confirm copy.
+4. Tests: unit tests for `collection.ts` helpers.
+
+## Review plan
+
+**Round 1 (plan review).** Three reviewers:
+
+- Spec/lexicon correctness — does the `org.hypercerts.collection` `items` shape with award strongRefs match the canonical lexicon? Will the magic-indexer parse it?
+- Build/typing — is the hook surface (`addSubjectToList`, `removeSubjectFromList`) shaped sensibly given how components consume it today? Any breaking type signatures we missed?
+- UX impact — does the new "delete list ≠ delete endorsements" semantics need additional UI signposting beyond a confirm-copy tweak?
+
+Decisions logged in `docs/lists-as-collections/review-round-1.md` before implementing.
+
+**Round 2 (impl review).** Two reviewers on the diff:
+
+- Functional correctness — does add/remove/edit/delete actually round-trip via PDS, no lost-update on items[].
+- Code quality + smoke test — type cleanliness, error handling at the optimistic edges, dev-server smoke (create/edit/delete a list end-to-end).

--- a/docs/lists-as-collections/plan.md
+++ b/docs/lists-as-collections/plan.md
@@ -69,9 +69,7 @@ See `discovery.md` and the user-facing pros/cons summary in the chat session —
   - `deleteEndorsementAward` extended to call `purgeAwardFromLists` (in `collection.ts`) before the actual award delete, so a revoke from the Given panel doesn't leave ghost rows on the issuer's lists.
   - Keep response helpers untouched.
 - `src/app/api/xrpc/[...method]/route.ts` — **no change.** `"org.hypercerts.collection"` is already in `ALLOWED_WRITE_COLLECTIONS` (used by the projects flow). Verified during review-round-1.
-- `src/lib/auth/rate-limit.ts` — `RATE_LIMITED_WRITE_COLLECTIONS`:
-  - Keep `"app.certified.badge.award" → "endorsement-issue"`.
-  - Add `"org.hypercerts.collection" → "endorsement-list-write"` (new scope, conservative limit: 30/hour, 100/day). Reason: prevents abuse via mass list creation.
+- `src/lib/auth/rate-limit.ts` — **no change.** The original plan added `"org.hypercerts.collection" → "endorsement-list-write"` to `RATE_LIMITED_WRITE_COLLECTIONS`, but that map keys on collection NSID, not on the `type` discriminator — adding it would silently rate-limit project writes too. Lists ride on the same un-rate-limited path as projects do today. If abuse becomes a concern, a follow-up can add a per-`type` layer.
 
 ### Hooks
 

--- a/docs/lists-as-collections/review-round-1.md
+++ b/docs/lists-as-collections/review-round-1.md
@@ -1,0 +1,61 @@
+# Plan review — round 1
+
+Three parallel reviewers: lexicon correctness, build/typing surface, UX impact. All returned YELLOW. Findings below are integrated into `plan.md` v2 unless marked Rejected.
+
+## Accepted
+
+| # | Source | Finding | Resolution |
+| --- | --- | --- | --- |
+| A1 | lexicon | `org.hypercerts.collection` is **already** in `ALLOWED_WRITE_COLLECTIONS` (`xrpc/[...method]/route.ts:48`). Plan's "add if missing" wording is misleading. | Plan updated: "already present, no XRPC route change needed." |
+| A2 | lexicon | Indexer support for `orgHypercertsCollection` exists ONLY for the Projects counts query. There's no `Lists` GraphQL op. | Plan updated: explicit "no indexer-side list query in v1; lists are PDS-read only." |
+| A3 | typing | `profile-endorsements.tsx` reads `endorsement.listTitle` and passes it to `<PersonCard listTitle?: string>`. NOT in the original plan's file list. | Plan updated to drop list-decoration on Given panel for v1 (simpler than `lists: string[]` overload). `listTitle?` field stays on `GivenEndorsement` for prop-shape continuity but is always `undefined` post-PR. Future follow-up can repopulate as `lists: string[]` once chip-row UX is designed. `profile-endorsements.tsx` stays untouched. |
+| A4 | typing + UX | Orphan-item rule: when collection `items[i].itemIdentifier.uri` doesn't resolve to a fetched award (revoked endorsement, foreign-PDS race), the item must not render. Inverse: when an award is revoked from the Given panel, every list that referenced it must drop that item or the next read renders ghost rows. | Plan updated: (a) read-side: skip unresolved items silently; (b) write-side: `deleteEndorsementAward` now scans the issuer's lists and removes matching items before deleting the award. Optimistic UI in the Given panel mirrors the change. |
+| A5 | UX | `RevokeListItemButton` confirm copy at `endorsement-lists.tsx:822-823` currently asserts award deletion. Now FALSE under the new model. | Plan updated: confirm copy becomes "Remove from list? Their endorsement from you stays — only the list membership is removed." |
+| A6 | UX | `EndorsePeopleModal` subtitle when used from a list should make the "endorse + add" dual action explicit. | Plan updated: when the modal is opened from a list, subtitle becomes "They'll be endorsed (if not already) and added to '<list-title>'." Default flow (not from a list) keeps existing copy. |
+| A7 | UX | "List delete" confirm copy clarification. | Already in v1 plan ("Your endorsements are not removed"). No additional change. |
+
+## Accepted-with-modification
+
+| # | Source | Finding | Resolution |
+| --- | --- | --- | --- |
+| M1 | UX | UX review asked for an additional "To unendorse, use the × on the Given panel" affordance somewhere in the list-detail view. | Deferred. The corrected `RevokeListItemButton` copy already says "endorsement stays"; a second hint risks copy noise. If user confusion shows up post-ship, add a small hint at the list-detail header in a follow-up. Noted in plan §"Out of scope". |
+| M2 | UX | UX review asked for multi-list chips spec on the Given panel. | Resolved by A3 (drop list-decoration on Given panel for v1). No chip-row work in this PR. |
+
+## Rejected
+
+| # | Source | Finding | Reason |
+| --- | --- | --- | --- |
+| R1 | typing | Reviewer suggested keeping `deletedAwards: number` on `deleteList` return for API compat. | Clean break is fine — the field has no external consumer and lying about "0 awards deleted" reinforces stale semantics. Return type drops to `void`. |
+
+## Updated file list
+
+Final files touched by this PR (`plan.md` updated to match):
+
+**Service layer**
+- `src/lib/atproto/collection.ts` — extend with list helpers + narrowed `EndorsementListCollectionValue` type.
+- `src/lib/atproto/badges.ts` — remove `createListDefinition`, `updateListDefinition`, `deleteListAndAwards`, `createListAward`. Add cross-list cleanup hook in `deleteEndorsementAward` (or expose a `purgeAwardFromLists` helper called alongside).
+
+**Hooks**
+- `src/hooks/use-endorsement-lists.ts` — full refactor.
+- `src/hooks/use-endorsements.ts` — drop `listTitle` population; type field stays for prop shape.
+
+**UI**
+- `src/components/profile/endorsement-lists.tsx` — rewire create/add/remove/delete; copy fixes for delete + revoke-item.
+- `src/components/profile/endorse-people-modal.tsx` — subtitle prop accepting per-context copy override (default vs. from-a-list).
+
+**Server**
+- *No* server changes — XRPC allowlist already covers `org.hypercerts.collection` (A1).
+- `src/lib/auth/rate-limit.ts` — add `"org.hypercerts.collection" → "endorsement-list-write"` (new scope, 30/hour, 100/day).
+
+**Tests**
+- `tests/atproto/collection.test.ts` (new) — unit tests for collection helpers.
+
+**Not touched** (explicitly out of scope this PR):
+- `src/components/profile/profile-endorsements.tsx` (per A3).
+- `src/app/api/indexer/route.ts` (per A2).
+- `src/app/api/xrpc/[...method]/route.ts` (per A1).
+- `src/hooks/use-received-endorsements.ts`.
+
+## Verdict
+
+GREEN after the above modifications land in `plan.md`. Proceed to implementation.

--- a/docs/lists-as-collections/review-round-2.md
+++ b/docs/lists-as-collections/review-round-2.md
@@ -1,0 +1,31 @@
+# Impl review — round 2
+
+Two parallel reviewers: functional correctness on the new write paths, and code-quality + smoke. Findings below are integrated into the implementation in a follow-up commit unless marked Rejected.
+
+## Accepted (HARD)
+
+| # | Source | Finding | Resolution |
+| --- | --- | --- | --- |
+| H1 | correctness | **Race-double-add creates duplicate awards.** `addSubjectToList` calls `createEndorsementAward` unconditionally (TID-keyed creates), then `appendItemToList` dedupes on award URI. If the modal's `alreadyEndorsedDids` set races (concurrent same-tab clicks; cross-tab adds), the second call mints a fresh award URI that the dedupe can't catch — the same subject appears twice in the list with two distinct awards. Plan acceptance #2 ("Re-adding the same subject is a no-op") doesn't hold. | Reviewed option (a) — short-circuit before the award create when the list's existing items already include an award for that subject. Cheaper than an inflight Map and also closes the cross-tab race the Map can't help with. Fix applied in `addSubjectToList`. |
+| H2 | code-quality | Stale comment in `src/components/profile/endorsement-lists.tsx:86-89` claims awards land under "THIS list" — wrong under the new model. | Rewritten. |
+| H3 | code-quality | Stale reference to deleted `updateListDefinition` in `src/lib/atproto/badges.ts` JSDoc. | Removed. |
+| H4 | code-quality | Stale reference to deleted `createListAward` in `src/lib/atproto/badges.ts` `writeBadgeAward` JSDoc. | Reworded to describe the surviving callers only. |
+| H5 | code-quality | Stale reference to deleted `createListAward` in `src/components/profile/endorse-people-modal.tsx:37`. | Reworded. |
+
+## Accepted (would-be-nice)
+
+| # | Source | Finding | Resolution |
+| --- | --- | --- | --- |
+| W1 | code-quality | Test gap: no assertion that `updateEndorsementListCollection` preserves `items[]` and `createdAt` across a metadata-only update. The most likely future regression (someone trims the spread). | Added a test. |
+
+## Rejected
+
+| # | Source | Finding | Reason |
+| --- | --- | --- | --- |
+| R1 | code-quality | Add tests for `purgeAwardFromLists` swallowing per-list errors and `appendItemToList` throwing on a deleted list. | Behaviour is documented and the code paths are straightforward (try/catch around `removeItemFromList`; `if (!existing) throw`). The marginal coverage cost a small failure surface that's well-isolated to one helper each. Worth adding if a regression actually appears. |
+| R2 | code-quality | Strip the two banner-comment dividers (`// ---` lines) in `collection.ts` and `endorsement-lists.tsx`. | Section dividers in long files aid navigation; CLAUDE.md's "no comments unless WHY non-obvious" rule targets inline why-comments. Keeping. |
+| R3 | correctness | Compensate the orphan-award scenario in Scenario 1 (create award succeeds, collection put fails). | Recoverable manually via the Given panel; adding a compensating delete would itself fail and double the surface area. Documented behaviour per plan §"Lifecycle" + §"Migration / backward compat" implies-no-cleanup; the orphan-item read-path drop makes the orphan invisible on the lists side already. |
+
+## Verdict
+
+GREEN to ship after H1–H5 and W1 land.

--- a/src/components/profile/endorse-people-modal.tsx
+++ b/src/components/profile/endorse-people-modal.tsx
@@ -34,9 +34,9 @@ interface EndorsePeopleModalProps {
    * Per-row write callback. Called once per selected DID inside the
    * confirm loop. The default endorsements path uses this to issue a
    * regular `createEndorsementAward`; the list-detail "+ Add people"
-   * flow uses this to issue a `createListAward` against the list's
-   * own badge ref. Anything that throws marks the row as failed but
-   * doesn't break the rest of the batch.
+   * flow uses this to ensure-endorse + append the new award to the
+   * list's collection record. Anything that throws marks the row as
+   * failed but doesn't break the rest of the batch.
    */
   readonly onEndorse: (subjectDid: string, note?: string) => Promise<unknown>
   /** Modal header text. Defaults to "Endorse people". */

--- a/src/components/profile/endorsement-lists.tsx
+++ b/src/components/profile/endorsement-lists.tsx
@@ -83,10 +83,10 @@ export default function EndorsementLists({
   } = useEndorsementLists(did)
   const { did: viewerDid } = useAuth()
   const [selectedListUri, setSelectedListUri] = useState<string | null>(null)
-  // `+` button on the list-detail toolbar opens the same modal we
-  // use for issuing regular endorsements, just bound to the list's
-  // own badge ref so awards land under THIS list instead of the
-  // user's default "Endorsement" definition.
+  // `+` button on the list-detail toolbar reuses the regular
+  // endorsement modal. On confirm each subject gets a default-def
+  // endorsement award (idempotency guard in `addSubjectToList`) plus
+  // a strong-ref entry in the list's collection record.
   const [isAddingPeople, setIsAddingPeople] = useState(false)
   const [sort, setSort] = useState<SortKey>("created-desc")
   const [sortOpen, setSortOpen] = useState(false)

--- a/src/components/profile/endorsement-lists.tsx
+++ b/src/components/profile/endorsement-lists.tsx
@@ -33,11 +33,7 @@ import { useAuth } from "@/lib/auth/auth-context"
 import { useAuthorInfo } from "@/hooks/use-author-info"
 import { formatShortDate } from "@/lib/utils/format-date"
 import { getInitials } from "@/lib/utils/initials"
-import {
-  createListAward,
-  deleteEndorsementAward,
-  extractAwardSubjectDid,
-} from "@/lib/atproto/badges"
+import { extractAwardSubjectDid } from "@/lib/atproto/badges"
 
 interface EndorsementListsProps {
   /** DID of the profile being viewed. */
@@ -74,8 +70,17 @@ export default function EndorsementLists({
   did,
   viewerIsOwner,
 }: EndorsementListsProps) {
-  const { lists, isLoading, error, refetch, createList, updateList, deleteList } =
-    useEndorsementLists(did)
+  const {
+    lists,
+    isLoading,
+    error,
+    refetch,
+    createList,
+    updateList,
+    deleteList,
+    addSubjectToList,
+    removeSubjectFromList,
+  } = useEndorsementLists(did)
   const { did: viewerDid } = useAuth()
   const [selectedListUri, setSelectedListUri] = useState<string | null>(null)
   // `+` button on the list-detail toolbar opens the same modal we
@@ -155,27 +160,25 @@ export default function EndorsementLists({
             setDeleteError(null)
             setIsConfirmingDelete(true)
           }}
-          onAfterItemRevoke={() => refetch()}
+          onRemoveItem={(awardUri) =>
+            removeSubjectFromList(selectedList.rkey, awardUri)
+          }
         />
         {isAddingPeople && viewerIsOwner && viewerDid ? (
           <EndorsePeopleModal
             viewerDid={viewerDid}
             alreadyEndorsedDids={alreadyInList}
             onEndorse={(subjectDid) =>
-              createListAward(viewerDid, subjectDid, {
-                uri: selectedList.uri,
-                cid: selectedList.cid,
-              })
+              addSubjectToList(selectedList.rkey, subjectDid)
             }
             title="Add people to list"
-            subtitle={`They'll be added to "${selectedList.title}".`}
+            subtitle={`They'll be endorsed (if not already) and added to "${selectedList.title}".`}
             confirmActionLabel="Add"
             alreadyLabel="In list"
             onClose={() => setIsAddingPeople(false)}
             onCompleted={async () => {
-              // Refetch so the new awards appear under this list
-              // and the item count bumps. The modal closes itself
-              // on completion.
+              // Refetch so the new items appear under this list and
+              // the count bumps. The modal closes itself on completion.
               setIsAddingPeople(false)
               await refetch()
             }}
@@ -198,9 +201,9 @@ export default function EndorsementLists({
             title={`Delete "${selectedList.title}"?`}
             message={
               selectedList.items.length > 0
-                ? `This will permanently delete the list AND remove all ${selectedList.items.length} endorsement${
+                ? `This will permanently delete the list. The ${selectedList.items.length} endorsement${
                     selectedList.items.length === 1 ? "" : "s"
-                  } in it. The people you endorsed via this list will no longer show up as endorsed by you.`
+                  } from you stay${selectedList.items.length === 1 ? "s" : ""} — only the list membership goes away.`
                 : "This will permanently delete the list. It has no endorsements in it yet."
             }
             confirmLabel="Delete list"
@@ -432,9 +435,10 @@ interface ListDetailProps {
   onAdd: () => void
   onEdit: () => void
   onDelete: () => void
-  /** Fired after a per-item × revoke succeeds. Caller should refetch
-   *  so the deleted award row drops and the counter ticks down. */
-  onAfterItemRevoke: () => void | Promise<void>
+  /** Called when the viewer confirms the × on an item row. Removes
+   *  the item from the list's collection record; the underlying
+   *  endorsement award is NOT deleted. */
+  onRemoveItem: (awardUri: string) => Promise<unknown>
 }
 
 function ListDetail({
@@ -445,10 +449,9 @@ function ListDetail({
   onAdd,
   onEdit,
   onDelete,
-  onAfterItemRevoke,
+  onRemoveItem,
 }: ListDetailProps) {
   const canRevokeItems = canEdit
-  const onAfterRevoke = onAfterItemRevoke
   return (
     <>
       <header className="endorsement-lists__header endorsement-lists__header--detail">
@@ -528,10 +531,9 @@ function ListDetail({
                 revoke={
                   canRevokeItems && viewerDid
                     ? {
-                        viewerDid,
-                        rkey: award.rkey,
+                        awardUri: award.uri,
                         listTitle: list.title,
-                        onAfterRevoke,
+                        onRemove: () => onRemoveItem(award.uri),
                       }
                     : null
                 }
@@ -548,14 +550,14 @@ interface ListItemRowProps {
   subjectDid: string | null
   createdAt: string
   note?: string
-  /** Owner-only delete handle for the linked award. When set, the
-   *  row renders a × that confirms + deletes the award + invokes
-   *  `onAfterRevoke` so the list refetches and the row drops. */
+  /** Owner-only "remove from list" handle. When set, the row renders
+   *  a × that confirms + drops the item from the list's collection
+   *  record. The underlying endorsement award is NOT deleted — the
+   *  subject still appears in the Given panel. */
   revoke: {
-    viewerDid: string
-    rkey: string
+    awardUri: string
     listTitle: string
-    onAfterRevoke: () => void | Promise<void>
+    onRemove: () => Promise<unknown>
   } | null
 }
 
@@ -613,11 +615,9 @@ function ListItemRow({ subjectDid, createdAt, note, revoke }: ListItemRowProps) 
       )}
       {revoke ? (
         <RevokeListItemButton
-          viewerDid={revoke.viewerDid}
-          rkey={revoke.rkey}
           listTitle={revoke.listTitle}
           subjectDisplay={displayName}
-          onAfterRevoke={revoke.onAfterRevoke}
+          onRemove={revoke.onRemove}
         />
       ) : null}
     </li>
@@ -762,26 +762,23 @@ function CreateListModal({
   )
 }
 
-// --------------------- Revoke a single list item ---------------------
+// --------------------- Remove a single list item ---------------------
 
 /**
  * `×` rendered to the right of each list-item row when the viewer
- * owns the list. Confirms in a destructive dialog, then deletes the
- * underlying `app.certified.badge.award` record. Doesn't touch the
- * list's definition — only one award disappears.
+ * owns the list. Confirms in a destructive dialog, then drops the
+ * item from the list's `org.hypercerts.collection` record. The
+ * underlying endorsement award survives — the subject still appears
+ * in the issuer's Given panel.
  */
 function RevokeListItemButton({
-  viewerDid,
-  rkey,
   listTitle,
   subjectDisplay,
-  onAfterRevoke,
+  onRemove,
 }: {
-  viewerDid: string
-  rkey: string
   listTitle: string
   subjectDisplay: string
-  onAfterRevoke: () => void | Promise<void>
+  onRemove: () => Promise<unknown>
 }) {
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [isRevoking, setIsRevoking] = useState(false)
@@ -790,8 +787,7 @@ function RevokeListItemButton({
     if (isRevoking) return
     setIsRevoking(true)
     try {
-      await deleteEndorsementAward(viewerDid, rkey)
-      await onAfterRevoke()
+      await onRemove()
       setConfirmOpen(false)
     } catch (err) {
       console.error("Failed to remove list item:", err)
@@ -820,7 +816,7 @@ function RevokeListItemButton({
       {confirmOpen ? (
         <ConfirmDialog
           title={`Remove ${subjectDisplay} from "${listTitle}"?`}
-          message="The endorsement awarded under this list will be deleted. The person will no longer appear in the list."
+          message="Their endorsement from you stays — only the list membership is removed."
           confirmLabel="Remove"
           cancelLabel="Cancel"
           confirmVariant="destructive"

--- a/src/hooks/use-endorsement-lists.ts
+++ b/src/hooks/use-endorsement-lists.ts
@@ -2,29 +2,38 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
-  ENDORSEMENT_BADGE_TITLE,
-  ENDORSEMENT_BADGE_TYPE,
-  createListDefinition,
-  deleteListAndAwards,
   listAwards,
-  listDefinitions,
-  updateListDefinition,
+  createEndorsementAward,
   type BadgeAwardRecord,
 } from "@/lib/atproto/badges"
+import {
+  appendItemToList,
+  createEndorsementListCollection,
+  deleteEndorsementListCollection,
+  listEndorsementListCollections,
+  removeItemFromList,
+  updateEndorsementListCollection,
+} from "@/lib/atproto/collection"
 
 /**
- * One "list" on a profile's Endorsements tab — an
- * `app.certified.badge.definition` whose `badgeType` is
- * `"endorsement"` and whose `title` is NOT the reserved default
- * (`"Endorsement"`). The default def is the auto-created shell that
- * backs the Received/Given panels; everything else with the same
- * badgeType is a user-created list.
+ * One "list" on a profile's Endorsements tab.
  *
- * `items` is every `app.certified.badge.award` on the same repo
- * whose `badge` strongRef points at this list's URI. We resolve
- * those locally — one PDS `listAwards` call covers the whole repo,
- * and we group by `badge.uri` here. See companion magic-indexer
- * issue for the server-side count we'd ideally consume instead.
+ * Backed by a single `org.hypercerts.collection` record with
+ * `type === "endorsement-list"`. The collection's `items[]` holds
+ * strongRefs to `app.certified.badge.award` records on the same
+ * issuer's repo. `items` here is resolved client-side — for each
+ * `itemIdentifier.uri` we look up the matching award record from a
+ * single `listAwards` call covering the whole repo.
+ *
+ * Unresolved items (URI doesn't appear in the issuer's awards — most
+ * likely because the underlying endorsement was revoked elsewhere)
+ * are dropped silently so the UI never renders ghost rows.
+ *
+ * Awards survive list lifecycle now:
+ *   - Removing a subject from a list = `items[]` shrinks; award untouched.
+ *   - Deleting the list = the collection record is removed; awards stay.
+ *   - Revoking an award from the Given panel triggers
+ *     `purgeAwardFromLists` so all of the issuer's lists self-heal.
  */
 export interface EndorsementList {
   uri: string
@@ -45,23 +54,31 @@ const STALE_MS = 5 * 60 * 1000
 const cache = new Map<string, CacheEntry>()
 
 /**
- * Read every list (custom endorsement definition) on `did`'s repo
- * plus the awards that link to each, grouped together.
+ * Read every endorsement-list on `did`'s repo plus the awards that
+ * each list curates, resolved together.
  *
  * Fetch shape:
- *   1. PDS `listDefinitions` and `listAwards` in parallel — both
- *      live on the same repo, so two cheap round-trips.
- *   2. Client-side filter + group: drop the default `"Endorsement"`
- *      def; for the rest, attach awards whose `badge.uri` matches.
+ *   1. PDS `listEndorsementListCollections` and `listAwards` in
+ *      parallel — both live on the same repo.
+ *   2. Client-side resolve: for each list's `items[i].itemIdentifier.uri`,
+ *      look up the matching award. Drop items that don't resolve.
  *
  * Exposes:
- *   - `lists`        — newest first.
- *   - `isLoading`    — true while the initial fetch is in flight.
- *   - `error`        — non-null on PDS failure.
- *   - `refetch`      — bypass cache, force a fresh page-walk.
- *   - `createList`   — viewer-only helper. Writes a new list def,
- *                      then optimistically inserts it so the UI
- *                      doesn't wait on refetch.
+ *   - `lists`                — newest first by `createdAt`.
+ *   - `isLoading`            — true while the initial fetch is in flight.
+ *   - `error`                — non-null on PDS failure.
+ *   - `refetch`              — bypass cache, force a fresh fetch.
+ *   - `createList`           — owner-only. Writes the new collection
+ *                              and optimistically inserts it.
+ *   - `updateList`           — owner-only. Round-trip title/description.
+ *   - `deleteList`           — owner-only. Removes the collection
+ *                              record; awards survive.
+ *   - `addSubjectToList`     — owner-only. Ensures an award exists for
+ *                              the subject then appends to `items[]`.
+ *                              Dedupes-on-URI so a double-click is a
+ *                              no-op rather than a double-write.
+ *   - `removeSubjectFromList` — owner-only. Drops the item by award
+ *                              URI; underlying award untouched.
  */
 export function useEndorsementLists(did: string | null): {
   lists: EndorsementList[]
@@ -74,7 +91,15 @@ export function useEndorsementLists(did: string | null): {
     title: string,
     description?: string,
   ) => Promise<EndorsementList>
-  deleteList: (rkey: string) => Promise<{ deletedAwards: number }>
+  deleteList: (rkey: string) => Promise<void>
+  addSubjectToList: (
+    rkey: string,
+    subjectDid: string,
+  ) => Promise<EndorsementList>
+  removeSubjectFromList: (
+    rkey: string,
+    awardUri: string,
+  ) => Promise<EndorsementList>
 } {
   const [lists, setLists] = useState<EndorsementList[]>([])
   const [isLoading, setIsLoading] = useState(!!did)
@@ -101,36 +126,33 @@ export function useEndorsementLists(did: string | null): {
       setIsLoading(true)
       setError(null)
       try {
-        const [defs, awards] = await Promise.all([
-          listDefinitions(targetDid, signal, force ? { noCache: true } : undefined),
+        const [collections, awards] = await Promise.all([
+          listEndorsementListCollections(targetDid, signal),
           listAwards(targetDid, signal, force ? { noCache: true } : undefined),
         ])
         if (signal?.aborted) return
-        // Group awards by their badge.uri so the per-list attach is
-        // O(awards) instead of O(lists × awards).
-        const awardsByDef = new Map<string, BadgeAwardRecord[]>()
-        for (const a of awards) {
-          const defUri = a.value.badge?.uri
-          if (typeof defUri !== "string") continue
-          const bucket = awardsByDef.get(defUri)
-          if (bucket) bucket.push(a)
-          else awardsByDef.set(defUri, [a])
-        }
-        const next: EndorsementList[] = defs
-          .filter(
-            (d) =>
-              d.value.badgeType === ENDORSEMENT_BADGE_TYPE &&
-              d.value.title !== ENDORSEMENT_BADGE_TITLE,
-          )
-          .map((d) => ({
-            uri: d.uri,
-            cid: d.cid,
-            rkey: d.rkey,
-            title: d.value.title,
-            description: d.value.description,
-            createdAt: d.value.createdAt,
-            items: awardsByDef.get(d.uri) ?? [],
-          }))
+        const awardByUri = new Map<string, BadgeAwardRecord>()
+        for (const a of awards) awardByUri.set(a.uri, a)
+        const next: EndorsementList[] = collections
+          .map((coll) => {
+            const items = Array.isArray(coll.value.items) ? coll.value.items : []
+            const resolved: BadgeAwardRecord[] = []
+            for (const item of items) {
+              const uri = item.itemIdentifier?.uri
+              if (typeof uri !== "string") continue
+              const award = awardByUri.get(uri)
+              if (award) resolved.push(award)
+            }
+            return {
+              uri: coll.uri,
+              cid: coll.cid,
+              rkey: coll.rkey,
+              title: coll.value.title,
+              description: coll.value.description,
+              createdAt: coll.value.createdAt,
+              items: resolved,
+            }
+          })
           .sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1))
         cache.set(targetDid, { lists: next, fetchedAt: Date.now() })
         setLists(next)
@@ -157,14 +179,18 @@ export function useEndorsementLists(did: string | null): {
     await doFetch(targetDid, undefined, true)
   }, [doFetch])
 
-  // Owner-only. Writes the new definition on the viewer's PDS and
+  // Owner-only. Writes the new collection on the viewer's PDS and
   // inserts it into local state so the UI flips to the new list
   // immediately. Throws if the write fails (caller surfaces).
   const createList = useCallback(
     async (title: string, description?: string): Promise<EndorsementList> => {
       const targetDid = didRef.current
       if (!targetDid) throw new Error("No active DID for createList")
-      const ref = await createListDefinition(targetDid, title, description)
+      const ref = await createEndorsementListCollection(
+        targetDid,
+        title,
+        description,
+      )
       const entry: EndorsementList = {
         uri: ref.uri,
         cid: ref.cid,
@@ -184,11 +210,9 @@ export function useEndorsementLists(did: string | null): {
     [],
   )
 
-  // Owner-only. Overwrites the existing definition's title /
-  // description while preserving its rkey and createdAt. Optimistic:
-  // we splice the updated entry into local state immediately so the
-  // detail view reflects the new metadata without waiting for a
-  // refetch.
+  // Owner-only. Overwrites the existing collection's title /
+  // description while preserving its rkey, createdAt, and items.
+  // Optimistic: splice the updated entry into local state immediately.
   const updateList = useCallback(
     async (
       rkey: string,
@@ -199,13 +223,7 @@ export function useEndorsementLists(did: string | null): {
       if (!targetDid) throw new Error("No active DID for updateList")
       const existing = lists.find((l) => l.rkey === rkey)
       if (!existing) throw new Error("List not found")
-      await updateListDefinition(
-        targetDid,
-        rkey,
-        existing.createdAt,
-        title,
-        description,
-      )
+      await updateEndorsementListCollection(targetDid, rkey, title, description)
       const updated: EndorsementList = {
         ...existing,
         title: title.trim(),
@@ -221,24 +239,74 @@ export function useEndorsementLists(did: string | null): {
     [lists],
   )
 
-  // Owner-only. Deletes every award linked to the list, then the
-  // list definition itself. The award delete happens first so an
-  // interrupted run never leaves orphan awards pointing at a missing
-  // definition. Optimistic local removal mirrors create/update.
+  // Owner-only. Removes the collection record only — awards survive.
+  // Optimistic local removal mirrors create/update.
   const deleteList = useCallback(
-    async (rkey: string): Promise<{ deletedAwards: number }> => {
+    async (rkey: string): Promise<void> => {
       const targetDid = didRef.current
       if (!targetDid) throw new Error("No active DID for deleteList")
       const existing = lists.find((l) => l.rkey === rkey)
       if (!existing) throw new Error("List not found")
-      const awardRkeys = existing.items.map((a) => a.rkey)
-      const result = await deleteListAndAwards(targetDid, rkey, awardRkeys)
+      await deleteEndorsementListCollection(targetDid, rkey)
       setLists((prev) => {
         const next = prev.filter((l) => l.rkey !== rkey)
         cache.set(targetDid, { lists: next, fetchedAt: Date.now() })
         return next
       })
-      return { deletedAwards: result.deletedAwards }
+    },
+    [lists],
+  )
+
+  // Owner-only. Ensure an award exists for `subjectDid` (always issue
+  // a fresh one — matches the default-endorsement flow's idempotency
+  // behaviour; the modal's `alreadyEndorsedDids` set already prevents
+  // double-add at the UX layer), then append to the list's items[].
+  // If the subject is already in the list, the append is a no-op and
+  // we return the existing entry without issuing a new award.
+  const addSubjectToList = useCallback(
+    async (rkey: string, subjectDid: string): Promise<EndorsementList> => {
+      const targetDid = didRef.current
+      if (!targetDid) throw new Error("No active DID for addSubjectToList")
+      const existing = lists.find((l) => l.rkey === rkey)
+      if (!existing) throw new Error("List not found")
+      // Award-write first; the collection update strong-refs the new
+      // award URI, so we need it to exist before the put.
+      const award = await createEndorsementAward(targetDid, subjectDid)
+      const result = await appendItemToList(targetDid, rkey, {
+        uri: award.uri,
+        cid: award.cid,
+      })
+      if (!result.added) return existing
+      // Locally we don't have the new award's full BadgeAwardRecord
+      // shape; rather than fake one and risk drift, just refetch on
+      // success. Optimistic insert isn't worth the divergence.
+      await refetch()
+      const refreshed = (cache.get(targetDid)?.lists ?? lists).find(
+        (l) => l.rkey === rkey,
+      )
+      return refreshed ?? existing
+    },
+    [lists, refetch],
+  )
+
+  // Owner-only. Drops the item from the list. Award is NOT deleted.
+  const removeSubjectFromList = useCallback(
+    async (rkey: string, awardUri: string): Promise<EndorsementList> => {
+      const targetDid = didRef.current
+      if (!targetDid) throw new Error("No active DID for removeSubjectFromList")
+      const existing = lists.find((l) => l.rkey === rkey)
+      if (!existing) throw new Error("List not found")
+      await removeItemFromList(targetDid, rkey, awardUri)
+      const updated: EndorsementList = {
+        ...existing,
+        items: existing.items.filter((a) => a.uri !== awardUri),
+      }
+      setLists((prev) => {
+        const next = prev.map((l) => (l.rkey === rkey ? updated : l))
+        cache.set(targetDid, { lists: next, fetchedAt: Date.now() })
+        return next
+      })
+      return updated
     },
     [lists],
   )
@@ -252,7 +320,19 @@ export function useEndorsementLists(did: string | null): {
       createList,
       updateList,
       deleteList,
+      addSubjectToList,
+      removeSubjectFromList,
     }),
-    [lists, isLoading, error, refetch, createList, updateList, deleteList],
+    [
+      lists,
+      isLoading,
+      error,
+      refetch,
+      createList,
+      updateList,
+      deleteList,
+      addSubjectToList,
+      removeSubjectFromList,
+    ],
   )
 }

--- a/src/hooks/use-endorsement-lists.ts
+++ b/src/hooks/use-endorsement-lists.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   listAwards,
   createEndorsementAward,
+  extractAwardSubjectDid,
   type BadgeAwardRecord,
 } from "@/lib/atproto/badges"
 import {
@@ -257,20 +258,26 @@ export function useEndorsementLists(did: string | null): {
     [lists],
   )
 
-  // Owner-only. Ensure an award exists for `subjectDid` (always issue
-  // a fresh one — matches the default-endorsement flow's idempotency
-  // behaviour; the modal's `alreadyEndorsedDids` set already prevents
-  // double-add at the UX layer), then append to the list's items[].
-  // If the subject is already in the list, the append is a no-op and
-  // we return the existing entry without issuing a new award.
+  // Owner-only. Ensures an award exists for `subjectDid` then appends
+  // it to the list's items[].
+  //
+  // Subject-level dedupe BEFORE the award create — `createEndorsementAward`
+  // always mints a fresh TID-keyed record, so without this short-
+  // circuit a race between two add-clicks for the same subject would
+  // leave two awards on the PDS pointing at the same person and both
+  // would render as separate rows. The dedupe-on-URI inside
+  // `appendItemToList` only catches identical-URI races, not
+  // distinct-URIs-same-subject ones.
   const addSubjectToList = useCallback(
     async (rkey: string, subjectDid: string): Promise<EndorsementList> => {
       const targetDid = didRef.current
       if (!targetDid) throw new Error("No active DID for addSubjectToList")
       const existing = lists.find((l) => l.rkey === rkey)
       if (!existing) throw new Error("List not found")
-      // Award-write first; the collection update strong-refs the new
-      // award URI, so we need it to exist before the put.
+      const alreadyInList = existing.items.some(
+        (a) => extractAwardSubjectDid(a.value.subject) === subjectDid,
+      )
+      if (alreadyInList) return existing
       const award = await createEndorsementAward(targetDid, subjectDid)
       const result = await appendItemToList(targetDid, rkey, {
         uri: award.uri,

--- a/src/hooks/use-endorsements.ts
+++ b/src/hooks/use-endorsements.ts
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from "react"
 import {
   listAwards,
   listDefinitions,
-  ENDORSEMENT_BADGE_TITLE,
   ENDORSEMENT_BADGE_TYPE,
   type BadgeAwardRecord,
   type BadgeDefinitionValue,
@@ -13,8 +12,7 @@ import {
 /**
  * A user's endorsement award, with the subject DID pre-extracted
  * from the (string-or-strongRef) `subject` union and the note
- * surfaced for display. Shape is intentionally close to the previous
- * `EndorsementRecord` so callers don't all need rewriting.
+ * surfaced for display.
  */
 export interface GivenEndorsement {
   uri: string
@@ -23,9 +21,15 @@ export interface GivenEndorsement {
   subjectDid: string
   createdAt: string
   note?: string
-  /** Title of the list this endorsement was awarded under, when it
-   *  belongs to a user-created list rather than the default
-   *  "Endorsement" definition. `undefined` for default endorsements. */
+  /**
+   * Vestigial — kept for `<PersonCard listTitle?: string>` prop-shape
+   * continuity. Always `undefined` after the lists-as-collections
+   * migration: there's only one endorsement definition per issuer
+   * now, and lists are a separate curation overlay (see
+   * `docs/lists-as-collections/`). Multi-list chip rendering on the
+   * Given panel is deferred — when it lands, replace this field with
+   * `lists: string[]` populated from the issuer's collection records.
+   */
   listTitle?: string
 }
 
@@ -33,9 +37,9 @@ export interface GivenEndorsement {
  * Fetch and track the endorsement awards **given** by a user — read
  * from their own PDS via two listRecords calls:
  *
- *   1. `app.certified.badge.definition` to find every definition the
- *      user owns
- *   2. `app.certified.badge.award` to list all awards they've issued
+ *   1. `app.certified.badge.definition` to find the issuer's
+ *      endorsement-typed definition(s).
+ *   2. `app.certified.badge.award` to list all awards they've issued.
  *
  * We then keep only awards whose `badge.uri` resolves to a definition
  * with `badgeType === "endorsement"`. This sidesteps the indexer
@@ -76,25 +80,22 @@ export function useGivenEndorsements(did: string | null): {
         ])
         if (signal?.aborted) return
 
-        // Build a URI → title map of endorsement-typed definitions
-        // owned by this user. The default endorsement def keeps the
-        // reserved title "Endorsement"; anything else with this
-        // badgeType is a user-created list. Attaching the title to
-        // each award lets the UI surface the list name when
-        // rendering Given cards on the endorsements tab.
-        const endorsementDefs = new Map<string, string>()
+        // Build the set of endorsement-typed definition URIs owned by
+        // this user — used to filter awards to "actually endorsements"
+        // (vs. some other badgeType if one ever lands here). Lists
+        // no longer live in this collection (see
+        // `docs/lists-as-collections/`); the set therefore typically
+        // contains exactly one entry (the default def) but we still
+        // walk it so legacy custom-typed endorsement defs from before
+        // the migration still show up in Given.
+        const endorsementDefUris = new Set<string>()
         for (const d of defs) {
-          if (isEndorsementDefinition(d.value)) {
-            endorsementDefs.set(d.uri, d.value.title)
-          }
+          if (isEndorsementDefinition(d.value)) endorsementDefUris.add(d.uri)
         }
 
         const mapped = awards
-          .filter((a) => endorsementDefs.has(a.value.badge?.uri ?? ""))
-          .map((award) => {
-            const defTitle = endorsementDefs.get(award.value.badge?.uri ?? "")
-            return toGiven(award, defTitle)
-          })
+          .filter((a) => endorsementDefUris.has(a.value.badge?.uri ?? ""))
+          .map(toGiven)
           .filter((e): e is GivenEndorsement => e !== null)
 
         // Newest first by createdAt — matches the Received view and
@@ -131,16 +132,9 @@ function isEndorsementDefinition(v: BadgeDefinitionValue): boolean {
   return v?.badgeType === ENDORSEMENT_BADGE_TYPE
 }
 
-function toGiven(
-  award: BadgeAwardRecord,
-  defTitle: string | undefined,
-): GivenEndorsement | null {
+function toGiven(award: BadgeAwardRecord): GivenEndorsement | null {
   const subjectDid = extractSubjectDid(award.value.subject)
   if (!subjectDid) return null
-  // Only attach `listTitle` for awards under a user-created list —
-  // the default "Endorsement" def is the implicit fallback, so its
-  // title would be noise on the card.
-  const isList = !!defTitle && defTitle !== ENDORSEMENT_BADGE_TITLE
   return {
     uri: award.uri,
     cid: award.cid,
@@ -148,7 +142,7 @@ function toGiven(
     subjectDid,
     createdAt: award.value.createdAt,
     note: award.value.note,
-    listTitle: isList ? defTitle : undefined,
+    // listTitle intentionally unset — see interface JSDoc.
   }
 }
 

--- a/src/lib/atproto/__tests__/collection.test.ts
+++ b/src/lib/atproto/__tests__/collection.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const mockAuthFetch = vi.fn()
+vi.mock("@/lib/auth/fetch", () => ({
+  authFetch: (url: string, init: RequestInit) => mockAuthFetch(url, init),
+}))
+
+beforeEach(() => {
+  mockAuthFetch.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function ok(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+function err(status: number, body: unknown = { error: "no" }): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+async function loadModule() {
+  const mod = await import("../collection")
+  return mod
+}
+
+const DID = "did:plc:alice"
+
+function awardRef(rkey: string) {
+  return {
+    uri: `at://${DID}/app.certified.badge.award/${rkey}`,
+    cid: `cid-${rkey}`,
+  }
+}
+
+describe("asEndorsementListValue", () => {
+  it("narrows a well-formed endorsement-list value", async () => {
+    const { asEndorsementListValue } = await loadModule()
+    const narrowed = asEndorsementListValue({
+      type: "endorsement-list",
+      title: "Frontend mentors",
+      createdAt: "2026-05-20T12:00:00Z",
+    })
+    expect(narrowed).not.toBeNull()
+    expect(narrowed?.title).toBe("Frontend mentors")
+  })
+
+  it("returns null for a project collection", async () => {
+    const { asEndorsementListValue } = await loadModule()
+    expect(
+      asEndorsementListValue({
+        type: "project",
+        title: "Hypercerts",
+        createdAt: "2026-05-20T12:00:00Z",
+      }),
+    ).toBeNull()
+  })
+
+  it("returns null when required fields are missing", async () => {
+    const { asEndorsementListValue } = await loadModule()
+    expect(
+      asEndorsementListValue({
+        type: "endorsement-list",
+        createdAt: "2026-05-20T12:00:00Z",
+      }),
+    ).toBeNull()
+    expect(
+      asEndorsementListValue({
+        type: "endorsement-list",
+        title: "x",
+      }),
+    ).toBeNull()
+  })
+})
+
+describe("createEndorsementListCollection", () => {
+  it("posts the canonical record shape and returns the new ref", async () => {
+    mockAuthFetch.mockResolvedValueOnce(ok({ uri: "at://x", cid: "c" }))
+    const { createEndorsementListCollection } = await loadModule()
+
+    const result = await createEndorsementListCollection(
+      DID,
+      "  Frontend mentors  ",
+      "  weekly cohort ",
+    )
+
+    expect(result).toEqual({ uri: "at://x", cid: "c" })
+    const [url, init] = mockAuthFetch.mock.calls[0]
+    expect(url).toBe("/api/xrpc/com/atproto/repo/createRecord")
+    const body = JSON.parse(init.body as string)
+    expect(body.collection).toBe("org.hypercerts.collection")
+    expect(body.record.type).toBe("endorsement-list")
+    expect(body.record.title).toBe("Frontend mentors")
+    expect(body.record.description).toBe("weekly cohort")
+    expect(body.record.items).toEqual([])
+  })
+
+  it("omits description when blank", async () => {
+    mockAuthFetch.mockResolvedValueOnce(ok({ uri: "at://x", cid: "c" }))
+    const { createEndorsementListCollection } = await loadModule()
+    await createEndorsementListCollection(DID, "Frontend", "   ")
+    const body = JSON.parse(mockAuthFetch.mock.calls[0][1].body as string)
+    expect(body.record.description).toBeUndefined()
+  })
+
+  it("rejects an empty title", async () => {
+    const { createEndorsementListCollection } = await loadModule()
+    await expect(
+      createEndorsementListCollection(DID, "  "),
+    ).rejects.toThrow(/required/)
+    expect(mockAuthFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe("appendItemToList", () => {
+  it("appends + dedupes-on-URI", async () => {
+    // 1st call: getRecord with one existing item.
+    mockAuthFetch.mockResolvedValueOnce(
+      ok({
+        value: {
+          type: "endorsement-list",
+          title: "Mentors",
+          createdAt: "2026-05-20T00:00:00Z",
+          items: [
+            {
+              itemIdentifier: awardRef("aaa"),
+              addedAt: "2026-05-20T00:00:00Z",
+            },
+          ],
+        },
+        cid: "c0",
+      }),
+    )
+    // 2nd call: putRecord.
+    mockAuthFetch.mockResolvedValueOnce(ok({ uri: "u1", cid: "c1" }))
+
+    const { appendItemToList } = await loadModule()
+    const result = await appendItemToList(DID, "list1", awardRef("bbb"))
+
+    expect(result.added).toBe(true)
+    expect(result.cid).toBe("c1")
+    const putCall = mockAuthFetch.mock.calls[1]
+    expect(putCall[0]).toBe("/api/xrpc/com/atproto/repo/putRecord")
+    const putBody = JSON.parse(putCall[1].body as string)
+    expect(putBody.record.items).toHaveLength(2)
+    expect(putBody.record.items[1].itemIdentifier.uri).toBe(
+      awardRef("bbb").uri,
+    )
+  })
+
+  it("is a no-op when the award is already in the list", async () => {
+    mockAuthFetch.mockResolvedValueOnce(
+      ok({
+        value: {
+          type: "endorsement-list",
+          title: "Mentors",
+          createdAt: "2026-05-20T00:00:00Z",
+          items: [{ itemIdentifier: awardRef("aaa") }],
+        },
+        cid: "c0",
+      }),
+    )
+
+    const { appendItemToList } = await loadModule()
+    const result = await appendItemToList(DID, "list1", awardRef("aaa"))
+
+    expect(result.added).toBe(false)
+    expect(mockAuthFetch).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("removeItemFromList", () => {
+  it("drops the matching item and returns removed=true", async () => {
+    mockAuthFetch.mockResolvedValueOnce(
+      ok({
+        value: {
+          type: "endorsement-list",
+          title: "Mentors",
+          createdAt: "2026-05-20T00:00:00Z",
+          items: [
+            { itemIdentifier: awardRef("aaa") },
+            { itemIdentifier: awardRef("bbb") },
+          ],
+        },
+        cid: "c0",
+      }),
+    )
+    mockAuthFetch.mockResolvedValueOnce(ok({ uri: "u", cid: "c1" }))
+
+    const { removeItemFromList } = await loadModule()
+    const result = await removeItemFromList(DID, "list1", awardRef("aaa").uri)
+
+    expect(result.removed).toBe(true)
+    const putBody = JSON.parse(mockAuthFetch.mock.calls[1][1].body as string)
+    expect(putBody.record.items).toHaveLength(1)
+    expect(putBody.record.items[0].itemIdentifier.uri).toBe(awardRef("bbb").uri)
+  })
+
+  it("returns removed=false (no put) when the award is absent", async () => {
+    mockAuthFetch.mockResolvedValueOnce(
+      ok({
+        value: {
+          type: "endorsement-list",
+          title: "Mentors",
+          createdAt: "2026-05-20T00:00:00Z",
+          items: [{ itemIdentifier: awardRef("aaa") }],
+        },
+        cid: "c0",
+      }),
+    )
+
+    const { removeItemFromList } = await loadModule()
+    const result = await removeItemFromList(DID, "list1", awardRef("zzz").uri)
+
+    expect(result.removed).toBe(false)
+    expect(mockAuthFetch).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("purgeAwardFromLists", () => {
+  it("scans every list, edits only the ones referencing the award", async () => {
+    // listRecords (page 1, terminal — no cursor).
+    mockAuthFetch.mockResolvedValueOnce(
+      ok({
+        records: [
+          {
+            uri: `at://${DID}/org.hypercerts.collection/list1`,
+            cid: "cidL1",
+            value: {
+              type: "endorsement-list",
+              title: "Mentors",
+              createdAt: "2026-05-20T00:00:00Z",
+              items: [{ itemIdentifier: awardRef("target") }],
+            },
+          },
+          {
+            uri: `at://${DID}/org.hypercerts.collection/list2`,
+            cid: "cidL2",
+            value: {
+              type: "endorsement-list",
+              title: "Reviewers",
+              createdAt: "2026-05-20T00:00:00Z",
+              items: [{ itemIdentifier: awardRef("other") }],
+            },
+          },
+          {
+            uri: `at://${DID}/org.hypercerts.collection/proj1`,
+            cid: "cidP1",
+            value: {
+              type: "project",
+              title: "Skip me",
+              createdAt: "2026-05-20T00:00:00Z",
+            },
+          },
+        ],
+      }),
+    )
+    // For list1: getRecord + putRecord.
+    mockAuthFetch.mockResolvedValueOnce(
+      ok({
+        value: {
+          type: "endorsement-list",
+          title: "Mentors",
+          createdAt: "2026-05-20T00:00:00Z",
+          items: [{ itemIdentifier: awardRef("target") }],
+        },
+        cid: "cidL1",
+      }),
+    )
+    mockAuthFetch.mockResolvedValueOnce(ok({ uri: "u", cid: "cidL1b" }))
+
+    const { purgeAwardFromLists } = await loadModule()
+    const result = await purgeAwardFromLists(DID, awardRef("target").uri)
+
+    // list1 + list2 are scanned; only list1 is edited (list2 doesn't
+    // reference the target; the project record is filtered out
+    // earlier).
+    expect(result.scanned).toBe(2)
+    expect(result.updated).toBe(1)
+  })
+})

--- a/src/lib/atproto/__tests__/collection.test.ts
+++ b/src/lib/atproto/__tests__/collection.test.ts
@@ -120,6 +120,45 @@ describe("createEndorsementListCollection", () => {
   })
 })
 
+describe("updateEndorsementListCollection", () => {
+  it("preserves items[] and createdAt across a title/description edit", async () => {
+    // 1st call: getRecord with one existing item.
+    const existingItems = [
+      {
+        itemIdentifier: awardRef("preserve-me"),
+        addedAt: "2026-05-19T00:00:00Z",
+      },
+    ]
+    mockAuthFetch.mockResolvedValueOnce(
+      ok({
+        value: {
+          type: "endorsement-list",
+          title: "Old title",
+          description: "Old desc",
+          createdAt: "2026-01-01T00:00:00Z",
+          items: existingItems,
+          // An unknown field a future-client could add; must round-trip.
+          futureField: "keep",
+        },
+        cid: "c0",
+      }),
+    )
+    // 2nd call: putRecord.
+    mockAuthFetch.mockResolvedValueOnce(ok({ uri: "u1", cid: "c1" }))
+
+    const { updateEndorsementListCollection } = await loadModule()
+    await updateEndorsementListCollection(DID, "list1", "New title", "New desc")
+
+    const putBody = JSON.parse(mockAuthFetch.mock.calls[1][1].body as string)
+    expect(putBody.record.title).toBe("New title")
+    expect(putBody.record.description).toBe("New desc")
+    expect(putBody.record.createdAt).toBe("2026-01-01T00:00:00Z")
+    expect(putBody.record.items).toEqual(existingItems)
+    expect(putBody.record.futureField).toBe("keep")
+    expect(putBody.swapRecord).toBe("c0")
+  })
+})
+
 describe("appendItemToList", () => {
   it("appends + dedupes-on-URI", async () => {
     // 1st call: getRecord with one existing item.

--- a/src/lib/atproto/badges.ts
+++ b/src/lib/atproto/badges.ts
@@ -1,4 +1,5 @@
 import { authFetch } from "@/lib/auth/fetch"
+import { purgeAwardFromLists } from "@/lib/atproto/collection"
 import type { ListRecordsResponse } from "@/lib/types/api"
 
 /**
@@ -428,155 +429,6 @@ async function createEndorsementDefinition(ownDid: string): Promise<StrongRef> {
 }
 
 /**
- * Create a new endorsement-typed badge definition with a custom
- * title (and optional description). Used by the "Lists" section on
- * the Endorsements tab — every list is a definition with
- * `badgeType = "endorsement"` and a `title != "Endorsement"` (the
- * reserved title is the auto-created default endorsement def).
- *
- * Returns the new record's strong ref.
- */
-export async function createListDefinition(
-  ownDid: string,
-  title: string,
-  description?: string,
-): Promise<StrongRef> {
-  const trimmedTitle = title.trim()
-  if (!trimmedTitle) throw new Error("List title is required")
-  if (trimmedTitle.toLowerCase() === ENDORSEMENT_BADGE_TITLE.toLowerCase()) {
-    throw new Error(
-      `"${ENDORSEMENT_BADGE_TITLE}" is reserved for the default endorsement def — pick another title.`,
-    )
-  }
-  const trimmedDescription = description?.trim()
-  const record: BadgeDefinitionValue = {
-    $type: BADGE_DEFINITION_COLLECTION,
-    badgeType: ENDORSEMENT_BADGE_TYPE,
-    title: trimmedTitle,
-    createdAt: new Date().toISOString(),
-  }
-  if (trimmedDescription) record.description = trimmedDescription
-  const res = await authFetch("/api/xrpc/com/atproto/repo/createRecord", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      repo: ownDid,
-      collection: BADGE_DEFINITION_COLLECTION,
-      record,
-    }),
-  })
-  const data = (await res.json().catch(() => ({}))) as {
-    uri?: string
-    cid?: string
-    error?: string
-  }
-  if (!res.ok || !data.uri || !data.cid) {
-    throw new Error(
-      data.error || `Failed to create list: ${res.status}`,
-    )
-  }
-  return { uri: data.uri, cid: data.cid }
-}
-
-/**
- * Overwrite an existing endorsement-typed `app.certified.badge.definition`
- * (a list) on the viewer's own repo. Only the title and description
- * change; `badgeType` and `createdAt` round-trip from the existing
- * record so the lexicon's required fields stay intact.
- *
- * Returns the updated record's strong ref.
- */
-export async function updateListDefinition(
-  ownDid: string,
-  rkey: string,
-  existingCreatedAt: string,
-  title: string,
-  description?: string,
-): Promise<StrongRef> {
-  const trimmedTitle = title.trim()
-  if (!trimmedTitle) throw new Error("List title is required")
-  if (trimmedTitle.toLowerCase() === ENDORSEMENT_BADGE_TITLE.toLowerCase()) {
-    throw new Error(
-      `"${ENDORSEMENT_BADGE_TITLE}" is reserved for the default endorsement def — pick another title.`,
-    )
-  }
-  const trimmedDescription = description?.trim()
-  const record: BadgeDefinitionValue = {
-    $type: BADGE_DEFINITION_COLLECTION,
-    badgeType: ENDORSEMENT_BADGE_TYPE,
-    title: trimmedTitle,
-    createdAt: existingCreatedAt,
-  }
-  if (trimmedDescription) record.description = trimmedDescription
-  const res = await authFetch("/api/xrpc/com/atproto/repo/putRecord", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      repo: ownDid,
-      collection: BADGE_DEFINITION_COLLECTION,
-      rkey,
-      record,
-    }),
-  })
-  const data = (await res.json().catch(() => ({}))) as {
-    uri?: string
-    cid?: string
-    error?: string
-  }
-  if (!res.ok || !data.uri || !data.cid) {
-    throw new Error(data.error || `Failed to update list: ${res.status}`)
-  }
-  return { uri: data.uri, cid: data.cid }
-}
-
-/**
- * Delete a list (an endorsement-typed `app.certified.badge.definition`)
- * AND every `app.certified.badge.award` on the same repo that strong-
- * refs that definition. Used by the Endorsements > Lists detail view's
- * Delete action. Awards are removed first so an interrupted run never
- * leaves orphan awards pointing at a missing definition.
- *
- * Returns the number of awards and the number of definitions that
- * were actually removed (both `0` or `1` for the definition).
- */
-export async function deleteListAndAwards(
-  ownDid: string,
-  listRkey: string,
-  awardRkeys: string[],
-): Promise<{ deletedAwards: number; deletedDefinition: boolean }> {
-  let deletedAwards = 0
-  for (const rkey of awardRkeys) {
-    const res = await authFetch("/api/xrpc/com/atproto/repo/deleteRecord", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        repo: ownDid,
-        collection: BADGE_AWARD_COLLECTION,
-        rkey,
-      }),
-    })
-    if (res.ok) deletedAwards++
-    // Carry on past per-award failures — the orphan can be cleaned
-    // up later; blocking the def-delete on a single transient PDS
-    // failure leaves the user unable to remove the list.
-  }
-  const res = await authFetch("/api/xrpc/com/atproto/repo/deleteRecord", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      repo: ownDid,
-      collection: BADGE_DEFINITION_COLLECTION,
-      rkey: listRkey,
-    }),
-  })
-  if (!res.ok) {
-    const data = (await res.json().catch(() => ({}))) as { error?: string }
-    throw new Error(data.error || `Failed to delete list: ${res.status}`)
-  }
-  return { deletedAwards, deletedDefinition: true }
-}
-
-/**
  * List badge awards from any user's PDS. Returns the raw records;
  * callers narrow to endorsement awards by resolving each record's
  * `badge` strongRef and filtering on the definition's `badgeType`.
@@ -696,25 +548,19 @@ export async function createEndorsementAward(
 }
 
 /**
- * Issue an award against a SPECIFIC list definition. Used by the
- * Endorsements > Lists detail view's "+ Add people" flow. Caller
- * passes the list's strong ref (`{uri, cid}`) so we skip the
- * ensure-default-def round-trip. Note isn't accepted because the
- * list itself is the reason — see profile-endorsements UX spec.
+ * Revoke an endorsement (delete the award record). Also purges the
+ * award from every endorsement-list owned by `ownDid` so a Given-
+ * panel revoke doesn't leave ghost rows on the Lists tab. The purge
+ * is best-effort (errors logged in dev, swallowed in prod) — the
+ * read path drops unresolved list items silently, so a partial
+ * failure delays cleanup but doesn't corrupt anything.
  */
-export async function createListAward(
-  ownDid: string,
-  subjectDid: string,
-  badge: StrongRef,
-): Promise<{ uri: string; cid: string }> {
-  return writeBadgeAward(ownDid, subjectDid, badge, "list award")
-}
-
-/** Revoke an endorsement (delete the award record). */
 export async function deleteEndorsementAward(
   ownDid: string,
   rkey: string,
 ): Promise<void> {
+  const awardUri = `at://${ownDid}/${BADGE_AWARD_COLLECTION}/${rkey}`
+  await purgeAwardFromLists(ownDid, awardUri)
   const res = await authFetch("/api/xrpc/com/atproto/repo/deleteRecord", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/src/lib/atproto/badges.ts
+++ b/src/lib/atproto/badges.ts
@@ -326,12 +326,10 @@ async function ensureEndorsementDefinitionInner(
  * earlier `createdAt` never loses to a later one regardless of
  * which tab does the read, so concurrent readers converge.
  *
- * Stale-config concern: the default endorsement def is currently
- * minimal (`title` + `badgeType` + `createdAt`) and never mutated
- * post-create — `updateListDefinition` (`badges.ts:~340`) is only
- * used for user-created list defs, not the default endorsement one.
- * If list-style customisation ever lands on the default def, this
- * invariant flips and the choice must be revisited.
+ * Stale-config concern: the default endorsement def is minimal
+ * (`title` + `badgeType` + `createdAt`) and never mutated
+ * post-create. If list-style customisation ever lands on it the
+ * invariant flips and the canonical choice must be revisited.
  */
 function resolveCanonicalEndorsementDef(
   defs: BadgeDefinitionRecord[],
@@ -467,11 +465,9 @@ export async function listAwards(
 }
 
 /**
- * Write a badge award on `ownDid`'s repo against an arbitrary badge
- * definition. Lower-level helper: callers supply the badge strongRef
- * directly. Used by both `createEndorsementAward` (which adds a
- * lazy ensure-default-def step on top) and `createListAward` (which
- * already has the list's badge ref in hand).
+ * Write a badge award on `ownDid`'s repo against the supplied badge
+ * strongRef. Lower-level helper consumed by `createEndorsementAward`,
+ * which wraps it with the lazy ensure-default-def step.
  */
 /** Max byte length we'll allow on `note` from the client. Mirrors
  *  what the UI's character counter caps at, so writes never get

--- a/src/lib/atproto/collection.ts
+++ b/src/lib/atproto/collection.ts
@@ -3,11 +3,21 @@ import { authFetch } from "@/lib/auth/fetch"
 const COLLECTION = "org.hypercerts.collection"
 
 /**
+ * `type` discriminator used by endorsement-list collection records.
+ * Sibling discriminator to the project flow's `"project"` value, which
+ * the Projects tab filters on. The two filters are symmetric — lists
+ * are excluded from the Projects tab and projects are excluded from
+ * the Lists tab.
+ */
+export const ENDORSEMENT_LIST_TYPE = "endorsement-list"
+
+/**
  * Loose shape of an `org.hypercerts.collection` record. The lexicon
  * lives outside this repo so the fields below are best-effort — the
  * components consuming the records narrow as needed and treat anything
  * else as optional / unknown. The `type` discriminator is what the
- * Projects tab filters on (`type === "project"`).
+ * Projects tab filters on (`type === "project"`) and what the Lists
+ * tab filters on (`type === "endorsement-list"`).
  */
 export interface CollectionValue {
   $type?: string
@@ -18,6 +28,42 @@ export interface CollectionValue {
   shortDescription?: string
   createdAt?: string
   [key: string]: unknown
+}
+
+/**
+ * Strong-ref shape used inside `items[i].itemIdentifier`. Matches the
+ * project flow (see `app/api/groups/[groupDid]/project/route.ts`):
+ * an at:// URI plus the referenced record's CID.
+ */
+export interface ItemIdentifier {
+  uri: string
+  cid: string
+}
+
+/**
+ * One entry in an endorsement-list collection's `items` array. The
+ * lexicon allows extra fields per item (preserved on round-trip);
+ * `itemIdentifier` is the only required shape. For lists, it strong-
+ * refs an `app.certified.badge.award` record on the same issuer's PDS.
+ */
+export interface CollectionItem {
+  itemIdentifier: ItemIdentifier
+  addedAt?: string
+  [key: string]: unknown
+}
+
+/**
+ * Narrowed view of an endorsement-list collection record. Used by the
+ * lists hook + components; reads remain loose at the boundary
+ * (`CollectionValue`) and narrow internally once `type === "endorsement-list"`
+ * is confirmed.
+ */
+export interface EndorsementListCollectionValue extends CollectionValue {
+  type: typeof ENDORSEMENT_LIST_TYPE
+  title: string
+  description?: string
+  createdAt: string
+  items?: CollectionItem[]
 }
 
 export interface CollectionRecord {
@@ -68,4 +114,333 @@ export async function fetchCollections(
     records: data.records ?? [],
     cursor: data.cursor,
   }
+}
+
+// ---------------------------------------------------------------------------
+// Endorsement-list collections — the curation overlay that replaced the
+// per-list `app.certified.badge.definition` model.
+// ---------------------------------------------------------------------------
+
+function extractRkey(uri: string): string {
+  const idx = uri.lastIndexOf("/")
+  return idx >= 0 ? uri.slice(idx + 1) : uri
+}
+
+/**
+ * Type-narrow a `CollectionValue` to `EndorsementListCollectionValue`.
+ * Returns null for anything that doesn't carry the list discriminator
+ * or is missing the required string fields. Read paths use this to
+ * drop project records (or future, unknown collection types) silently.
+ */
+export function asEndorsementListValue(
+  value: CollectionValue,
+): EndorsementListCollectionValue | null {
+  if (value.type !== ENDORSEMENT_LIST_TYPE) return null
+  if (typeof value.title !== "string" || !value.title) return null
+  if (typeof value.createdAt !== "string" || !value.createdAt) return null
+  return value as EndorsementListCollectionValue
+}
+
+/**
+ * Page through `fetchCollections` and return only endorsement-list
+ * records on `did`'s PDS. Used by the lists hook + read paths. Walks
+ * the cursor so very-prolific accounts (lists + projects together
+ * exceeding one page) don't silently truncate.
+ */
+export async function listEndorsementListCollections(
+  did: string,
+  signal?: AbortSignal,
+): Promise<
+  Array<{
+    uri: string
+    cid: string
+    rkey: string
+    value: EndorsementListCollectionValue
+  }>
+> {
+  const out: Array<{
+    uri: string
+    cid: string
+    rkey: string
+    value: EndorsementListCollectionValue
+  }> = []
+  let cursor: string | undefined
+  do {
+    const page = await fetchCollections(did, cursor, 50, signal)
+    for (const r of page.records) {
+      const narrow = asEndorsementListValue(r.value)
+      if (!narrow) continue
+      out.push({
+        uri: r.uri,
+        cid: r.cid,
+        rkey: extractRkey(r.uri),
+        value: narrow,
+      })
+    }
+    cursor = page.cursor
+  } while (cursor)
+  return out
+}
+
+/**
+ * Fetch a single `org.hypercerts.collection` record by rkey. Used by
+ * the write helpers below to do read-modify-write on `items[]` (so
+ * concurrent edits in different tabs only lose updates within the
+ * same single round-trip window, matching the project flow's
+ * lost-update profile).
+ */
+async function getCollectionRecord(
+  did: string,
+  rkey: string,
+): Promise<{ value: CollectionValue; cid: string } | null> {
+  const params = new URLSearchParams({
+    repo: did,
+    collection: COLLECTION,
+    rkey,
+  })
+  const res = await authFetch(
+    `/api/xrpc/com/atproto/repo/getRecord?${params.toString()}`,
+    { cache: "no-store" },
+  )
+  if (!res.ok) {
+    if (res.status === 400 || res.status === 404) return null
+    throw new Error(`Failed to read list record: ${res.status}`)
+  }
+  const data = (await res.json()) as { value?: CollectionValue; cid?: string }
+  if (!data.value || !data.cid) return null
+  return { value: data.value, cid: data.cid }
+}
+
+interface WriteResult {
+  uri: string
+  cid: string
+}
+
+/**
+ * Create a new endorsement-list collection record on the viewer's
+ * PDS. Title is required; description optional. Returns the new
+ * record's strong ref so callers can mirror it in local state without
+ * a re-read.
+ */
+export async function createEndorsementListCollection(
+  ownDid: string,
+  title: string,
+  description?: string,
+): Promise<WriteResult> {
+  const trimmedTitle = title.trim()
+  if (!trimmedTitle) throw new Error("List title is required")
+  const trimmedDescription = description?.trim()
+  const record: EndorsementListCollectionValue = {
+    $type: COLLECTION,
+    type: ENDORSEMENT_LIST_TYPE,
+    title: trimmedTitle,
+    createdAt: new Date().toISOString(),
+    items: [],
+  }
+  if (trimmedDescription) record.description = trimmedDescription
+  const res = await authFetch("/api/xrpc/com/atproto/repo/createRecord", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      repo: ownDid,
+      collection: COLLECTION,
+      record,
+    }),
+  })
+  const data = (await res.json().catch(() => ({}))) as {
+    uri?: string
+    cid?: string
+    error?: string
+  }
+  if (!res.ok || !data.uri || !data.cid) {
+    throw new Error(data.error || `Failed to create list: ${res.status}`)
+  }
+  return { uri: data.uri, cid: data.cid }
+}
+
+/**
+ * Overwrite title/description on an existing endorsement-list. Does
+ * read-modify-write so `createdAt`, `type`, and `items` round-trip
+ * intact regardless of what the caller supplies. The XRPC proxy's
+ * lexicon-validator + the magic-indexer pin nothing here, so we own
+ * the contract.
+ */
+export async function updateEndorsementListCollection(
+  ownDid: string,
+  rkey: string,
+  title: string,
+  description?: string,
+): Promise<WriteResult> {
+  const trimmedTitle = title.trim()
+  if (!trimmedTitle) throw new Error("List title is required")
+  const existing = await getCollectionRecord(ownDid, rkey)
+  if (!existing) throw new Error("List not found")
+  const narrow = asEndorsementListValue(existing.value)
+  if (!narrow) throw new Error("Record is not an endorsement-list")
+  const trimmedDescription = description?.trim()
+  const next: EndorsementListCollectionValue = {
+    ...narrow,
+    $type: COLLECTION,
+    type: ENDORSEMENT_LIST_TYPE,
+    title: trimmedTitle,
+    createdAt: narrow.createdAt,
+    description: trimmedDescription || undefined,
+  }
+  return putCollectionRecord(ownDid, rkey, next, existing.cid)
+}
+
+/**
+ * Delete an endorsement-list collection record. Awards survive — see
+ * `plan.md` for the semantics shift from the old badge-definition
+ * model.
+ */
+export async function deleteEndorsementListCollection(
+  ownDid: string,
+  rkey: string,
+): Promise<void> {
+  const res = await authFetch("/api/xrpc/com/atproto/repo/deleteRecord", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      repo: ownDid,
+      collection: COLLECTION,
+      rkey,
+    }),
+  })
+  if (!res.ok) {
+    const data = (await res.json().catch(() => ({}))) as { error?: string }
+    throw new Error(data.error || `Failed to delete list: ${res.status}`)
+  }
+}
+
+/**
+ * Append a strongRef to the list's `items[]`, dedupe-on-URI so a
+ * double-click can't double-add. Read-modify-write — concurrent tabs
+ * editing the same list can still clobber each other (same risk
+ * surface as the project items flow).
+ *
+ * Returns the new record's strong ref and a flag telling the caller
+ * whether anything actually changed (so an unconditional refetch
+ * after a no-op add is avoidable).
+ */
+export async function appendItemToList(
+  ownDid: string,
+  rkey: string,
+  awardRef: ItemIdentifier,
+): Promise<{ uri: string; cid: string; added: boolean }> {
+  const existing = await getCollectionRecord(ownDid, rkey)
+  if (!existing) throw new Error("List not found")
+  const narrow = asEndorsementListValue(existing.value)
+  if (!narrow) throw new Error("Record is not an endorsement-list")
+  const currentItems = Array.isArray(narrow.items) ? narrow.items : []
+  if (currentItems.some((it) => it.itemIdentifier?.uri === awardRef.uri)) {
+    return { uri: existingUri(ownDid, rkey), cid: existing.cid, added: false }
+  }
+  const next: EndorsementListCollectionValue = {
+    ...narrow,
+    items: [
+      ...currentItems,
+      {
+        itemIdentifier: { uri: awardRef.uri, cid: awardRef.cid },
+        addedAt: new Date().toISOString(),
+      },
+    ],
+  }
+  const result = await putCollectionRecord(ownDid, rkey, next, existing.cid)
+  return { ...result, added: true }
+}
+
+/**
+ * Drop the entry whose `itemIdentifier.uri === awardUri` from the
+ * list's `items[]`. No-op (with `removed: false`) if not found. Does
+ * NOT delete the underlying award.
+ */
+export async function removeItemFromList(
+  ownDid: string,
+  rkey: string,
+  awardUri: string,
+): Promise<{ uri: string; cid: string; removed: boolean }> {
+  const existing = await getCollectionRecord(ownDid, rkey)
+  if (!existing) throw new Error("List not found")
+  const narrow = asEndorsementListValue(existing.value)
+  if (!narrow) throw new Error("Record is not an endorsement-list")
+  const currentItems = Array.isArray(narrow.items) ? narrow.items : []
+  const nextItems = currentItems.filter(
+    (it) => it.itemIdentifier?.uri !== awardUri,
+  )
+  if (nextItems.length === currentItems.length) {
+    return { uri: existingUri(ownDid, rkey), cid: existing.cid, removed: false }
+  }
+  const next: EndorsementListCollectionValue = { ...narrow, items: nextItems }
+  const result = await putCollectionRecord(ownDid, rkey, next, existing.cid)
+  return { ...result, removed: true }
+}
+
+/**
+ * Scan every endorsement-list owned by `ownDid` and drop any item
+ * whose `itemIdentifier.uri === awardUri`. Called by
+ * `deleteEndorsementAward` so revoking an award from the Given panel
+ * doesn't leave ghost rows on the issuer's lists.
+ *
+ * Errors on individual list edits are swallowed (best-effort cleanup
+ * — the orphan-item read path drops unresolved items silently so a
+ * partial failure here just delays cleanup, not data integrity).
+ */
+export async function purgeAwardFromLists(
+  ownDid: string,
+  awardUri: string,
+): Promise<{ scanned: number; updated: number }> {
+  const lists = await listEndorsementListCollections(ownDid)
+  let updated = 0
+  for (const list of lists) {
+    const items = list.value.items
+    if (!Array.isArray(items)) continue
+    if (!items.some((it) => it.itemIdentifier?.uri === awardUri)) continue
+    try {
+      const result = await removeItemFromList(ownDid, list.rkey, awardUri)
+      if (result.removed) updated++
+    } catch (err) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          "[collection] purgeAwardFromLists failed for list",
+          list.rkey,
+          err,
+        )
+      }
+    }
+  }
+  return { scanned: lists.length, updated }
+}
+
+async function putCollectionRecord(
+  ownDid: string,
+  rkey: string,
+  record: EndorsementListCollectionValue,
+  swapRecord?: string,
+): Promise<WriteResult> {
+  const body: Record<string, unknown> = {
+    repo: ownDid,
+    collection: COLLECTION,
+    rkey,
+    record,
+  }
+  if (swapRecord) body.swapRecord = swapRecord
+  const res = await authFetch("/api/xrpc/com/atproto/repo/putRecord", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  const data = (await res.json().catch(() => ({}))) as {
+    uri?: string
+    cid?: string
+    error?: string
+  }
+  if (!res.ok || !data.uri || !data.cid) {
+    throw new Error(data.error || `Failed to update list: ${res.status}`)
+  }
+  return { uri: data.uri, cid: data.cid }
+}
+
+function existingUri(ownDid: string, rkey: string): string {
+  return `at://${ownDid}/${COLLECTION}/${rkey}`
 }


### PR DESCRIPTION
## Summary

- Lists move from one `app.certified.badge.definition` per list to one `org.hypercerts.collection` record per list (`type: \"endorsement-list\"`).
- Awards continue to point at a single per-issuer default badge definition; the list becomes a curation overlay whose `items[]` holds strongRefs to those awards.
- Deleting a list and removing a subject from a list no longer cascade to delete the underlying endorsement award.

## Why

User decision in chat: keep one shared endorsement-badge definition and make lists a separate, queryable, composable curation primitive. The full pros/cons live in [`docs/lists-as-collections/`](docs/lists-as-collections/).

## Files of note

- `src/lib/atproto/collection.ts` — new helpers: `listEndorsementListCollections`, `createEndorsementListCollection`, `updateEndorsementListCollection`, `deleteEndorsementListCollection`, `appendItemToList`, `removeItemFromList`, `purgeAwardFromLists`, plus the `ENDORSEMENT_LIST_TYPE` discriminator and the `EndorsementListCollectionValue` narrowing.
- `src/lib/atproto/badges.ts` — drops `createListDefinition` / `updateListDefinition` / `createListAward` / `deleteListAndAwards`. `deleteEndorsementAward` now calls `purgeAwardFromLists` first so revokes from the Given panel don't leave ghost rows on lists.
- `src/hooks/use-endorsement-lists.ts` — full rewrite. New `addSubjectToList(rkey, did)` (subject-level dedupe + ensure-award + append) and `removeSubjectFromList(rkey, awardUri)` (drops item; award survives).
- `src/components/profile/endorsement-lists.tsx` — rewires create/add/remove/delete. Confirm copy updated to reflect the new semantics.
- `src/hooks/use-endorsements.ts` — stops populating `GivenEndorsement.listTitle` (field stays as a vestigial optional for prop-shape continuity).
- Tests: `src/lib/atproto/__tests__/collection.test.ts` (12 cases).

## Plan + reviews

- [docs/lists-as-collections/discovery.md](docs/lists-as-collections/discovery.md)
- [docs/lists-as-collections/plan.md](docs/lists-as-collections/plan.md)
- [docs/lists-as-collections/review-round-1.md](docs/lists-as-collections/review-round-1.md) (plan review)
- [docs/lists-as-collections/review-round-2.md](docs/lists-as-collections/review-round-2.md) (impl review)

## Breaking changes / migration

No backfill is shipped. Existing lists written under the old `app.certified.badge.definition` shape disappear from the Lists tab after this lands; the underlying awards still render in Given/Received. Acceptable on staging; a one-shot migration is out of scope for this PR and can land separately if real user data warrants it.

## Local verification

- \`npx tsc --noEmit\` — 0 errors (baseline 0).
- \`npx vitest run\` — 149 passing (the 11 new + 1 round-trip case under \`collection.test.ts\`).
- \`npm run lint\` — 2 errors, 36 warnings; all pre-existing in untouched files (\`built-for-trust.tsx\`, etc.).
- \`npm run build\` — succeeds, no warnings emitted.

## Test plan

- [ ] Owner can create a list (title + optional description); list appears in Lists tab immediately.
- [ ] Owner can add a subject; the subject gains an endorsement in Given AND appears as a row on the list.
- [ ] Adding the same subject twice (e.g. double-click) does NOT create a second award.
- [ ] Owner can remove a subject; the row disappears; the underlying endorsement still shows in Given.
- [ ] Owner can edit title/description; \`items[]\` survives the edit.
- [ ] Owner can delete a list; the underlying endorsements survive.
- [ ] Revoking an award from the Given panel removes the matching item from any list that contained it (no ghost rows after reload).
- [ ] Visitor (not the owner) can read another user's lists.
- [ ] Projects tab does not show endorsement-list records; Lists tab does not show project records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)