### PR TITLE
feat(auth): opt in to ePDS "Or sign in with ATProto/Bluesky" button

### DIFF
--- a/src/app/.well-known/oauth-client-metadata/route.ts
+++ b/src/app/.well-known/oauth-client-metadata/route.ts
@@ -17,6 +17,11 @@ export async function GET() {
     policy_uri: `${origin}/privacy`,
     email_template_uri: `${origin}/email/otp-email-template.html`,
     email_subject_template: "{{code}} — Your Certified sign-in code",
+    // Opt in to ePDS's "Or sign in with ATProto/Bluesky" button. ePDS
+    // redirects here with ?handle=<value>; the GET handler in
+    // src/app/api/auth/login/route.ts resolves the handle to its PDS
+    // and starts a fresh OAuth flow.
+    epds_handle_login_url: `${origin}/api/auth/login`,
   }
 
   return NextResponse.json(metadata, {

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -86,3 +86,42 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Authentication failed" }, { status: 500 })
   }
 }
+
+// ePDS handle-mode hand-off. Wired up via `epds_handle_login_url` in
+// the OAuth client metadata. When a user clicks "Or sign in with
+// ATProto/Bluesky" on the ePDS login page and types a handle, ePDS
+// navigates the browser here with ?handle=<value>; we resolve the
+// handle to its PDS and start a fresh OAuth flow against it.
+//
+// No CSRF: no state-changing body to forge — the OAuth state param
+// protects the round-trip.
+export async function GET(request: NextRequest) {
+  const raw = request.nextUrl.searchParams.get("handle")
+  if (!raw) {
+    return NextResponse.redirect(new URL("/", request.url))
+  }
+
+  const handle = sanitizeHandle(raw)
+  if (!handle) {
+    return NextResponse.redirect(new URL("/?error=invalid_handle", request.url))
+  }
+
+  try {
+    const client = await getOAuthClient()
+    const scope = "atproto transition:generic identity:handle account:email"
+    let url: URL
+    try {
+      url = await client.authorize(handle, { scope })
+    } catch (err) {
+      if (!handle.startsWith("http") && !handle.startsWith("did")) {
+        url = await client.authorize("https://" + handle, { scope })
+      } else {
+        throw err
+      }
+    }
+    return NextResponse.redirect(url)
+  } catch (err) {
+    console.error("[Auth] Handle login error:", err)
+    return NextResponse.redirect(new URL("/?error=auth_failed", request.url))
+  }
+}

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -98,12 +98,12 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   const raw = request.nextUrl.searchParams.get("handle")
   if (!raw) {
-    return NextResponse.redirect(new URL("/", request.url))
+    return NextResponse.redirect(new URL("/", request.url), { status: 302 })
   }
 
   const handle = sanitizeHandle(raw)
   if (!handle) {
-    return NextResponse.redirect(new URL("/?error=invalid_handle", request.url))
+    return NextResponse.redirect(new URL("/?error=invalid_handle", request.url), { status: 302 })
   }
 
   try {
@@ -119,9 +119,9 @@ export async function GET(request: NextRequest) {
         throw err
       }
     }
-    return NextResponse.redirect(url)
+    return NextResponse.redirect(url, { status: 302 })
   } catch (err) {
     console.error("[Auth] Handle login error:", err)
-    return NextResponse.redirect(new URL("/?error=auth_failed", request.url))
+    return NextResponse.redirect(new URL("/?error=auth_failed", request.url), { status: 302 })
   }
 }


### PR DESCRIPTION
## Summary

Wires up `epds_handle_login_url` so the ePDS login page renders the "Or sign in with ATProto/Bluesky" button under the email form, letting users sign in with any AT Protocol handle (Bluesky, third-party PDSes, etc.).

- Declared `epds_handle_login_url: \`\${origin}/api/auth/login\`` in the OAuth client metadata route. Per the ePDS spec, when this field is present + parseable as `https:`, the button is rendered.
- Added a `GET` handler at `/api/auth/login` that takes `?handle=<value>`, resolves it via the OAuth client (same one-fallback as the existing POST `mode: "handle"` path — try as-is, retry with `https://` prefix for typed PDS URLs), and 302-redirects to the resulting OAuth authorize URL.

No CSRF on the GET: no state-changing body to forge, and the OAuth `state` parameter protects the round-trip. Errors redirect to `/?error=…` rather than returning JSON, since this is a browser navigation.

## Flow once deployed

1. User clicks the Certified-branded button on ePDS's login page.
2. New "Or sign in with ATProto/Bluesky" button now appears below the email form.
3. User types \`alice.bsky.social\` → ePDS navigates browser to \`https://certified.app/api/auth/login?handle=alice.bsky.social\`.
4. GET handler resolves the handle → PDS, starts a PAR against that PDS, 302-redirects the browser to the authorize URL there.
5. Standard atproto OAuth callback back to \`/oauth/callback\`.

## Test plan

- [ ] Deploy and verify \`https://certified.app/.well-known/oauth-client-metadata\` returns \`epds_handle_login_url\` in the JSON.
- [ ] Open the ePDS login page via the Certified Sign-in button on a partner app — confirm the "Or sign in with ATProto/Bluesky" button renders under the email form.
- [ ] Click it, enter a Bluesky handle (e.g. \`you.bsky.social\`), confirm browser is redirected to bsky's PDS authorize URL.
- [ ] Complete OAuth, confirm callback lands the user signed in.
- [ ] Repeat with a custom-domain handle hosted on a third-party PDS to verify the \`https://\`-prefix fallback path.
- [ ] Confirm existing POST flow (in-app sign-in modal handle entry) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ePDS handle-mode authentication flow enabling seamless OAuth integration with external identity providers.
  * Extended OAuth metadata to support ePDS redirect URL configuration for improved third-party service coordination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypercerts-org/certified-app/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->