### PR TITLE
feat(explore): add list view to Projects tab

### DIFF
--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -464,7 +464,7 @@ html:has(.explore-page) .desktop-top-bar__row {
   margin: 0;
 }
 
-/* ---------- View toggle (certs only) ---------- */
+/* ---------- View toggle (certs + projects) ---------- */
 
 .explore__view-toggle {
   display: inline-flex;
@@ -507,7 +507,7 @@ html:has(.explore-page) .desktop-top-bar__row {
   border-left: 1px solid var(--border-subtle);
 }
 
-/* ---------- List view (certs) ---------- */
+/* ---------- List view (certs + projects) ---------- */
 
 .explore__list {
   list-style: none;

--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -19,6 +19,7 @@ import ActivityCard from "@/components/feed/activity-card"
 import CertListRow from "./cert-list-row"
 import ExploreUserCard from "./explore-user-card"
 import ExploreProjectCard from "./explore-project-card"
+import ProjectListRow from "./project-list-row"
 import {
   ACCOUNT_FILTERS,
   CERT_FILTERS,
@@ -54,8 +55,8 @@ function parseSort(v: string | null): SortOrder {
   return "newest"
 }
 
-type CertView = "list" | "gallery"
-function parseView(v: string | null): CertView {
+type ListGalleryView = "list" | "gallery"
+function parseView(v: string | null): ListGalleryView {
   return v === "gallery" ? "gallery" : "list"
 }
 
@@ -77,7 +78,7 @@ export default function Explore() {
   const sub = parseSubForKind(kind, searchParams?.get("sub") ?? null)
   const search = searchParams?.get("q") ?? ""
   const sort = parseSort(searchParams?.get("sort") ?? null)
-  const certView = parseView(searchParams?.get("view") ?? null)
+  const view = parseView(searchParams?.get("view") ?? null)
   const { did: viewerDid } = useAuth()
 
   // Client-side filter chip(s) — kind-specific simple boolean attributes
@@ -175,17 +176,17 @@ export default function Explore() {
             </label>
 
             <div className="explore__chrome-actions">
-              {kind === "certs" ? (
+              {kind === "certs" || kind === "projects" ? (
                 <div
                   className="explore__view-toggle"
                   role="group"
-                  aria-label="Cert view"
+                  aria-label={`${kind === "certs" ? "Cert" : "Project"} view`}
                 >
                   <button
                     type="button"
                     aria-label="List view"
-                    aria-pressed={certView === "list"}
-                    className={`explore__view-btn${certView === "list" ? " explore__view-btn--active" : ""}`}
+                    aria-pressed={view === "list"}
+                    className={`explore__view-btn${view === "list" ? " explore__view-btn--active" : ""}`}
                     onClick={() => setUrl({ view: null })}
                   >
                     <ListIcon size={14} strokeWidth={1.75} aria-hidden />
@@ -193,8 +194,8 @@ export default function Explore() {
                   <button
                     type="button"
                     aria-label="Gallery view"
-                    aria-pressed={certView === "gallery"}
-                    className={`explore__view-btn${certView === "gallery" ? " explore__view-btn--active" : ""}`}
+                    aria-pressed={view === "gallery"}
+                    className={`explore__view-btn${view === "gallery" ? " explore__view-btn--active" : ""}`}
                     onClick={() => setUrl({ view: "gallery" })}
                   >
                     <LayoutGrid size={14} strokeWidth={1.75} aria-hidden />
@@ -284,7 +285,7 @@ export default function Explore() {
             data={data}
             sort={sort}
             attrs={attrs}
-            certView={certView}
+            view={view}
           />
           {data.hasMore || data.isLoadingMore ? (
             <LoadMoreSentinel
@@ -477,13 +478,13 @@ function ResultsArea({
   data,
   sort,
   attrs,
-  certView,
+  view,
 }: {
   kind: ExploreKind
   data: ReturnType<typeof useExploreData>
   sort: SortOrder
   attrs: Set<string>
-  certView: CertView
+  view: ListGalleryView
 }) {
   if (data.isLoading && data.users.length === 0 && data.projects.length === 0 && data.certs.length === 0) {
     return (
@@ -524,6 +525,17 @@ function ResultsArea({
       )
     projects = sortProjects(projects, sort)
     if (projects.length === 0) return <EmptyResults kind={kind} />
+    if (view === "list") {
+      return (
+        <ul className="explore__list explore__list--projects">
+          {projects.map((p) => (
+            <li key={p.uri}>
+              <ProjectListRow project={p} />
+            </li>
+          ))}
+        </ul>
+      )
+    }
     return (
       <ul className="explore__grid explore__grid--projects">
         {projects.map((p) => (
@@ -547,7 +559,7 @@ function ResultsArea({
   certs = sortCerts(certs, sort)
   if (certs.length === 0) return <EmptyResults kind={kind} />
 
-  if (certView === "list") {
+  if (view === "list") {
     return (
       <ul className="explore__list explore__list--certs">
         {certs.map((rec) => {

--- a/src/components/explore-page/project-list-row.tsx
+++ b/src/components/explore-page/project-list-row.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { FolderGit2 } from "lucide-react"
+import { resolveActivityImageUrl, formatRelativeTime } from "@/lib/atproto/activity"
+import { parseAtUri } from "@/lib/atproto/activity-uri"
+import ActivityAuthor from "@/components/feed/activity-author"
+import type { CollectionRecord } from "@/lib/atproto/collection"
+
+/**
+ * Dense single-row representation of a project for the /explore list
+ * view. Mirrors <CertListRow>'s grid:
+ *
+ *   [thumb] [ title             ] [ author col ] [ date ]
+ *           [ short desc · N certs ]
+ */
+export default function ProjectListRow({
+  project,
+}: {
+  project: CollectionRecord
+}) {
+  const { value, uri } = project
+  const parsed = parseAtUri(uri)
+  const did = parsed?.did ?? ""
+  const detailHref = parsed
+    ? `/project/${encodeURIComponent(parsed.did)}/${encodeURIComponent(parsed.rkey)}`
+    : null
+
+  const title =
+    asString(value.title) || asString(value.name) || "Untitled project"
+  const shortDesc = asString(value.shortDescription)
+  const createdAt = asString(value.createdAt)
+
+  const rawImage = (value as Record<string, unknown>).banner ?? value.image
+  const imageUrl =
+    rawImage && did
+      ? resolveActivityImageUrl(
+          rawImage as Parameters<typeof resolveActivityImageUrl>[0],
+          did,
+        )
+      : null
+  const [imageFailed, setImageFailed] = useState(false)
+
+  const itemCount = countItems(value.items)
+  const countLabel = `${itemCount} cert${itemCount === 1 ? "" : "s"}`
+  const metaParts = [shortDesc, countLabel].filter(
+    (s): s is string => !!s,
+  )
+
+  return (
+    <article className="cert-list-row">
+      {detailHref ? (
+        <Link href={detailHref} className="cert-list-row__link">
+          <div className="cert-list-row__thumb">
+            {imageUrl && !imageFailed ? (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                className="cert-list-row__img"
+                src={imageUrl}
+                alt=""
+                loading="lazy"
+                onError={() => setImageFailed(true)}
+              />
+            ) : (
+              <FolderGit2
+                size={20}
+                strokeWidth={1.25}
+                aria-hidden
+                className="cert-list-row__img-fallback"
+              />
+            )}
+          </div>
+          <div className="cert-list-row__body">
+            <h3 className="cert-list-row__title">{title}</h3>
+            {metaParts.length > 0 ? (
+              <p className="cert-list-row__meta">
+                {metaParts.map((m, i) => (
+                  <span key={i} className="cert-list-row__meta-item">
+                    {i > 0 ? (
+                      <span
+                        className="cert-list-row__meta-sep"
+                        aria-hidden
+                      >
+                        ·
+                      </span>
+                    ) : null}
+                    {m}
+                  </span>
+                ))}
+              </p>
+            ) : null}
+          </div>
+        </Link>
+      ) : null}
+
+      <div className="cert-list-row__author-col">
+        {did ? <ActivityAuthor did={did} /> : null}
+      </div>
+      <time className="cert-list-row__time">
+        {createdAt ? formatRelativeTime(createdAt) : ""}
+      </time>
+    </article>
+  )
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null
+}
+
+function countItems(items: unknown): number {
+  return Array.isArray(items) ? items.length : 0
+}


### PR DESCRIPTION
## Summary
- Adds a list-view toggle to the Projects tab on `/explore`, matching the existing affordance on the Certs tab.
- New `<ProjectListRow>` mirrors `<CertListRow>` so the row chrome (thumb · title/meta · author byline · date) is consistent between kinds.
- Project list rows reuse the `.cert-list-row` CSS to stay visually in lockstep — the only new styling is comment updates flagging that the toggle / list block now serves both kinds.

## Test plan
- [ ] Visit `/explore?kind=projects` — confirm the list/gallery toggle appears next to Sort/Filter.
- [ ] Switch to list view: rows render with banner thumb (or `FolderGit2` fallback), title + `shortDescription · N certs`, author byline, and relative time.
- [ ] Switch to gallery view: original card grid is unchanged.
- [ ] Confirm `/explore?kind=certs` toggle still behaves as before (default list, `?view=gallery` switches).
- [ ] Verify the `view` query param round-trips per kind and the choice persists when changing filters/sub/sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)