### PR TITLE
style(layout): full-bleed navbar + footer on every page

### DIFF
--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -16,14 +16,6 @@
   max-width: none;
 }
 
-/* Let the top bar stretch edge-to-edge too — same intent as the
-   .app-shell__grid override. `.desktop-top-bar` is a sibling of
-   `.app-shell` so we anchor on `html:has(.explore-page)` to reach
-   it from this stylesheet without touching layout.css. */
-html:has(.explore-page) .desktop-top-bar__row {
-  max-width: none;
-}
-
 @media (min-width: 800px) {
   .app-shell:has(.explore-page) .app-shell__grid {
     grid-template-columns: 1fr;

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -1945,7 +1945,11 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   display: flex;
   align-items: center;
   width: 100%;
-  max-width: 1536px;
+  /* No max-width cap — the chrome stretches viewport-wide on every
+     page so the navbar border-bottom and footer border-top run
+     edge-to-edge in lockstep (matches the framing on /explore and
+     /settings). Inner content keeps its 12px gutter via the padding
+     below. */
   margin: 0 auto;
   padding: 0 12px;
 }
@@ -3520,9 +3524,12 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
 
    One horizontal row at desktop (small brandmark + copyright on the
    left, link list on the right); wraps to two stacked rows on
-   narrow viewports. Sits inside `.app-shell__center` so the
-   gutters / max-width come from the existing grid. Top border
-   keeps the line between content and footer subtle.
+   narrow viewports. Sits as a sibling of `.app-shell__grid` (NOT
+   inside it) so the footer spans the full viewport width on every
+   page — the border-top reads as a page-frame divider that matches
+   the navbar's border-bottom edge-to-edge. Interior padding
+   (16px 32px 24px) gives the brandmark + link list breathing room
+   inset from the viewport edges.
    ============================================================ */
 
 .site-footer {

--- a/src/app/styles/settings-page.css
+++ b/src/app/styles/settings-page.css
@@ -55,13 +55,6 @@
   max-width: none;
 }
 
-/* Let the top bar stretch edge-to-edge too. `.desktop-top-bar` is a
-   sibling of `.app-shell`, so we anchor on `html:has(.sx)` to reach
-   it from this stylesheet without touching layout.css. */
-html:has(.sx) .desktop-top-bar__row {
-  max-width: none;
-}
-
 @media (min-width: 800px) {
   .app-shell:has(.sx) .app-shell__grid {
     grid-template-columns: 1fr;

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -12,6 +12,11 @@ import SiteFooter from "@/components/layout/site-footer";
  *     .app-shell__grid                max-width 1320; margin 0 auto
  *       .app-shell__center            grid cell (center column)
  *         .app-shell__content         reading-width container
+ *     SiteFooter                      sibling of the grid — sits at
+ *                                     viewport width so the footer
+ *                                     border-top runs edge-to-edge
+ *                                     on every page (matches the
+ *                                     full-bleed navbar).
  *
  * The desktop top bar is mounted in the root layout (sibling to <main>),
  * NOT inside this grid. The left rail and right rail were both retired
@@ -43,9 +48,9 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           <div className="app-shell__content">
             {children}
           </div>
-          <SiteFooter />
         </div>
       </div>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/components/layout/site-footer.tsx
+++ b/src/components/layout/site-footer.tsx
@@ -4,9 +4,12 @@ import Brandmark from "@/components/ui/brandmark"
 /**
  * Minimal site footer — GitHub-flavour. Single horizontal row at
  * desktop: small brandmark + copyright on the left, link list on
- * the right. Wraps to two stacked rows on narrow viewports. The
- * row sits inside the `.app-shell__center` column so the gutter
- * matches the rest of the page chrome.
+ * the right. Wraps to two stacked rows on narrow viewports.
+ *
+ * Rendered as a sibling of `.app-shell__grid` (NOT inside it) so
+ * the footer spans the full viewport width on every page — its
+ * border-top reads as a page-frame divider that matches the
+ * navbar's border-bottom edge-to-edge.
  *
  * Kept intentionally short — no marketing copy, no newsletter
  * signup, no social rail. Just identity + a handful of links the


### PR DESCRIPTION
## Summary
- Drop the `max-width: 1536px` cap on `.desktop-top-bar__row` so the navbar's content + border-bottom run viewport-edge-to-edge on every page.
- Move `<SiteFooter />` out of `.app-shell__grid` (now a sibling of the grid inside `.app-shell`) so the footer + its border-top span the full viewport width instead of being capped by the 1280/1300px grid column.
- Remove the now-redundant `html:has(.explore-page) .desktop-top-bar__row { max-width: none }` and `html:has(.sx) ...` overrides — they're folded into the global rule.

The framing the `/explore` and `/settings` pages already opted into is now the default everywhere.

## Test plan
- [ ] `/about`, `/home`, `/apps`, `/endorsements`, `/notifications` — navbar's bottom border and footer's top border both run viewport-edge-to-edge.
- [ ] `/explore` — unchanged: chrome edge-to-edge, sidebar/main divider still meets the footer border flush.
- [ ] `/settings` — unchanged: same edge-to-edge behaviour, divider flush.
- [ ] Profile pages (`/profile/<handle>`) — full-bleed banner still operates inside `.app-shell__content`; navbar tab row and footer span the full viewport.
- [ ] `/welcome` — bypasses `<AppShell>`; its own layout/footer is unaffected.
- [ ] Mobile (<800px) — bottom-nav still pinned; footer no longer constrained inside the grid is acceptable (it follows content as before, only its width changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)