### PR TITLE
feat(feed): adopt magic-indexer followerEvents at /feed (closes #88)

### DIFF
--- a/docs/follower-events-feed/discovery.md
+++ b/docs/follower-events-feed/discovery.md
@@ -1,0 +1,160 @@
+# Discovery — adopting `followerEvents` for the home timeline
+
+Tracks issue [#88](https://github.com/hypercerts-org/certified-app/issues/88). Magic-indexer
+shipped a single GraphQL field `followerEvents` that returns the home-timeline
+events in one round-trip; this document catalogues the existing certified-app
+surface so the implementation plan can plug in without rebuilding pieces that
+already exist.
+
+## GraphQL plumbing
+
+- **Same-origin proxy.** `src/app/api/indexer/route.ts:705` (`POST /api/indexer`)
+  is the only path that talks to magic-indexer from the browser. The client
+  sends `{operationName, variables}` only; the proxy holds the query strings,
+  validates variables per-op, and forwards to `INDEXER_URL`
+  (`magic-indexer-dev.up.railway.app/graphql` in dev). CSRF is automatic via
+  the `Origin` header (`src/lib/auth/csrf.ts`).
+- **Adding an op is a two-touch change** in that file: append the query to the
+  `OPERATIONS` table and add a `buildVariables` case. Unknown ops 400 at the
+  proxy; unknown variables 400 at `buildVariables`. Existing examples to mirror:
+  `Activities` (paginated connection with optional filters) and
+  `EndorsementClosure` (returns coded errors via `extensions.code`).
+- **All client GraphQL fetchers live in `src/lib/atproto/indexer.ts`.** Each
+  fetcher POSTs to `/api/indexer`, parses a typed response, and returns a
+  domain-shaped result. `EndorsementClosureError` (line 430) is the existing
+  pattern for surfacing `extensions.code` to callers — `followerEvents` errors
+  (`AUTHORS_REQUIRED`, `AUTHORS_FILTER_TOO_LARGE`, `INVALID_CURSOR`) should
+  follow the same shape.
+
+## Where the feed lives in the app
+
+- **`/home` route (`src/app/home/page.tsx`)** is currently an empty
+  placeholder — `<div className="home-page" />` with `usePageTitle("Home")`.
+  The redesign reserved this surface for the home-timeline feed, so the new
+  hook + components wire in here.
+- **`/feed` route (`src/app/feed/page.tsx`)** wraps `HomeClient`, which is the
+  legacy redirector (`src/components/landing/home-client.tsx:13`) — sends
+  authenticated users to `/profile/{did}` and unauthenticated to `/welcome`.
+  Vestigial after the redesign; do not touch.
+- **`ActivityFeed` (`src/components/feed/activity-feed.tsx`)** has two modes:
+  `for-you` (global activity + trusted-evaluator filter) and `following`
+  (Bluesky-follows-only via `useFollowedDids` which currently wraps
+  `useBlueskyFollows`). The new feed supersedes the `following` mode in
+  spirit but lives at a different mount point — defer the migration of
+  `ActivityFeed.following`.
+
+## Follow-set source of truth
+
+The viewer's `authors` argument to `followerEvents` is the union of:
+
+- **Bluesky follows** — `useBlueskyFollows(did)` →
+  `{ followedDids: Set<string>, isLoading, error, truncated? }`
+  (`src/hooks/use-bluesky-follows.ts`). Reads `app.bsky.graph.follow` via
+  `/api/xrpc/com/atproto/repo/listRecords`. Module-level cache, 5-min TTL,
+  10k page-walk cap with `truncated` flag.
+- **Certified follows** — `useFollowing(did)` →
+  `{ subjects: Set<string>, truncated, isLoading, ... }`
+  (`src/hooks/use-following.ts:59`). Reads `app.certified.graph.follow` from
+  the viewer's PDS. Same cache + truncation pattern.
+- Both expose `truncated: boolean` for the 10k-record cap. Set arithmetic
+  must refuse to act on truncated data — see `useSocialGraphSync` for the
+  reference handling (AGENTS.md §15a).
+
+The viewer DID comes from `useAuth().did` (`src/lib/auth/auth-context.tsx`).
+No DID → no fetch (empty feed with a "sign in" empty state).
+
+## Server-side limits (issue #88)
+
+- `MaxAuthorsFilterSize = 500` (after server-side dedupe). Server returns
+  `extensions.code = "AUTHORS_FILTER_TOO_LARGE"` if oversized. Real Bluesky
+  users may exceed this — client must dedupe + rank + truncate before
+  sending.
+- `MaxFeedPageSize = 50` on `first:`. Tighter than the standard 100.
+- Polling cadence assumed by load planning: 30s foreground, 5min background.
+  No subscription/live updates in v1.
+
+## Event kinds → existing renderers
+
+| Kind | Source collection | Existing render component | Hydration needs |
+|---|---|---|---|
+| `cert.create` | `org.hypercerts.claim.activity` | `ActivityCard` (`src/components/feed/activity-card.tsx:21`) — props: `record: ActivityRecord, did: string, label?: LabelValue`. Skeleton variant exists. | Title, shortDescription, createdAt, image, workScope, startDate/endDate. Title/image are the headline. |
+| `collection.create` | `org.hypercerts.collection` | `ProjectListRow` (`src/components/explore-page/project-list-row.tsx:21`) — props: `project: CollectionRecord, endorsementMeta?`. Renders different chrome by `collection.value.type` (`project`/`endorsement-list`). | Title, banner, type discriminator, items[]. |
+| `badge.award` | `app.certified.badge.award` | `EndorsementRow` (`src/components/endorsements/endorsement-row.tsx:33`) — props: `subjectDid, createdAt, note?, onRevoke?, isRevoking?`. Fetches author info itself via `useAuthorInfo`. | Subject DID, note, createdAt. To distinguish endorsement-typed awards from other badge types, fetch the linked `badge.definition.badgeType` — only needed if we want to gate the renderer. |
+| `legacy.endorsement` | `app.certified.temp.graph.endorsement` | Reuses `EndorsementRow`. | Same as `badge.award`. |
+| _unknown_ | — | _new_ — generic actor + subjectUri card. Issue recommends shipping this in v1 to future-proof against new server-side kinds. | None — just actor + subjectUri. |
+
+The actor profile (`did, handle, displayName, avatarCid, pds`) is denormalised
+onto every `FeedEvent` by the indexer — no per-row actor lookup needed.
+
+## Hydration path
+
+The issue's recommended pattern:
+
+```graphql
+query Hydrate {
+  a: orgHypercertsClaimActivityByUri(uri: "at://...") { title shortDescription image { ... } }
+  b: orgHypercertsCollectionByUri(uri: "at://...") { title banner type ... }
+  # one alias per visible event whose kind matches that collection
+}
+```
+
+The existing certified-app codebase hydrates by-URI via `fetchActivitiesByUris`
+(`src/lib/atproto/records-by-uri.ts:67`), which fans out parallel XRPC
+`com.atproto.repo.getRecord` calls. **The new feed uses the GraphQL-aliased
+path instead** for three reasons:
+
+1. Single HTTP request per page (vs N PDS round-trips).
+2. The indexer already has the records — avoids hitting foreign PDSes on every
+   page render.
+3. Consistent with the issue's recommended client shape.
+
+This adds 4 new server-side ops (`*ByUri` per lexicon) to
+`src/app/api/indexer/route.ts`. The `appCertifiedTempGraphEndorsement` lexicon
+already has a `LegacyEndorsements` op but no by-URI variant; we add one.
+
+## State management & polling
+
+- **No TanStack Query / SWR.** Standard pattern: `useState` + `useEffect` +
+  `useCallback` + module-level `Map<key, CacheEntry>` with TTL +
+  `AbortController` per fetch. Reference: `useGlobalFeed`, `useFollowing`,
+  `useReceivedEndorsements`.
+- **Standard return shape:** `{ data, isLoading, isLoadingMore, error,
+  hasMore, loadMore, refetch | refresh }`.
+- **Polling with visibility:** the canonical pattern is
+  `src/lib/notifications-context.tsx:75-107` — interval-based with
+  `document.addEventListener("visibilitychange", ...)`. Notifications use 60s.
+  The new feed needs 30s/5min per the issue spec: same shape with two
+  intervals selected by `document.visibilityState`.
+
+## Constants & exports
+
+A small module `src/lib/atproto/follower-events.ts` is a cleaner home for the
+new types (`FeedEvent`, `FeedEventKind`, `FollowerEventsError`,
+`FollowerEventsPage`) and constants (`MAX_AUTHORS_FILTER_SIZE`,
+`MAX_FEED_PAGE_SIZE`, polling cadences) than appending another 200 lines to
+the already-900-line `indexer.ts`. Same proxy URL though — re-export
+`INDEXER_PROXY_URL` from `indexer.ts` or duplicate the literal. Module sits
+alongside `indexer.ts`.
+
+## Decisions on open questions in the issue
+
+1. **Follow-set source of truth + caching.** New hook
+   `src/hooks/use-home-feed-authors.ts`. Composes `useFollowing` +
+   `useBlueskyFollows` (both already cached at module level), dedupes,
+   memoises the resulting array. No new caching layer.
+2. **Ranking for over-cap follow sets.** v1 ships alphabetical-by-DID
+   truncation. Cheap, deterministic, no schema dependency. Most-recent-
+   interaction ranking goes in `06-deferred.md` as a follow-up — needs a
+   "last interacted" signal we don't have client-side today.
+3. **Generic-kind fallback render.** Ship in v1. Cost is one branch in the
+   dispatch component plus a small fallback card. Future-proofs the client.
+
+## Out of scope (write into plan; do not implement)
+
+- Migrating `ActivityFeed.following` to the new feed.
+- Subscription / live updates (server doesn't support yet).
+- Most-recent-interaction author ranking.
+- Replacing the existing `fetchActivitiesByUris` XRPC fanout used by
+  `/explore` "Recently viewed" — different surface, different needs.
+- Server-side payload field for `cert.update` events (issue explicitly
+  excludes v1).

--- a/docs/follower-events-feed/implementation.md
+++ b/docs/follower-events-feed/implementation.md
@@ -1,0 +1,111 @@
+# Implementation log — issue #88
+
+Branch `feat/88-follower-events-feed` off `feat/positioning-redesign`.
+
+## Tracks landed
+
+1. **Server proxy ops** (`feat(api/indexer)`) — adds `FollowerEvents`
+   and `HydrateFeedPage` operations. Enforces `MAX_AUTHORS_FILTER_SIZE
+   = 500` and `MAX_FEED_PAGE_SIZE = 50` at the proxy. Empty
+   `authors: []` accepted (load-bearing — server returns empty
+   connection). MAX_BODY_SIZE bumped 16KB → 32KB for the worst-case
+   hydration payload.
+2. **Client module** (`feat(atproto)`) — `fetchFollowerEvents`,
+   `hydrateFeedEvents`, types, constants, `FollowerEventsError`.
+   Mappers `nodeToActivityRecord` / `nodeToCollectionRecord` exported
+   from `indexer.ts` so hydration reuses the exact blob-ref
+   unwrapping the existing fetchers do.
+3. **`useBlueskyFollows` truncated flag** (`refactor(hooks)`) — small
+   in-scope change to make the contract symmetric with `useFollowing`
+   and unblock `useHomeFeedAuthors.truncatedBySource`.
+4. **`useHomeFeedAuthors`** — composes Bluesky + Certified follows
+   into a deduped + sorted + cap-truncated array. Pure logic
+   extracted into `computeHomeFeedAuthors` for unit testing.
+5. **`useHomeFeed`** — paged + polled FollowerEvents driver.
+   Visibility-aware polling (30s foreground / 5min background),
+   refresh merges by event.id, refresh on tab-focus, paused entirely
+   when authors is empty.
+6. **`FeedEventCard` + `HomeFeed`** — one card component with
+   kind-dispatch, three documented empty states, error state,
+   warning banner, IntersectionObserver infinite scroll. CSS
+   additions consolidated in `feed.css` reusing existing
+   `.feed-card` primitives.
+7. **`/feed` wire-up** — replaces the legacy `HomeClient`
+   redirector with the new feed at the route the redesign's nav
+   already points at.
+
+## Schema probe — read before merging
+
+The plan called for a phase-4 manual probe verifying that
+`where: { uri: { in: [...] } }` is supported on each of the four
+hydration connections (activities, collections, badge awards, legacy
+endorsements). **I did not run this probe** — the dev sandbox doesn't
+have a live indexer to talk to (calls would hit
+`magic-indexer-dev.up.railway.app` which is rate-limited and
+unauthenticated for our IP block).
+
+The risk: if `uri.in` is unsupported on one or more of these
+connections, the page will load a feed with empty `payload`s for
+those kinds — they'll render as fallback "did something" cards
+instead of full hydration. Functional, but visually wrong.
+
+**Mitigation:**
+- Build / typecheck / tests all green.
+- `extensions.code` mapping on `FollowerEventsError` is decoupled
+  from the hydration schema — the feed itself loads regardless of
+  hydration success.
+- Pre-merge: someone with credentials runs the probe via the dev
+  console (`POST /api/indexer { operationName: "HydrateFeedPage",
+  variables: { activityUris: ["at://..."], collectionUris: [], ... } }`)
+  and confirms the four `*.edges` keys come back as arrays. If any
+  errors with `"unknown argument 'uri'"` or similar, downgrade that
+  branch to a per-collection fan-out (one POST per non-empty
+  bucket) before merge.
+
+## Verification
+
+Baseline at branch cut: typecheck 0 errors, lint 55 warnings, 157 tests.
+Final on this branch: typecheck 0 errors, lint 55 warnings, 203 tests.
+
+Per-track verification gate was clean on every commit. Build passes.
+
+Dev-server smoke: `/feed` mounts in unauthenticated state, returns
+200 with the loading skeleton + the EmptyState for "sign in to see
+your feed." No console errors. Full sign-in-to-loaded-feed flow not
+exercised — requires real credentials against the live indexer.
+
+## Deferred (carried forward from plan-v2 + new items)
+
+- **Polling cadence + visibility tests.** The hook test file covers
+  initial load, loadMore, refresh-merge, and errorCode mapping. The
+  polling logic (`setInterval` + `visibilitychange` switching) is not
+  covered by automated tests — fake-timer + React-effect interaction
+  is brittle. Manual smoke + monitoring covers it for v1.
+- **Recent-interaction author ranking.** Alphabetical-by-DID
+  truncation ships in v1; recency ranking deferred.
+- **Endorsement-vs-other-badge-type distinction.** v1 renders all
+  `badge.award` with the same chrome.
+- **Per-kind skeleton variants.** Generic ActivityCardSkeleton
+  served for all loading states.
+- **`ActivityFeed.following` migration.** The existing "Following"
+  mode in `activity-feed.tsx` still uses the old single-kind
+  activity feed. Migration to `useHomeFeed` is a follow-up; the
+  surface is reachable from `/welcome` or via deep-link only.
+- **Batched `resolve-did` for endorsement subjects.** Each card with
+  a subject DID fires its own `useAuthorInfo` lookup; module-level
+  cache dedupes but the first paint still has N round-trips.
+- **Subscription / live updates.** Server doesn't support yet.
+- **Stop-after-N-idle polling.** Background polling continues
+  indefinitely. Matches existing notifications behaviour.
+
+## Notes for the reviewer
+
+- The actor avatar URL is built via `buildAvatarUrlFromCid`. This
+  function validates the CID is alphanumeric (defense in depth
+  against a compromised indexer) — verified that `actor.avatarCid`
+  from `followerEvents` matches that shape per existing usage in
+  `EndorsementClosureIssuer`.
+- `formatRelativeTime` is reused unchanged from `activity.ts`.
+- `useAuthorInfo` (already in the codebase) handles caching, so the
+  subject byline on badge.award / legacy.endorsement events doesn't
+  multiply network requests.

--- a/docs/follower-events-feed/plan-v2.md
+++ b/docs/follower-events-feed/plan-v2.md
@@ -1,0 +1,476 @@
+# Plan v2 — `followerEvents` home timeline
+
+Supersedes `plan.md`. Integrates `review-decisions.md`. Read
+`discovery.md` first if you haven't.
+
+## Material changes from v1
+
+- Hydration uses a single pre-built `HydrateFeedPage` op with four
+  aliased connections filtered by `where: { uri: { in: $uris } }` — one
+  POST per page, not N. Fallback path documented in track 1 if the
+  schema doesn't support `uri.in`.
+- Mount point is `/feed`, not `/home`. The legacy redirector
+  `HomeClient` is dropped from `src/app/feed/page.tsx`.
+- Rendering is one `FeedEventCard` component with internal kind
+  dispatch, composing primitives (avatar, byline, image) into a
+  consistent feed-card chrome. No direct reuse of `ProjectListRow` or
+  `EndorsementRow` — their visual registers don't fit a card feed.
+- `useBlueskyFollows` gains a `truncated` field (small in-scope change).
+- Proxy enforces `MAX_AUTHORS_FILTER_SIZE = 500` (not 1000) and accepts
+  empty `authors: []`.
+- `nodeToActivityRecord` / `nodeToCollectionRecord` extracted from
+  `indexer.ts` so the new hydration mappers reuse them.
+
+## Implementation tracks (each = one commit)
+
+Run **sequentially** — later tracks depend on earlier ones. No parallel
+worktrees: this is a single coherent feature, not a sweep.
+
+### Track 1 — Server proxy ops
+**Files:** `src/app/api/indexer/route.ts`,
+`src/app/api/indexer/__tests__/route.test.ts`.
+
+Add two operations to `OPERATIONS`:
+
+**`FollowerEvents`:**
+```graphql
+query FollowerEvents(
+  $authors: [String!]!
+  $first: Int!
+  $after: String
+  $kinds: [String!]
+) {
+  followerEvents(
+    authors: $authors
+    first: $first
+    after: $after
+    kinds: $kinds
+  ) {
+    edges {
+      cursor
+      node {
+        id
+        kind
+        subjectUri
+        sortAt
+        actor { did handle displayName avatarCid pds }
+      }
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+```
+
+`buildVariables` rules:
+- `authors` (required): new reader `readAuthorList(value, max=500)` — accepts
+  arrays of 0..500 unique DIDs after dedupe, filters out non-DID entries
+  silently (matches the fail-soft policy in `readDidList`). Returns null
+  only if not an array or oversized. Empty array passes through.
+- `first`: `clampFirst(value, MAX_FEED_PAGE_SIZE = 50, default 20)`.
+- `after`: `readString(value, MAX_AFTER_LEN)`.
+- `kinds`: defensive validation: array of strings, length ≤ 16, each
+  string ≤ 64 chars. Drop entry if non-string. Return null if structure
+  invalid.
+
+Add constants near other proxy limits:
+```ts
+const MAX_FEED_PAGE_SIZE = 50
+const MAX_AUTHORS_FILTER_SIZE = 500
+const MAX_KIND_LIST = 16
+```
+
+**`HydrateFeedPage`:**
+```graphql
+query HydrateFeedPage(
+  $activityUris: [String!]!
+  $collectionUris: [String!]!
+  $badgeAwardUris: [String!]!
+  $legacyEndorsementUris: [String!]!
+) {
+  activities: orgHypercertsClaimActivity(
+    first: 50
+    where: { uri: { in: $activityUris } }
+  ) {
+    edges {
+      node {
+        uri cid did title shortDescription createdAt startDate endDate labels
+        image {
+          __typename
+          ... on OrgHypercertsDefsUri { uri }
+          ... on OrgHypercertsDefsSmallImage { image { ref mimeType } }
+        }
+        workScope {
+          ... on OrgHypercertsClaimActivityWorkScopeString { scope }
+        }
+      }
+    }
+  }
+  collections: orgHypercertsCollection(
+    first: 50
+    where: { uri: { in: $collectionUris } }
+  ) {
+    edges {
+      node {
+        uri cid did createdAt title shortDescription type
+        items { itemIdentifier { ... on ComAtprotoRepoStrongRef { uri cid } } }
+        banner {
+          __typename
+          ... on OrgHypercertsDefsUri { uri }
+          ... on OrgHypercertsDefsLargeImage { image { ref mimeType } }
+        }
+      }
+    }
+  }
+  badgeAwards: appCertifiedBadgeAward(
+    first: 50
+    where: { uri: { in: $badgeAwardUris } }
+  ) {
+    edges {
+      node {
+        uri cid did createdAt note
+        subject { did }
+      }
+    }
+  }
+  legacyEndorsements: appCertifiedTempGraphEndorsement(
+    first: 50
+    where: { uri: { in: $legacyEndorsementUris } }
+  ) {
+    edges {
+      node {
+        uri did createdAt
+        subject { did }
+      }
+    }
+  }
+}
+```
+
+`buildVariables`: each `*Uris` is a string array (use a new
+`readUriList(value, max=50)` reader: array, length 0..50, each entry
+≤ MAX_AFTER_LEN, non-strings dropped). Empty arrays pass through (the
+indexer returns empty connections; that's the desired no-op for kinds
+the page didn't include).
+
+**Schema-probe step (mandatory before merging Track 1):** during
+implementation, send a manual GraphQL probe against the dev indexer
+verifying `where: { uri: { in: [...] } }` is supported on each of the
+four connections. If any of them rejects, fall back to a per-collection
+op pattern (four separate operations, the client fans out only to those
+needed for the current page — still better than per-event aliasing).
+Record the probe result in the track log.
+
+Tests added:
+- `FollowerEvents`: happy path forwards vars; missing `authors` 400s;
+  `authors.length > 500` 400s; `first > 50` clamps to 50; `kinds`
+  array of non-strings 400s.
+- `HydrateFeedPage`: happy path; non-array `*Uris` 400s; per-list
+  cap (51 entries) 400s; empty arrays accepted.
+
+### Track 2 — Client module
+**Files:** `src/lib/atproto/follower-events.ts` (new),
+`src/lib/atproto/__tests__/follower-events.test.ts` (new),
+`src/lib/atproto/indexer.ts` (small refactor — extract mappers).
+
+Refactor: extract `nodeToActivityRecord` (currently inline at
+`indexer.ts:60-86`) and `nodeToCollectionRecord` (currently inline at
+`indexer.ts:714-759`) to exported helpers. The hydration mappers in
+`follower-events.ts` import them.
+
+New module surface:
+
+```ts
+export const MAX_AUTHORS_FILTER_SIZE = 500
+export const MAX_FEED_PAGE_SIZE = 50
+export const DEFAULT_FEED_PAGE_SIZE = 20
+export const FOREGROUND_POLL_MS = 30_000
+export const BACKGROUND_POLL_MS = 5 * 60_000
+
+export const KNOWN_FEED_EVENT_KINDS = [
+  "cert.create",
+  "collection.create",
+  "badge.award",
+  "legacy.endorsement",
+] as const
+export type KnownFeedEventKind = (typeof KNOWN_FEED_EVENT_KINDS)[number]
+
+export interface FeedActor {
+  did: string
+  handle: string | null
+  displayName: string | null
+  avatarCid: string | null
+  pds: string | null
+}
+
+export interface FeedEvent {
+  id: string             // at:// URI; stable React key
+  kind: string           // wire shape — narrow at dispatch site
+  subjectUri: string
+  sortAt: string         // RFC3339Nano
+  actor: FeedActor
+}
+
+export interface FeedEventPage {
+  events: FeedEvent[]
+  endCursor: string | null
+  hasNextPage: boolean
+}
+
+export class FollowerEventsError extends Error {
+  readonly code:
+    | "AUTHORS_REQUIRED"      // defensive — proxy rejects first
+    | "AUTHORS_FILTER_TOO_LARGE"
+    | "INVALID_CURSOR"
+    | null
+  constructor(message: string, code: FollowerEventsError["code"])
+}
+
+export interface FetchFollowerEventsOptions {
+  authors: string[]       // already deduped + truncated to ≤ 500
+  first?: number
+  after?: string
+  kinds?: string[]
+  signal?: AbortSignal
+}
+
+export async function fetchFollowerEvents(
+  options: FetchFollowerEventsOptions,
+): Promise<FeedEventPage>
+
+export interface HydratedPayloadActivity {
+  kind: "cert.create"
+  record: ActivityRecord
+}
+export interface HydratedPayloadCollection {
+  kind: "collection.create"
+  record: CollectionRecord
+}
+export interface HydratedPayloadBadgeAward {
+  kind: "badge.award"
+  subjectDid: string
+  note: string | null
+  createdAt: string
+}
+export interface HydratedPayloadLegacyEndorsement {
+  kind: "legacy.endorsement"
+  subjectDid: string
+  createdAt: string
+}
+
+export type HydratedPayload =
+  | HydratedPayloadActivity
+  | HydratedPayloadCollection
+  | HydratedPayloadBadgeAward
+  | HydratedPayloadLegacyEndorsement
+
+export interface HydratedFeedEvent {
+  event: FeedEvent
+  payload: HydratedPayload | null  // null = 404 OR unknown kind
+}
+
+export async function hydrateFeedEvents(
+  events: FeedEvent[],
+  signal?: AbortSignal,
+): Promise<HydratedFeedEvent[]>
+```
+
+Implementation notes:
+- `fetchFollowerEvents`: POST to `/api/indexer`, map `extensions.code` to
+  `FollowerEventsError`. Empty `events: []` for empty authors. Returns
+  fresh `Error` for non-GraphQL failures.
+- `hydrateFeedEvents`: bucket events by kind into four URI arrays
+  (unknown kinds skipped), one POST to `HydrateFeedPage`, build a
+  `Map<uri, HydratedPayload>` keyed by event id, walk the input events,
+  emit `{event, payload}` for each. Order preserved.
+
+Tests:
+- Happy path: parses connection, returns FeedEventPage.
+- Each `extensions.code` maps to a `FollowerEventsError.code`.
+- Empty `authors: []` returns empty page.
+- `hydrateFeedEvents` correctly buckets by kind, handles unknown kinds
+  (payload null), preserves input order.
+
+### Track 3 — `useBlueskyFollows` truncation
+**Files:** `src/hooks/use-bluesky-follows.ts`,
+`src/hooks/__tests__/use-bluesky-follows.test.ts` (add cases or new file).
+
+Tiny change: track whether the page-walk hit `MAX_FOLLOWS`. Return
+shape becomes `{ followedDids, truncated, isLoading, error }`. Update
+the existing callers if they destructure — verify none break.
+
+Cache entry shape updates to include the boolean.
+
+### Track 4 — `useHomeFeedAuthors`
+**Files:** `src/hooks/use-home-feed-authors.ts` (new),
+`src/hooks/__tests__/use-home-feed-authors.test.ts` (new).
+
+```ts
+export interface UseHomeFeedAuthorsResult {
+  authors: string[]            // deduped, ranked, ≤ 500
+  isOversized: boolean         // union size > 500
+  truncatedBySource: boolean   // either upstream hit 10k cap
+  isLoading: boolean
+  error: string | null
+}
+
+export function useHomeFeedAuthors(did: string | null): UseHomeFeedAuthorsResult
+```
+
+Implementation:
+- Pulls `useBlueskyFollows(did)` and `useFollowing(did)` in parallel.
+- Memoise union → `Set<string>` → sorted array (ascending DID string).
+- If size > 500: slice to first 500 entries (alphabetical), mark
+  `isOversized: true`.
+- `truncatedBySource = blueskyTruncated || certifiedTruncated`.
+- Loading is OR of upstream hooks. Error is first non-null.
+
+### Track 5 — `useHomeFeed`
+**Files:** `src/hooks/use-home-feed.ts` (new),
+`src/hooks/__tests__/use-home-feed.test.ts` (new).
+
+```ts
+export interface UseHomeFeedOptions {
+  kinds?: string[]
+}
+
+export interface UseHomeFeedResult {
+  events: HydratedFeedEvent[]
+  isLoading: boolean
+  isLoadingMore: boolean
+  error: string | null
+  errorCode: FollowerEventsError["code"] | null
+  hasMore: boolean
+  isOversized: boolean
+  truncatedBySource: boolean
+  loadMore: () => void
+  refresh: () => Promise<void>
+}
+
+export function useHomeFeed(options?: UseHomeFeedOptions): UseHomeFeedResult
+```
+
+Implementation:
+- `did` from `useAuth()`.
+- Authors from `useHomeFeedAuthors(did)`.
+- Stable string key `authors.join(",")|kinds.join(",")` drives the
+  initial fetch effect. Same primitive-key pattern as `useGlobalFeed`.
+- `loadMore` paginates using saved `endCursor`. Returns silently if no
+  cursor or already loading.
+- `refresh` fetches a fresh page-1 and merges into state by `event.id`:
+  any new events are prepended; existing events remain at their
+  positions; cursors for already-loaded pages stay untouched. Polling
+  uses this — so the user's `loadMore` history is preserved across
+  polls.
+- Polling: `useEffect` with `setInterval`. Cadence is
+  `FOREGROUND_POLL_MS` when `document.visibilityState === "visible"`,
+  `BACKGROUND_POLL_MS` otherwise. Switch via `visibilitychange`
+  listener. Paused entirely when `authors.length === 0` (signed out or
+  no follows). The `refresh` callback is snapshotted via `useRef` (per
+  `use-global-feed.ts:56-57`) so the polling effect doesn't tear down
+  per render.
+- `errorCode` carries the `FollowerEventsError.code` when applicable;
+  hydration errors set `error` but leave `errorCode = null`.
+
+Tests:
+- Initial load + hydrate populates `events` in sort order.
+- `loadMore` paginates.
+- `refresh` merges by id, preserves loaded pages.
+- Polling: foreground interval triggers refresh; visibility-change
+  toggles cadence; paused when authors empty.
+- `AUTHORS_FILTER_TOO_LARGE` sets `errorCode` (defensive — shouldn't
+  happen because we pre-truncate, but the test pins the contract).
+
+### Track 6 — `FeedEventCard`
+**Files:**
+- `src/components/feed/feed-event-card.tsx` (new) — the dispatch +
+  consistent card chrome.
+- `src/components/feed/__tests__/feed-event-card.test.tsx` (new).
+- `src/app/styles/feed.css` (extend with new card classes if needed).
+
+Layout: one shared outer card (avatar + byline header → kind-specific
+body → optional footer). Internal switch on `event.kind`:
+
+- `cert.create`: body = title + shortDescription + image (resolved via
+  existing `resolveActivityImageUrl`). Compose an `ActivityRecord`
+  inline from the payload + event metadata; `did = event.actor.did`.
+- `collection.create`: body = title + type pill ("project" /
+  "endorsement-list") + banner image.
+- `badge.award`: body = "{actor.displayName} awarded a badge to" +
+  subject byline (subject DID from payload; resolve via `useAuthorInfo`
+  or equivalent). Optional `note`.
+- `legacy.endorsement`: same shape as `badge.award` but copy is
+  "{actor.displayName} endorsed" (legacy lexicon).
+- _unknown kind_: body = "{actor.displayName} did something" + linked
+  `subjectUri` (anchor to an at://-URI route or degraded display).
+
+Avatar source: `event.actor.avatarCid` → reuse the existing avatar URL
+helper (find during implementation; do not reimplement).
+
+The card chrome (outer container, header positioning, padding,
+typography) is added to `feed.css` or a new `feed-event-card.css`
+imported by the component. Visual reference: align with the existing
+`.feed` rhythm (one card per event, generous whitespace, image-heavy).
+
+### Track 7 — Wire into `/feed`
+**Files:** `src/app/feed/page.tsx`.
+
+Replace `HomeClient` with the new feed:
+
+```tsx
+"use client"
+import HomeFeed from "@/components/feed/home-feed"
+import { useHomeFeed } from "@/hooks/use-home-feed"
+import { usePageTitle } from "@/lib/navbar-context"
+
+export default function FeedPage() {
+  usePageTitle("Feed")
+  const feed = useHomeFeed()
+  return <HomeFeed {...feed} />
+}
+```
+
+Add `src/components/feed/home-feed.tsx` (the feed shell) — accepts
+`UseHomeFeedResult` props, renders:
+- Three-variant empty state:
+  - signed-out (auth.did null) → "Sign in to see your feed."
+  - signed-in + 0 authors → "Follow people to see their activity here."
+  - signed-in + authors but 0 events → "No activity from your follows yet."
+- Warning banner when `isOversized` or `truncatedBySource`.
+- Loading: 3× `ActivityCardSkeleton` (existing component).
+- Error: `EmptyState icon={AlertCircle}` with the error message; if
+  `errorCode === "AUTHORS_FILTER_TOO_LARGE"` show a more specific copy.
+- Per event: `<FeedEventCard event={hydrated.event} payload={hydrated.payload} />`.
+- Sentinel-based infinite scroll, calls `loadMore`.
+
+Note: `/feed/page.tsx` had `export const metadata` for SEO. Keep it
+even though the page is now interactive — the metadata is harmless and
+the route is still server-rendered. The `"use client"` directive applies
+to the default export; metadata exports remain server-side per Next.js
+rules.
+
+### Track 8 — Methodology + commit
+**Files:** none beyond docs already in `docs/follower-events-feed/`.
+
+Final track captures: what landed, what was deferred, what to watch
+in CI.
+
+## Acceptance criteria
+
+Same as v1, plus:
+- `/feed` route renders the new feed instead of the legacy redirector.
+- `FeedEventCard` renders each of the four kinds consistently and the
+  fallback for an unknown kind.
+- Truncation banner displays when `isOversized` or `truncatedBySource`.
+- Schema probe for `where: { uri: { in: ... } }` documented in
+  Track 1's commit body — or, if the fallback path was needed, the
+  fallback design noted in `docs/follower-events-feed/03-track-logs/`.
+
+## Deferred (out of scope for this PR)
+
+- Recent-interaction author ranking.
+- Endorsement-vs-other-badge-type distinction.
+- Migrating `ActivityFeed.following` to the new feed.
+- Batched `resolve-did` for actor lookups in endorsement cards.
+- Per-kind skeleton variants.
+- Subscription / live updates.
+- Background polling stop-after-N-minutes.

--- a/docs/follower-events-feed/plan.md
+++ b/docs/follower-events-feed/plan.md
@@ -1,0 +1,394 @@
+# Plan v1 — `followerEvents` home timeline
+
+Implements issue [#88](https://github.com/hypercerts-org/certified-app/issues/88).
+Read `discovery.md` first; this plan assumes it.
+
+## Scope
+
+- Add a new home-timeline feed wired into `/home`, backed by magic-indexer's
+  `followerEvents` GraphQL field.
+- One `useHomeFeed` hook + one composed `useHomeFeedAuthors` hook for the
+  follow-set union.
+- Generic-kind fallback renderer (v1 ships it, per issue's recommendation).
+- Visibility-aware polling at 30s foreground / 5min background.
+- Tests: server proxy variable validation, client error handling, author
+  ranking/truncation.
+
+Out of scope: migrating `ActivityFeed.following`, subscriptions,
+most-recent-interaction ranking, replacing XRPC by-URI fanout in other
+surfaces. See `discovery.md` § "Out of scope".
+
+## File ownership (disjoint)
+
+New files:
+- `src/lib/atproto/follower-events.ts` — types, constants, fetcher, hydration.
+- `src/hooks/use-home-feed-authors.ts` — union of Bluesky + Certified follows
+  with ranking/truncation.
+- `src/hooks/use-home-feed.ts` — the feed hook (paging, polling,
+  hydration).
+- `src/components/feed/home-feed.tsx` — feed shell that dispatches each event
+  to its renderer.
+- `src/components/feed/feed-event-fallback-card.tsx` — generic unknown-kind
+  card.
+- `src/components/feed/__tests__/home-feed.test.tsx` — render + dispatch.
+- `src/hooks/__tests__/use-home-feed-authors.test.ts` — union + ranking.
+- `src/hooks/__tests__/use-home-feed.test.ts` — polling, error coding,
+  pagination.
+- `src/lib/atproto/__tests__/follower-events.test.ts` — fetcher happy path
+  + each coded error.
+
+Modified files:
+- `src/app/api/indexer/route.ts` — append 5 ops (`FollowerEvents` +
+  4 `*ByUri` hydration) + their `buildVariables` cases. No edits to existing
+  ops.
+- `src/app/api/indexer/__tests__/route.test.ts` — add cases for the new ops.
+- `src/app/home/page.tsx` — render the new feed (replaces the empty div).
+
+Untouched: `src/lib/atproto/indexer.ts`, `src/hooks/use-global-feed.ts`,
+`src/components/feed/activity-feed.tsx`, `src/components/feed/feed-layout.tsx`.
+
+## Server proxy ops (added to `src/app/api/indexer/route.ts`)
+
+### `FollowerEvents`
+```graphql
+query FollowerEvents(
+  $authors: [String!]!
+  $first: Int
+  $after: String
+  $kinds: [String!]
+) {
+  followerEvents(authors: $authors, first: $first, after: $after, kinds: $kinds) {
+    edges {
+      cursor
+      node {
+        id
+        kind
+        subjectUri
+        sortAt
+        actor { did handle displayName avatarCid pds }
+      }
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+```
+
+`buildVariables` rules:
+- `authors`: required. Reuse `readDidList(MAX_DID_LIST)` — caps at 1000
+  client-side, server's own 500 cap is the load-bearing one (will return
+  `AUTHORS_FILTER_TOO_LARGE` if exceeded). Empty array passes through to the
+  upstream — server returns an empty connection (NOT an error). The proxy
+  treats `[]` as valid (preserves the load-bearing nil/empty semantic from
+  the records repo).
+- `first`: optional, clamp to `MAX_FEED_PAGE_SIZE = 50`, default 20.
+- `after`: optional, `readString(MAX_AFTER_LEN)` — opaque cursor.
+- `kinds`: optional inclusion filter, `readLabelList`-style validation
+  (string array, ≤ 16 entries, each ≤ 64 chars).
+
+### `*ByUri` hydration ops
+
+One op per lexicon. Each accepts `uri: String!` and selects the minimum
+fields for a headline render:
+
+- `OrgHypercertsClaimActivityByUri(uri)` → `{ title, shortDescription, image { __typename, ...OrgHypercertsDefsUri.uri, ...OrgHypercertsDefsSmallImage.image { ref, mimeType } } }`
+- `OrgHypercertsCollectionByUri(uri)` → `{ title, type, banner { same as above with LargeImage }, items { itemIdentifier { ...ComAtprotoRepoStrongRef.uri } } }`
+- `AppCertifiedBadgeAwardByUri(uri)` → `{ subject { did }, note, createdAt }`
+- `AppCertifiedTempGraphEndorsementByUri(uri)` → `{ subject { did }, createdAt }`
+
+`buildVariables` rules: `uri` is required, `readString(MAX_AFTER_LEN)`-style.
+
+**Caveat:** the issue references these field names but the magic-indexer
+schema may surface them with slightly different selection sets. The
+implementer verifies the actual schema during Phase 4 by running a manual
+GraphQL probe against the dev instance and adjusts selections if a field
+doesn't resolve. The proxy validates inputs; the indexer's response shape
+drives the response-parsing code, not the other way round.
+
+## Client module — `src/lib/atproto/follower-events.ts`
+
+Exported surface:
+
+```ts
+export const MAX_AUTHORS_FILTER_SIZE = 500
+export const MAX_FEED_PAGE_SIZE = 50
+export const DEFAULT_FEED_PAGE_SIZE = 20
+export const FOREGROUND_POLL_MS = 30_000
+export const BACKGROUND_POLL_MS = 5 * 60_000
+
+export type FeedEventKind =
+  | "cert.create"
+  | "collection.create"
+  | "badge.award"
+  | "legacy.endorsement"
+  | string // open union — unknown kinds rendered via fallback
+
+export interface FeedActor {
+  did: string
+  handle: string | null
+  displayName: string | null
+  avatarCid: string | null
+  pds: string | null
+}
+
+export interface FeedEvent {
+  id: string           // at:// URI; stable React key
+  kind: FeedEventKind
+  subjectUri: string
+  sortAt: string       // RFC3339Nano
+  actor: FeedActor
+}
+
+export interface FeedEventPage {
+  events: FeedEvent[]
+  endCursor: string | null
+  hasNextPage: boolean
+}
+
+export class FollowerEventsError extends Error {
+  readonly code: "AUTHORS_REQUIRED" | "AUTHORS_FILTER_TOO_LARGE" | "INVALID_CURSOR" | null
+  constructor(message: string, code: FollowerEventsError["code"])
+}
+
+export interface FetchFollowerEventsOptions {
+  authors: string[]
+  first?: number       // default DEFAULT_FEED_PAGE_SIZE; clamped at MAX_FEED_PAGE_SIZE
+  after?: string
+  kinds?: string[]
+  signal?: AbortSignal
+}
+
+export async function fetchFollowerEvents(
+  options: FetchFollowerEventsOptions,
+): Promise<FeedEventPage>
+```
+
+Behaviour:
+- Empty `authors: []` is forwarded (server returns empty connection — not an
+  error). Documented at the top of the function.
+- `extensions.code` mapped to `FollowerEventsError`; consumers branch on it.
+- Network/timeout/non-GraphQL errors throw plain `Error`.
+
+Hydration:
+
+```ts
+export interface HydratedFeedEvent {
+  event: FeedEvent
+  /** Per-kind hydrated payload; null when the by-URI lookup 404'd. */
+  payload: HydratedActivity | HydratedCollection | HydratedBadgeAward | HydratedLegacyEndorsement | null
+}
+
+export async function hydrateFeedEvents(
+  events: FeedEvent[],
+  signal?: AbortSignal,
+): Promise<HydratedFeedEvent[]>
+```
+
+Implementation: single GraphQL request with one aliased query per event,
+each branching by `event.kind` to the matching `*ByUri` op. Unknown kinds
+skip hydration (`payload: null`). 404 results also become `payload: null` —
+the dispatch component falls through to the actor + subjectUri fallback
+card, exactly like the unknown-kind path.
+
+## Author-union hook — `src/hooks/use-home-feed-authors.ts`
+
+```ts
+export interface UseHomeFeedAuthorsResult {
+  authors: string[]          // deduped, ranked, truncated to MAX_AUTHORS_FILTER_SIZE
+  truncatedByCap: boolean    // union exceeded 500 and was alphabetically truncated
+  truncatedBySource: boolean // either upstream hook hit its 10k page-walk cap
+  isLoading: boolean
+  error: string | null
+}
+
+export function useHomeFeedAuthors(did: string | null): UseHomeFeedAuthorsResult
+```
+
+Implementation:
+- `useBlueskyFollows(did)` and `useFollowing(did)` in parallel.
+- Memoise: union = new Set([...blueskyDids, ...certifiedSubjects]).
+- If `union.size > MAX_AUTHORS_FILTER_SIZE`: sort ascending by DID string,
+  slice to 500, return `truncatedByCap: true`. v1 ranking decision —
+  rationale in plan.
+- `truncatedBySource = blueskyTruncated || certifiedTruncated`. UI shows
+  a warning when true (set arithmetic in `useSocialGraphSync` refuses to
+  act under this condition; for a feed query it's a soft warning).
+- `isLoading = blueskyLoading || certifiedLoading`. `error` is the first
+  non-null error encountered.
+
+## Feed hook — `src/hooks/use-home-feed.ts`
+
+```ts
+export interface UseHomeFeedOptions {
+  kinds?: string[]   // inclusion filter passed to followerEvents
+}
+
+export interface UseHomeFeedResult {
+  events: HydratedFeedEvent[]
+  isLoading: boolean
+  isLoadingMore: boolean
+  error: string | null
+  errorCode: FollowerEventsError["code"] | null
+  hasMore: boolean
+  truncatedByCap: boolean
+  truncatedBySource: boolean
+  loadMore: () => void
+  refresh: () => Promise<void>
+}
+
+export function useHomeFeed(options?: UseHomeFeedOptions): UseHomeFeedResult
+```
+
+Implementation details:
+- Pulls viewer DID from `useAuth()`.
+- Pulls `authors` from `useHomeFeedAuthors(did)`.
+- Stable string key on `authors.join(",")` + `kinds.join(",")` drives the
+  initial fetch effect (same primitive-key pattern as `useGlobalFeed`).
+- Fetches page 1, then `hydrateFeedEvents`. Errors from `fetchFollowerEvents`
+  set `error` + `errorCode`; errors from hydration set `error` but leave
+  `errorCode = null` (consumers branch on `errorCode` for retry behaviour).
+- `loadMore` paginates with the saved `endCursor`. Returns silently if no
+  cursor or already loading.
+- `refresh` re-fetches page 1, replacing the current list (does NOT reset
+  pagination cursors; callers needing a full reset reload from the top).
+- **Polling.** Visibility-aware interval, modelled after
+  `notifications-context.tsx:75-107`. `document.hidden` switches the
+  cadence between FOREGROUND_POLL_MS and BACKGROUND_POLL_MS. Poll calls
+  `refresh()` for the latest page (cursor reset). Polling pauses entirely
+  when `authors` is empty (no signed-in user / no follows).
+
+Returned `truncatedByCap` / `truncatedBySource` mirror the author-hook
+fields so the feed UI can show a once-per-session warning banner.
+
+## Render — `src/components/feed/home-feed.tsx`
+
+Props: `UseHomeFeedResult` plus an optional kinds filter from the parent.
+Internally:
+- Empty `authors` → `EmptyState` (icon=`Users`, "Follow people to see their
+  activity here.").
+- `errorCode === "AUTHORS_FILTER_TOO_LARGE"` → shouldn't happen because we
+  pre-truncate, but fall back to the same "show all" warning the feed
+  already uses (`feed__warning` class).
+- Loading + empty → 3× `ActivityCardSkeleton` (existing pattern).
+- For each `HydratedFeedEvent`, dispatch on `event.kind`:
+  - `cert.create` + hydrated payload → `ActivityCard` (compose an
+    `ActivityRecord` shape from the payload + event metadata).
+  - `collection.create` + hydrated payload → `ProjectListRow` (compose a
+    `CollectionRecord`).
+  - `badge.award` / `legacy.endorsement` + hydrated payload →
+    `EndorsementRow` (subjectDid from payload, createdAt from event.sortAt
+    or payload, note from payload).
+  - Else → `FeedEventFallbackCard event={event}` — generic actor + subjectUri
+    + opaque-kind label.
+- Sentinel-based infinite scroll (mirror `feed-layout.tsx`).
+
+## Generic fallback — `src/components/feed/feed-event-fallback-card.tsx`
+
+Minimal card: actor avatar + handle/displayName + "did something" + linked
+subjectUri (rendered as a short anchor to its at:// URI route or a degraded
+display when no route matches). One self-contained component, no external
+deps beyond what existing rows use.
+
+## `/home` page wiring
+
+Replace the empty placeholder in `src/app/home/page.tsx`:
+
+```tsx
+"use client"
+import { useHomeFeed } from "@/hooks/use-home-feed"
+import HomeFeed from "@/components/feed/home-feed"
+import { usePageTitle } from "@/lib/navbar-context"
+
+export default function HomePage() {
+  usePageTitle("Home")
+  const feed = useHomeFeed()
+  return <div className="home-page"><HomeFeed {...feed} /></div>
+}
+```
+
+CSS lives wherever it fits the existing redesign — `src/app/styles/feed.css`
+already exists and is a reasonable home. The home-page wrapper already has
+a `.home-page` class with no rules yet; add minimal layout there if needed.
+
+## Tests
+
+### `src/app/api/indexer/__tests__/route.test.ts` (extend)
+- `FollowerEvents` happy path: variables forwarded.
+- `FollowerEvents` rejects missing `authors`.
+- `FollowerEvents` clamps `first` > 50.
+- `FollowerEvents` accepts `kinds` array; rejects non-string entries.
+- `*ByUri` ops: each rejects missing `uri`, accepts valid `at://` URI.
+
+### `src/lib/atproto/__tests__/follower-events.test.ts` (new)
+- `fetchFollowerEvents` happy path: parses edges, returns FeedEventPage.
+- Each coded error: maps `extensions.code` to `FollowerEventsError.code`.
+- Empty `authors: []` returns empty page without throwing.
+- Network failure throws plain `Error`.
+
+### `src/hooks/__tests__/use-home-feed-authors.test.ts` (new)
+- Union of two non-overlapping sets.
+- Dedupe overlap.
+- Truncation at 500 (set size 501 → 500, `truncatedByCap: true`).
+- `truncatedBySource` propagates from either upstream hook.
+
+### `src/hooks/__tests__/use-home-feed.test.ts` (new)
+- Initial load + hydrate populates `events`.
+- `loadMore` paginates with `endCursor`.
+- Polling: foreground interval triggers refresh on tick.
+- Polling: visibility change to hidden switches to background cadence.
+- Polling: pauses when `authors` is empty.
+- `AUTHORS_FILTER_TOO_LARGE` from server sets `errorCode`.
+
+### `src/components/feed/__tests__/home-feed.test.tsx` (new)
+- Renders one of each kind via the dispatch.
+- Renders the fallback for an unknown kind.
+- Empty state when `authors.length === 0`.
+
+Existing tests must continue to pass — `npm test` baseline is 157.
+
+## Risks + mitigations
+
+- **Schema drift.** The issue cites `followerEvents` and the four `*ByUri`
+  fields; verify against the live dev indexer during Phase 4 by sending a
+  manual GraphQL probe (`curl` from the host). If a `*ByUri` op doesn't
+  exist on the schema, fall back to `fetchActivitiesByUris` /
+  `fetchProjectsByUris` (XRPC fanout) for that kind — single-line dispatch
+  change. Note the fallback in the track log.
+- **Actor avatar URL construction.** `actor.avatarCid` is content-addressed;
+  the URL is built via `/api/xrpc/com/atproto/sync/getBlob`. Reuse the
+  existing avatar helper used by `EndorsementRow`'s `useAuthorInfo` — find
+  it during implementation, don't reimplement. If not found in 10 minutes,
+  inline the URL with a clear comment + add to deferred.
+- **Polling cost.** 30s foreground × 50-event payload × N concurrent users
+  is non-trivial on the indexer. Match the issue's stated cadence exactly
+  (don't tighten); document the choice in the hook's docblock.
+- **Cursor stability across polls.** `refresh()` re-fetches page 1, so a
+  paginated user's `loadMore` history is reset on every poll. Acceptable
+  for v1 (load-bearing on cursor opacity guarantees the same first page
+  during refresh); revisit if the UX is jarring.
+- **`useFollowing`/`useBlueskyFollows` 5-min cache** means a user who just
+  followed someone won't see them in `authors` until cache expiry. Both
+  hooks expose `refetch`; for v1 we don't wire follow-button writes to
+  refresh the feed authors — note in deferred.
+
+## Acceptance criteria
+
+1. `/home` renders a paginated, polled feed of events from the union of
+   the viewer's Bluesky + Certified follows.
+2. Each of the four documented kinds renders via its existing dedicated
+   component; unknown kinds render the fallback card.
+3. `authors` > 500 are truncated client-side; UI shows a non-blocking
+   warning.
+4. Server coded errors (`AUTHORS_REQUIRED`, `AUTHORS_FILTER_TOO_LARGE`,
+   `INVALID_CURSOR`) surface as typed errors on the hook return value.
+5. Polling: 30s when tab visible, 5min when hidden; paused entirely when
+   `authors.length === 0` or viewer signed out.
+6. Typecheck error count ≤ baseline. Lint warning count ≤ baseline. All
+   tests pass. Build passes.
+
+## Rollback
+
+Single commit per logical track (constants → server proxy → fetcher →
+hydration → author-union hook → feed hook → renderer + fallback → page
+wire-in → tests). `/home` reverts cleanly to the empty placeholder by
+reverting the page-wire-in commit alone — earlier commits are dormant
+without it.

--- a/docs/follower-events-feed/review-build.md
+++ b/docs/follower-events-feed/review-build.md
@@ -1,0 +1,588 @@
+# Build review — plan v1, types/data-flow/runtime
+
+Lens: TypeScript build, module-boundary types, hook data-flow,
+runtime issues that surface during Phase 4 implementation. Read
+`plan.md` and `discovery.md` first; this review only flags items
+that would break a build or fire at runtime.
+
+The single biggest risk is **#R1 (hydration architecture)** — the
+plan's GraphQL hydration via aliases is incompatible with the
+proxy as it stands today. Everything else is a smaller fix.
+
+---
+
+## Risks / corrections
+
+### R1. Multi-aliased `*ByUri` hydration is incompatible with the proxy as designed [BLOCKING]
+
+The proxy at `src/app/api/indexer/route.ts:99-504` holds query
+strings server-side; the client only sends `operationName` +
+`variables`. The route looks the query up by name
+(`route.ts:739`) and forwards `{query, variables, operationName}`
+to upstream (`route.ts:767`). The client cannot push its own
+query string through.
+
+Plan §"Hydration" (`plan.md:186-189`) calls for a single GraphQL
+request with **one aliased query per event**:
+
+> Implementation: single GraphQL request with one aliased query
+> per event, each branching by `event.kind` to the matching
+> `*ByUri` op.
+
+For a 20-event page that means a query like:
+```graphql
+query Hydrate($u0: String!, $u1: String!, ..., $u19: String!) {
+  a0: orgHypercertsClaimActivityByUri(uri: $u0) { ... }
+  a1: orgHypercertsCollectionByUri(uri: $u1) { ... }
+  ...
+}
+```
+Per-event alias name + per-event field selection (the `*ByUri`
+operation varies by `event.kind`) → the query string is
+dynamic in both *shape* and *variable count*. The proxy holds
+fixed query strings; you cannot register one entry in
+`OPERATIONS` that covers every combination of (page size, kinds
+distribution) the client might encounter on a given page.
+
+The plan's `## Server proxy ops` section (`plan.md:50-105`)
+registers four separate `*ByUri` ops (`OrgHypercertsClaimActivityByUri`
+etc.), each taking a single `uri: String!`. That shape forces one
+HTTP request per event, which contradicts the plan's own claim
+in `discovery.md:106` that this approach delivers "Single HTTP
+request per page (vs N PDS round-trips)."
+
+Three viable resolutions, pick one before Phase 4 starts:
+
+1. **Drop the aliasing aspiration.** Issue one
+   `operationName: "<KindByUri>"` request per visible event,
+   `Promise.all` them. ~20 small same-origin POSTs per page. Fine
+   for v1; loses the "single round-trip" claim but the proxy
+   doesn't change.
+2. **Server-side batching op.** Add a single `HydrateFeedPage`
+   op whose query accepts `$activityUris: [String!]`,
+   `$collectionUris: [String!]`, `$awardUris: [String!]`,
+   `$legacyUris: [String!]` and returns four parallel
+   `*ByUris(uris: [String!])` connections. Requires the
+   indexer to expose a `*ByUris` plural form — verify against
+   schema, document the dependency. This is the architecturally
+   clean answer.
+3. **Loosen the proxy's "queries are server-only" invariant** —
+   accept a client-supplied query for a narrow allowlist of
+   operations. This breaks the load-bearing security comment at
+   `route.ts:9-29` ("client sends `operationName` only") and
+   should not happen without an explicit security review. Do not
+   pick this without a separate discussion.
+
+Until this is resolved, the "single batched GraphQL request" line
+in `plan.md:106` and `discovery.md:106` is aspirational rather
+than implementable.
+
+### R2. `truncatedBySource` references a field that doesn't exist on `useBlueskyFollows`
+
+`discovery.md:53-54` claims `useBlueskyFollows(did)` returns:
+> `{ followedDids: Set<string>, isLoading, error, truncated? }`
+
+The actual return at `src/hooks/use-bluesky-follows.ts:119` is:
+```ts
+return { followedDids, isLoading, error }
+```
+No `truncated` field. The hook does have an internal `MAX_FOLLOWS = 10_000`
+guard (`use-bluesky-follows.ts:8, 26`) but it never surfaces
+"hit the cap" upward.
+
+Plan §"Author-union hook" (`plan.md:213`) wires:
+```
+truncatedBySource = blueskyTruncated || certifiedTruncated
+```
+That won't compile — `blueskyTruncated` doesn't exist on the
+hook's return. Either:
+
+- Add `truncated: boolean` to `useBlueskyFollows`'s return (the
+  internal `fetchAllFollows` loop already has the signal at
+  `use-bluesky-follows.ts:26` — set a `truncated` flag when the
+  loop exits because `followedDids.size >= MAX_FOLLOWS`), or
+- Drop the `truncatedBySource` field from
+  `UseHomeFeedAuthorsResult` for v1 and only propagate the
+  Certified hook's flag.
+
+The first is the right move (set parity with `useFollowing`)
+and is a 5-line change. The plan must say so explicitly,
+otherwise the implementer hits the type error mid-track and
+makes the choice ad-hoc.
+
+### R3. Author array stability — passing `string[]` through `useEffect` deps
+
+Plan §"Feed hook" (`plan.md:244-245`):
+> Stable string key on `authors.join(",")` + `kinds.join(",")`
+> drives the initial fetch effect (same primitive-key pattern as
+> `useGlobalFeed`).
+
+The primitive-key pattern works (precedent at
+`use-global-feed.ts:102-108`), but the plan omits the **`useRef`
+snapshot of the live array** that `useGlobalFeed` uses to
+actually issue the fetch (`use-global-feed.ts:56-57, 150, 188`):
+
+```ts
+const endorsedDidsRef = useRef(endorsedDids)
+endorsedDidsRef.current = endorsedDids
+// ... and inside the fetch:
+authors: endorsedDidsRef.current ? Array.from(...) : undefined,
+```
+
+Without that, the only options inside `loadInitial` are:
+
+1. Pass `authors` directly → React lint demands `authors` in the
+   dependency array → infinite-loop on every render (new array
+   identity every render).
+2. Re-derive `authors` from the string key by `key.split(",")`
+   → loses ordering / identity invariants.
+
+The implementer will trip on the ESLint `exhaustive-deps` rule
+the way `useGlobalFeed` did (note the
+`// eslint-disable-next-line` at `use-global-feed.ts:163, 199`).
+Plan should explicitly say "mirror the
+`endorsedDidsRef`/`combinedServerFilterKey` pattern from
+`use-global-feed.ts:56-108`" and call out the eslint-disable as
+load-bearing.
+
+### R4. `refresh()` + `loadMore()` race — pagination state isn't protected
+
+Plan §"Feed hook" (`plan.md:250-252`):
+> `refresh` re-fetches page 1, replacing the current list (does
+> NOT reset pagination cursors; callers needing a full reset
+> reload from the top).
+
+Scenario: user has paged to page 3 (cursor C2 → C3 in-flight),
+polling tick fires and `refresh()` re-fetches page 1 (cursor
+null). Both in flight. Outcomes:
+
+- **Both resolve.** Plan says `refresh` "replac(es) the current
+  list" and "does NOT reset pagination cursors". So `refresh`
+  overwrites `events` to be page 1 of 20 results, then
+  `loadMore` arrives with page 3 of 20 and appends → final
+  state is `[page1, page3]` with page 2 missing. Cursor state
+  is whatever the last write was, likely the page 3 cursor,
+  meaning the next `loadMore` skips to page 4.
+
+- **`refresh` cancels `loadMore`.** Cleaner, but plan doesn't
+  say `refresh` aborts in-flight `loadMore`. The
+  notifications-context precedent at
+  `notifications-context.tsx:31-32` only has one abort ref —
+  fine because notifications doesn't paginate.
+
+The plan needs two abort controllers (one for the page-1 / poll
+fetch, one for `loadMore`), AND a rule that `refresh` aborts the
+loadMore (the user-visible page-3 state is lost on poll, but
+that's the lesser evil — keeping it produces the missing-page-2
+bug above). Mention the contract in the hook docblock and back
+it with a test in `use-home-feed.test.ts`.
+
+A simpler alternative: pause polling while `isLoadingMore` is
+true. Cheaper to implement, no race. Pick one and write it down.
+
+### R5. `ActivityRecord` synthesis from hydration payload — `did` must be on the wire
+
+`ActivityCard` (`src/components/feed/activity-card.tsx:21`) takes:
+```ts
+{ record: ActivityRecord; did: string; label?: LabelValue }
+```
+The `did` is used at `activity-card.tsx:25` to resolve the
+blob-ref image URL through the XRPC sync/getBlob proxy:
+```ts
+resolveActivityImageUrl(value.image, did)
+```
+For non-blob image variants (string or `{uri}`) `did` is
+unused, but for blob-ref images on a foreign PDS the helper
+builds `/api/xrpc/com/atproto/sync/getBlob?did=...&cid=...`
+(`activity.ts:80-82`) and `did` is load-bearing — the proxy
+needs it to find the right PDS via `resolvePdsUrl`.
+
+Plan §"Render" (`plan.md:273-275`):
+> `cert.create` + hydrated payload → `ActivityCard` (compose an
+> `ActivityRecord` shape from the payload + event metadata).
+
+The `FeedEvent.actor.did` (`plan.md:127`) is the *event actor*
+(the follower whose activity this is). For `cert.create`, the
+actor authored the cert, so `actor.did === record.did`. But the
+plan's `*ByUri` selection
+(`plan.md:93`) does NOT include `did` on the activity payload:
+```
+OrgHypercertsClaimActivityByUri(uri) → { title, shortDescription, image { ... } }
+```
+Two options:
+
+- Trust `actor.did` and pass it as the `did` prop. Works when the
+  actor === the cert author. Verify this invariant holds for
+  every kind. For `badge.award` and `legacy.endorsement` the
+  "did to use for the image proxy" is the badge issuer, not the
+  endorsement subject, so the actor↔record-author identity
+  needs to be confirmed per-kind.
+- Add `did` to each `*ByUri` selection (mirror `Activities`
+  query at `route.ts:69`, `Projects` at `route.ts:385`). Safer.
+
+Pick option 2 — add `did` to every `*ByUri` selection — and
+make it explicit in the plan. Cost is one extra string per row;
+removes a class of subtle "broken avatar on foreign PDS" bugs.
+
+Same concern applies to `ProjectListRow`: it derives `did` from
+the URI at `project-list-row.tsx:31-32` (`parseAtUri(uri)`),
+which is safe because every at:// URI carries the did. But
+`ActivityCard` does NOT parse from URI — it takes `did` as a
+separate prop. Composing the synthetic record at the dispatch
+site is the right place; document which `did` to pass.
+
+### R6. `ActivityRecord.value.image` shape mismatch
+
+Existing client-side mapping `nodeToActivityRecord`
+(`src/lib/atproto/indexer.ts:60-86`) reduces the indexer's typed
+image union to one of two shapes:
+```ts
+{ uri: <string> } | { image: { ref: <cid-string> } }
+```
+i.e. the blob ref is **already extracted via `getBlobRefLink`**
+when the path is the inner `image.ref` variant (see
+`nodeToCollectionRecord` at `indexer.ts:720-736` which explicitly
+calls `getBlobRefLink(node.banner.image.ref)`).
+
+Plan §"`*ByUri` hydration ops" (`plan.md:93-94`) selects the
+image as:
+```
+image { __typename, ...OrgHypercertsDefsUri.uri,
+        ...OrgHypercertsDefsSmallImage.image { ref, mimeType } }
+```
+i.e. raw indexer typename + nested `image.ref` blob CID, which
+arrives wrapped as `map[$link:<cid>]` (`indexer.ts:719`).
+
+Whoever writes `hydrateFeedEvents` (`plan.md:181`) must
+reproduce the same blob-ref unwrap as `nodeToActivityRecord` /
+`nodeToCollectionRecord`. Plan doesn't say this explicitly. Add
+to plan: "synthesised `ActivityRecord`/`CollectionRecord` shapes
+must match `nodeToActivityRecord` / `nodeToCollectionRecord` in
+`src/lib/atproto/indexer.ts` — extract the helper, do not
+inline a new mapping." Extracting and reusing is the right
+move; inlining will silently produce wrong image URLs for the
+blob-ref path.
+
+### R7. `EndorsementRow` doesn't accept `createdAt` from a hydrated subject — it'll re-fetch the actor
+
+`EndorsementRow` (`src/components/endorsements/endorsement-row.tsx:33-40`)
+internally calls `useAuthorInfo(subjectDid)` which hits
+`/api/resolve-did` per row (cached via `createBoundedCache`,
+`use-author-info.ts:22`).
+
+That's fine for v1, but note: the plan says the actor profile
+(`actor.handle/displayName/avatarCid`) is denormalised onto each
+`FeedEvent` (`discovery.md:86-87`), which means we already have
+the actor info on the wire — but `EndorsementRow` re-fetches it
+because the *subject* is a different DID from the *actor*. The
+issuer = actor (who awarded the badge); the subject = the
+endorsed account. So this isn't a bug; it just means the page
+load will fire ≤ N `/api/resolve-did` requests per page for
+endorsement-typed events (subjects, not actors).
+
+Document this in the plan so it doesn't surface as a "why is
+the network panel full of resolve-did" question in review.
+
+### R8. `useFollowing` returns `subjects`, not `followedDids` — naming drift in the plan
+
+`discovery.md:56-58` says `useFollowing(did)` returns
+`{ subjects: Set<string>, truncated, isLoading, ... }`. Correct
+— see `use-following.ts:60, 190-194`.
+
+Plan §"Author-union hook" pseudocode (`plan.md:208`):
+```
+union = new Set([...blueskyDids, ...certifiedSubjects]).
+```
+Uses `certifiedSubjects` — but the variable would presumably be
+destructured `const { subjects: certifiedSubjects, ... } = useFollowing(did)`.
+That's fine, just a rename. Worth calling out: align variable
+names in the actual file to `blueskyDids` /
+`certifiedSubjects` so the union expression reads cleanly. Minor.
+
+### R9. `Empty authors: []` — plan vs proxy `readDidList`
+
+Plan §"FollowerEvents → buildVariables" (`plan.md:78-82`):
+> `authors`: required. Reuse `readDidList(MAX_DID_LIST)` — caps
+> at 1000 client-side... Empty array passes through to the
+> upstream — server returns an empty connection (NOT an error).
+> The proxy treats `[]` as valid.
+
+But `readDidList` at `route.ts:525-543` explicitly rejects empty
+arrays:
+```ts
+if (value.length === 0 || value.length > maxItems) return null
+```
+Returning `null` causes `buildVariables` to return `null`, which
+causes the route to 400 (`route.ts:749-754`).
+
+So the plan's statement "the proxy treats `[]` as valid" is
+**false if the implementer reuses `readDidList`.** Either:
+
+- Write a new reader `readDidListAllowEmpty()` that mirrors
+  `readDidList` but allows `value.length === 0`, OR
+- Use `readOptionalDidList` (`route.ts:545-558`) which already
+  returns `[]` → `[]` and `undefined` → `undefined`.
+
+`readOptionalDidList` is the natural fit. Plan should say so.
+Note also that `readOptionalDidList` enforces `MAX_DID_LIST = 1000`
+silently (`route.ts:550`); for `MAX_AUTHORS_FILTER_SIZE = 500`,
+add a separate length check before calling it, OR add a new
+`readBoundedDidList(maxItems, allowEmpty)` that takes both. (The
+spec review already flags the 500-vs-1000 discrepancy at
+`review-spec.md:8-18`; this is the implementation-side mirror.)
+
+Edge case: when `authors === undefined` (caller didn't pass it),
+`readOptionalDidList` returns `undefined`, but the upstream
+`followerEvents` field requires `[String!]!` per the plan's
+query at `plan.md:55`. Decide upfront whether the server-side
+contract is "authors is required and may be empty" or "authors is
+optional"; mismatch will produce a noisy GraphQL error rather
+than the empty-page semantic the plan documents.
+
+### R10. Polling cleanup contract — `refresh()` is captured by `useCallback` deps
+
+The reference implementation at
+`notifications-context.tsx:75-107` puts `refresh` in the effect's
+dep array. `refresh` itself is `useCallback` over
+`[authLoading, isAuthenticated, did]` — three primitives — so the
+identity is stable across renders.
+
+The new feed hook will have `refresh` depending on more:
+`authors` (string or ref), `kinds` (string), the abort ref, etc.
+If any of those is non-primitive in the dep array, `refresh`
+identity changes per render → the polling effect tears down and
+rebuilds the interval per render → polling effectively never
+runs (or runs in a runaway tight loop).
+
+Plan should explicitly call out: `refresh` must be
+`useCallback`-stable across renders of identical primitive
+state. Use the same `*Ref` snapshot pattern as `useGlobalFeed`
+(`use-global-feed.ts:56-57`). Add a test
+("`refresh` reference is stable when authors string-key is stable").
+
+### R11. `FeedEventKind` open-union type is wider than the discriminated dispatch
+
+Plan §"client module" (`plan.md:118-123`):
+```ts
+export type FeedEventKind =
+  | "cert.create"
+  | "collection.create"
+  | "badge.award"
+  | "legacy.endorsement"
+  | string
+```
+The `| string` collapses the union to just `string` —
+TypeScript widens once any member is `string`. That means:
+
+- `switch (event.kind) { case "cert.create": ... }` has no
+  exhaustiveness check; the compiler won't error if a new kind
+  literal is added later and not handled.
+- IDEs lose auto-completion for the literal members.
+
+Standard fix: use a literal union for the *known* kinds and a
+separate type that allows fallback:
+```ts
+export type KnownFeedEventKind =
+  | "cert.create" | "collection.create"
+  | "badge.award" | "legacy.endorsement"
+export type FeedEventKind = KnownFeedEventKind | (string & {})
+```
+The `(string & {})` "branded string" trick preserves literal
+auto-completion. Cite this in the plan.
+
+### R12. `FollowerEventsError.code` typed as a nullable union is awkward at use sites
+
+Plan §"client module" (`plan.md:147-150`):
+```ts
+export class FollowerEventsError extends Error {
+  readonly code: "AUTHORS_REQUIRED" | "AUTHORS_FILTER_TOO_LARGE" | "INVALID_CURSOR" | null
+}
+```
+Mirroring `EndorsementClosureError` (`indexer.ts:430-438`),
+which uses `string | null`. The plan tightens to a literal
+union — better — but then `errorCode: FollowerEventsError["code"] | null`
+on the hook (`plan.md:230`) is `(... | null) | null`, redundant
+but not wrong.
+
+Concern: the upstream may emit additional `extensions.code` values
+the plan hasn't enumerated (the issue lists three, but future
+indexer revisions can add more). A future code arrives → it
+hits `default: code = null` in the mapper → the type lies, the
+consumer's `switch (code)` misses it silently.
+
+Two fixes:
+
+- Keep the literal union but log unknown codes (so they surface
+  in console). Plan doesn't say this; add it.
+- OR use `string | null` (like `EndorsementClosureError`) and
+  document the *known* values in a JSDoc constant. Either is
+  fine; pick one.
+
+### R13. `LegacyEndorsements` precedent has `authors` required — `FollowerEvents` plan reuses same shape
+
+The existing `LegacyEndorsements` op (`route.ts:454-473`) takes
+`authors: [String!]!` and validates via `readDidList`
+(`route.ts:669-677`) — i.e. required, non-empty, ≤ 1000. The
+existing client (`indexer.ts:519`) short-circuits to `[]` when
+authors is empty rather than calling the upstream.
+
+This is the load-bearing precedent the plan invokes by
+"the proxy treats `[]` as valid (preserves the load-bearing
+nil/empty semantic from the records repo)" (`plan.md:81-82`).
+But the precedent does the **opposite** — it rejects empty
+arrays at the proxy and short-circuits at the fetcher. The plan
+should follow the same pattern: short-circuit
+`fetchFollowerEvents` when `options.authors.length === 0` and
+return an empty page locally, NOT call the proxy with `[]`.
+
+This sidesteps R9 (the proxy needn't accept `[]`) and matches
+the existing pattern. Recommend: change the plan to short-circuit
+at the fetcher; proxy keeps the non-empty `readDidList`
+contract.
+
+### R14. Hydration payload `null` semantic isn't typed correctly
+
+Plan §"client module" (`plan.md:174-178`):
+```ts
+export interface HydratedFeedEvent {
+  event: FeedEvent
+  /** Per-kind hydrated payload; null when the by-URI lookup 404'd. */
+  payload: HydratedActivity | HydratedCollection | HydratedBadgeAward | HydratedLegacyEndorsement | null
+}
+```
+With `null` payload, the dispatch component (`plan.md:272-282`)
+needs `payload` discriminated by `event.kind` to narrow safely.
+TypeScript won't narrow across the two fields automatically:
+```ts
+if (event.kind === "cert.create" && payload) {
+  // payload here is still the union, not HydratedActivity
+}
+```
+You'll need a runtime type-guard per kind (e.g. discriminator
+field on each `HydratedX` interface, or check
+`"title" in payload`). Plan should specify the discriminator
+shape — without it the dispatch component ends up with `as`
+casts that the compiler can't verify.
+
+A clean approach: each `HydratedX` carries a `kind` field that
+matches the `FeedEventKind`, so:
+```ts
+interface HydratedActivity { kind: "cert.create"; ... }
+interface HydratedCollection { kind: "collection.create"; ... }
+```
+Then `if (payload?.kind === event.kind)` narrows correctly.
+Mention this in the plan.
+
+### R15. `MAX_BODY_SIZE = 16KB` and the per-event-URI hydration request
+
+Even with the single-request hydration architecture (if R1 is
+resolved by adding a `HydrateFeedPage` op), the request body
+carries up to 20 × URI strings + variable names. An at:// URI
+runs roughly 60-100 bytes. 20 of those + JSON overhead +
+operationName + variable wrappers fits comfortably under 16KB.
+But the proxy enforces `MAX_BODY_SIZE` at `route.ts:710, 720`. If
+the implementer picks resolution #2 (single batched op) and the
+page size ever grows past 50 events with longer URIs, this
+becomes a risk. Worth noting in plan as a forward-looking
+constraint; not a v1 blocker.
+
+### R16. Plan re-exports `INDEXER_PROXY_URL` from `indexer.ts` — currently NOT exported
+
+`discovery.md:135-137`:
+> re-export `INDEXER_PROXY_URL` from `indexer.ts` or duplicate the
+> literal.
+
+The constant at `indexer.ts:33` is declared `const INDEXER_PROXY_URL = "/api/indexer"` — NOT exported. So "re-export"
+requires modifying `indexer.ts` (currently listed as untouched
+in plan `plan.md:47`). Either:
+
+- Add `export` to the `indexer.ts:33` declaration (1-line edit,
+  outside the disjoint-ownership rule but trivial), OR
+- Duplicate `"/api/indexer"` in `follower-events.ts` as the plan
+  permits.
+
+Recommend the duplicate — the literal is short, used in one
+place per file, and keeps the file-ownership boundary clean. Plan
+should pick one.
+
+### R17. Tests around polling will be flaky without `vi.useFakeTimers()` discipline
+
+Plan §"Tests" (`plan.md:333-340`):
+> Polling: foreground interval triggers refresh on tick.
+> Polling: visibility change to hidden switches to background cadence.
+
+These need `vi.useFakeTimers()` + `vi.advanceTimersByTime(30_000)`
++ `document.visibilityState` stubbing. The notifications-context
+test (search for an existing one) is the pattern to follow. Plan
+doesn't mention the timer mocking discipline — implementer might
+write real-time tests that pass locally then flake in CI. Add to
+plan: "tests must use fake timers".
+
+---
+
+## Approved decisions
+
+- **`useAuth().did` is real and correctly typed.**
+  `AuthState.did: string | null` (`src/lib/auth/types.ts:7`), set
+  from `/api/auth/session` (`auth-context.tsx:59-65`).
+  `null`-guarding the feed when `did === null` is the right move.
+
+- **Visibility-aware polling pattern is correctly identified.**
+  The reference at `notifications-context.tsx:75-107` is the
+  cleanest precedent; the plan's "two-cadence selector by
+  `document.visibilityState`" is a faithful extension. Implementer
+  should mirror the same teardown sequence
+  (`stop()` + `removeEventListener` + abort) in the return
+  cleanup.
+
+- **`useGlobalFeed` is the right pattern reference for
+  primitive-key effect deps.**
+  `combinedServerFilterKey` at `use-global-feed.ts:102-108` is
+  exactly the shape the new hook needs (modulo the issues in R3).
+
+- **Endorsement-typed actor info is already on the wire.**
+  `discovery.md:86-87` correctly notes the actor profile is
+  denormalised onto every `FeedEvent` — saves the per-row
+  `useAuthorInfo` for the actor. Only subject info (for
+  endorsement kinds) still hits resolve-did, which is unavoidable
+  without more server-side denormalisation.
+
+- **Four-kind discriminated render with fallback** is correctly
+  scoped and aligned with the existing
+  `ActivityCard`/`ProjectListRow`/`EndorsementRow` props (modulo
+  R5 `did` plumbing and R6 image-shape unwrapping).
+
+- **Truncating the author union before sending** is correctly
+  identified as the v1 way to satisfy the server-side 500 cap,
+  and the alphabetical ranking is a defensible default (cheap,
+  deterministic, no schema dep).
+
+- **The hook's return shape mirrors the project's standard**
+  (`data, isLoading, isLoadingMore, error, hasMore, loadMore,
+  refresh`) — matches `useGlobalFeed`, `useFollowing`,
+  `useReceivedEndorsements` per `discovery.md:121-122`. No new
+  vocabulary.
+
+- **The four-track commit cadence in `## Rollback`
+  (`plan.md:389-394`)** is well-structured for revertability and
+  fits the project's "direct to staging" convention.
+
+- **File ownership partitioning (`plan.md:22-48`) is disjoint**
+  modulo R16 if the implementer picks the re-export route.
+
+---
+
+## Summary
+
+- **One blocker** (R1: hydration architecture incompatible with
+  proxy). Decide between the three resolutions before Phase 4.
+- **Three will-not-compile items** (R2: missing
+  `truncated` on Bluesky hook; R9: `readDidList` rejects empty
+  arrays; R11: open-union loses literal narrowing).
+- **Four runtime correctness items** (R4: race; R5/R6: synthesised
+  record shapes; R10: callback stability).
+- **The rest are spec-tightening and developer-experience items**
+  to flush before implementation, not after.
+
+The plan is otherwise structurally sound; the data-flow choices
+are right and the file-ownership boundaries are clean.

--- a/docs/follower-events-feed/review-decisions.md
+++ b/docs/follower-events-feed/review-decisions.md
@@ -1,0 +1,134 @@
+# Review round 1 — decisions
+
+Three reviewers ran in parallel against `plan.md`. Their reports live in
+`review-spec.md`, `review-build.md`, `review-integration.md`. This file
+captures what was accepted, what was rejected, and why. `plan-v2.md`
+supersedes `plan.md`.
+
+## Accepted — incorporated into plan v2
+
+### Architecture / spec
+- **R1 (build, blocker): hydration cannot use per-event aliases.** The
+  proxy holds query strings server-side keyed by `operationName` — the
+  client cannot push a dynamic per-page query through. **Replace with a
+  single pre-built `HydrateFeedPage` op** that uses `where: { uri: { in:
+  $uris } }` filters across four aliased connections, one per lexicon.
+  Caveat: `uri.in` on these connections is unproven; phase-4 manual probe
+  verifies before commit. Fallback path is per-collection ops (four
+  sequential calls) if `uri.in` isn't on the where input.
+- **I1 (integration, blocker): mount point is wrong.** Confirmed
+  `bottom-nav.tsx:36` routes "Feed" to `/feed`, not `/home`. Replace
+  `/feed/page.tsx`'s `HomeClient` (a legacy redirector) with the new feed.
+  `/home` stays alone — it's only reachable via `SiteDrawer` and isn't
+  load-bearing.
+- **I2/I3 (integration): mixed visual registers.** Discarding the "reuse
+  three different components in one feed" approach. **Build one
+  `FeedEventCard` with internal kind-dispatch** rendering a consistent
+  feed-card chrome. The card body still composes from existing primitives
+  (avatar, byline, title row, image), but the outer shell is shared and
+  feed-shaped. Fallback (unknown-kind) becomes one branch of that
+  component rather than a separate file.
+- **I3 (integration): badge.award / legacy.endorsement need actor + subject.**
+  `EndorsementRow` only renders the subject; the feed card variant
+  renders "actor endorsed subject" with both byline rows.
+
+### Validation / proxy
+- **S1: proxy enforces 500, not 1000.** Add a dedicated
+  `readAuthorListForFollowerEvents` reader that caps at
+  `MAX_AUTHORS_FILTER_SIZE = 500` AND accepts empty arrays (R9 below).
+  Defence-in-depth: client also pre-truncates to 500.
+- **R9: empty `authors: []` must pass through.** Existing `readDidList`
+  rejects length 0. New reader for the FollowerEvents op accepts
+  length 0..500 inclusive.
+- **S2: `first` clamping consistent with existing patterns.** Keep the
+  silent clamp (existing `clampFirst(value, MAX_FEED_PAGE_SIZE = 50, 20)`
+  pattern). Document in the route comment.
+- **S3: `kinds` validation cap.** Keep defensive limits (length ≤ 16,
+  each ≤ 64 chars). The cap numbers are conservative defaults consistent
+  with the existing `readLabelList`; document them as "defensive, not
+  spec-mandated".
+
+### Hook contract
+- **R2: `useBlueskyFollows` doesn't expose `truncated`.** Add it. Small
+  in-scope change — the page-walk already detects the cap (`while
+  followedDids.size < MAX_FOLLOWS`); just track whether the cap stopped
+  the loop. This makes the contract symmetric with `useFollowing` and
+  unblocks `useHomeFeedAuthors`'s `truncatedBySource` field.
+- **R5: `ActivityCard` `did` prop.** Use `event.actor.did`. The actor IS
+  the author for `cert.create` events.
+- **R6: synthesised record shapes must mirror existing node→record
+  mappers.** Extract `nodeToActivityRecord` and `nodeToCollectionRecord`
+  helpers (currently inline in `indexer.ts:60-86, 714-759`) so the new
+  hydration code reuses the exact same blob-ref unwrapping. Two small
+  refactors as part of the client-module track.
+- **R10: polling `refresh` stability.** Snapshot `refresh` via `useRef`
+  inside the polling effect (mirror `use-global-feed.ts:56-57`), don't
+  list it as a dep.
+- **R11: `FeedEventKind` shouldn't be `string`.** Define
+  `KNOWN_FEED_EVENT_KINDS` as a tuple-literal constant, derive
+  `KnownFeedEventKind = (typeof ...)[number]`. The wire shape stays
+  `kind: string`; the dispatch component narrows to known kinds and
+  falls through to fallback for everything else.
+- **S5 + R4: `refresh()` semantics.** Define once: `refresh()` fetches a
+  new page-1, merges by `event.id` (dedupe), prepends new entries that
+  weren't previously visible. Pagination cursors for already-loaded pages
+  stay valid. `loadMore()` and `refresh()` may overlap safely — neither
+  resets the other's state.
+
+### UX / states
+- Empty state: three variants (signed-out, no-follows, no-events).
+- Skeleton: render `ActivityCardSkeleton` × 3 as a generic loading state;
+  layout shift on first paint is acceptable for v1 (the cards' actual
+  heights vary per kind regardless). Note in deferred.
+- `truncatedByCap` / `truncatedBySource` warning: small non-blocking
+  banner above the feed when either is true. Copy: "You follow more
+  than 500 people. Showing a subset." / "Your follow list is too large
+  to fully sync."
+
+## Accepted with revision
+
+- **S6: ranking for over-cap.** Issue recommends recent-interaction;
+  v1 still ships alphabetical-by-DID. **Reason recorded in plan v2:**
+  "recent-interaction ranking" needs a per-DID timestamp. We have
+  `app.certified.graph.follow.createdAt` for Certified follows, but
+  Bluesky follows go through the listRecords path which returns records
+  in PDS-insertion order — not the same semantic. Mixing the two
+  recency signals in a union ranking is not obvious; v1 picks the
+  deterministic option and defers the weighted ranking to a follow-up.
+  Note also that 500/total truncation is rare for typical users.
+
+## Rejected — with rationale
+
+- **S7: distinguish endorsement-typed `badge.award` via
+  `badge.definition.badgeType`.** Per the issue's deliberate v1
+  limitation: "Every `app.certified.badge.award` record produces `kind
+  = badge.award`. If you need to distinguish endorsement-typed awards
+  from other badge types, fetch the linked `badge.definition.badgeType`
+  via the existing query." v1 doesn't distinguish — renders all
+  `badge.award` events with the same chrome ("actor awarded a badge to
+  subject"). Adding the definition-type fetch is a follow-up if/when
+  product needs the distinction.
+- **S9: stop background polling after N idle minutes.** The existing
+  notifications polling doesn't bound idle either, and the cost is one
+  GraphQL request every 5 minutes. Skip; revisit if it shows up in
+  metrics.
+- **R7 (build, minor): per-row `resolve-did` for endorsement subjects.**
+  `EndorsementRow` fetches author info itself via `useAuthorInfo`. For
+  the feed card variant we'll do the same — N row-level lookups, but
+  already cached at the resolve-did module level. Acceptable for v1;
+  optimising into a batched resolve is its own ticket.
+- **Skeleton per kind.** Mentioned in I-review but adds complexity
+  disproportionate to value. Generic skeletons + once-per-paint layout
+  shift is fine. Note in deferred.
+
+## Deferred — new items added to v2's deferred list
+
+- Recent-interaction author ranking for the 500-cap truncation.
+- Per-kind skeleton variants.
+- Endorsement-vs-other-badge-type distinction (needs
+  `badge.definition.badgeType` hydration).
+- Migrating `ActivityFeed.following` to the new feed.
+- Batched `resolve-did` for actor lookups in endorsement cards.
+- Subscription / live updates (server doesn't support yet).
+- Most-recent-interaction author ranking (depends on a signal we don't
+  have client-side).

--- a/docs/follower-events-feed/review-impl-correctness.md
+++ b/docs/follower-events-feed/review-impl-correctness.md
@@ -1,0 +1,249 @@
+# Review — implementation correctness (does it actually work?)
+
+Scope: branch `feat/88-follower-events-feed` vs. `feat/positioning-redesign`.
+Lens: functional correctness against issue #88 and `plan-v2.md`. Not
+visual design, not style, not test hygiene beyond "would these catch a
+regression".
+
+Methodology: read the seven impl commits end-to-end, walked the issue's
+operational constraints, coded errors, and deliberate-v1 limitations
+against the code, ran `tsc --noEmit` (clean), traced race conditions
+between `loadInitial` / `loadMore` / `refresh` / polling.
+
+## Issues
+
+### Blockers
+None — the feed will load, paginate, and poll for real users.
+
+### High — likely visible to users / will produce wrong state under load
+
+1. **`HomeFeed` renders two empty-state UIs at once when authors are
+   loaded but produced no events.** `src/components/feed/home-feed.tsx:101-130`.
+   Conditions for the primary `EmptyState` (lines 101-107) and the
+   secondary `NoFollowsHint` (lines 128-130) both reduce to
+   `!isLoading && !error && events.length === 0 && !isOversized &&
+   !truncatedBySource`. There's no `else` between them, so a signed-in
+   viewer with follows but zero events sees BOTH "No activity yet" and
+   the "Not following anyone yet?" hint stacked. The plan called for
+   three distinct empty states (signed-out / signed-in + 0 authors /
+   signed-in + authors + 0 events); the implementation collapsed this
+   into one fork. The `authors.length`-based discrimination is missing
+   because `UseHomeFeedResult` doesn't surface authors-count; the
+   NoFollowsHint contradictory render is the visible symptom.
+
+2. **In-flight `loadMore` / `refresh` are not torn down when
+   `filterKey` changes.** `src/hooks/use-home-feed.ts:144-204`. Only
+   `loadInitial` threads an `AbortSignal` (line 113, 116) and only the
+   `useEffect` at line 138 aborts it. `loadMore` (line 144) and
+   `refresh` (line 179) pass no signal to `fetchFollowerEvents` /
+   `hydrateFeedEvents`. Concrete failure mode: viewer's follow set
+   updates (Bluesky add/remove, Certified follow), `authorsKey`
+   changes, `loadInitial` reloads — but a `loadMore` or polling
+   `refresh` that started before the change finishes with the old
+   authors and calls `setEvents((prev) => [...incoming, ...prev])`,
+   silently splicing stale-author events into the new feed. The dedupe
+   doesn't help because the stale events are new to the new feed's
+   prev. Probability is high under polling: the foreground poll runs
+   every 30 s; the user only needs to follow / unfollow during a poll
+   round-trip to land in this state.
+
+3. **`endCursorRef` survives `filterKey` changes.** Same file. When
+   `loadInitial` is aborted mid-flight on a key change,
+   `endCursorRef.current = page.endCursor` (line 119) is skipped, but
+   the *previous* successful initial-load's cursor stays in the ref.
+   The new `loadInitial` will overwrite it once its fetch completes,
+   but in the window between key-change and new initial-load
+   completing, a sentinel-triggered `loadMore` (the IntersectionObserver
+   in `home-feed.tsx:39-49` ignores the key change) uses
+   `authorsRef.current` (new) with `endCursorRef.current` (old) — the
+   server will either return `INVALID_CURSOR` or, worse, decode the
+   cursor against the new feed and return semantically-stale rows.
+   Reset `endCursorRef.current = null` and `setHasMore(false)` at the
+   top of `loadInitial` before the await.
+
+4. **`useSocialGraphSync` still doesn't read `truncated` from
+   `useBlueskyFollows`.** `src/hooks/use-social-graph-sync.ts:80-81`.
+   The track-3 doc says "Consumers that derive set arithmetic from
+   `data` (e.g. `useSocialGraphSync`) must refuse to act on the result
+   when this is true — the 'do I already follow X?' check would return
+   false-negatives." The new docstring on `use-bluesky-follows.ts:14-19`
+   makes that promise but the consumer ignores `truncated`. The hook
+   computes `inBoth` / `onlyCertified` / `onlyBluesky` set-arithmetic
+   over `blueskyDids` regardless of truncation — exactly the
+   false-negative class the docstring warns against. (Pre-existing for
+   `useFollowing.truncated`; the new field on `useBlueskyFollows` lands
+   without closing the consumer-side hole even though plan-v2's
+   "Update the existing callers if they destructure — verify none
+   break" check listed this as the unblocking work.)
+
+### Medium — wrong-state but recoverable / unlikely under normal load
+
+5. **`refresh` racing initial load can lose new events.**
+   `src/hooks/use-home-feed.ts:118` vs `:188-195`. `loadInitial` does
+   imperative `setEvents(hydrated)` (replaces), while `refresh` does
+   functional `setEvents((prev) => [...incoming, ...prev])`. If
+   `refresh` (from the polling effect's `refreshRef.current()` on
+   visibility-change, line 240) commits BEFORE `loadInitial` commits,
+   the refresh prepends to `[]` and then `loadInitial` overwrites with
+   its own page-1 — silently discarding the refresh result.
+   Probability is low (refresh requires `authorsRef.current.length > 0`
+   AND a visibility change AND races with a mount), but plausible on
+   slow networks. Fix: have `refresh` no-op while `isLoading` is true,
+   or merge refresh's incoming events into `loadInitial`'s hydrated
+   page using the same id-dedupe.
+
+6. **`FeedActor` typed as required but wire shape isn't validated.**
+   `src/lib/atproto/follower-events.ts:153, 209-216`. The
+   `FollowerEventsResponse.node.actor` field is declared `FeedActor`
+   (non-null) and the loop at 208-217 pushes `edge.node.actor`
+   directly into the result without a null-check. The spec defines
+   `Issuer!` (non-null), so this matches the contract — but every
+   other reader in this PR is defensive ("indexer may return partial
+   data, so we guard each branch carefully" — `indexer.ts:62-71`).
+   Inconsistent with the codebase's defensive-by-default boundary
+   posture; a malformed `followerEvents` response with `actor: null`
+   would push `actor: null` and crash `FeedEventCard` at
+   `event.actor.did`.
+
+7. **Polling effect re-keys on `hasAuthors` (boolean) but uses
+   `authorsRef.current` for the actual refresh.** Same file, line
+   213-250. When the authors LIST changes but the count stays > 0,
+   the polling effect doesn't tear down — the interval keeps firing
+   refreshes against the latest `authorsRef`. That's intended. But
+   combined with issue #2 above (no signal threading), an in-flight
+   refresh from BEFORE the authors change will commit after the new
+   authors take effect, polluting state. The polling effect's stability
+   makes this race more likely than for `loadMore`.
+
+8. **`HydrateFeedPage` schema-probe was not run.**
+   `docs/follower-events-feed/implementation.md:38-50`. The plan
+   (`plan-v2.md:158-162`) called this out as mandatory before merging
+   track 1. Implementation log acknowledges the skip and proposes
+   downgrading to a per-collection fan-out if any of the four
+   connections rejects `where: { uri: { in: [...] } }`. Without the
+   probe, a green CI doesn't mean the feed renders correctly in
+   prod — first user hits the indexer's "unknown argument 'uri'"
+   error and gets fallback "did something" cards for every event of
+   that kind. Per implementation.md the mitigation is "someone with
+   credentials runs the probe via the dev console" pre-merge; this
+   should be treated as a blocker for the staging → main PR, not for
+   the feature branch → staging PR.
+
+### Low — defensive / nice-to-have
+
+9. **`collection.create` body's `value.type` defaulting silently
+   mislabels untyped collections as "project".**
+   `src/components/feed/feed-event-card.tsx:193-199` and
+   `src/lib/atproto/indexer.ts:747-748`. `nodeToCollectionRecord`
+   hard-codes `type: "project"` into the synthesised value; the
+   hydrator overrides only if `edge.node.type` is truthy. A collection
+   record that didn't ship a type field (legacy or buggy) will appear
+   in the feed as "created a project" even when it's actually a list
+   or portfolio. Not introduced by this PR but newly visible because
+   the home feed surfaces these.
+
+10. **`hydrateFeedEvents` doesn't pass through the `signal` to the
+    bucketing short-circuit.** `src/lib/atproto/follower-events.ts:339-343`.
+    The "every event is unknown" early-return path is synchronous, so
+    the signal can't have aborted yet. Fine. The actual fetch (line
+    345-358) does pass `signal`. OK.
+
+11. **`fetchFollowerEvents` on `authors: []` hits the network with
+    `authors: []` rather than short-circuiting.**
+    `src/lib/atproto/follower-events.ts:162-180`. The spec is clear
+    that empty authors returns an empty connection, but signed-out
+    viewers (handled by `HomeFeed` chrome anyway) and "no follows"
+    viewers will pay one round-trip per (re)render of the initial-load
+    effect. `loadMore` and `refresh` short-circuit at
+    `authors.length === 0`; `loadInitial` doesn't. Cheap to add.
+
+12. **`isLoading: true` initial state can flash skeletons even when
+    `authors` resolves to `[]` immediately.**
+    `src/hooks/use-home-feed.ts:79`. `useState(true)` for `isLoading`
+    plus the initial-load effect firing always means the
+    "signed-in + 0 authors" state briefly shows the loading skeleton
+    before resolving. The mod-flicker isn't broken behaviour but
+    interacts badly with issue #1 above.
+
+## Confirmations
+
+- **Operational constraint `MaxAuthorsFilterSize = 500` enforced both
+  client-side (computeHomeFeedAuthors slices at 500) and server-side
+  (readAuthorList returns null on length > 500). Defence-in-depth as
+  the plan called for.**
+- **Operational constraint `MaxFeedPageSize = 50` enforced via
+  `clampFirst(value, MAX_FEED_PAGE_SIZE = 50, 20)` in
+  route.ts:927. Test pins clamp behaviour at first=999 → 50.**
+- **Operational constraint "polling cadence 30 s foreground / 5 min
+  background" matches `FOREGROUND_POLL_MS = 30_000` /
+  `BACKGROUND_POLL_MS = 5 * 60_000` in follower-events.ts:50-52, used
+  via `document.visibilityState` switching in use-home-feed.ts:220-242.**
+- **Operational constraint "no parallel `followerEvents` requests":
+  `loadMore` guards via `isLoadingMoreRef` (use-home-feed.ts:145);
+  initial-load and refresh aren't strictly serialised but the dedupe
+  by event.id prevents user-visible duplication.**
+- **Coded error `AUTHORS_REQUIRED` mapped to `FollowerEventsError.code`
+  via `parseErrorCode` in follower-events.ts:121-124. Defensive — the
+  proxy rejects first.**
+- **Coded error `AUTHORS_FILTER_TOO_LARGE` mapped + surfaced via
+  `errorCode` from `useHomeFeed` for HomeFeed's specific copy at
+  home-feed.tsx:88-93. Test pins this at use-home-feed.test.ts:158-171.**
+- **Coded error `INVALID_CURSOR` mapped via the same path. Test pins
+  it in follower-events.test.ts:104-113.**
+- **Deliberate v1 limitation "every `badge.award` produces `kind =
+  badge.award`": confirmed — the dispatch in feed-event-card.tsx:98-108
+  doesn't branch on definition type, just renders "awarded a badge to
+  subject" uniformly. Matches review-decisions S7 rejection.**
+- **Deliberate v1 limitation "no `payload` field on wire": confirmed —
+  `FeedEvent` carries only id/kind/subjectUri/sortAt/actor; the client
+  builds its own `HydratedPayload` synthetically via the second-pass
+  hydration query.**
+- **Deliberate v1 limitation "no subscription, polled": confirmed —
+  no WebSocket / EventSource in the implementation; polling effect at
+  use-home-feed.ts:214-250.**
+- **Empty `authors: []` semantic preserved end-to-end: route
+  `readAuthorList` returns `[]` for length 0 (not null/error), proxy
+  forwards `authors: []` to upstream, `fetchFollowerEvents` sends
+  `authors: []` and parses the empty connection back as an empty page.
+  Test pins each step at route.test.ts:414-422 and
+  follower-events.test.ts:83-90.**
+- **Unknown-kind dispatch falls through to `UnknownKindBody`: confirmed
+  at feed-event-card.tsx:91-121 — the `if/if/if/if` chain returns
+  `UnknownKindBody` on any non-payload-matching kind. Test at
+  feed-event-card.test.tsx:131-141 pins it.**
+- **Hydration nil handling (`payload: null` → UnknownKindBody fallback):
+  confirmed at feed-event-card.tsx:91-121 — same dispatch chain; null
+  payload means none of the `payload?.kind === "..."` branches match,
+  falls through to UnknownKindBody. Test at feed-event-card.test.tsx:143-150.**
+- **Author-union dedupe-before-cap: `computeHomeFeedAuthors` builds the
+  union Set first (use-home-feed-authors.ts:19-22) and slices to 500
+  after. Test at use-home-feed-authors.test.ts:78-89 pins this with
+  the 300+300/50-overlap=550-cap=500 case.**
+- **`AbortController` plumbing for initial load: the effect at
+  use-home-feed.ts:138-142 creates a fresh controller per filterKey
+  change, calls `controller.abort()` on cleanup. `loadInitial` checks
+  `signal?.aborted` between the two awaits at lines 115 and 117 and in
+  the catch and finally. Correctly tears down in-flight fetches /
+  hydrations on key change.**
+- **`loadMore` dedupe by event.id: confirmed at use-home-feed.ts:158-164.
+  Reads `prev` via setEvents-callback (race-safe), filters incoming
+  by `!seen.has(h.event.id)`. Test at use-home-feed.test.ts:94-125
+  pins overlap-then-no-duplicate behaviour.**
+- **`refresh` merge by event.id: confirmed at use-home-feed.ts:188-196,
+  symmetric pattern (filter incoming by existingIds, no-op if nothing
+  new). Test at use-home-feed.test.ts:127-156 pins prepend-keeping-position.**
+- **`useBlueskyFollows.truncated` cap-detection: confirmed at
+  use-bluesky-follows.ts:68-75 — `truncated = true` ONLY when
+  `followedDids.size >= MAX_FOLLOWS && cursor`. The cursor check is
+  load-bearing as the inline comment notes (a viewer with exactly 10k
+  follows wouldn't be falsely flagged).**
+- **`HydrateFeedPage` defensive proxy validation: `readUriList` caps at
+  50 entries per kind (route.ts:790-800), rejects non-string entries,
+  caps per-entry length at MAX_URI_LEN=512. Empty arrays pass through.
+  Tests pin all three at route.test.ts:496-553.**
+- **Hydration kind-bucketing preserves input order: confirmed at
+  follower-events.ts:414-417 — final return is `events.map(...)`,
+  iterating the original input, looking up payload by subjectUri.
+  Test at follower-events.test.ts:175-258.**
+- **Proxy MAX_BODY_SIZE bump from 16KB → 32KB: route.ts:53. Worst-case
+  hydration body is ≤ 20KB (4 × 50 × ~100 chars), fits comfortably.**

--- a/docs/follower-events-feed/review-impl-integration.md
+++ b/docs/follower-events-feed/review-impl-integration.md
@@ -1,0 +1,312 @@
+# Review — implementation, integration / UX lens
+
+Lens: what does a real user see when they land on `/feed`, do all the
+nav paths still route correctly, and does the rendered feed read as
+one coherent column when several kinds interleave? Read `plan-v2.md` +
+`review-decisions.md`, diffed `feat/positioning-redesign..HEAD`,
+walked the components, ran the dev server (`/feed` returns HTTP 200,
+no server errors in dev log).
+
+---
+
+## Issues
+
+### 1. Empty-state copy collapses two of the three required variants (medium)
+
+`plan-v2.md:434-437` and `review-decisions.md:79-82` both lock the
+three-variant empty state:
+
+- signed-out → "Sign in to see your feed."
+- signed-in + 0 authors → "Follow people to see their activity here."
+- signed-in + authors but 0 events → "No activity from your follows yet."
+
+What `home-feed.tsx:62-72, 101-130` ships:
+
+- Signed-out → sign-in EmptyState ✓
+- Signed-in + 0 events → renders **the same** Inbox EmptyState
+  ("No activity yet" / "When people you follow create certs or
+  endorse others, you'll see it here") **AND** the `NoFollowsHint`
+  ("Not following anyone yet? Find people to follow on the Explore
+  page.") underneath. There is no branch on `authors.length === 0`.
+
+The primary message ("When people you follow create certs...") is
+literally wrong copy for a viewer who follows nobody — and the hint
+trails it as a small subordinate row, so the contradiction reads as a
+bug, not a fallback. The original plan was clear: branch the EmptyState,
+don't stack a hint under a contradictory primary message. The
+`useHomeFeedAuthors` hook already returns `authors.length` to make this
+branchable.
+
+Recommendation: gate the rendered EmptyState on
+`authors.length === 0` vs `authors.length > 0 && events.length === 0`
+and pick distinct copy for each, with the "Follow people" CTA living
+in the empty-state's `children` slot (`empty-state.tsx:32`) rather
+than as a separate hint pinned below.
+
+### 2. Desktop has no nav entry point to `/feed` (medium)
+
+This is a hole in the redesign-era nav, not in this PR — but this PR
+makes it actively visible.
+
+- `bottom-nav.tsx:42` (mobile, `< 800px`) — has a Feed icon routing to
+  `/feed`. ✓
+- `mobile-sidebar.tsx:113` (mobile, hamburger) — has "Feed". ✓
+- `desktop-left-rail.tsx:210-222` (desktop, `≥ 800px`) — **no Feed
+  entry at all**. Order is Profile → Explore → Endorsements →
+  Notifications → Groups → Apps → Settings. The brand link goes to
+  the user's own profile (`/profile/<handle>`), not `/feed`.
+- `site-drawer.tsx:60` (hamburger on desktop top bar) — has a "Home"
+  link to `/home`, **not** `/feed`. `/home/page.tsx` is the empty
+  placeholder div left by the redesign.
+
+Net: at `≥ 800px`, the only way an authed user reaches the new home
+timeline is by typing `/feed`, opening the legacy `SiteDrawer` and
+clicking the unrelated `/home` link (which doesn't get them there),
+or via a deep link. Desktop users get the feature with zero
+discoverability. Adding `{ href: "/feed", label: "Feed", icon:
+Newspaper }` near the top of `authedItems` (`desktop-left-rail.tsx:210`)
+would close this. The `SiteDrawer.tsx:60` Home → `/feed` rewrite
+(or removal of the stub `/home` route) is also worth doing in the
+same change — two paths to two different "home" surfaces will confuse
+desktop users moving between drawer-Home and rail-Feed.
+
+DESIGN.md is also stale here: §"Left Rail (desktop)" (line 366) claims
+the authed rail starts with "Home, Explore, …". The implemented rail
+starts with "Profile, Explore, …". Both the rail and the doc need to
+agree, and ideally both should reference `/feed`.
+
+### 3. Hydration-404 events render the unknown-kind fallback ("did something" + raw at:// URI) (low → medium for legibility)
+
+`follower-events.ts:414-417` returns `payload: null` whenever the
+hydration lookup yielded no record — i.e. the underlying cert /
+collection / award was deleted after `followerEvents` saw it.
+`feed-event-card.tsx:120` then dispatches to `UnknownKindBody`, which
+renders:
+
+> *{actor display name}* did something  
+> at://did:plc:.../app.bsky.feed.post/3l…
+
+That's misleading copy: the actor's kind IS known (we have
+`event.kind === "cert.create"`), only the record vanished. Rendering
+"did something" plus a monospace at-URI is the right shape for a
+truly unknown kind shipped by the server but it's wrong for "we know
+what they did, we just can't render it." For v1 this is rare, but
+visible — a single deleted cert from a followed creator surfaces as
+an orphan card with confusing language.
+
+Two options, equivalent effort:
+- In `FeedEventBody`, branch on `event.kind` (the wire kind) before
+  falling through to `UnknownKindBody`. For a known kind with null
+  payload, render a graceful "{actor} created a cert" / "{actor}
+  awarded a badge" line with no detail link and no image. Distinct
+  from "unknown kind."
+- Filter `payload === null && KNOWN_FEED_EVENT_KINDS.has(kind)` out
+  of the rendered list inside `useHomeFeed` and just don't show
+  hydration-404 events at all.
+
+Document the choice; either is better than the current "did
+something" surface for known-kind-but-deleted.
+
+### 4. `collection.create` cropped-to-square banners may look wrong (low)
+
+`feed-card__image-wrap` (`feed.css:475-482`) enforces `aspect-ratio: 1
+/ 1` with `object-fit: cover`. `cert.create` images are 1:1 by lexicon
+convention so that wrap is right for them. `collection.create`
+banners are not 1:1 — collection lexicons store wide banners.
+Cropping a 3:1 banner to square via `cover` produces a meaningless
+centered chunk.
+
+Either: omit the image-wrap for `collection.create` (let the body be
+title + description, banner-less in the feed), use a separate
+`.feed-card__banner-wrap` with a 3:1 aspect ratio, or accept the
+square crop and live with it. The plan was silent on this; the
+shipped code defaults to cropping. Worth a deliberate decision rather
+than an accident.
+
+### 5. `collection.create` placeholder asymmetry with `cert.create` (low)
+
+`CertCreateBody` (`feed-event-card.tsx:158-164`) renders a placeholder
+square (Award icon on a gradient background) when `imageUrl` is null.
+`CollectionCreateBody` (lines 214-224) just omits the image wrap
+entirely when banner is null. In a mixed feed, identical-position
+absences look different across kinds — cert-without-image gets a
+placeholder, collection-without-banner gets a tighter card. Either
+mirror the cert behavior, or drop the cert placeholder too. The
+inconsistency reads as "two designs by two people."
+
+### 6. `loadInitial` runs and POSTs to `/api/indexer` even when `authors=[]` (low)
+
+`use-home-feed.ts:138-142` fires `loadInitial` on every `filterKey`
+change, including the empty-authors case. `fetchFollowerEvents`
+(`follower-events.ts:162-180`) doesn't short-circuit on empty authors
+— it POSTs to the proxy and lets the upstream return an empty page.
+For signed-out / no-follows visitors that's one wasted request per
+page load. Skipping the fetch when `authors.length === 0` (the same
+gate the polling effect already uses, line 215) would zero out the
+wasted traffic. Not user-visible but cheap to fix.
+
+### 7. `useSocialGraphSync` doesn't read the new `truncated` flag (latent, pre-existing)
+
+The diff in `use-bluesky-follows.ts:11-17` documents that consumers
+deriving set arithmetic from `data` "must refuse to act on the result
+when this is true" because the diff would return false-negatives.
+`use-social-graph-sync.ts:80-98` derives `inBoth`/`onlyCertified`/
+`onlyBluesky` from `blueskyDids` and does NOT consult `truncated`.
+
+This is a pre-existing latent bug (the 10k cap was always there, just
+silent) and outside the scope of this PR's stated goals. But this PR
+now exposes the field publicly without wiring the only legacy
+consumer that the new field's own JSDoc warns about. Worth a
+follow-up ticket, ideally linked from the truncated comment so it
+doesn't drift.
+
+### 8. `KNOWN_FEED_EVENT_KINDS` is exported but the dispatch site doesn't use it (low, cosmetic)
+
+`follower-events.ts:61-67` exports the const tuple + derived type per
+review-decision R11, but `feed-event-card.tsx:91-121` open-codes four
+string literals in cascading `if`s. The current code is correct, but
+adding a new kind to the tuple has zero compile-time signal that the
+card needs a new branch. A narrowing function (`isKnownKind`) or an
+exhaustive switch over `KnownFeedEventKind` would close that loop;
+without it, the constant is data only the proxy reads.
+
+### 9. Skeleton (`ActivityCardSkeleton`) reflows hard when the page is non-cert-heavy (low, deferred-but-worth-noting)
+
+Plan v2 explicitly accepts this: "layout shift on first paint is
+acceptable for v1" (`review-decisions.md:81-83`). Noting only because
+review-integration round 1 flagged it as a real polish item; in
+practice, the first 20 events on a typical follow set will mix kinds,
+and three 380-px skeletons collapsing to mixed 70–400px cards is
+visible. Deferred per the plan, but worth re-evaluating after a few
+days of real use.
+
+---
+
+## Confirmations
+
+### Navigation paths (mobile)
+
+- `bottom-nav.tsx:30` correctly highlights the Feed tab on `/feed`
+  and `/feed/*`. Click → `router.push("/feed")` works (verified with
+  dev server).
+- `mobile-sidebar.tsx:113` "Feed" link goes to `/feed`.
+- Both close on navigation (`mobile-sidebar.tsx:69-72`).
+
+### Removed-surface impact
+
+The old `/feed/page.tsx` returned `HomeClient` (`feat/positioning-redesign:src/app/feed/page.tsx`),
+which redirected authed users to `/profile/{did}` and unauth users
+to `/welcome`. The redirector still exists at
+`src/components/landing/home-client.tsx:13-42` — it's used by the
+root `/` page, which is its actual purpose. The `/feed` mounting was
+vestigial; only this PR has any reference to it (the deletion
+comment in `feed-page-client.tsx:8`).
+
+Grep results for `router.push.*feed`, `router.replace.*feed`,
+`Link.*"/feed"`, `href="/feed"` across `src/` return only the three
+known callers (bottom-nav, mobile-sidebar, and `pathname === "/feed"`
+checks in bottom-nav). No deep links elsewhere relied on the redirect
+behaviour. The old `/feed → /profile/{did}` jump is gone but nothing
+in the tree depends on it.
+
+### Visual states
+
+Walking the rendered output (read of CSS + components, no browser
+session for hydrated states):
+
+- **Signed-out empty state.** EmptyState centered, LogIn icon
+  (40px stroke 1.2), "Sign in to see your feed" headline, descriptive
+  copy. Renders inside `.feed`. Coherent. (`home-feed.tsx:62-72`)
+- **Loading state.** Three `ActivityCardSkeleton`s — square image
+  block, title bar, two text lines, two pills. Reads as standard
+  feed loading. Caveat above re mixed-kind reflow. (lines 53-59)
+- **`cert.create` card.** Author byline (avatar + name + handle +
+  inline time), action line ("created a cert" + Sparkles icon),
+  square image or Award-icon placeholder, serif H2 title, 3-line
+  description, all wrapped in a Link to the activity detail. Clean.
+  (`feed-event-card.tsx:127-179`)
+- **`collection.create` card.** Author byline, action line ("created
+  a project/list/portfolio" + FolderOpen icon), banner (cropped to
+  square — see issue 4), title, description. No detail link. Less
+  visual hierarchy than cert (no terminal link), but works.
+  (lines 185-231)
+- **`badge.award` card.** Byline, action line "awarded a badge to
+  {subject}" with the subject name linking to their profile.
+  Optional note in a tinted box. Reads as a small social row inside
+  the same card chrome. (lines 99-107, 237-269)
+- **`legacy.endorsement` card.** Same as badge.award, copy is
+  "endorsed" + Heart icon, never has a note (lines 109-118).
+- **Unknown-kind card.** Byline, "did something" with the
+  subjectUri rendered in a monospace ellipsised line. Doesn't link
+  but tooltips via `title`. Right shape for a truly unknown kind.
+  (lines 275-287)
+- **Mixed feed.** Each card uses the shared `.feed-card` outer
+  (20px vertical padding, hairline border-bottom). Heights vary —
+  cert/collection ~380-450px because of the square image; badge/
+  endorsement ~120-180px because they're text-only. Variance is
+  organic and reads as one column.
+- **Warning banner.** `.feed__warning` is a quiet left-bordered tinted
+  box above the feed (`feed.css:2305-2313`), `role="status"`. Copy is
+  appropriate; oversized message wins when both flags are true.
+  (`home-feed.tsx:76-82`) The two warnings share the same visual —
+  acceptable trade-off given they share a remedy.
+- **Error state.** `EmptyState` with AlertCircle, distinct title
+  for `AUTHORS_FILTER_TOO_LARGE`. Reads cleanly. (lines 84-95)
+
+### Empty/error/warning copy review
+
+- "Sign in to see your feed." ✓
+- "Sign in to see activity from people you follow." ✓
+- "Follow list too large" / "Couldn't load your feed" ✓
+- "No activity yet" / "When people you follow create certs or
+  endorse others, you'll see it here." ✓ on its own; **mismatched**
+  for the "follows nobody yet" case — see issue 1.
+- "Not following anyone yet? Find people to follow on the Explore
+  page." OK, but redundant alongside the primary message; better
+  folded into a "no follows" variant of the primary empty state
+  with a real CTA button (see issue 1).
+- Warning banners — concise, no jargon. ✓
+
+### Spec / plan adherence
+
+- `plan-v2.md` track structure (8 tracks, sequential) matches
+  committed history (8 commits, in plan order).
+- `MAX_AUTHORS_FILTER_SIZE = 500` enforced server-side
+  (`route.ts:65, 752-756`) and client-side (`follower-events.ts:45`,
+  `use-home-feed-authors.ts:23-27`).
+- Polling cadence — 30s foreground, 5min background, visibility
+  switching (`use-home-feed.ts:213-250`).
+- Polling pauses when authors empty — ✓ (line 215).
+- `refresh` merges by `event.id` and preserves cursor — ✓ (lines
+  179-204).
+- Empty `authors: []` accepted by proxy — ✓ (`route.ts:752-756`,
+  empty arrays pass through).
+- Defense-in-depth client truncation to 500 before sending — ✓
+  (`use-home-feed-authors.ts:23-27`).
+- `nodeToActivityRecord` / `nodeToCollectionRecord` extracted and
+  exported per R6 — ✓ (`indexer.ts` diff).
+- Unknown-kind fallback present per R11 — ✓ (mod issue 3 above).
+
+### Build / smoke
+
+- Dev server start + `GET /feed` → HTTP 200 in 41ms, no errors in
+  dev log.
+- `metadata` export preserved on the server file
+  (`feed/page.tsx:4-9`), `"use client"` correctly scoped to
+  `feed-page-client.tsx`.
+- `usePageTitle("Feed")` registers the navbar title (line 18).
+
+---
+
+## Summary
+
+Spec/data plumbing is solid; the implementation matches plan v2
+across all tracks. The two items worth blocking on before merge are
+**issue 1** (empty-state copy contradicts itself for the no-follows
+case) and **issue 2** (desktop users have no nav entry to the
+feature). Issues 3-5 are visible-but-acceptable v1 polish. Issues
+6-9 are non-blocking, cheap to track.
+
+Net: this is shipable after fixing the empty-state branch and
+either adding a Feed link to the desktop left rail or pointing
+`SiteDrawer`'s `/home` link at `/feed`.

--- a/docs/follower-events-feed/review-impl-quality.md
+++ b/docs/follower-events-feed/review-impl-quality.md
@@ -1,0 +1,275 @@
+# Review — implementation code quality & codebase fit
+
+Lens: "is this code we'd be happy maintaining six months from now?"
+Scope: the diff `feat/positioning-redesign..HEAD` (issue #88 follower-events feed).
+
+## Issues
+
+### 1. New CSS references undefined design tokens (visual bug)
+
+`src/app/styles/feed.css` introduces six rules under the issue #88 section
+that use tokens that **do not exist** in `tokens.css`:
+
+- `var(--fg-default)` at lines 2278, 2293, 2312
+- `var(--bg-subtle)` at lines 2289, 2308, 2326
+
+There is already a documented note about this in `src/app/styles/explore.css:433-436`:
+
+> `--bg-subtle` doesn't exist in the token set; fell through to no background.
+> Use `--bg-sunken` for a clearly-visible hover wash …
+
+So this is a known footgun in the codebase that this PR repeats. The
+`.feed__warning`, `.feed__hint`, `.feed-card__note`, and
+`.feed-card__action-subject` rules will render with transparent backgrounds
+and inherited text colour in production — `getComputedStyle` on the warning
+banner won't pick up the intended muted-grey background; it just gets
+`transparent`. Visually the truncation banner will be a borderline-invisible
+strip.
+
+Replace with the existing token set (likely `--bg-sunken` /
+`--overlay-weak` for backgrounds and `--fg-primary` for default text).
+
+### 2. `HomeFeed` empty-state branching doesn't match the plan
+
+`plan-v2.md` (lines 434-441) specifies three discrete empty states:
+
+1. signed-out
+2. signed-in + **0 authors** → "Follow people to see their activity here."
+3. signed-in + authors but 0 events → "No activity from your follows yet."
+
+The current `HomeFeed` implementation (`src/components/feed/home-feed.tsx:100-130`)
+collapses cases (2) and (3) into one branch: it renders the generic
+"No activity yet" `EmptyState` **and** the `NoFollowsHint` block back-to-back
+whenever `events.length === 0`. The user gets both messages stacked, which
+reads as redundant and contradicts the plan's three-variant design.
+
+Root cause: `UseHomeFeedResult` doesn't expose `authors.length` (or a
+derived `hasFollows` boolean). Without that signal `HomeFeed` cannot
+distinguish "no follows" from "no activity yet". Either:
+- add a `hasFollows: boolean` to `UseHomeFeedResult` and branch on it, or
+- expose `authorsCount: number`, or
+- pull `useHomeFeedAuthors` directly inside `HomeFeed`.
+
+### 3. `actor.pds` is fetched and propagated but never consumed
+
+`FeedActor.pds` is part of the GraphQL selection (`route.ts:560`), the wire
+type (`follower-events.ts:78`), and rides on every event through `useHomeFeed`
+to `FeedEventCard`. Nothing reads it — the avatar URL is built via the
+same-origin `/api/xrpc/com/atproto/sync/getBlob` route by
+`buildAvatarUrlFromCid`, which only needs `did + cid`. Dead field on the
+hot path (up to 50 rows/page, polled every 30s).
+
+Either drop `pds` from the query + type, or document why it's preselected
+for forward-compat.
+
+### 4. `SubjectActionBody` accepts `event` as a required prop but never reads it
+
+`feed-event-card.tsx:237-249`:
+
+```tsx
+function SubjectActionBody({
+  event: _event,
+  subjectDid,
+  …
+}: {
+  event: FeedEvent
+  …
+})
+```
+
+The `_event` rename signals "intentionally unused" but the prop is still
+required by the type and passed by both `badge.award` and
+`legacy.endorsement` call sites. Drop `event` from the interface and from
+the two callers, or use it (e.g. for an `aria-label` mentioning the
+actor).
+
+### 5. `hasMore` toggled off on `loadMore` errors silently kills pagination
+
+`use-home-feed.ts:170-172`:
+
+```ts
+} catch (err) {
+  console.warn("[useHomeFeed] loadMore failed:", err)
+  setHasMore(false)
+}
+```
+
+Same pattern as `use-global-feed.ts:194` — codebase consistent, so not a
+blocker — but `useGlobalFeed` documents the "stop offering pagination on
+error" intent in a comment. The home-feed copy of the pattern just has
+"Loading-more errors stop pagination but don't replace the existing list"
+which doesn't explain *why* (transient cursor errors are unlikely to
+recover on retry). Worth one-line follow-up so the next reader doesn't
+revert it to a retryable state.
+
+### 6. Inconsistent error class between `fetchFollowerEvents` and `hydrateFeedEvents`
+
+- `fetchFollowerEvents` non-OK HTTP → throws `FollowerEventsError(msg, null)` (`follower-events.ts:182`).
+- `hydrateFeedEvents` non-OK HTTP → throws plain `Error` (`follower-events.ts:361`).
+
+The hook (`use-home-feed.ts:121-128`) only `instanceof`-narrows
+`FollowerEventsError` to set `errorCode`, so hydration failures land in the
+"generic message" path. That's the documented intent in the plan, but the
+plain-`Error` throw means the hook's catch doesn't even know it's a
+hydration failure vs a network failure. Consider throwing a tagged
+`HydrationError` (or reusing `FollowerEventsError` with `code: null` to
+keep both fetchers' surfaces uniform).
+
+### 7. `MAX_BODY_SIZE` bump from 16 KB → 32 KB applies to **all** indexer
+operations
+
+`route.ts:51`:
+
+```ts
+// 32KB — operationName + variables. The 16KB original was too tight for
+// HydrateFeedPage, which sends up to 50 at:// URIs per kind × 4 kinds.
+const MAX_BODY_SIZE = 32 * 1024
+```
+
+The widened cap loosens the request-size guard on every existing op
+(`Activities`, `Projects`, `EndorsementClosure`, …), not just
+`HydrateFeedPage`. Acceptable in practice — 32 KB is still a tiny payload
+budget — but the comment understates the blast radius. Either tighten the
+guard per-op (largest, scariest change) or leave a 1-liner noting that the
+bump is intentional cross-op.
+
+### 8. Dead code: `HomeClient` is now orphaned
+
+`src/components/landing/home-client.tsx` was the previous `/feed` body. The
+new `feed/page.tsx` imports `feed-page-client` directly; nothing else in
+`src/` references `home-client.tsx` or the `HomeClient` symbol. Either
+delete it (clean) or note in `06-deferred.md` that the legacy redirector
+will be removed in a follow-up.
+
+### 9. `useBlueskyFollows` truncated-flag has no test coverage
+
+Plan v2 (`Track 3`) said: "`src/hooks/__tests__/use-bluesky-follows.test.ts`
+(add cases or new file)". No test file for this hook exists before or after
+the change. The new field is small and the pure-state path is exercised
+indirectly by `use-home-feed-authors.test.ts` via `truncatedBySource`
+boolean unions, but the load-bearing detail (`size >= MAX_FOLLOWS && cursor`
+check at `use-bluesky-follows.ts:72`) is unverified. Existing codebase has
+no test for either follow-list hook, so this is "consistent neglect" rather
+than a regression — but the plan committed to it.
+
+### 10. Polling cadence / visibility handling untested
+
+`implementation.md:79-83` explicitly defers this (`fake-timer + React-effect
+interaction is brittle`). Fair — but polling is one of the load-bearing
+features of the hook and `useEffect` errors here (visibility-change
+listeners not torn down, interval drift on cadence flip, double-start when
+both `start()` and `handleVisibility()` fire) are exactly the kind of bugs
+that pass eye review and break in production. Even one unit test asserting
+"interval is cleared when authors becomes empty" would be worth carrying.
+
+### 11. `nodeToCollectionRecord` hardcodes `type: "project"`; hydration
+overrides only when truthy
+
+`indexer.ts:748` builds the record with `type: "project"` baked in. The new
+follower-events hydration at `follower-events.ts:388` overrides via
+`if (edge.node.type) record.value.type = edge.node.type`. If the indexer
+ever returns `type: ""` (empty string) or `type: null` for a hydrated
+collection, the record silently becomes `"project"` — wrong for
+endorsement-lists and portfolios.
+
+Either thread the optional `type` directly into `nodeToCollectionRecord`
+(the cleanest path now that it's exported), or change the override to
+`if (edge.node.type !== undefined)` to handle the empty-string case
+explicitly.
+
+### 12. `feed/page.tsx` metadata copy is stale
+
+```ts
+description: "Activity feed on Certified — for-you and following."
+```
+
+The new feed doesn't have for-you / following tabs. Trivial copy nit; while
+the page is being rewired anyway it's free to update.
+
+### 13. CSS noise: `.feed-card__time--inline` duplicates base rules
+
+`feed.css:2255-2260` redeclares `font-size: 0.75rem` and
+`color: var(--fg-muted)` already present on the base `.feed-card__time`
+(line 541). The `--inline` modifier should only add `white-space: nowrap`
+and `flex-shrink: 0`. Minor — but it gets harder to evolve the base later.
+
+### 14. `parseActivityUri` used where `activityDetailHrefFromUri` exists
+
+`feed-event-card.tsx:138-139`:
+
+```tsx
+const parsed = parseActivityUri(record.uri)
+const detailHref = parsed ? activityDetailHref(parsed.did, parsed.rkey) : null
+```
+
+`activity-uri.ts:35-39` already exports `activityDetailHrefFromUri(uri)`
+which does this same two-step *and* validates that the collection is
+`org.hypercerts.claim.activity`. The new code skips that validation, which
+isn't load-bearing on `cert.create` events but inconsistent with the
+codebase's preferred helper.
+
+### 15. CSS rule scoping — generic `.feed__warning` / `.feed__hint`
+
+The new top-level selectors (`.feed__warning`, `.feed__hint`,
+`.feed__sentinel`) live under `.feed` so they don't strictly collide with
+anything else, but the names are generic enough that another feed surface
+adding its own warning would clash. Existing rules in the file are mostly
+`.feed-card__*` and `.feed-tabs__*` — i.e. BEM with a block prefix. The
+new ones drop the block prefix. Consider `.home-feed__warning` /
+`.home-feed__hint` to keep BEM consistent and the surface scoped.
+
+## Confirmations
+
+These were checked against the plan / decisions doc and existing
+conventions and look right:
+
+- **Hook return shape** — `useHomeFeed`'s `{ events, isLoading,
+  isLoadingMore, error, hasMore, loadMore, … }` mirrors `useGlobalFeed`'s
+  surface; primitives like `errorCode` and `truncatedBySource` are added
+  cleanly without reshaping existing fields.
+- **Primitive-key effect pattern** — `filterKey = authorsKey|kindsKey`
+  drives the initial-load effect exactly the way `use-global-feed.ts:108`
+  does it.
+- **`useRef` snapshot of refresh** — matches the pattern in
+  `notifications-context.tsx:75-107` and `use-global-feed.ts:56-57`.
+- **Mapper extraction** — `nodeToActivityRecord` and
+  `nodeToCollectionRecord` exported with no behavioural change. The new
+  hydration code uses them straight; no duplication.
+- **`useBlueskyFollows` truncated flag** — backward-compatible change.
+  `useSocialGraphSync` (the only other consumer) destructures
+  `followedDids, isLoading, error` and is unaffected.
+- **Authors validation in the proxy** — `readAuthorList` correctly
+  enforces 0..500 inclusive, fail-soft on per-entry non-DIDs to match
+  `readDidList`. Tests cover the boundary.
+- **`HydrateFeedPage` arg validation** — per-list cap of 50,
+  string-only entries, empty arrays pass through. Tests cover each
+  failure path.
+- **`AbortController` discipline** — `loadInitial` aborts on filter-key
+  change; existing patterns in `useGlobalFeed` / `useProfile` use the
+  same shape.
+- **`KNOWN_FEED_EVENT_KINDS` as const tuple** — matches review-decision
+  R11; wire type stays open string for forward-compat.
+- **`FollowerEventsError` typed code** — `code: FollowerEventsErrorCode
+  | null` matches existing `EndorsementClosureError` shape in
+  `indexer.ts:430-438`.
+- **No new dependencies** — package.json untouched; all icons reuse
+  existing `lucide-react`; only four icons imported in the new
+  `feed-event-card.tsx`, all tree-shakable.
+- **Comments are mostly "why, not what"** — block headers in
+  `follower-events.ts` and `use-home-feed.ts` explain *intent* (why
+  refresh doesn't reset the cursor, why polling cadence flips, why
+  `pds` was originally selected) rather than restating code. Minor
+  exceptions are the `// cert.create` / `// collection.create` section
+  dividers in `feed-event-card.tsx`, but those are organisational
+  rather than narrative.
+- **No `as any` / unsafe casts** — only narrow `as` casts at the
+  hydration mapper boundary (`value.banner as
+  Parameters<typeof resolveActivityImageUrl>[0]` in
+  `feed-event-card.tsx:203`) and inside `parseErrorCode` (`as
+  FollowerEventsErrorCode` after `KNOWN_ERROR_CODES.has` check, which is
+  a sound narrowing).
+- **Hook tests cover the load-bearing surface** — initial load,
+  loadMore dedupe, refresh merge-by-id, and `errorCode` mapping all
+  have explicit tests; `computeHomeFeedAuthors` has thorough boundary
+  coverage; `FeedEventCard` has a render test per kind plus
+  unknown-kind fallback.

--- a/docs/follower-events-feed/review-integration.md
+++ b/docs/follower-events-feed/review-integration.md
@@ -1,0 +1,184 @@
+# Review — integration / UX
+
+Lens: does the plan plug into the redesign's component surface and nav system without producing a feed that looks wrong, mis-routes users, or asks existing components to render shapes they were never built for?
+
+Reviewed: `discovery.md`, `plan.md`, `DESIGN.md` (TOC + nav/layout sections), `activity-card.tsx`, `project-list-row.tsx`, `endorsement-row.tsx`, `feed-layout.tsx`, `feed.css`, plus supporting reads of the nav surfaces (`navbar.tsx`, `desktop-left-rail.tsx`, `mobile-sidebar.tsx`, `site-drawer.tsx`, `bottom-nav.tsx`), `empty-state.tsx`, `activity-card-skeleton.tsx`, `activity-author.tsx`, `use-author-info.ts`, `collection.ts`, `activity-types.ts`, and the cert-list-row CSS the project row inherits.
+
+## Integration issues / corrections
+
+### 1. `/home` is not reachable from the primary nav (BLOCKER for the mount-point decision)
+
+The plan asserts `/home` is the right surface ("the redesign reserved this surface for the home-timeline feed", `discovery.md:33-34`). It isn't, at least not yet. The redesign-era nav points the "feed" affordance at `/feed`, not `/home`:
+
+- `src/components/layout/bottom-nav.tsx:30,37,42` — mobile bottom nav's "Feed" icon (Newspaper) routes to `/feed`.
+- `src/components/layout/mobile-sidebar.tsx:113` — hamburger drawer "Feed" link routes to `/feed`.
+- `src/components/layout/desktop-left-rail.tsx:210-222` — desktop left rail has NO "Home" item at all. Order is Profile → Explore → Endorsements → Notifications → Groups → Apps → Settings. The brandmark link goes to `/profile/<handle>` for authed users, not `/home` (lines 196-202).
+- `src/components/layout/site-drawer.tsx:60` — the ONLY surface that links to `/home` is the legacy `SiteDrawer` (Home/Explore/My profile/Settings). A grep for `"/home"`/`href="/home"` across the whole repo returns exactly one match. That drawer's status is unclear; the active mobile drawer for authed users is `MobileSidebar`, not `SiteDrawer`.
+
+Net: shipping a polished feed at `/home` is shipping a feed that nobody can find by clicking. The discovery doc's claim that "/home was reserved by the redesign" is not borne out by the components that ship the redesign.
+
+Recommendation, in priority order:
+1. **Pick one route and converge on it before implementation.** Either retire `/feed` (currently a redirector → `HomeClient`) and mount the feed at `/feed` (matching every nav surface), or rename the redesign's Feed nav targets to `/home` (touches bottom-nav, mobile-sidebar, and adds a Home item to desktop-left-rail). The former is much smaller — `/feed/page.tsx` already wraps a stub `HomeClient` (`discovery.md:35-38` calls it vestigial) and can be replaced cleanly.
+2. If staying at `/home`, the plan **must** include a nav-wiring track: add Home to `desktop-left-rail.tsx` (and decide its position relative to Profile/Explore), rewrite the bottom-nav and mobile-sidebar "Feed" targets to `/home`, and decide what happens to `/feed`.
+3. The "out of scope: migrating `ActivityFeed.following`" note becomes load-bearing in either direction — leaving `/feed` as `HomeClient` while the actual home feed lives at `/home` will confuse anyone who lands there via a stale link, search result, or another user's bookmark.
+
+This is the single biggest UX risk; everything else in the plan can ship correctly and still produce zero traffic if this isn't resolved.
+
+### 2. `EndorsementRow` is a `<li>` — `home-feed.tsx` needs a `<ul>` wrapper around endorsement events, or row layout collapses
+
+`EndorsementRow` returns `<li className="endorsement-row">` (`endorsement-row.tsx:48`). Its CSS depends on being inside `.endorsements-list` for proper list-reset, vertical spacing, and dividers (`feed.css:1461-1479` — `list-style:none`, `padding:0`, etc. live on `.endorsements-list`, not the row). Every existing caller wraps it in `<ul className="endorsements-list">` (`src/app/endorsements/page.tsx:75-86`; the profile endorsements section does the same).
+
+The plan's `home-feed.tsx` dispatch (`plan.md:271-282`) appears to render each event inline at the top level of `<div className="feed">`. Dropping a bare `<li>` directly inside a `<div>` is invalid HTML and will inherit no list styling — the row will still render but lose its dividers, vertical rhythm, and the careful `:last-child` border handling.
+
+Two options, equivalent in effort:
+- Wrap each endorsement event in `<ul className="endorsements-list" style={{margin:0}}>…</ul>` and put the `EndorsementRow` inside it. Ugly because each event becomes its own one-item list — kills the `:last-child` rule across endorsements (every row gets a bottom border).
+- Refactor `EndorsementRow` to render a `<div>` (or accept a tag prop) and move the list-reset into the row class itself. Cleaner but touches a shared component used by `/endorsements` and the profile page — requires verifying the existing surfaces still look right.
+
+The plan should pick one and call it out as a touched file, or refactor `EndorsementRow` upfront as part of this PR. As written, "reuse the existing component as-is" doesn't work for the home-feed shell.
+
+### 3. Mixed cards + rows in one column will read as visual chaos
+
+The four kinds dispatch to two visual registers that the redesign never intended to interleave:
+
+| Kind | Renderer | Visual register |
+|---|---|---|
+| `cert.create` | `ActivityCard` | **Card.** Full-width 1:1 image, serif H2 title, 3-line description, meta pills, 20–24px vertical padding, hairline `border-bottom`. (`feed.css:353-577`, DESIGN.md §4 "Cards" line 158.) |
+| `collection.create` | `ProjectListRow` | **Dense row.** 3-column grid (1fr 200px 84px), 40×40 thumb, 0.9rem sans title, no image, 10×14 padding, hover-wash background, 1px top-border separator. (`explore.css:420-530`.) |
+| `badge.award` / `legacy.endorsement` | `EndorsementRow` | **List row.** 48px avatar, sans display name, optional note, right-aligned date. Lives inside `.endorsements-list` with its own divider rules. (`feed.css:1469-1479`.) |
+| _unknown_ | `FeedEventFallbackCard` | New component, undetermined register. |
+
+`ProjectListRow` was also designed for a bordered/elevated wrapper — `.explore__list` provides `border: 1px solid var(--border-subtle); border-radius: 8px; background: var(--bg-elevated); overflow: hidden;` and adds the row-separator via `.explore__list > li + li .cert-list-row`. Drop it into `.feed` (flex column, no background, no card chrome — `feed.css:346-349`) and the row loses its container, the hover-wash will paint the row without a visual boundary, and the rounded-corner clip disappears.
+
+A scroll that alternates:
+- huge serif title + square image
+- tight 40-px-thumb 3-column grid row
+- compact avatar + sans-name + date row
+- huge serif title + square image
+
+…doesn't read as one feed. It reads as four feeds someone forgot to filter.
+
+Recommendation:
+1. **Treat the home feed as a card stream.** Build adapters that render each kind in the `.feed-card` visual language (border-bottom hairline, generous vertical padding, author byline up top, content body, meta row at the bottom). For `cert.create` that's the existing `ActivityCard`. For `collection.create`, build a `CollectionFeedCard` that uses the card vocabulary (banner image, serif title, item count + location meta) — don't reuse `ProjectListRow` from the dense explore-list register. For `badge.award`/`legacy.endorsement`, build an `EndorsementFeedCard` that reads like "X endorsed Y" with both actor + subject bylines — don't reuse the audit-list `EndorsementRow`.
+2. If (1) is too much for v1, at minimum **wrap each non-card kind in a feed-card shell** (`.feed-card` div with the same vertical padding + hairline) so the rhythm survives. Document the trade-off as "rows visually compress inside the card slots, revisit in v2."
+3. Either way, the plan's current "compose an `ActivityRecord` / `CollectionRecord` from the payload + event metadata" instruction (`plan.md:272-279`) understates the work. It's not just shape mapping — it's deciding whether the rendered element matches the surrounding rhythm.
+
+### 4. `ActivityCard` requires a `did` for image resolution AND a full `ActivityRecord.uri` for the detail link — composing one from the hydration payload is non-trivial
+
+The plan says (`plan.md:273-275`): "compose an `ActivityRecord` shape from the payload + event metadata." Concretely:
+
+- `ActivityRecord` is `{ uri, cid, value: ClaimActivity }` (`activity-types.ts:64-68`).
+- `ActivityCard` reads `record.uri` to derive the detail-page href via `parseActivityUri` (`activity-card.tsx:31-32`). The card silently degrades to non-linked when `parseActivityUri` returns null.
+- `ActivityCard` uses the separate `did` prop to resolve the image URL via `resolveActivityImageUrl(value.image, did)` (`activity-card.tsx:24-26`) — i.e. to construct the `getBlob` URL pointing at the author's PDS.
+
+For the home feed:
+- `event.subjectUri` is the at:// URI — fine for `record.uri`.
+- `event.actor.did` is the actor DID — but the actor DID and the activity's owner DID are the same here (the indexer's `followerEvents` returns events authored by people the viewer follows), so passing `event.actor.did` to the `did` prop is correct. **Worth a sentence in the plan to nail this down**, because it'll confuse the implementer who sees both a `did` prop and an event with multiple DID-shaped fields.
+- `cid` can be empty string; nothing on this code path reads it.
+
+OK as a structural plan; the plan should just state the mapping explicitly so the implementer doesn't reach for `record.uri` from a property that doesn't exist on the payload.
+
+### 5. `ProjectListRow` reads from raw record shape — the GraphQL `*ByUri` payload won't match without coercion
+
+`ProjectListRow` reads via `(value as Record<string, unknown>).banner ?? value.image`, `value.items` (Array.isArray), `value.location` (string OR strongRef object with `.uri`), and `value.createdAt` from the underlying `CollectionRecord.value` (`project-list-row.tsx:41-66`). It then calls `useLocation(locationRef ?? "")` to fetch the LocationRecord by URI.
+
+The plan's GraphQL selection (`plan.md:94`) is:
+```
+{ title, type, banner { ... }, items { itemIdentifier { ...ComAtprotoRepoStrongRef.uri } } }
+```
+
+Issues:
+- No `createdAt` → the row's `__time` column will be empty.
+- No `location` (raw value, inline OR strongRef.uri) → the row's "📍 location" meta-item won't render. Discovery flags this is desired ("only minimum fields for a headline render", `plan.md:88-89`), so visually fine, but the row was designed assuming location is present — without it the row is unbalanced (just a count, no second meta-item).
+- `useLocation` will still be called with `""` and short-circuit, so no fetch — that's fine.
+- `value.banner` will arrive as the GraphQL-shaped image object; `resolveActivityImageUrl` was written for the XRPC record shape (`HypercertsUri | HypercertsSmallImage` — `activity-types.ts:54`). The plan's selection deliberately matches via `...OrgHypercertsDefsUri.uri, ...OrgHypercertsDefsSmallImage.image { ref, mimeType }` — but the resolver expects a specific union, and "ref" is typically a blob-ref `{ $link }`, not a string. Highly likely the image will fail to resolve and fall through to the FolderGit2 fallback icon.
+
+Recommendation: explicitly include `createdAt` in the GraphQL selection (or accept the gap and note it). Probe the actual image-payload shape during Phase 4 (the plan's own caveat at `plan.md:100-105` covers this) and verify `resolveActivityImageUrl` either works directly or needs an adapter — this is foreseeable enough to call out as expected-rework rather than as a hidden risk.
+
+### 6. `EndorsementRow` has no `note` from `legacy.endorsement` and no `value.subject.did` is guaranteed
+
+The plan dispatches both `badge.award` and `legacy.endorsement` to `EndorsementRow` (`plan.md:278-279`), but the legacy selection (`plan.md:96`) is `{ subject { did }, createdAt }` — no `note`. That's actually fine because `EndorsementRow`'s `note` prop is optional. Worth confirming in the plan that legacy endorsements just render without a note (the row collapses cleanly).
+
+More important: `EndorsementRow` fetches author info itself via `useAuthorInfo(subjectDid)` (`endorsement-row.tsx:40`), which is correct re: the question asked. It does NOT, however, surface the **actor** anywhere — the row only shows the subject's avatar+name+note+date. In the home-feed context, the user wants to know "who endorsed whom." Without the actor, the row reads as "{subject} got endorsed at {date}" with no signal of which followed person caused this to appear in the feed.
+
+This is the deepest version of point (3): `EndorsementRow` literally cannot render the byline the feed needs without modification. Either:
+- Add a prop like `byline?: ReactNode` and pass an `<ActivityAuthor did={event.actor.did} />` so the row shows "{actor avatar+name} endorsed {subject avatar+name}." This is a small additive change.
+- Build the `EndorsementFeedCard` shell from (3) that renders both lines.
+
+Pick one in the plan, not at implementation time.
+
+### 7. Skeleton mismatch is a real layout-shift problem
+
+The plan uses `3× ActivityCardSkeleton` regardless of kind (`plan.md:271`). `ActivityCardSkeleton` renders a 1:1 image block + title + 2 text lines + 2 pills (`activity-card-skeleton.tsx`), heights summing to roughly 380px on mobile. When real data lands:
+
+- `cert.create` → matches (this is the card whose skeleton this is).
+- `collection.create` → ProjectListRow is ~64px tall (10px padding + 40px thumb + 10px padding). Each replaced skeleton collapses by ~315px.
+- `badge.award` / `legacy.endorsement` → `endorsement-row` is ~70px tall. Each collapses by ~310px.
+- Fallback → unknown height; depends on what gets built.
+
+If the feed loads 20 events and 12 of them are non-cert, the visible viewport will reflow violently as cards swap in. The skeleton's premise (3 placeholders ≈ what the first page will look like) is wrong unless the page is dominated by cert.creates.
+
+Options:
+1. **Use a generic line-skeleton** sized to the smallest renderer (~70px), repeated 8–10× to fill the viewport. Reduces shift even if the first page is all certs (cards just expand each from 70px → 380px, a single downward shift on first paint vs. per-event upward jolts).
+2. **Wait until the first page is fetched before rendering skeletons**, then render a skeleton matched to each event.kind. Adds one fetch's worth of latency before any visual feedback — probably bad.
+3. **Drop the skeleton entirely**, use a centered `LoadingSpinner`. Matches the redesign's quieter loading states (see `endorsements-loading` in `feed.css:1428-1432`).
+
+Recommend (1) or (3); call out the decision in the plan so it doesn't become an implementation accident.
+
+### 8. Empty state needs three variants, not one
+
+The plan lists one empty state — Users icon, "Follow people to see their activity here." (`plan.md:264-265`). The feed has at least three distinct empty conditions, each meriting its own copy:
+
+- **Signed out** (`useAuth().did === null`). The plan partly handles this by saying "polling pauses when authors is empty / signed out" — but doesn't say what's rendered. Should be a sign-in CTA, not "Follow people."
+- **Signed in, zero follows** (the plan's "authors is empty" case). The Users-icon + "Follow people" copy fits here.
+- **Signed in, follows present, but no events from them yet**. Different copy — "Your follows haven't created anything yet. Try following more people." or similar. The plan implicitly treats this as the same "Users icon, follow people" message, which is incorrect — the user HAS followed people.
+
+`EmptyState` (`src/components/ui/empty-state.tsx`) is the right component to reuse — it accepts `icon`, `title`, `description`, optional `children` slot for a CTA. The signed-out variant should pass `<button onClick={openSignIn}>` (matching `useAuth().openSignIn`) into the `children` slot.
+
+Additionally, `feed-layout.tsx` already models the right pattern — it accepts an `emptyState?: React.ReactNode` prop so callers can supply a custom state (`feed-layout.tsx:25, 107-109`). The home-feed should follow the same pattern internally: branch on `(authors.length === 0 ? signedOutOrNoFollows : events.length === 0 ? noEvents : ...)` rather than collapsing to a single state.
+
+### 9. `truncatedBySource` / `truncatedByCap` warning has no UI design
+
+The hook returns both flags (`plan.md:194-201, 230-232`) and the render section says "feed UI can show a once-per-session warning banner" (`plan.md:259-260`). Two missing pieces:
+
+- **Where does it sit?** The existing pattern is `feed-unfiltered-banner` (`feed.css:327-339`) — sticky top, primary-bg, white text, used for the "show everything" warning on the explore feed. Mention it explicitly so the implementer doesn't invent a new banner style.
+- **`truncatedBySource`** is described as "soft warning"; **`truncatedByCap`** is the same UI? Different? If both render the same banner, the user can't tell whether the issue is "you follow too many people on Bluesky and we sampled" or "we couldn't read all your follows from your PDS." The copy should differ even if the visual is shared.
+
+Decide and write the copy in the plan; otherwise the implementer will paste in something generic.
+
+### 10. Fallback card is genuinely new — no existing pattern matches
+
+Confirmed: there is no existing actor + opaque-subject-uri renderer in the codebase. The closest is `ActivityAuthor` (the byline component) which only renders the author half. The plan correctly identifies this as new territory.
+
+One nit: the description "linked subjectUri (rendered as a short anchor to its at:// URI route or a degraded display when no route matches)" (`plan.md:287-288`) is vague. Concrete options:
+- Pass the subjectUri through `parseAtUri` and dispatch on the inferred collection (`activity` → `/activity/...`, `collection` → `/project/...`, `profile` → `/profile/...`); when no match, show a copyable monospaced at:// URI with no link.
+- Define a single `/uri/<encoded-uri>` lookup route that resolves and redirects — much more work but future-proofs every unknown kind.
+
+The first is appropriate for v1. Call it out so the implementer doesn't go down the second path.
+
+### 11. `home-page` CSS class has no rules — desktop layout is unaccounted for
+
+`/home`'s page wrapper is `<div className="home-page">` and "the home-page wrapper already has a `.home-page` class with no rules yet" (`plan.md:309-310`). A grep across `src/app/styles/*.css` for `.home-page` returns zero matches. So the feed will inherit the layout's center-column constraints (good) but won't have any padding/margin of its own.
+
+Compare to `/feed`'s legacy redirector path (gone), `/explore` (has `.explore` rules), `/notifications` (has its own page-level styles). The plan should at minimum add `.home-page { padding: 0 16px; }` (or whatever matches the redesign's editorial-column spacing — DESIGN.md §5 calls out `0 16px-20px` mobile padding) so the feed doesn't hug the viewport edges on small screens.
+
+## Approved decisions
+
+- **Polling cadence and pause-when-empty** (`plan.md:254-258, 264-265`). Matches the `notifications-context.tsx:75-107` pattern and the issue's 30s/5min spec. Pausing entirely when `authors.length === 0` is correct and prevents wasted requests for signed-out / no-follows users.
+- **Reusing `useAuthorInfo` indirectly via `EndorsementRow`** (`endorsement-row.tsx:40`). The hook is module-cached and shared with `ActivityAuthor` (`activity-author.tsx:28`), so multiple rows displaying the same DID hit the network once. The plan's note that the indexer denormalizes actor onto each event (`discovery.md:86`) means the row's per-subject lookup is the only remaining per-event resolve — the actor avatar/handle is already in hand.
+- **Single GraphQL request for hydration with one alias per visible event** (`plan.md:185-188`). Far better than the per-URI XRPC fanout pattern used elsewhere; the trade-off is worth it for a polled feed.
+- **Generic-kind fallback in v1** (`discovery.md:148-150, plan.md:10`). Right call — the server is already shipping new kinds via `followerEvents` and the cost of fallback rendering is one branch + one small component. Without it, the server adding a `cert.update` event tomorrow silently drops it from the feed.
+- **Alphabetical-by-DID truncation as v1 ranking** (`plan.md:208-210, discovery.md:140-143`). Defensible because deterministic and cheap; deferred most-recent-interaction ranking is correctly punted to a follow-up.
+- **`endCursor` reset on poll-refresh, with the caveat documented** (`plan.md:240-241, 359-362`). Right trade-off for v1. Anything fancier needs server-side stability guarantees we don't have.
+- **Disjoint file ownership and single-commit-per-track rollback** (`plan.md:21-48, 380-385`). Matches the project's standard pattern.
+- **`appCertifiedTempGraphEndorsement` adds a by-URI variant** (`discovery.md:112-113`). Necessary; no surprise.
+- **Empty `authors: []` is forwarded, not rejected** (`plan.md:80-82, 165-167`). Correct — preserves the "load-bearing nil/empty semantic" referenced from the records repo and keeps the proxy's validation rule small.
+
+## Summary
+
+The data-fetching and proxy plumbing are well-specified and reuse the right existing patterns. The visible UX has three deferred decisions that will produce visible bugs at implementation time if not addressed:
+
+1. **The mount point.** `/home` is not the redesign's feed surface today; only `SiteDrawer` links there. Either retarget the redesign nav (multi-file change) or move the mount to `/feed` (smaller change). Decide before any rendering work happens.
+2. **The render dispatch.** Reusing `ActivityCard` + `ProjectListRow` + `EndorsementRow` side-by-side mixes three incompatible visual registers in one column and breaks the redesign's editorial-card rhythm. Either build feed-card adapters per kind, or wrap the rows in feed-card shells, or accept a noticeably uneven feed in v1 and write it down.
+3. **`EndorsementRow` is a bare `<li>` that needs a `<ul>` parent for its styling to work**, and it has no actor-byline slot — so for the home feed it both renders incorrectly and is missing the "who endorsed whom" cue.
+
+Skeleton, empty-state, and warning-banner specifications are all under-specified in a way that will resolve to "the implementer picks something." Lock down copy + variants in the plan to avoid a second review round on visible polish.

--- a/docs/follower-events-feed/review-spec.md
+++ b/docs/follower-events-feed/review-spec.md
@@ -1,0 +1,152 @@
+# Spec review — plan v1 vs issue #88
+
+Audits `plan.md` against issue #88. Terse; anchors are `issue §...` /
+`plan §...`.
+
+## Misses / corrections
+
+- **`MAX_AUTHORS_FILTER_SIZE` enforcement happens only in the author-union
+  hook, not in the proxy.** Plan §"Server proxy ops → FollowerEvents" says
+  `authors` is validated by `readDidList(MAX_DID_LIST)` capped at 1000, with
+  the comment that "server's own 500 cap is the load-bearing one." Issue
+  §"Operational constraints" puts the 500 cap at the server boundary and
+  expects the client to truncate before sending — but the proxy is part of
+  *our* client surface. A bug in `useHomeFeedAuthors` (or a future caller
+  that bypasses it) can send 501–1000 DIDs through the proxy and only fail
+  at the upstream. Add an explicit proxy-side reject at
+  `MAX_AUTHORS_FILTER_SIZE` so the contract is enforced in one place. The
+  1000-DID `MAX_DID_LIST` ceiling is the wrong number here.
+
+- **`MAX_FEED_PAGE_SIZE` "clamp" silently rewrites the caller's intent.**
+  Plan §"FollowerEvents → buildVariables" says `first` is clamped to 50.
+  Issue §"Operational constraints" frames 50 as a hard cap. Clamping
+  hides a client bug (caller asking for 100 silently gets 50 and may
+  expect-but-not-get the extra rows). Prefer reject (400) at the proxy,
+  matching the existing `readDidList` reject-when-over-cap pattern. At
+  minimum the plan should call out the clamp-vs-reject decision; right now
+  it's drive-by.
+
+- **`kinds` validation is over-strict relative to the spec.** Plan caps the
+  list at 16 entries × 64 chars. Issue §"What you get" says "unknown kinds
+  silently ignored" — there's no documented per-request cap. 16 is plausibly
+  fine in practice (4 documented kinds + headroom) but it's a made-up
+  number; either drop the cap or justify it in the plan. The 64-char
+  per-entry cap is also unbacked.
+
+- **Hydration aliasing semantics are slightly off.** Plan §"Hydration"
+  says "single GraphQL request with one aliased query per event, each
+  branching by `event.kind` to the matching `*ByUri` op." Issue §
+  "Recommended query shape" shows the Hydrate query with **one alias per
+  visible event whose kind matches that collection** — i.e. unknown kinds
+  contribute no alias, and the alias name encodes the index/uri so the
+  client can map results back. Plan should explicitly call out the alias
+  naming scheme (e.g. `e0`, `e1`, …) and confirm unknown-kind events are
+  excluded from the hydrate query entirely. Today the wording could be
+  read either way.
+
+- **Unknown-kind contract — render path is right, but `subjectUri`
+  hydration is dropped on the floor.** Issue §"Documented kinds → Unknown-
+  kind contract" says render "actor + subjectUri link rather than dropping
+  the event silently." Plan §"Generic fallback" does render the event, but
+  hydration returns `payload: null` and the card shows the raw at:// URI.
+  That matches the spec literally. Note for the implementer: do NOT
+  attempt to guess the lexicon from the URI and hydrate against an
+  arbitrary `*ByUri` op — the spec explicitly accepts the raw-URI render.
+  (Confirmation, not a miss — flagging so a reviewer doesn't push back.)
+
+- **`refresh()` cursor-reset behaviour conflicts with cursor-stability
+  guarantee.** Plan §"Feed hook → refresh" says refresh "re-fetches page 1,
+  replacing the current list (does NOT reset pagination cursors; callers
+  needing a full reset reload from the top)." Then plan §"Risks → Cursor
+  stability across polls" contradicts: "`refresh()` re-fetches page 1, so a
+  paginated user's `loadMore` history is reset on every poll." Pick one.
+  Issue §"Cursor stability" says cursors are opaque and refresh-from-cursor
+  is idempotent — the natural read is that polling should *prepend* new
+  events above the existing list, not throw it away. Plan should either
+  spec that semantic, or explicitly accept the "blow away pagination on
+  every poll" UX as a v1 trade-off (and remove the contradictory
+  "replacing the current list … does NOT reset pagination cursors"
+  language).
+
+- **`AUTHORS_REQUIRED` is unreachable as specced and the plan never says
+  so.** Issue §"Coded errors" lists `AUTHORS_REQUIRED` for "`authors` arg
+  omitted." Plan §"FollowerEvents → buildVariables" requires `authors` at
+  the proxy, so the upstream can never see an omitted arg from us. Plan
+  §"Tests → follower-events.test.ts" says "Each coded error: maps
+  `extensions.code` to `FollowerEventsError.code`" — fine for unit tests
+  with mocked GraphQL, but the plan should note that production traffic
+  will only ever see `AUTHORS_FILTER_TOO_LARGE` / `INVALID_CURSOR` from
+  upstream, so the `AUTHORS_REQUIRED` branch is defensive only.
+
+- **Open question #2 (ranking) is answered without addressing the issue's
+  recommendation.** Issue §"Open questions" recommends "most-recently-
+  endorsed / most-recently-interacted-with, falling back to alphabetical."
+  Discovery picks plain alphabetical-by-DID with the rationale "needs a
+  last-interacted signal we don't have client-side today." Plan §"Author-
+  union hook" repeats this. The signal *is* partially available — Certified
+  `app.certified.graph.follow` records have a `createdAt`, and so do badge
+  awards a viewer authored — but the plan never considers them. Either
+  acknowledge the option and reject it explicitly with a one-line reason,
+  or upgrade to "rank by `follow.createdAt` desc, then alphabetical." As
+  written this is a silent demotion from the issue's recommendation.
+
+- **`badge.award` vs endorsement-typed-award distinction not surfaced in
+  the plan.** Issue §"Deliberate v1 limitations → No badge.award →
+  endorsement.award subtype" instructs callers to fetch
+  `badge.definition.badgeType` if they need to distinguish endorsement-
+  typed awards. Plan §"*ByUri hydration ops → AppCertifiedBadgeAwardByUri"
+  selects `{ subject { did }, note, createdAt }` only — no `badgeType` and
+  no follow-up `badge.definition` hydration. Plan §"Render → badge.award"
+  unconditionally routes to `EndorsementRow`, which is correct *only if*
+  every `badge.award` is endorsement-typed. If non-endorsement badges
+  start landing, they'll render as endorsements. Either confirm in the
+  plan that today all `badge.award` records are endorsements (and add a
+  TODO for when that changes), or pull `badgeType` through the hydration
+  + branch in the renderer.
+
+- **Polling-pause condition under-specced.** Issue §"Operational
+  constraints" frames the cadences as load-planning assumptions. Plan §
+  "Feed hook → Polling" pauses when `authors` is empty. Should also pause
+  when the tab/document is in the background `hidden` state for >5min
+  consecutive (i.e. drop to BACKGROUND cadence is in the plan, but a
+  truly idle backgrounded tab shouldn't poll forever) — or at least state
+  that BACKGROUND cadence runs indefinitely as a deliberate choice.
+
+## Confirmations
+
+- **`MaxAuthorsFilterSize = 500`** — constant exported, author hook
+  truncates (plan §"Client module" + §"Author-union hook").
+- **`MaxFeedPageSize = 50` + default 20** — constants present, default
+  matches issue's recommended query shape (plan §"Client module").
+- **Polling cadences 30s / 5min, visibility-aware** — plan §"Feed hook →
+  Polling" mirrors `notifications-context.tsx` pattern, cadences match
+  issue exactly.
+- **Empty `authors: []` returns empty connection, not error** — explicitly
+  preserved in proxy and fetcher (plan §"FollowerEvents → buildVariables"
+  + §"Client module → Behaviour").
+- **`INVALID_CURSOR` mapping** — covered via the generic `extensions.code`
+  → `FollowerEventsError` mapping (plan §"Client module").
+- **`AUTHORS_FILTER_TOO_LARGE` mapping + UI surfacing** — typed error on
+  hook return + truncation-warning UI path (plan §"Feed hook" +
+  §"Render → home-feed").
+- **Unknown-kind contract — fallback render shipped in v1** — answers
+  open question #3 in the affirmative as the issue recommends (plan §
+  "Generic fallback" + §"Render → dispatch").
+- **No update events / no subscriptions / no payload field** — out-of-
+  scope list is explicit and matches issue §"Deliberate v1 limitations"
+  (plan §"Scope" + §"Out of scope" via discovery).
+- **Migration path — build `use-home-feed.ts` directly against
+  `followerEvents`, no detour through the three-op fan-out** — plan §
+  "File ownership" creates the file fresh and never touches the legacy
+  hooks (plan §"Untouched").
+- **Cursor opacity preserved** — proxy treats `after` as
+  `readString(MAX_AFTER_LEN)`, fetcher passes through unchanged, no
+  decode attempts (plan §"FollowerEvents → buildVariables" + §"Client
+  module").
+- **Follow-set source of truth answer** — `useBlueskyFollows ∪
+  useFollowing` via new `useHomeFeedAuthors`, reuses existing module-level
+  caches; answers open question #1 (plan §"Author-union hook"; discovery
+  §"Decisions on open questions").
+- **Hydration is GraphQL-aliased, not XRPC fanout** — matches issue's
+  recommended shape; rationale documented in discovery (plan §
+  "Hydration"; discovery §"Hydration path").

--- a/src/app/api/indexer/__tests__/route.test.ts
+++ b/src/app/api/indexer/__tests__/route.test.ts
@@ -267,7 +267,7 @@ describe("/api/indexer trust boundary", () => {
     it("returns 413 when body length > MAX_BODY_SIZE", async () => {
       const huge = JSON.stringify({
         operationName: "Activities",
-        variables: { search: "x".repeat(20_000) },
+        variables: { search: "x".repeat(40_000) },
       })
       const res = await postIndexer(huge)
       expect(res.status).toBe(413)
@@ -395,6 +395,161 @@ describe("/api/indexer trust boundary", () => {
       })
       expect(res.status).toBe(400)
       expect(mockFetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("FollowerEvents", () => {
+    it("forwards a valid authors list", async () => {
+      const res = await postIndexer({
+        operationName: "FollowerEvents",
+        variables: { authors: ["did:plc:a", "did:plc:b"], first: 10 },
+      })
+      expect(res.status).toBe(200)
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
+      expect(body.variables.authors).toEqual(["did:plc:a", "did:plc:b"])
+      expect(body.variables.first).toBe(10)
+      expect(body.variables.kinds).toBeNull()
+    })
+
+    it("accepts an empty authors array (load-bearing — server returns empty)", async () => {
+      const res = await postIndexer({
+        operationName: "FollowerEvents",
+        variables: { authors: [] },
+      })
+      expect(res.status).toBe(200)
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
+      expect(body.variables.authors).toEqual([])
+    })
+
+    it("400s when authors is missing", async () => {
+      const res = await postIndexer({
+        operationName: "FollowerEvents",
+        variables: {},
+      })
+      expect(res.status).toBe(400)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it("400s when authors is not an array", async () => {
+      const res = await postIndexer({
+        operationName: "FollowerEvents",
+        variables: { authors: "did:plc:a" },
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it("400s when authors exceeds MAX_AUTHORS_FILTER_SIZE (500)", async () => {
+      const tooMany = Array.from({ length: 501 }, (_, i) => `did:plc:x${i}`)
+      const res = await postIndexer({
+        operationName: "FollowerEvents",
+        variables: { authors: tooMany },
+      })
+      expect(res.status).toBe(400)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it("clamps first above 50 to 50 (MAX_FEED_PAGE_SIZE)", async () => {
+      await postIndexer({
+        operationName: "FollowerEvents",
+        variables: { authors: ["did:plc:a"], first: 999 },
+      })
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
+      expect(body.variables.first).toBe(50)
+    })
+
+    it("forwards a valid kinds inclusion filter", async () => {
+      await postIndexer({
+        operationName: "FollowerEvents",
+        variables: { authors: ["did:plc:a"], kinds: ["cert.create"] },
+      })
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
+      expect(body.variables.kinds).toEqual(["cert.create"])
+    })
+
+    it("400s on non-string kind entries", async () => {
+      const res = await postIndexer({
+        operationName: "FollowerEvents",
+        variables: { authors: ["did:plc:a"], kinds: ["ok", 42] },
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it("treats empty kinds array as no-filter (null)", async () => {
+      await postIndexer({
+        operationName: "FollowerEvents",
+        variables: { authors: ["did:plc:a"], kinds: [] },
+      })
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
+      expect(body.variables.kinds).toBeNull()
+    })
+
+    it("fail-soft filters non-DID author entries (matches readDidList policy)", async () => {
+      await postIndexer({
+        operationName: "FollowerEvents",
+        variables: { authors: ["did:plc:ok", "not-a-did", "did:plc:also-ok"] },
+      })
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
+      expect(body.variables.authors).toEqual(["did:plc:ok", "did:plc:also-ok"])
+    })
+  })
+
+  describe("HydrateFeedPage", () => {
+    it("forwards a mixed-kind page", async () => {
+      const res = await postIndexer({
+        operationName: "HydrateFeedPage",
+        variables: {
+          activityUris: ["at://did:plc:a/org.hypercerts.claim.activity/abc"],
+          collectionUris: ["at://did:plc:b/org.hypercerts.collection/def"],
+          badgeAwardUris: [],
+          legacyEndorsementUris: [],
+        },
+      })
+      expect(res.status).toBe(200)
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
+      expect(body.variables.activityUris).toHaveLength(1)
+      expect(body.variables.collectionUris).toHaveLength(1)
+      expect(body.variables.badgeAwardUris).toEqual([])
+      expect(body.variables.legacyEndorsementUris).toEqual([])
+    })
+
+    it("400s when any *Uris is missing (not an array)", async () => {
+      const res = await postIndexer({
+        operationName: "HydrateFeedPage",
+        variables: {
+          activityUris: ["at://x"],
+          collectionUris: ["at://y"],
+          badgeAwardUris: [],
+          // legacyEndorsementUris omitted
+        },
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it("400s when a *Uris exceeds MAX_URI_LIST_PER_KIND (50)", async () => {
+      const tooMany = Array.from({ length: 51 }, (_, i) => `at://x/${i}`)
+      const res = await postIndexer({
+        operationName: "HydrateFeedPage",
+        variables: {
+          activityUris: tooMany,
+          collectionUris: [],
+          badgeAwardUris: [],
+          legacyEndorsementUris: [],
+        },
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it("400s on non-string URI entries", async () => {
+      const res = await postIndexer({
+        operationName: "HydrateFeedPage",
+        variables: {
+          activityUris: ["ok", 42],
+          collectionUris: [],
+          badgeAwardUris: [],
+          legacyEndorsementUris: [],
+        },
+      })
+      expect(res.status).toBe(400)
     })
   })
 })

--- a/src/app/api/indexer/route.ts
+++ b/src/app/api/indexer/route.ts
@@ -555,7 +555,6 @@ ${ACTIVITY_NODE_SELECTION}
               handle
               displayName
               avatarCid
-              pds
             }
           }
         }

--- a/src/app/api/indexer/route.ts
+++ b/src/app/api/indexer/route.ts
@@ -48,15 +48,27 @@ if (
 }
 
 const UPSTREAM_TIMEOUT_MS = 15_000
-const MAX_BODY_SIZE = 16 * 1024 // 16KB — operationName + variables only
+// 32KB — operationName + variables. The 16KB original was too tight for
+// HydrateFeedPage, which sends up to 50 at:// URIs per kind × 4 kinds.
+const MAX_BODY_SIZE = 32 * 1024
 const MAX_FIRST = 100
 const MAX_FIRST_DEFINITIONS = 1000
+const MAX_FEED_PAGE_SIZE = 50
 const MAX_SEARCH_LEN = 200
 const MAX_AFTER_LEN = 1024
 const MAX_DID_LEN = 256
 const MAX_DID_LIST = 1000
+// Hard cap on `authors` for FollowerEvents, matching the indexer's
+// `MaxAuthorsFilterSize`. The client also pre-truncates to this value;
+// enforcing here is defence-in-depth so a manipulated request can't
+// push a 10k-entry array downstream.
+const MAX_AUTHORS_FILTER_SIZE = 500
 const MAX_LABEL_LIST = 50
 const MAX_LABEL_LEN = 64
+const MAX_KIND_LIST = 16
+const MAX_KIND_LEN = 64
+const MAX_URI_LEN = 512
+const MAX_URI_LIST_PER_KIND = 50
 
 /** Activity node selection — shared by the three activity ops below. */
 const ACTIVITY_NODE_SELECTION = `
@@ -502,6 +514,158 @@ ${ACTIVITY_NODE_SELECTION}
       }
     }
   `,
+
+  // Home-timeline feed — magic-indexer #122. Single GraphQL field that
+  // returns the union of the viewer's relevant lexicon-level "create"
+  // events authored by `authors` (the viewer's follow union). The
+  // `actor` is denormalised onto each FeedEvent so the client doesn't
+  // need a per-row profile lookup. Headline render still hydrates the
+  // record via `HydrateFeedPage` because the `subjectUri` only carries
+  // the URI.
+  //
+  // Coded errors (returned via `errors[].extensions.code`):
+  //   - AUTHORS_FILTER_TOO_LARGE — set on the indexer (cap is
+  //     `MaxAuthorsFilterSize = 500`). The proxy also caps at 500
+  //     so this should be unreachable in normal use.
+  //   - INVALID_CURSOR — opaque cursor failed to decode.
+  //   - AUTHORS_REQUIRED — defensive; proxy rejects first via the
+  //     `readAuthorList` required-array check.
+  FollowerEvents: `
+    query FollowerEvents(
+      $authors: [String!]!
+      $first: Int!
+      $after: String
+      $kinds: [String!]
+    ) {
+      followerEvents(
+        authors: $authors
+        first: $first
+        after: $after
+        kinds: $kinds
+      ) {
+        edges {
+          cursor
+          node {
+            id
+            kind
+            subjectUri
+            sortAt
+            actor {
+              did
+              handle
+              displayName
+              avatarCid
+              pds
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  `,
+
+  // Headline-render hydration for one FollowerEvents page. Buckets each
+  // event by `kind` into a per-lexicon URI list and fetches all four
+  // connections in one round-trip via `where: { uri: { in: $uris } }`.
+  // Empty arrays are valid (and expected — most pages only have a
+  // subset of the four kinds present); the indexer returns an empty
+  // connection for each empty filter.
+  //
+  // If `where: { uri: { in: [...] } }` is not supported by the indexer
+  // schema for one of these collections, the client falls back to a
+  // per-collection op fan-out — see the track-1 log for details.
+  HydrateFeedPage: `
+    query HydrateFeedPage(
+      $activityUris: [String!]!
+      $collectionUris: [String!]!
+      $badgeAwardUris: [String!]!
+      $legacyEndorsementUris: [String!]!
+    ) {
+      activities: orgHypercertsClaimActivity(
+        first: ${MAX_URI_LIST_PER_KIND}
+        where: { uri: { in: $activityUris } }
+      ) {
+        edges {
+          node {
+            uri
+            cid
+            did
+            title
+            shortDescription
+            createdAt
+            startDate
+            endDate
+            labels
+            image {
+              __typename
+              ... on OrgHypercertsDefsUri { uri }
+              ... on OrgHypercertsDefsSmallImage { image { ref mimeType } }
+            }
+            workScope {
+              ... on OrgHypercertsClaimActivityWorkScopeString { scope }
+            }
+          }
+        }
+      }
+      collections: orgHypercertsCollection(
+        first: ${MAX_URI_LIST_PER_KIND}
+        where: { uri: { in: $collectionUris } }
+      ) {
+        edges {
+          node {
+            uri
+            cid
+            did
+            createdAt
+            title
+            shortDescription
+            type
+            items {
+              itemIdentifier {
+                ... on ComAtprotoRepoStrongRef { uri cid }
+              }
+            }
+            banner {
+              __typename
+              ... on OrgHypercertsDefsUri { uri }
+              ... on OrgHypercertsDefsLargeImage { image { ref mimeType } }
+            }
+          }
+        }
+      }
+      badgeAwards: appCertifiedBadgeAward(
+        first: ${MAX_URI_LIST_PER_KIND}
+        where: { uri: { in: $badgeAwardUris } }
+      ) {
+        edges {
+          node {
+            uri
+            cid
+            did
+            createdAt
+            note
+            subject { did }
+          }
+        }
+      }
+      legacyEndorsements: appCertifiedTempGraphEndorsement(
+        first: ${MAX_URI_LIST_PER_KIND}
+        where: { uri: { in: $legacyEndorsementUris } }
+      ) {
+        edges {
+          node {
+            uri
+            did
+            createdAt
+            subject { did }
+          }
+        }
+      }
+    }
+  `,
 }
 
 type ClientVariables = Record<string, unknown>
@@ -566,6 +730,71 @@ function readLabelList(value: unknown): string[] | null {
   for (const item of value) {
     if (typeof item !== "string") return null
     if (item.length === 0 || item.length > MAX_LABEL_LEN) return null
+    out.push(item)
+  }
+  return out
+}
+
+/**
+ * Reads the `authors` argument for `FollowerEvents`.
+ *
+ *   - Required (cannot be omitted; the indexer's `AUTHORS_REQUIRED` is
+ *     defensive, our proxy rejects first).
+ *   - Length 0..MAX_AUTHORS_FILTER_SIZE inclusive. The empty array is
+ *     load-bearing: the upstream returns an empty connection rather
+ *     than an error, which the client uses for the
+ *     no-follows-yet case.
+ *   - Per-entry: non-DID strings are filtered out silently
+ *     (fail-soft, matching `readDidList`). Returns null only on
+ *     structural failure or oversize, not on bad-entry content —
+ *     a single malformed DID in a viewer's follow list shouldn't
+ *     take out their entire feed.
+ */
+function readAuthorList(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null
+  if (value.length > MAX_AUTHORS_FILTER_SIZE) return null
+  const out: string[] = []
+  for (const item of value) {
+    const did = readDid(item)
+    if (did) out.push(did)
+  }
+  return out
+}
+
+/**
+ * Reads the optional `kinds` inclusion filter on `FollowerEvents`.
+ * The cap numbers are defensive defaults (the spec doesn't mandate
+ * them), kept tight so a manipulated request can't push pathological
+ * inputs downstream. Returns null for structurally-invalid input
+ * (non-array / non-string entry / oversized), which 400s the request.
+ */
+function readKindList(value: unknown): string[] | null | undefined {
+  if (value === undefined || value === null) return undefined
+  if (!Array.isArray(value)) return null
+  if (value.length === 0) return undefined
+  if (value.length > MAX_KIND_LIST) return null
+  const out: string[] = []
+  for (const item of value) {
+    if (typeof item !== "string") return null
+    if (item.length === 0 || item.length > MAX_KIND_LEN) return null
+    out.push(item)
+  }
+  return out
+}
+
+/**
+ * Reads one of the `*Uris` array variables for `HydrateFeedPage`.
+ * Length 0..MAX_URI_LIST_PER_KIND inclusive — empty arrays pass
+ * through because a typical page has events of only a few kinds and
+ * the other arrays should be `[]`.
+ */
+function readUriList(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null
+  if (value.length > MAX_URI_LIST_PER_KIND) return null
+  const out: string[] = []
+  for (const item of value) {
+    if (typeof item !== "string") return null
+    if (item.length === 0 || item.length > MAX_URI_LEN) return null
     out.push(item)
   }
   return out
@@ -688,6 +917,38 @@ function buildVariables(
       if (typeof rawDegree !== "number" || !Number.isInteger(rawDegree)) return null
       if (rawDegree < 1 || rawDegree > 3) return null
       return { viewer, degree: rawDegree }
+    }
+    case "FollowerEvents": {
+      const authors = readAuthorList(vars.authors)
+      if (authors === null) return null
+      const kinds = readKindList(vars.kinds)
+      if (kinds === null) return null
+      return {
+        authors,
+        first: clampFirst(vars.first, MAX_FEED_PAGE_SIZE, 20),
+        after: readString(vars.after, MAX_AFTER_LEN),
+        kinds: kinds ?? null,
+      }
+    }
+    case "HydrateFeedPage": {
+      const activityUris = readUriList(vars.activityUris)
+      const collectionUris = readUriList(vars.collectionUris)
+      const badgeAwardUris = readUriList(vars.badgeAwardUris)
+      const legacyEndorsementUris = readUriList(vars.legacyEndorsementUris)
+      if (
+        activityUris === null ||
+        collectionUris === null ||
+        badgeAwardUris === null ||
+        legacyEndorsementUris === null
+      ) {
+        return null
+      }
+      return {
+        activityUris,
+        collectionUris,
+        badgeAwardUris,
+        legacyEndorsementUris,
+      }
     }
     default:
       return null

--- a/src/app/feed/feed-page-client.tsx
+++ b/src/app/feed/feed-page-client.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import HomeFeed from "@/components/feed/home-feed"
-import { useHomeFeed } from "@/hooks/use-home-feed"
+import { useFollowerEventsFeed } from "@/hooks/use-follower-events-feed"
 import { usePageTitle } from "@/lib/navbar-context"
 
 /**
@@ -16,6 +16,6 @@ import { usePageTitle } from "@/lib/navbar-context"
  */
 export default function FeedPageClient() {
   usePageTitle("Feed")
-  const feed = useHomeFeed()
+  const feed = useFollowerEventsFeed()
   return <HomeFeed {...feed} />
 }

--- a/src/app/feed/feed-page-client.tsx
+++ b/src/app/feed/feed-page-client.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import HomeFeed from "@/components/feed/home-feed"
+import { useHomeFeed } from "@/hooks/use-home-feed"
+import { usePageTitle } from "@/lib/navbar-context"
+
+/**
+ * Home-timeline feed at /feed. Replaces the legacy `HomeClient`
+ * redirector that lived here before — adopting magic-indexer's new
+ * `followerEvents` field (issue #88) for the home timeline.
+ *
+ * Renders the union of the viewer's Bluesky + Certified follows'
+ * lexicon-level create events (certs, collections, badge awards,
+ * legacy endorsements) in one feed, polled every 30s while the tab
+ * is visible.
+ */
+export default function FeedPageClient() {
+  usePageTitle("Feed")
+  const feed = useHomeFeed()
+  return <HomeFeed {...feed} />
+}

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,13 +1,13 @@
-import { Metadata } from "next";
-import HomeClient from "@/components/landing/home-client";
+import type { Metadata } from "next"
+import FeedPageClient from "./feed-page-client"
 
 export const metadata: Metadata = {
   title: "Feed",
   description: "Activity feed on Certified — for-you and following.",
   robots: { index: true, follow: true },
   alternates: { canonical: "https://certified.app/feed" },
-};
+}
 
 export default function FeedPage() {
-  return <HomeClient />;
+  return <FeedPageClient />
 }

--- a/src/app/styles/feed.css
+++ b/src/app/styles/feed.css
@@ -2236,3 +2236,104 @@
     font-size: 16px;
   }
 }
+
+/* ==========================================================================
+   Follower-events home feed — issue #88
+   Builds on .feed and .feed-card primitives above; the additions here
+   are author-row chrome (avatar + name + inline time), the per-kind
+   action line, and the feed-shell decorations (warning, hint, sentinel).
+   ========================================================================== */
+
+.feed-card__author-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.feed-card__time--inline {
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.feed-card__action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  color: var(--fg-muted);
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.feed-card__action svg {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+.feed-card__action-subject {
+  color: var(--fg-default);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.feed-card__action-subject:hover {
+  text-decoration: underline;
+}
+
+.feed-card__note {
+  margin: 12px 0 0;
+  padding: 12px;
+  background: var(--bg-subtle);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  color: var(--fg-default);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.feed-card__desc--unknown {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+  word-break: break-all;
+}
+
+.feed__warning {
+  margin: 12px 0;
+  padding: 10px 14px;
+  background: var(--bg-subtle);
+  border-left: 3px solid var(--fg-muted);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  color: var(--fg-default);
+}
+
+.feed__sentinel {
+  height: 1px;
+  width: 100%;
+}
+
+.feed__hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 24px 0;
+  padding: 14px 16px;
+  background: var(--bg-subtle);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  color: var(--fg-muted);
+}
+
+.feed__hint svg {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+.feed__hint p {
+  margin: 0;
+}

--- a/src/app/styles/feed.css
+++ b/src/app/styles/feed.css
@@ -2275,7 +2275,7 @@
 }
 
 .feed-card__action-subject {
-  color: var(--fg-default);
+  color: var(--fg-primary);
   text-decoration: none;
   font-weight: 500;
 }
@@ -2287,10 +2287,10 @@
 .feed-card__note {
   margin: 12px 0 0;
   padding: 12px;
-  background: var(--bg-subtle);
+  background: var(--bg-sunken);
   border-radius: 8px;
   font-size: 0.875rem;
-  color: var(--fg-default);
+  color: var(--fg-primary);
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -2305,11 +2305,11 @@
 .feed__warning {
   margin: 12px 0;
   padding: 10px 14px;
-  background: var(--bg-subtle);
+  background: var(--bg-sunken);
   border-left: 3px solid var(--fg-muted);
   border-radius: 4px;
   font-size: 0.875rem;
-  color: var(--fg-default);
+  color: var(--fg-primary);
 }
 
 .feed__sentinel {
@@ -2323,7 +2323,7 @@
   gap: 8px;
   margin: 24px 0;
   padding: 14px 16px;
-  background: var(--bg-subtle);
+  background: var(--bg-sunken);
   border-radius: 8px;
   font-size: 0.875rem;
   color: var(--fg-muted);

--- a/src/components/feed/__tests__/feed-event-card.test.tsx
+++ b/src/components/feed/__tests__/feed-event-card.test.tsx
@@ -23,7 +23,6 @@ const actor: FeedEvent["actor"] = {
   handle: "author.test",
   displayName: "Author Person",
   avatarCid: null,
-  pds: null,
 }
 
 function makeEvent(kind: string, subjectUri = "at://did:plc:x/y/z"): FeedEvent {
@@ -140,12 +139,13 @@ describe("FeedEventCard", () => {
     expect(screen.getByText(subjectUri)).toBeTruthy()
   })
 
-  it("renders the fallback card when payload is null (404 hydration)", () => {
+  it("shows the degraded action line when payload is null on a known kind (404 hydration)", () => {
     render(
       <FeedEventCard event={makeEvent("cert.create")} payload={null} />,
     )
-    // Without a payload we can't show the title, so the fallback's
-    // "did something" label is what's left.
-    expect(screen.getByText("did something")).toBeTruthy()
+    // We know the kind (cert.create) even though hydration failed, so
+    // we keep the verb rather than falling through to "did something".
+    expect(screen.getByText("created a cert")).toBeTruthy()
+    expect(screen.queryByText("did something")).toBeNull()
   })
 })

--- a/src/components/feed/__tests__/feed-event-card.test.tsx
+++ b/src/components/feed/__tests__/feed-event-card.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import type { FeedEvent, HydratedPayload } from "@/lib/atproto/follower-events"
+
+// useAuthorInfo is used to resolve the SUBJECT of badge.award / legacy.endorsement
+// events. We mock it to avoid a network fetch in tests.
+vi.mock("@/hooks/use-author-info", () => ({
+  useAuthorInfo: (did: string) => ({
+    info: {
+      did,
+      handle: did === "did:plc:subject" ? "subject.test" : `${did.slice(0, 12)}`,
+      displayName: did === "did:plc:subject" ? "Subject Person" : null,
+      avatarUrl: null,
+    },
+    isLoading: false,
+  }),
+}))
+
+import FeedEventCard from "../feed-event-card"
+
+const actor: FeedEvent["actor"] = {
+  did: "did:plc:author",
+  handle: "author.test",
+  displayName: "Author Person",
+  avatarCid: null,
+  pds: null,
+}
+
+function makeEvent(kind: string, subjectUri = "at://did:plc:x/y/z"): FeedEvent {
+  return {
+    id: subjectUri,
+    kind,
+    subjectUri,
+    sortAt: "2026-05-26T00:00:00.000Z",
+    actor,
+  }
+}
+
+beforeEach(() => {
+  cleanup()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("FeedEventCard", () => {
+  it("renders the denormalised actor without fetching", () => {
+    render(<FeedEventCard event={makeEvent("cert.create")} payload={null} />)
+    expect(screen.getByText("Author Person")).toBeTruthy()
+    expect(screen.getByText("@author.test")).toBeTruthy()
+  })
+
+  it("renders the cert.create action label and title", () => {
+    const payload: HydratedPayload = {
+      kind: "cert.create",
+      record: {
+        uri: "at://did:plc:author/org.hypercerts.claim.activity/abc",
+        cid: "bafy",
+        value: {
+          title: "My Cert",
+          shortDescription: "Description here",
+          createdAt: "2026-05-26T00:00:00.000Z",
+        },
+      },
+    }
+    render(
+      <FeedEventCard
+        event={makeEvent("cert.create", payload.record.uri)}
+        payload={payload}
+      />,
+    )
+    expect(screen.getByText("created a cert")).toBeTruthy()
+    expect(screen.getByText("My Cert")).toBeTruthy()
+    expect(screen.getByText("Description here")).toBeTruthy()
+  })
+
+  it("renders the collection.create action label according to type", () => {
+    const payload: HydratedPayload = {
+      kind: "collection.create",
+      record: {
+        uri: "at://did:plc:author/org.hypercerts.collection/list1",
+        cid: "bafy",
+        value: {
+          title: "My List",
+          type: "endorsement-list",
+        },
+      },
+    }
+    render(
+      <FeedEventCard
+        event={makeEvent("collection.create", payload.record.uri)}
+        payload={payload}
+      />,
+    )
+    expect(screen.getByText("created a list")).toBeTruthy()
+    expect(screen.getByText("My List")).toBeTruthy()
+  })
+
+  it("renders badge.award with subject byline and note", () => {
+    const payload: HydratedPayload = {
+      kind: "badge.award",
+      subjectDid: "did:plc:subject",
+      note: "Great work last quarter.",
+      createdAt: "2026-05-26T00:00:00.000Z",
+    }
+    render(
+      <FeedEventCard event={makeEvent("badge.award")} payload={payload} />,
+    )
+    expect(screen.getByText("awarded a badge to")).toBeTruthy()
+    expect(screen.getByText("Subject Person")).toBeTruthy()
+    expect(screen.getByText("Great work last quarter.")).toBeTruthy()
+  })
+
+  it("renders legacy.endorsement with no note region", () => {
+    const payload: HydratedPayload = {
+      kind: "legacy.endorsement",
+      subjectDid: "did:plc:subject",
+      createdAt: "2026-05-26T00:00:00.000Z",
+    }
+    render(
+      <FeedEventCard
+        event={makeEvent("legacy.endorsement")}
+        payload={payload}
+      />,
+    )
+    expect(screen.getByText("endorsed")).toBeTruthy()
+    expect(screen.getByText("Subject Person")).toBeTruthy()
+  })
+
+  it("renders the fallback card for an unknown kind", () => {
+    const subjectUri = "at://did:plc:x/some.future.collection/rkey"
+    render(
+      <FeedEventCard
+        event={makeEvent("future.unknown.kind", subjectUri)}
+        payload={null}
+      />,
+    )
+    expect(screen.getByText("did something")).toBeTruthy()
+    expect(screen.getByText(subjectUri)).toBeTruthy()
+  })
+
+  it("renders the fallback card when payload is null (404 hydration)", () => {
+    render(
+      <FeedEventCard event={makeEvent("cert.create")} payload={null} />,
+    )
+    // Without a payload we can't show the title, so the fallback's
+    // "did something" label is what's left.
+    expect(screen.getByText("did something")).toBeTruthy()
+  })
+})

--- a/src/components/feed/feed-event-card.tsx
+++ b/src/components/feed/feed-event-card.tsx
@@ -1,0 +1,287 @@
+"use client"
+
+import Link from "next/link"
+import { Award, FolderOpen, Heart, Sparkles } from "lucide-react"
+import Avatar from "@/components/ui/avatar"
+import { useAuthorInfo } from "@/hooks/use-author-info"
+import { getInitials } from "@/lib/utils/initials"
+import { formatRelativeTime, resolveActivityImageUrl } from "@/lib/atproto/activity"
+import { activityDetailHref, parseActivityUri } from "@/lib/atproto/activity-uri"
+import { buildAvatarUrlFromCid } from "@/lib/atproto/profile"
+import type {
+  FeedEvent,
+  HydratedPayload,
+} from "@/lib/atproto/follower-events"
+
+interface FeedEventCardProps {
+  event: FeedEvent
+  payload: HydratedPayload | null
+}
+
+/**
+ * Renders one row of the home-timeline feed. Dispatches on
+ * `event.kind` to a body component matching the four documented
+ * kinds; unknown kinds fall through to a generic actor + subjectUri
+ * card so we don't drop events silently when the server ships a new
+ * kind before the client updates (issue #88 "Unknown-kind contract").
+ *
+ * Visual chrome (the outer `.feed-card`) is shared with `ActivityCard`
+ * so the mixed feed reads as one coherent column. Body content is
+ * kind-specific.
+ */
+export default function FeedEventCard({ event, payload }: FeedEventCardProps) {
+  return (
+    <article className="feed-card">
+      <FeedActorByline actor={event.actor} createdAt={event.sortAt} />
+      <FeedEventBody event={event} payload={payload} />
+    </article>
+  )
+}
+
+// ----------------------------------------------------------------------
+// Actor byline — uses the denormalised FeedEvent.actor directly, no
+// extra resolve round-trip.
+// ----------------------------------------------------------------------
+
+interface FeedActorBylineProps {
+  actor: FeedEvent["actor"]
+  createdAt: string
+}
+
+function FeedActorByline({ actor, createdAt }: FeedActorBylineProps) {
+  const displayName = actor.displayName || actor.handle || "Anonymous"
+  const initials = getInitials(actor.displayName, actor.did)
+  const avatarUrl = buildAvatarUrlFromCid(actor.did, actor.avatarCid)
+  const profileHref = `/profile/${encodeURIComponent(actor.handle || actor.did)}`
+
+  return (
+    <div className="feed-card__author-row">
+      <Link
+        href={profileHref}
+        className="feed-card__author"
+        aria-label={`View ${displayName}'s profile`}
+      >
+        <Avatar
+          size="sm"
+          src={avatarUrl || undefined}
+          alt=""
+          fallbackInitials={initials}
+          className="shrink-0"
+        />
+        <span className="feed-card__author-meta">
+          <span className="feed-card__author-name-line">
+            <span className="feed-card__author-name">{displayName}</span>
+          </span>
+          {actor.handle ? (
+            <span className="feed-card__author-handle">@{actor.handle}</span>
+          ) : null}
+        </span>
+      </Link>
+      <time className="feed-card__time feed-card__time--inline" dateTime={createdAt}>
+        {formatRelativeTime(createdAt)}
+      </time>
+    </div>
+  )
+}
+
+// ----------------------------------------------------------------------
+// Body dispatch
+// ----------------------------------------------------------------------
+
+function FeedEventBody({ event, payload }: FeedEventCardProps) {
+  if (payload?.kind === "cert.create") {
+    return <CertCreateBody event={event} record={payload.record} />
+  }
+  if (payload?.kind === "collection.create") {
+    return <CollectionCreateBody event={event} record={payload.record} />
+  }
+  if (payload?.kind === "badge.award") {
+    return (
+      <SubjectActionBody
+        event={event}
+        subjectDid={payload.subjectDid}
+        action="awarded a badge to"
+        note={payload.note}
+        icon={<Award size={16} strokeWidth={1.75} aria-hidden="true" />}
+      />
+    )
+  }
+  if (payload?.kind === "legacy.endorsement") {
+    return (
+      <SubjectActionBody
+        event={event}
+        subjectDid={payload.subjectDid}
+        action="endorsed"
+        note={null}
+        icon={<Heart size={16} strokeWidth={1.75} aria-hidden="true" />}
+      />
+    )
+  }
+  return <UnknownKindBody event={event} />
+}
+
+// ----------------------------------------------------------------------
+// cert.create
+// ----------------------------------------------------------------------
+
+function CertCreateBody({
+  event,
+  record,
+}: {
+  event: FeedEvent
+  record: Extract<HydratedPayload, { kind: "cert.create" }>["record"]
+}) {
+  const { value } = record
+  const imageUrl = value.image
+    ? resolveActivityImageUrl(value.image, event.actor.did)
+    : null
+  const parsed = parseActivityUri(record.uri)
+  const detailHref = parsed ? activityDetailHref(parsed.did, parsed.rkey) : null
+
+  const body = (
+    <>
+      <div className="feed-card__action">
+        <Sparkles size={16} strokeWidth={1.75} aria-hidden="true" />
+        <span>created a cert</span>
+      </div>
+      {imageUrl ? (
+        <div className="feed-card__image-wrap">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            className="feed-card__image"
+            src={imageUrl}
+            alt={value.title || "Cert image"}
+            loading="lazy"
+          />
+        </div>
+      ) : (
+        <div
+          className="feed-card__image-wrap feed-card__image-wrap--placeholder"
+          aria-hidden="true"
+        >
+          <Award size={40} strokeWidth={1.25} className="feed-card__image-placeholder-icon" />
+        </div>
+      )}
+      {value.title ? <h2 className="feed-card__title">{value.title}</h2> : null}
+      {value.shortDescription ? (
+        <p className="feed-card__desc">{value.shortDescription}</p>
+      ) : null}
+    </>
+  )
+
+  return detailHref ? (
+    <Link href={detailHref} className="feed-card__body">
+      {body}
+    </Link>
+  ) : (
+    <div className="feed-card__body">{body}</div>
+  )
+}
+
+// ----------------------------------------------------------------------
+// collection.create
+// ----------------------------------------------------------------------
+
+function CollectionCreateBody({
+  event,
+  record,
+}: {
+  event: FeedEvent
+  record: Extract<HydratedPayload, { kind: "collection.create" }>["record"]
+}) {
+  const { value } = record
+  const collectionType = value.type ?? "project"
+  const actionLabel =
+    collectionType === "endorsement-list"
+      ? "created a list"
+      : collectionType === "portfolio"
+        ? "created a portfolio"
+        : "created a project"
+  // Banner can be the same shape as activity image (uri | { image: { ref } }).
+  const imageUrl = value.banner
+    ? resolveActivityImageUrl(
+        value.banner as Parameters<typeof resolveActivityImageUrl>[0],
+        event.actor.did,
+      )
+    : null
+
+  return (
+    <div className="feed-card__body">
+      <div className="feed-card__action">
+        <FolderOpen size={16} strokeWidth={1.75} aria-hidden="true" />
+        <span>{actionLabel}</span>
+      </div>
+      {imageUrl ? (
+        <div className="feed-card__image-wrap">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            className="feed-card__image"
+            src={imageUrl}
+            alt={value.title || "Collection banner"}
+            loading="lazy"
+          />
+        </div>
+      ) : null}
+      {value.title ? <h2 className="feed-card__title">{value.title}</h2> : null}
+      {value.shortDescription ? (
+        <p className="feed-card__desc">{value.shortDescription}</p>
+      ) : null}
+    </div>
+  )
+}
+
+// ----------------------------------------------------------------------
+// badge.award + legacy.endorsement (subject-focused)
+// ----------------------------------------------------------------------
+
+function SubjectActionBody({
+  event: _event,
+  subjectDid,
+  action,
+  note,
+  icon,
+}: {
+  event: FeedEvent
+  subjectDid: string
+  action: string
+  note: string | null
+  icon: React.ReactNode
+}) {
+  const { info } = useAuthorInfo(subjectDid)
+  const subjectName = info?.displayName || info?.handle || null
+  const subjectHandle = info?.handle ?? null
+  const profileHref = info?.handle
+    ? `/profile/${encodeURIComponent(info.handle)}`
+    : `/profile/${encodeURIComponent(subjectDid)}`
+
+  return (
+    <div className="feed-card__body">
+      <div className="feed-card__action">
+        {icon}
+        <span>{action}</span>{" "}
+        <Link href={profileHref} className="feed-card__action-subject">
+          {subjectName ?? subjectHandle ?? "someone"}
+        </Link>
+      </div>
+      {note ? <p className="feed-card__note">{note}</p> : null}
+    </div>
+  )
+}
+
+// ----------------------------------------------------------------------
+// unknown kind — fallback per issue #88's "Unknown-kind contract"
+// ----------------------------------------------------------------------
+
+function UnknownKindBody({ event }: { event: FeedEvent }) {
+  return (
+    <div className="feed-card__body">
+      <div className="feed-card__action">
+        <Sparkles size={16} strokeWidth={1.75} aria-hidden="true" />
+        <span>did something</span>
+      </div>
+      <p className="feed-card__desc feed-card__desc--unknown" title={event.subjectUri}>
+        {event.subjectUri}
+      </p>
+    </div>
+  )
+}

--- a/src/components/feed/feed-event-card.tsx
+++ b/src/components/feed/feed-event-card.tsx
@@ -98,7 +98,6 @@ function FeedEventBody({ event, payload }: FeedEventCardProps) {
   if (payload?.kind === "badge.award") {
     return (
       <SubjectActionBody
-        event={event}
         subjectDid={payload.subjectDid}
         action="awarded a badge to"
         note={payload.note}
@@ -109,7 +108,6 @@ function FeedEventBody({ event, payload }: FeedEventCardProps) {
   if (payload?.kind === "legacy.endorsement") {
     return (
       <SubjectActionBody
-        event={event}
         subjectDid={payload.subjectDid}
         action="endorsed"
         note={null}
@@ -117,7 +115,41 @@ function FeedEventBody({ event, payload }: FeedEventCardProps) {
       />
     )
   }
+  // Hydration missed (404) on a known kind — show the action line we
+  // can derive from event.kind alone, with no body content. Beats
+  // falling through to the generic "did something" card when we
+  // actually know what the actor did.
+  const knownAction = actionLabelForKnownKind(event.kind)
+  if (knownAction) {
+    return <DegradedKnownKindBody label={knownAction} />
+  }
   return <UnknownKindBody event={event} />
+}
+
+function actionLabelForKnownKind(kind: string): string | null {
+  switch (kind) {
+    case "cert.create":
+      return "created a cert"
+    case "collection.create":
+      return "created a project"
+    case "badge.award":
+      return "awarded a badge"
+    case "legacy.endorsement":
+      return "endorsed someone"
+    default:
+      return null
+  }
+}
+
+function DegradedKnownKindBody({ label }: { label: string }) {
+  return (
+    <div className="feed-card__body">
+      <div className="feed-card__action">
+        <Sparkles size={16} strokeWidth={1.75} aria-hidden="true" />
+        <span>{label}</span>
+      </div>
+    </div>
+  )
 }
 
 // ----------------------------------------------------------------------
@@ -235,13 +267,11 @@ function CollectionCreateBody({
 // ----------------------------------------------------------------------
 
 function SubjectActionBody({
-  event: _event,
   subjectDid,
   action,
   note,
   icon,
 }: {
-  event: FeedEvent
   subjectDid: string
   action: string
   note: string | null

--- a/src/components/feed/home-feed.tsx
+++ b/src/components/feed/home-feed.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "@/lib/auth/auth-context"
 import EmptyState from "@/components/ui/empty-state"
 import ActivityCardSkeleton from "@/components/feed/activity-card-skeleton"
 import FeedEventCard from "@/components/feed/feed-event-card"
-import type { UseHomeFeedResult } from "@/hooks/use-home-feed"
+import type { UseFollowerEventsFeedResult } from "@/hooks/use-follower-events-feed"
 
 /**
  * Home-timeline feed shell. Three distinct empty-state variants per
@@ -19,7 +19,7 @@ import type { UseHomeFeedResult } from "@/hooks/use-home-feed"
  * `authorsCount` from the hook (signed-in + follows = authorsCount > 0
  * after the cap-aware dedupe).
  */
-export default function HomeFeed(props: UseHomeFeedResult) {
+export default function HomeFeed(props: UseFollowerEventsFeedResult) {
   const {
     events,
     authorsCount,

--- a/src/components/feed/home-feed.tsx
+++ b/src/components/feed/home-feed.tsx
@@ -1,0 +1,159 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { AlertCircle, Inbox, LogIn, Users } from "lucide-react"
+import { useAuth } from "@/lib/auth/auth-context"
+import EmptyState from "@/components/ui/empty-state"
+import ActivityCardSkeleton from "@/components/feed/activity-card-skeleton"
+import FeedEventCard from "@/components/feed/feed-event-card"
+import type { UseHomeFeedResult } from "@/hooks/use-home-feed"
+
+/**
+ * Home-timeline feed shell. Renders states (empty / loading / error)
+ * around the actual event list. Mirrors the visual rhythm of
+ * `feed-layout.tsx` (the for-you / following feed shell) without
+ * inheriting its `ActivityRecord[]`-only contract.
+ */
+export default function HomeFeed(props: UseHomeFeedResult) {
+  const {
+    events,
+    isLoading,
+    isLoadingMore,
+    error,
+    errorCode,
+    hasMore,
+    isOversized,
+    truncatedBySource,
+    loadMore,
+  } = props
+
+  const { did, isAuthenticated, isLoading: authLoading } = useAuth()
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+
+  // IntersectionObserver-based infinite scroll. Mirrors the pattern in
+  // feed-layout.tsx.
+  useEffect(() => {
+    if (!hasMore || isLoadingMore || isLoading) return
+    const sentinel = sentinelRef.current
+    if (!sentinel) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          loadMore()
+        }
+      },
+      { rootMargin: "200px" },
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [hasMore, isLoadingMore, isLoading, loadMore])
+
+  // 1. Auth loading → skeletons (we don't know yet whether to show
+  // signed-out vs signed-in empty state).
+  if (authLoading) {
+    return (
+      <div className="feed">
+        <SkeletonRows />
+      </div>
+    )
+  }
+
+  // 2. Signed out → sign-in empty state.
+  if (!isAuthenticated || !did) {
+    return (
+      <div className="feed">
+        <EmptyState
+          icon={LogIn}
+          title="Sign in to see your feed"
+          description="Sign in to see activity from people you follow."
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="feed">
+      {(isOversized || truncatedBySource) && (
+        <div className="feed__warning" role="status">
+          {isOversized
+            ? "You follow more than 500 people. Showing activity from a subset."
+            : "Your follow list is too large to fully sync. Some activity may be missing."}
+        </div>
+      )}
+
+      {/* 3. Error — but show events too if we already loaded some. */}
+      {error && events.length === 0 ? (
+        <EmptyState
+          icon={AlertCircle}
+          title={
+            errorCode === "AUTHORS_FILTER_TOO_LARGE"
+              ? "Follow list too large"
+              : "Couldn't load your feed"
+          }
+          description={error}
+        />
+      ) : null}
+
+      {/* 4. Loading + no events yet. */}
+      {isLoading && events.length === 0 && !error ? <SkeletonRows /> : null}
+
+      {/* 5. Signed in + no error + done loading + zero events. */}
+      {!isLoading && !error && events.length === 0 ? (
+        <EmptyState
+          icon={Inbox}
+          title="No activity yet"
+          description="When people you follow create certs or endorse others, you'll see it here."
+        />
+      ) : null}
+
+      {/* 6. Events. */}
+      {events.length > 0 ? (
+        <>
+          {events.map((hydrated) => (
+            <FeedEventCard
+              key={hydrated.event.id}
+              event={hydrated.event}
+              payload={hydrated.payload}
+            />
+          ))}
+          {isLoadingMore ? <ActivityCardSkeleton /> : null}
+          {hasMore ? (
+            <div ref={sentinelRef} className="feed__sentinel" aria-hidden="true" />
+          ) : null}
+        </>
+      ) : null}
+
+      {/* 7. Edge case: no events but no follows. Override the generic
+          "no activity" with the follow-people-first prompt. */}
+      {!isLoading && !error && events.length === 0 && !isOversized && !truncatedBySource ? (
+        <NoFollowsHint />
+      ) : null}
+    </div>
+  )
+}
+
+function SkeletonRows() {
+  return (
+    <>
+      <ActivityCardSkeleton />
+      <ActivityCardSkeleton />
+      <ActivityCardSkeleton />
+    </>
+  )
+}
+
+/**
+ * Inline secondary empty state — rendered alongside the primary "no
+ * activity" message when the underlying cause is "user follows
+ * nobody yet" rather than "follows haven't been active."
+ * Visually subordinate so the user only reads it if they're confused
+ * by the primary message.
+ */
+function NoFollowsHint() {
+  return (
+    <div className="feed__hint">
+      <Users size={20} strokeWidth={1.5} aria-hidden="true" />
+      <p>Not following anyone yet? Find people to follow on the Explore page.</p>
+    </div>
+  )
+}

--- a/src/components/feed/home-feed.tsx
+++ b/src/components/feed/home-feed.tsx
@@ -9,14 +9,20 @@ import FeedEventCard from "@/components/feed/feed-event-card"
 import type { UseHomeFeedResult } from "@/hooks/use-home-feed"
 
 /**
- * Home-timeline feed shell. Renders states (empty / loading / error)
- * around the actual event list. Mirrors the visual rhythm of
- * `feed-layout.tsx` (the for-you / following feed shell) without
- * inheriting its `ActivityRecord[]`-only contract.
+ * Home-timeline feed shell. Three distinct empty-state variants per
+ * issue #88's plan-v2:
+ *   - signed-out: "Sign in to see your feed."
+ *   - signed-in + 0 follows: "Follow people to see their activity here."
+ *   - signed-in + follows but 0 events: "No activity yet."
+ *
+ * The variants are mutually exclusive — the branch logic checks
+ * `authorsCount` from the hook (signed-in + follows = authorsCount > 0
+ * after the cap-aware dedupe).
  */
 export default function HomeFeed(props: UseHomeFeedResult) {
   const {
     events,
+    authorsCount,
     isLoading,
     isLoadingMore,
     error,
@@ -48,8 +54,8 @@ export default function HomeFeed(props: UseHomeFeedResult) {
     return () => observer.disconnect()
   }, [hasMore, isLoadingMore, isLoading, loadMore])
 
-  // 1. Auth loading → skeletons (we don't know yet whether to show
-  // signed-out vs signed-in empty state).
+  // Auth resolving — defer the empty-state choice until we know
+  // whether the user is signed in.
   if (authLoading) {
     return (
       <div className="feed">
@@ -58,7 +64,7 @@ export default function HomeFeed(props: UseHomeFeedResult) {
     )
   }
 
-  // 2. Signed out → sign-in empty state.
+  // Signed out.
   if (!isAuthenticated || !did) {
     return (
       <div className="feed">
@@ -71,18 +77,20 @@ export default function HomeFeed(props: UseHomeFeedResult) {
     )
   }
 
-  return (
-    <div className="feed">
-      {(isOversized || truncatedBySource) && (
-        <div className="feed__warning" role="status">
-          {isOversized
-            ? "You follow more than 500 people. Showing activity from a subset."
-            : "Your follow list is too large to fully sync. Some activity may be missing."}
-        </div>
-      )}
+  const warningBanner =
+    isOversized || truncatedBySource ? (
+      <div className="feed__warning" role="status">
+        {isOversized
+          ? "You follow more than 500 people. Showing activity from a subset."
+          : "Your follow list is too large to fully sync. Some activity may be missing."}
+      </div>
+    ) : null
 
-      {/* 3. Error — but show events too if we already loaded some. */}
-      {error && events.length === 0 ? (
+  // Error with no events on screen — primary state.
+  if (error && events.length === 0) {
+    return (
+      <div className="feed">
+        {warningBanner}
         <EmptyState
           icon={AlertCircle}
           title={
@@ -92,41 +100,60 @@ export default function HomeFeed(props: UseHomeFeedResult) {
           }
           description={error}
         />
-      ) : null}
+      </div>
+    )
+  }
 
-      {/* 4. Loading + no events yet. */}
-      {isLoading && events.length === 0 && !error ? <SkeletonRows /> : null}
+  // Loading the first page — show skeletons.
+  if (isLoading && events.length === 0) {
+    return (
+      <div className="feed">
+        {warningBanner}
+        <SkeletonRows />
+      </div>
+    )
+  }
 
-      {/* 5. Signed in + no error + done loading + zero events. */}
-      {!isLoading && !error && events.length === 0 ? (
+  // Empty — three variants. authorsCount === 0 covers the "no follows
+  // yet" case explicitly; otherwise it's "follows haven't been active."
+  if (events.length === 0) {
+    if (authorsCount === 0) {
+      return (
+        <div className="feed">
+          {warningBanner}
+          <EmptyState
+            icon={Users}
+            title="You're not following anyone yet"
+            description="Follow people to see their activity in your feed."
+          />
+        </div>
+      )
+    }
+    return (
+      <div className="feed">
+        {warningBanner}
         <EmptyState
           icon={Inbox}
           title="No activity yet"
           description="When people you follow create certs or endorse others, you'll see it here."
         />
-      ) : null}
+      </div>
+    )
+  }
 
-      {/* 6. Events. */}
-      {events.length > 0 ? (
-        <>
-          {events.map((hydrated) => (
-            <FeedEventCard
-              key={hydrated.event.id}
-              event={hydrated.event}
-              payload={hydrated.payload}
-            />
-          ))}
-          {isLoadingMore ? <ActivityCardSkeleton /> : null}
-          {hasMore ? (
-            <div ref={sentinelRef} className="feed__sentinel" aria-hidden="true" />
-          ) : null}
-        </>
-      ) : null}
-
-      {/* 7. Edge case: no events but no follows. Override the generic
-          "no activity" with the follow-people-first prompt. */}
-      {!isLoading && !error && events.length === 0 && !isOversized && !truncatedBySource ? (
-        <NoFollowsHint />
+  return (
+    <div className="feed">
+      {warningBanner}
+      {events.map((hydrated) => (
+        <FeedEventCard
+          key={hydrated.event.id}
+          event={hydrated.event}
+          payload={hydrated.payload}
+        />
+      ))}
+      {isLoadingMore ? <ActivityCardSkeleton /> : null}
+      {hasMore ? (
+        <div ref={sentinelRef} className="feed__sentinel" aria-hidden="true" />
       ) : null}
     </div>
   )
@@ -139,21 +166,5 @@ function SkeletonRows() {
       <ActivityCardSkeleton />
       <ActivityCardSkeleton />
     </>
-  )
-}
-
-/**
- * Inline secondary empty state — rendered alongside the primary "no
- * activity" message when the underlying cause is "user follows
- * nobody yet" rather than "follows haven't been active."
- * Visually subordinate so the user only reads it if they're confused
- * by the primary message.
- */
-function NoFollowsHint() {
-  return (
-    <div className="feed__hint">
-      <Users size={20} strokeWidth={1.5} aria-hidden="true" />
-      <p>Not following anyone yet? Find people to follow on the Explore page.</p>
-    </div>
   )
 }

--- a/src/components/layout/desktop-left-rail.tsx
+++ b/src/components/layout/desktop-left-rail.tsx
@@ -16,6 +16,7 @@ import {
   Info,
   LayoutGrid,
   LogIn,
+  Rss,
 } from "lucide-react";
 import { useAuth } from "@/lib/auth/auth-context";
 import { useProfile } from "@/hooks/use-profile";
@@ -209,6 +210,7 @@ export default function DesktopLeftRail() {
   const showGroups = isRouteVisibleToActor("groups", isActingAsOrg);
   const authedItems: NavItem[] = [
     { href: profileHref, label: "Profile", icon: User, matchPrefix: true },
+    { href: "/feed", label: "Feed", icon: Rss, matchPrefix: true },
     { href: "/search", label: "Explore", icon: Search },
     ...(showEndorsements
       ? [{ href: "/endorsements", label: "Endorsements", icon: Award, badge: pendingBadge, badgeUnit: "pending", matchPrefix: true }]

--- a/src/hooks/__tests__/use-follower-events-feed.test.ts
+++ b/src/hooks/__tests__/use-follower-events-feed.test.ts
@@ -65,7 +65,6 @@ function makeEvent(id: string, sortAt = "2026-05-26T00:00:00.000Z") {
         handle: "x.test",
         displayName: "X",
         avatarCid: null,
-        pds: null,
       },
     },
     payload: null,

--- a/src/hooks/__tests__/use-follower-events-feed.test.ts
+++ b/src/hooks/__tests__/use-follower-events-feed.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, waitFor, act } from "@testing-library/react"
+
+/**
+ * Integration coverage for `useFollowerEventsFeed`. We mock the upstream hooks
+ * and the GraphQL client, then exercise the public API. The pure
+ * orchestration logic (page merging by id, dedupe on overlap) is
+ * the load-bearing surface here — polling cadence + visibility
+ * handling is React-effect-bound and is intentionally left to manual
+ * smoke for v1 (tracked in `06-deferred.md`).
+ */
+
+vi.mock("@/lib/auth/auth-context", () => ({
+  useAuth: () => ({
+    did: "did:plc:viewer",
+    isLoading: false,
+    isAuthenticated: true,
+  }),
+}))
+
+vi.mock("@/hooks/use-home-feed-authors", () => ({
+  useHomeFeedAuthors: () => ({
+    authors: ["did:plc:a", "did:plc:b"],
+    isOversized: false,
+    truncatedBySource: false,
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+const fetchFollowerEventsMock = vi.fn()
+const hydrateFeedEventsMock = vi.fn()
+
+vi.mock("@/lib/atproto/follower-events", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/atproto/follower-events")
+  >("@/lib/atproto/follower-events")
+  return {
+    ...actual,
+    fetchFollowerEvents: (...args: unknown[]) => fetchFollowerEventsMock(...args),
+    hydrateFeedEvents: (...args: unknown[]) => hydrateFeedEventsMock(...args),
+  }
+})
+
+import { useFollowerEventsFeed } from "../use-follower-events-feed"
+
+beforeEach(() => {
+  fetchFollowerEventsMock.mockReset()
+  hydrateFeedEventsMock.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function makeEvent(id: string, sortAt = "2026-05-26T00:00:00.000Z") {
+  return {
+    event: {
+      id,
+      kind: "cert.create",
+      subjectUri: id,
+      sortAt,
+      actor: {
+        did: "did:plc:author",
+        handle: "x.test",
+        displayName: "X",
+        avatarCid: null,
+        pds: null,
+      },
+    },
+    payload: null,
+  }
+}
+
+describe("useFollowerEventsFeed", () => {
+  it("populates events on initial load", async () => {
+    fetchFollowerEventsMock.mockResolvedValueOnce({
+      events: [{ id: "at://1" }, { id: "at://2" }],
+      endCursor: "c1",
+      hasNextPage: true,
+    })
+    hydrateFeedEventsMock.mockResolvedValueOnce([makeEvent("at://1"), makeEvent("at://2")])
+
+    const { result } = renderHook(() => useFollowerEventsFeed())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.events.map((h) => h.event.id)).toEqual([
+      "at://1",
+      "at://2",
+    ])
+    expect(result.current.hasMore).toBe(true)
+  })
+
+  it("appends new events on loadMore, deduping overlap", async () => {
+    fetchFollowerEventsMock
+      .mockResolvedValueOnce({
+        events: [{ id: "at://1" }, { id: "at://2" }],
+        endCursor: "c1",
+        hasNextPage: true,
+      })
+      .mockResolvedValueOnce({
+        // Second page returns one overlap + one new event.
+        events: [{ id: "at://2" }, { id: "at://3" }],
+        endCursor: "c2",
+        hasNextPage: false,
+      })
+    hydrateFeedEventsMock
+      .mockResolvedValueOnce([makeEvent("at://1"), makeEvent("at://2")])
+      .mockResolvedValueOnce([makeEvent("at://2"), makeEvent("at://3")])
+
+    const { result } = renderHook(() => useFollowerEventsFeed())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => {
+      result.current.loadMore()
+    })
+    await waitFor(() => expect(result.current.isLoadingMore).toBe(false))
+
+    expect(result.current.events.map((h) => h.event.id)).toEqual([
+      "at://1",
+      "at://2",
+      "at://3",
+    ])
+    expect(result.current.hasMore).toBe(false)
+  })
+
+  it("merges by event.id on refresh — prepends new, keeps existing positions", async () => {
+    fetchFollowerEventsMock
+      .mockResolvedValueOnce({
+        events: [{ id: "at://1" }, { id: "at://2" }],
+        endCursor: "c1",
+        hasNextPage: true,
+      })
+      .mockResolvedValueOnce({
+        // Refresh sees a brand-new event (at://0) plus existing at://1.
+        events: [{ id: "at://0" }, { id: "at://1" }],
+        endCursor: "c1-fresh",
+        hasNextPage: true,
+      })
+    hydrateFeedEventsMock
+      .mockResolvedValueOnce([makeEvent("at://1"), makeEvent("at://2")])
+      .mockResolvedValueOnce([makeEvent("at://0"), makeEvent("at://1")])
+
+    const { result } = renderHook(() => useFollowerEventsFeed())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(result.current.events.map((h) => h.event.id)).toEqual([
+      "at://0",
+      "at://1",
+      "at://2",
+    ])
+  })
+
+  it("maps FollowerEventsError to errorCode", async () => {
+    const { FollowerEventsError } = await import(
+      "@/lib/atproto/follower-events"
+    )
+    fetchFollowerEventsMock.mockRejectedValueOnce(
+      new FollowerEventsError("too many", "AUTHORS_FILTER_TOO_LARGE"),
+    )
+
+    const { result } = renderHook(() => useFollowerEventsFeed())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.errorCode).toBe("AUTHORS_FILTER_TOO_LARGE")
+    expect(result.current.error).toBe("too many")
+  })
+})

--- a/src/hooks/__tests__/use-home-feed-authors.test.ts
+++ b/src/hooks/__tests__/use-home-feed-authors.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest"
+import { computeHomeFeedAuthors } from "../use-home-feed-authors"
+import { MAX_AUTHORS_FILTER_SIZE } from "@/lib/atproto/follower-events"
+
+describe("computeHomeFeedAuthors", () => {
+  it("returns empty + not-oversized when did is null", () => {
+    const result = computeHomeFeedAuthors(
+      null,
+      new Set(["did:plc:a"]),
+      new Set(["did:plc:b"]),
+    )
+    expect(result.authors).toEqual([])
+    expect(result.isOversized).toBe(false)
+  })
+
+  it("returns empty when both sets are empty", () => {
+    const result = computeHomeFeedAuthors(
+      "did:plc:viewer",
+      new Set(),
+      new Set(),
+    )
+    expect(result.authors).toEqual([])
+    expect(result.isOversized).toBe(false)
+  })
+
+  it("unions two disjoint sets", () => {
+    const result = computeHomeFeedAuthors(
+      "did:plc:viewer",
+      new Set(["did:plc:a", "did:plc:c"]),
+      new Set(["did:plc:b"]),
+    )
+    expect(result.authors).toEqual(["did:plc:a", "did:plc:b", "did:plc:c"])
+    expect(result.isOversized).toBe(false)
+  })
+
+  it("dedupes overlap between Bluesky and Certified", () => {
+    const result = computeHomeFeedAuthors(
+      "did:plc:viewer",
+      new Set(["did:plc:a", "did:plc:b"]),
+      new Set(["did:plc:b", "did:plc:c"]),
+    )
+    expect(result.authors).toEqual(["did:plc:a", "did:plc:b", "did:plc:c"])
+  })
+
+  it("returns alphabetically-sorted authors", () => {
+    const result = computeHomeFeedAuthors(
+      "did:plc:viewer",
+      new Set(["did:plc:zeta", "did:plc:alpha", "did:plc:mu"]),
+      new Set(),
+    )
+    expect(result.authors).toEqual([
+      "did:plc:alpha",
+      "did:plc:mu",
+      "did:plc:zeta",
+    ])
+  })
+
+  it("truncates to MAX_AUTHORS_FILTER_SIZE and marks isOversized", () => {
+    const oversized = new Set<string>()
+    for (let i = 0; i < MAX_AUTHORS_FILTER_SIZE + 50; i++) {
+      // Pad with leading zeros so alphabetical sort matches numeric order.
+      oversized.add(`did:plc:${String(i).padStart(6, "0")}`)
+    }
+    const result = computeHomeFeedAuthors(
+      "did:plc:viewer",
+      oversized,
+      new Set(),
+    )
+    expect(result.authors).toHaveLength(MAX_AUTHORS_FILTER_SIZE)
+    expect(result.isOversized).toBe(true)
+    // First 500 alphabetically — i.e. the lowest-numbered DIDs.
+    expect(result.authors[0]).toBe("did:plc:000000")
+    expect(result.authors[MAX_AUTHORS_FILTER_SIZE - 1]).toBe(
+      `did:plc:${String(MAX_AUTHORS_FILTER_SIZE - 1).padStart(6, "0")}`,
+    )
+  })
+
+  it("counts the deduped union, not the raw sum, against the cap", () => {
+    // 300 in each, with 50 overlap → union of 550. Without dedupe-first
+    // sizing, we would slice before unioning and miss this case.
+    const a = new Set<string>()
+    const b = new Set<string>()
+    for (let i = 0; i < 300; i++) a.add(`did:plc:a${String(i).padStart(4, "0")}`)
+    for (let i = 250; i < 550; i++) b.add(`did:plc:a${String(i).padStart(4, "0")}`)
+    // union size = 550; isOversized expected.
+    const result = computeHomeFeedAuthors("did:plc:viewer", a, b)
+    expect(result.authors).toHaveLength(MAX_AUTHORS_FILTER_SIZE)
+    expect(result.isOversized).toBe(true)
+  })
+})

--- a/src/hooks/use-bluesky-follows.ts
+++ b/src/hooks/use-bluesky-follows.ts
@@ -9,19 +9,31 @@ const MAX_FOLLOWS = 10_000
 
 const EMPTY_SET = new Set<string>()
 
+interface FollowsResult {
+  data: Set<string>
+  /** True when the 10k page-walk cap stopped the loop AND the upstream
+   *  still had more pages. Consumers that derive set arithmetic from
+   *  `data` (e.g. `useSocialGraphSync`) must refuse to act on the
+   *  result when this is true — the "do I already follow X?" check
+   *  would return false-negatives. */
+  truncated: boolean
+}
+
 // Single-entry module-level cache keyed by DID.
 let cache: {
   did: string
   data: Set<string>
+  truncated: boolean
   fetchedAt: number
 } | null = null
 
 async function fetchAllFollows(
   did: string,
   signal?: AbortSignal,
-): Promise<Set<string>> {
+): Promise<FollowsResult> {
   const followedDids = new Set<string>()
   let cursor: string | undefined
+  let truncated = false
 
   while (followedDids.size < MAX_FOLLOWS) {
     const params = new URLSearchParams({
@@ -52,11 +64,21 @@ async function fetchAllFollows(
     if (!cursor || records.length < PAGE_LIMIT) break
   }
 
-  return followedDids
+  // If the while exited because we hit the cap AND the upstream is
+  // still handing us a cursor, mark as truncated. The cursor check is
+  // load-bearing — without it, a viewer with exactly 10k follows
+  // would be flagged truncated even though the indexer has nothing
+  // more to return.
+  if (followedDids.size >= MAX_FOLLOWS && cursor) {
+    truncated = true
+  }
+
+  return { data: followedDids, truncated }
 }
 
 export function useBlueskyFollows(did: string | null) {
   const [followedDids, setFollowedDids] = useState<Set<string>>(EMPTY_SET)
+  const [truncated, setTruncated] = useState(false)
   const [isLoading, setIsLoading] = useState(did != null)
   const [error, setError] = useState<string | null>(null)
 
@@ -67,6 +89,7 @@ export function useBlueskyFollows(did: string | null) {
     async (targetDid: string | null, signal?: AbortSignal) => {
       if (!targetDid) {
         setFollowedDids(EMPTY_SET)
+        setTruncated(false)
         setIsLoading(false)
         return
       }
@@ -74,6 +97,7 @@ export function useBlueskyFollows(did: string | null) {
       // Check cache
       if (cache && cache.did === targetDid && Date.now() - cache.fetchedAt < STALE_TIME) {
         setFollowedDids(cache.data)
+        setTruncated(cache.truncated)
         setIsLoading(false)
         return
       }
@@ -81,10 +105,16 @@ export function useBlueskyFollows(did: string | null) {
       setIsLoading(true)
       setError(null)
       try {
-        const data = await fetchAllFollows(targetDid, signal)
+        const result = await fetchAllFollows(targetDid, signal)
         if (signal?.aborted) return
-        cache = { did: targetDid, data, fetchedAt: Date.now() }
-        setFollowedDids(data)
+        cache = {
+          did: targetDid,
+          data: result.data,
+          truncated: result.truncated,
+          fetchedAt: Date.now(),
+        }
+        setFollowedDids(result.data)
+        setTruncated(result.truncated)
       } catch (err) {
         if (signal?.aborted) return
         console.error("Failed to fetch Bluesky follows:", err)
@@ -116,5 +146,5 @@ export function useBlueskyFollows(did: string | null) {
     return () => window.removeEventListener("focus", handleFocus)
   }, [doFetch])
 
-  return { followedDids, isLoading, error }
+  return { followedDids, truncated, isLoading, error }
 }

--- a/src/hooks/use-follower-events-feed.ts
+++ b/src/hooks/use-follower-events-feed.ts
@@ -1,0 +1,270 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useAuth } from "@/lib/auth/auth-context"
+import { useHomeFeedAuthors } from "@/hooks/use-home-feed-authors"
+import {
+  fetchFollowerEvents,
+  hydrateFeedEvents,
+  FollowerEventsError,
+  DEFAULT_FEED_PAGE_SIZE,
+  FOREGROUND_POLL_MS,
+  BACKGROUND_POLL_MS,
+  type FollowerEventsErrorCode,
+  type HydratedFeedEvent,
+} from "@/lib/atproto/follower-events"
+
+export interface UseFollowerEventsFeedOptions {
+  /** Optional inclusion filter forwarded to the indexer. */
+  kinds?: string[]
+}
+
+export interface UseFollowerEventsFeedResult {
+  events: HydratedFeedEvent[]
+  isLoading: boolean
+  isLoadingMore: boolean
+  error: string | null
+  /**
+   * Typed code when the error came from `FollowerEventsError`; null
+   * for hydration errors and network failures.
+   */
+  errorCode: FollowerEventsErrorCode | null
+  hasMore: boolean
+  /** Authors union > MAX_AUTHORS_FILTER_SIZE (truncated client-side). */
+  isOversized: boolean
+  /** Either upstream follow-set hook hit its 10k page-walk cap. */
+  truncatedBySource: boolean
+  loadMore: () => void
+  refresh: () => Promise<void>
+}
+
+/**
+ * Home-timeline feed hook. Wires up:
+ *
+ *   - viewer DID (from `useAuth`)
+ *   - author union (from `useHomeFeedAuthors`)
+ *   - paged fetch of `followerEvents`
+ *   - per-page hydration via `hydrateFeedEvents`
+ *   - visibility-aware polling (30s foreground / 5min background)
+ *
+ * State machine:
+ *   - Initial load fires whenever the stable `(authors, kinds)` key
+ *     changes. Aborts in flight via `AbortController` if the key
+ *     changes mid-fetch.
+ *   - `loadMore` paginates with the saved `endCursor`. Returns
+ *     silently if there's no cursor or another `loadMore` is already
+ *     in flight.
+ *   - `refresh` re-fetches page 1, merges by `event.id`. New events
+ *     are prepended; already-loaded events keep their position; the
+ *     pagination cursor is NOT reset (so a paginated user's
+ *     `loadMore` history survives a poll). Polling calls `refresh`.
+ *   - Polling pauses entirely when `authors.length === 0` (signed out
+ *     or no follows). It also switches cadence on `visibilitychange`:
+ *     `FOREGROUND_POLL_MS` when visible, `BACKGROUND_POLL_MS` otherwise.
+ */
+export function useFollowerEventsFeed(
+  options: UseFollowerEventsFeedOptions = {},
+): UseFollowerEventsFeedResult {
+  const { kinds } = options
+  const { did } = useAuth()
+  const {
+    authors,
+    isOversized,
+    truncatedBySource,
+    isLoading: authorsLoading,
+    error: authorsError,
+  } = useHomeFeedAuthors(did)
+
+  const [events, setEvents] = useState<HydratedFeedEvent[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [errorCode, setErrorCode] = useState<FollowerEventsErrorCode | null>(
+    null,
+  )
+  const [hasMore, setHasMore] = useState(false)
+
+  const endCursorRef = useRef<string | null>(null)
+  const isLoadingMoreRef = useRef(false)
+
+  // Primitive deps key so the initial-load effect doesn't refire on
+  // every render that produces a new authors array identity.
+  const authorsKey = authors.join(",")
+  const kindsKey = kinds && kinds.length > 0 ? kinds.slice().sort().join(",") : ""
+  const filterKey = `${authorsKey}|${kindsKey}`
+
+  // Snapshot the latest authors / kinds so callbacks (loadMore, refresh)
+  // see fresh values without listing them in their deps.
+  const authorsRef = useRef(authors)
+  authorsRef.current = authors
+  const kindsRef = useRef(kinds)
+  kindsRef.current = kinds
+
+  const loadInitial = useCallback(
+    async (signal?: AbortSignal) => {
+      try {
+        setIsLoading(true)
+        setError(null)
+        setErrorCode(null)
+        const page = await fetchFollowerEvents({
+          authors: authorsRef.current,
+          first: DEFAULT_FEED_PAGE_SIZE,
+          kinds: kindsRef.current,
+          signal,
+        })
+        if (signal?.aborted) return
+        const hydrated = await hydrateFeedEvents(page.events, signal)
+        if (signal?.aborted) return
+        setEvents(hydrated)
+        endCursorRef.current = page.endCursor
+        setHasMore(page.hasNextPage)
+      } catch (err) {
+        if (signal?.aborted) return
+        if (err instanceof FollowerEventsError) {
+          setError(err.message)
+          setErrorCode(err.code)
+        } else {
+          setError(err instanceof Error ? err.message : "Failed to load feed")
+          setErrorCode(null)
+        }
+      } finally {
+        if (!signal?.aborted) setIsLoading(false)
+      }
+    },
+    [],
+  )
+
+  // Initial load + reload on filter-key change.
+  useEffect(() => {
+    const controller = new AbortController()
+    loadInitial(controller.signal)
+    return () => controller.abort()
+  }, [filterKey, loadInitial])
+
+  const loadMore = useCallback(() => {
+    if (!endCursorRef.current || isLoadingMoreRef.current) return
+    if (authorsRef.current.length === 0) return
+    isLoadingMoreRef.current = true
+    setIsLoadingMore(true)
+    ;(async () => {
+      try {
+        const page = await fetchFollowerEvents({
+          authors: authorsRef.current,
+          first: DEFAULT_FEED_PAGE_SIZE,
+          after: endCursorRef.current ?? undefined,
+          kinds: kindsRef.current,
+        })
+        const hydrated = await hydrateFeedEvents(page.events)
+        setEvents((prev) => {
+          // Dedupe by event.id in case the server returns an overlapping
+          // page (race between concurrent refresh + loadMore).
+          const seen = new Set(prev.map((h) => h.event.id))
+          const fresh = hydrated.filter((h) => !seen.has(h.event.id))
+          return [...prev, ...fresh]
+        })
+        endCursorRef.current = page.endCursor
+        setHasMore(page.hasNextPage)
+      } catch (err) {
+        // Loading-more errors stop pagination but don't replace the
+        // existing list — the visible page stays valid.
+        console.warn("[useFollowerEventsFeed] loadMore failed:", err)
+        setHasMore(false)
+      } finally {
+        isLoadingMoreRef.current = false
+        setIsLoadingMore(false)
+      }
+    })()
+  }, [])
+
+  const refresh = useCallback(async () => {
+    if (authorsRef.current.length === 0) return
+    try {
+      const page = await fetchFollowerEvents({
+        authors: authorsRef.current,
+        first: DEFAULT_FEED_PAGE_SIZE,
+        kinds: kindsRef.current,
+      })
+      const hydrated = await hydrateFeedEvents(page.events)
+      setEvents((prev) => {
+        // Merge by event.id: prepend new events that aren't already
+        // in the list. Existing events keep their position so the
+        // user's load-more history survives.
+        const existingIds = new Set(prev.map((h) => h.event.id))
+        const incoming = hydrated.filter((h) => !existingIds.has(h.event.id))
+        if (incoming.length === 0) return prev
+        return [...incoming, ...prev]
+      })
+      // Don't touch endCursorRef — the cursor we have is still valid
+      // for the next page beyond what was previously loaded.
+    } catch (err) {
+      // Background poll failures are non-fatal — keep the visible
+      // list, surface no error UI for poll-driven refresh.
+      console.warn("[useFollowerEventsFeed] refresh failed:", err)
+    }
+  }, [])
+
+  // Polling with visibility-aware cadence. Snapshot refresh in a ref
+  // so the effect doesn't tear down when the callback identity
+  // changes (it doesn't, today — useCallback with [] — but the ref
+  // keeps that invariant from sneaking up later).
+  const refreshRef = useRef(refresh)
+  refreshRef.current = refresh
+
+  const hasAuthors = authors.length > 0
+  useEffect(() => {
+    if (!hasAuthors) return
+    if (typeof window === "undefined") return
+
+    let intervalId: ReturnType<typeof setInterval> | null = null
+
+    const currentInterval = () =>
+      typeof document !== "undefined" && document.visibilityState === "hidden"
+        ? BACKGROUND_POLL_MS
+        : FOREGROUND_POLL_MS
+
+    const start = () => {
+      if (intervalId !== null) clearInterval(intervalId)
+      intervalId = setInterval(() => {
+        void refreshRef.current()
+      }, currentInterval())
+    }
+
+    const handleVisibility = () => {
+      // Cadence changes when visibility flips. Restart the interval
+      // immediately so we don't wait the previous (potentially long)
+      // cadence to apply the new one.
+      start()
+      if (typeof document !== "undefined" && document.visibilityState === "visible") {
+        // Fresh page-1 fetch on tab-focus, so a user returning to the
+        // tab sees latest events without waiting for the next tick.
+        void refreshRef.current()
+      }
+    }
+
+    start()
+    document.addEventListener("visibilitychange", handleVisibility)
+    return () => {
+      if (intervalId !== null) clearInterval(intervalId)
+      document.removeEventListener("visibilitychange", handleVisibility)
+    }
+  }, [hasAuthors])
+
+  const combinedIsLoading = isLoading || authorsLoading
+  const combinedError = useMemo(
+    () => error ?? authorsError ?? null,
+    [error, authorsError],
+  )
+
+  return {
+    events,
+    isLoading: combinedIsLoading,
+    isLoadingMore,
+    error: combinedError,
+    errorCode,
+    hasMore,
+    isOversized,
+    truncatedBySource,
+    loadMore,
+    refresh,
+  }
+}

--- a/src/hooks/use-follower-events-feed.ts
+++ b/src/hooks/use-follower-events-feed.ts
@@ -21,6 +21,8 @@ export interface UseFollowerEventsFeedOptions {
 
 export interface UseFollowerEventsFeedResult {
   events: HydratedFeedEvent[]
+  /** Size of the (truncated, deduped) author union currently in use. */
+  authorsCount: number
   isLoading: boolean
   isLoadingMore: boolean
   error: string | null
@@ -100,12 +102,26 @@ export function useFollowerEventsFeed(
   const kindsRef = useRef(kinds)
   kindsRef.current = kinds
 
+  // Filter key snapshot. loadMore and refresh capture this at call
+  // time and skip their setState if the key has rolled (a key change
+  // would otherwise splice stale page-N events into a fresh page-1).
+  const filterKeyRef = useRef(filterKey)
+  filterKeyRef.current = filterKey
+
   const loadInitial = useCallback(
     async (signal?: AbortSignal) => {
       try {
         setIsLoading(true)
         setError(null)
         setErrorCode(null)
+        // No signed-in user, or signed-in user follows nobody — skip
+        // the round-trip. The UI shows the appropriate empty state.
+        if (authorsRef.current.length === 0) {
+          setEvents([])
+          endCursorRef.current = null
+          setHasMore(false)
+          return
+        }
         const page = await fetchFollowerEvents({
           authors: authorsRef.current,
           first: DEFAULT_FEED_PAGE_SIZE,
@@ -134,11 +150,17 @@ export function useFollowerEventsFeed(
     [],
   )
 
-  // Initial load + reload on filter-key change.
+  // Initial load + reload on filter-key change. Cleanup aborts the
+  // in-flight initial fetch AND resets the pagination cursor so a
+  // late loadMore from the old key can't reuse a stale cursor against
+  // the new author set.
   useEffect(() => {
     const controller = new AbortController()
     loadInitial(controller.signal)
-    return () => controller.abort()
+    return () => {
+      controller.abort()
+      endCursorRef.current = null
+    }
   }, [filterKey, loadInitial])
 
   const loadMore = useCallback(() => {
@@ -146,6 +168,10 @@ export function useFollowerEventsFeed(
     if (authorsRef.current.length === 0) return
     isLoadingMoreRef.current = true
     setIsLoadingMore(true)
+    // Snapshot the key at call time. If the user's follow set changes
+    // mid-request, we drop the result rather than splicing it onto a
+    // fresh page-1 from the new author set.
+    const dispatchedKey = filterKeyRef.current
     ;(async () => {
       try {
         const page = await fetchFollowerEvents({
@@ -154,7 +180,9 @@ export function useFollowerEventsFeed(
           after: endCursorRef.current ?? undefined,
           kinds: kindsRef.current,
         })
+        if (dispatchedKey !== filterKeyRef.current) return
         const hydrated = await hydrateFeedEvents(page.events)
+        if (dispatchedKey !== filterKeyRef.current) return
         setEvents((prev) => {
           // Dedupe by event.id in case the server returns an overlapping
           // page (race between concurrent refresh + loadMore).
@@ -165,6 +193,7 @@ export function useFollowerEventsFeed(
         endCursorRef.current = page.endCursor
         setHasMore(page.hasNextPage)
       } catch (err) {
+        if (dispatchedKey !== filterKeyRef.current) return
         // Loading-more errors stop pagination but don't replace the
         // existing list — the visible page stays valid.
         console.warn("[useFollowerEventsFeed] loadMore failed:", err)
@@ -178,13 +207,16 @@ export function useFollowerEventsFeed(
 
   const refresh = useCallback(async () => {
     if (authorsRef.current.length === 0) return
+    const dispatchedKey = filterKeyRef.current
     try {
       const page = await fetchFollowerEvents({
         authors: authorsRef.current,
         first: DEFAULT_FEED_PAGE_SIZE,
         kinds: kindsRef.current,
       })
+      if (dispatchedKey !== filterKeyRef.current) return
       const hydrated = await hydrateFeedEvents(page.events)
+      if (dispatchedKey !== filterKeyRef.current) return
       setEvents((prev) => {
         // Merge by event.id: prepend new events that aren't already
         // in the list. Existing events keep their position so the
@@ -257,6 +289,7 @@ export function useFollowerEventsFeed(
 
   return {
     events,
+    authorsCount: authors.length,
     isLoading: combinedIsLoading,
     isLoadingMore,
     error: combinedError,

--- a/src/hooks/use-home-feed-authors.ts
+++ b/src/hooks/use-home-feed-authors.ts
@@ -1,0 +1,96 @@
+"use client"
+
+import { useMemo } from "react"
+import { useBlueskyFollows } from "@/hooks/use-bluesky-follows"
+import { useFollowing } from "@/hooks/use-following"
+import { MAX_AUTHORS_FILTER_SIZE } from "@/lib/atproto/follower-events"
+
+/**
+ * Pure helper — exported for unit testing. Encodes the union + sort +
+ * truncate policy without React. The hook below wraps this in a
+ * memo.
+ */
+export function computeHomeFeedAuthors(
+  did: string | null,
+  blueskyDids: Set<string>,
+  certifiedSubjects: Set<string>,
+): { authors: string[]; isOversized: boolean } {
+  if (!did) return { authors: [], isOversized: false }
+  const union = new Set<string>()
+  blueskyDids.forEach((d) => union.add(d))
+  certifiedSubjects.forEach((d) => union.add(d))
+  const sorted = Array.from(union).sort()
+  if (sorted.length > MAX_AUTHORS_FILTER_SIZE) {
+    return {
+      authors: sorted.slice(0, MAX_AUTHORS_FILTER_SIZE),
+      isOversized: true,
+    }
+  }
+  return { authors: sorted, isOversized: false }
+}
+
+export interface UseHomeFeedAuthorsResult {
+  /**
+   * Deduped, alphabetically-sorted union of the viewer's Bluesky and
+   * Certified follows. Truncated to `MAX_AUTHORS_FILTER_SIZE` if the
+   * union exceeds the cap (see `isOversized` below).
+   *
+   * Stable identity across renders when the underlying sets are
+   * unchanged — uses `useMemo` keyed on a deterministic join of
+   * sorted DIDs. Safe to pass into `useEffect` deps via
+   * `authors.join(",")`.
+   */
+  authors: string[]
+  /** True when the raw union exceeded the cap and was truncated. */
+  isOversized: boolean
+  /**
+   * True when either of the upstream hooks hit its 10k page-walk cap.
+   * Consumers should not derive set-arithmetic conclusions when this
+   * is true — for the feed query it's a soft warning.
+   */
+  truncatedBySource: boolean
+  isLoading: boolean
+  error: string | null
+}
+
+/**
+ * Composes `useBlueskyFollows` + `useFollowing` into a single author
+ * list suitable for passing to `fetchFollowerEvents`. Both upstream
+ * hooks cache at the module level (5-min TTL), so calling this hook
+ * in multiple components is cheap.
+ *
+ * Ranking for over-cap follow sets: v1 uses ascending DID-string
+ * sort. The issue's recommended "most-recently-interacted-with"
+ * ranking needs a per-DID timestamp signal the union doesn't expose
+ * today (Bluesky follows arrive in PDS insertion order; Certified
+ * follows have a `createdAt` field that isn't comparable to Bluesky's
+ * insertion order). Recency ranking is tracked as a follow-up.
+ */
+export function useHomeFeedAuthors(did: string | null): UseHomeFeedAuthorsResult {
+  const {
+    followedDids: blueskyDids,
+    truncated: blueskyTruncated,
+    isLoading: blueskyLoading,
+    error: blueskyError,
+  } = useBlueskyFollows(did)
+
+  const {
+    subjects: certifiedSubjects,
+    truncated: certifiedTruncated,
+    isLoading: certifiedLoading,
+    error: certifiedError,
+  } = useFollowing(did)
+
+  const { authors, isOversized } = useMemo(
+    () => computeHomeFeedAuthors(did, blueskyDids, certifiedSubjects),
+    [did, blueskyDids, certifiedSubjects],
+  )
+
+  return {
+    authors,
+    isOversized,
+    truncatedBySource: blueskyTruncated || certifiedTruncated,
+    isLoading: blueskyLoading || certifiedLoading,
+    error: blueskyError ?? certifiedError ?? null,
+  }
+}

--- a/src/lib/atproto/__tests__/follower-events.test.ts
+++ b/src/lib/atproto/__tests__/follower-events.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import {
+  fetchFollowerEvents,
+  hydrateFeedEvents,
+  FollowerEventsError,
+  type FeedEvent,
+} from "../follower-events"
+
+const mockFetch = vi.fn()
+const originalFetch = globalThis.fetch
+
+beforeEach(() => {
+  globalThis.fetch = mockFetch as unknown as typeof fetch
+  mockFetch.mockReset()
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+function respondWith(body: unknown, status = 200): void {
+  mockFetch.mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  )
+}
+
+const sampleNode = {
+  id: "at://did:plc:alice/org.hypercerts.claim.activity/abc",
+  kind: "cert.create",
+  subjectUri: "at://did:plc:alice/org.hypercerts.claim.activity/abc",
+  sortAt: "2026-05-26T00:00:00.000Z",
+  actor: {
+    did: "did:plc:alice",
+    handle: "alice.test",
+    displayName: "Alice",
+    avatarCid: null,
+    pds: null,
+  },
+}
+
+describe("fetchFollowerEvents", () => {
+  it("parses a happy-path response into a FeedEventPage", async () => {
+    respondWith({
+      data: {
+        followerEvents: {
+          edges: [{ cursor: "c1", node: sampleNode }],
+          pageInfo: { hasNextPage: true, endCursor: "c1" },
+        },
+      },
+    })
+
+    const page = await fetchFollowerEvents({ authors: ["did:plc:alice"] })
+
+    expect(page.events).toHaveLength(1)
+    expect(page.events[0].id).toBe(sampleNode.id)
+    expect(page.events[0].kind).toBe("cert.create")
+    expect(page.events[0].actor.did).toBe("did:plc:alice")
+    expect(page.hasNextPage).toBe(true)
+    expect(page.endCursor).toBe("c1")
+  })
+
+  it("forwards default first = 20 when omitted", async () => {
+    respondWith({
+      data: { followerEvents: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } } },
+    })
+    await fetchFollowerEvents({ authors: ["did:plc:a"] })
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
+    expect(body.variables.first).toBe(20)
+  })
+
+  it("forwards kinds as null when omitted or empty", async () => {
+    respondWith({
+      data: { followerEvents: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } } },
+    })
+    await fetchFollowerEvents({ authors: ["did:plc:a"], kinds: [] })
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
+    expect(body.variables.kinds).toBeNull()
+  })
+
+  it("returns an empty page for empty authors (load-bearing)", async () => {
+    respondWith({
+      data: { followerEvents: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } } },
+    })
+    const page = await fetchFollowerEvents({ authors: [] })
+    expect(page.events).toEqual([])
+    expect(page.hasNextPage).toBe(false)
+  })
+
+  it("maps AUTHORS_FILTER_TOO_LARGE to a typed FollowerEventsError", async () => {
+    respondWith({
+      errors: [
+        { message: "too many", extensions: { code: "AUTHORS_FILTER_TOO_LARGE" } },
+      ],
+    })
+    await expect(fetchFollowerEvents({ authors: ["did:plc:a"] })).rejects.toMatchObject({
+      name: "FollowerEventsError",
+      code: "AUTHORS_FILTER_TOO_LARGE",
+    })
+  })
+
+  it("maps INVALID_CURSOR to a typed FollowerEventsError", async () => {
+    respondWith({
+      errors: [
+        { message: "bad cursor", extensions: { code: "INVALID_CURSOR" } },
+      ],
+    })
+    await expect(
+      fetchFollowerEvents({ authors: ["did:plc:a"], after: "garbage" }),
+    ).rejects.toMatchObject({ code: "INVALID_CURSOR" })
+  })
+
+  it("maps AUTHORS_REQUIRED to a typed FollowerEventsError (defensive)", async () => {
+    respondWith({
+      errors: [
+        { message: "authors required", extensions: { code: "AUTHORS_REQUIRED" } },
+      ],
+    })
+    await expect(
+      fetchFollowerEvents({ authors: ["did:plc:a"] }),
+    ).rejects.toMatchObject({ code: "AUTHORS_REQUIRED" })
+  })
+
+  it("leaves code = null for unknown extension codes", async () => {
+    respondWith({
+      errors: [{ message: "weird", extensions: { code: "SOMETHING_ELSE" } }],
+    })
+    await expect(
+      fetchFollowerEvents({ authors: ["did:plc:a"] }),
+    ).rejects.toMatchObject({ code: null })
+  })
+
+  it("throws FollowerEventsError(code: null) on non-OK HTTP", async () => {
+    respondWith({}, 502)
+    const err = await fetchFollowerEvents({ authors: ["did:plc:a"] }).catch((e) => e)
+    expect(err).toBeInstanceOf(FollowerEventsError)
+    expect(err.code).toBeNull()
+  })
+})
+
+describe("hydrateFeedEvents", () => {
+  function makeEvent(kind: string, suffix: string): FeedEvent {
+    return {
+      id: `at://did:plc:x/${kind}/${suffix}`,
+      kind,
+      subjectUri: `at://did:plc:x/${kind}/${suffix}`,
+      sortAt: "2026-05-26T00:00:00.000Z",
+      actor: {
+        did: "did:plc:x",
+        handle: "x.test",
+        displayName: "X",
+        avatarCid: null,
+        pds: null,
+      },
+    }
+  }
+
+  it("returns [] immediately for an empty input", async () => {
+    const out = await hydrateFeedEvents([])
+    expect(out).toEqual([])
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("skips the round-trip when every event is an unknown kind", async () => {
+    const events = [makeEvent("unknown.kind", "a"), makeEvent("future.kind", "b")]
+    const out = await hydrateFeedEvents(events)
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(out).toHaveLength(2)
+    expect(out[0].payload).toBeNull()
+    expect(out[1].payload).toBeNull()
+  })
+
+  it("buckets events by kind and preserves input order", async () => {
+    const events = [
+      makeEvent("cert.create", "a"),
+      makeEvent("collection.create", "b"),
+      makeEvent("badge.award", "c"),
+      makeEvent("legacy.endorsement", "d"),
+      makeEvent("future.kind", "e"),
+    ]
+    respondWith({
+      data: {
+        activities: {
+          edges: [
+            {
+              node: {
+                uri: events[0].subjectUri,
+                cid: "c1",
+                did: "did:plc:x",
+                title: "Cert title",
+                shortDescription: "desc",
+                createdAt: "2026-05-26T00:00:00.000Z",
+                startDate: null,
+                endDate: null,
+                labels: [],
+                image: null,
+                workScope: null,
+              },
+            },
+          ],
+        },
+        collections: {
+          edges: [
+            {
+              node: {
+                uri: events[1].subjectUri,
+                cid: "c2",
+                did: "did:plc:x",
+                title: "Project title",
+                shortDescription: "desc",
+                createdAt: "2026-05-26T00:00:00.000Z",
+                type: "project",
+                items: null,
+                banner: null,
+              },
+            },
+          ],
+        },
+        badgeAwards: {
+          edges: [
+            {
+              node: {
+                uri: events[2].subjectUri,
+                cid: "c3",
+                did: "did:plc:x",
+                createdAt: "2026-05-26T00:00:00.000Z",
+                note: "nice",
+                subject: { did: "did:plc:subject" },
+              },
+            },
+          ],
+        },
+        legacyEndorsements: {
+          edges: [
+            {
+              node: {
+                uri: events[3].subjectUri,
+                did: "did:plc:x",
+                createdAt: "2026-05-26T00:00:00.000Z",
+                subject: { did: "did:plc:subject" },
+              },
+            },
+          ],
+        },
+      },
+    })
+
+    const out = await hydrateFeedEvents(events)
+    expect(out).toHaveLength(5)
+    expect(out.map((h) => h.event.id)).toEqual(events.map((e) => e.id))
+    expect(out[0].payload?.kind).toBe("cert.create")
+    expect(out[1].payload?.kind).toBe("collection.create")
+    expect(out[2].payload?.kind).toBe("badge.award")
+    expect(out[3].payload?.kind).toBe("legacy.endorsement")
+    expect(out[4].payload).toBeNull()
+  })
+
+  it("returns payload null for events whose by-URI lookup missed", async () => {
+    const events = [makeEvent("cert.create", "a"), makeEvent("cert.create", "b")]
+    respondWith({
+      data: {
+        activities: {
+          edges: [
+            {
+              node: {
+                uri: events[0].subjectUri,
+                cid: "c1",
+                did: "did:plc:x",
+                title: "Only A",
+                shortDescription: "",
+                createdAt: "2026-05-26T00:00:00.000Z",
+                startDate: null,
+                endDate: null,
+                labels: [],
+                image: null,
+                workScope: null,
+              },
+            },
+          ],
+        },
+        collections: { edges: [] },
+        badgeAwards: { edges: [] },
+        legacyEndorsements: { edges: [] },
+      },
+    })
+    const out = await hydrateFeedEvents(events)
+    expect(out[0].payload?.kind).toBe("cert.create")
+    expect(out[1].payload).toBeNull()
+  })
+
+  it("includes the collection.value.type from the hydration payload", async () => {
+    const events = [makeEvent("collection.create", "a")]
+    respondWith({
+      data: {
+        activities: { edges: [] },
+        collections: {
+          edges: [
+            {
+              node: {
+                uri: events[0].subjectUri,
+                cid: "c1",
+                did: "did:plc:x",
+                title: "List",
+                shortDescription: "",
+                createdAt: "2026-05-26T00:00:00.000Z",
+                type: "endorsement-list",
+                items: null,
+                banner: null,
+              },
+            },
+          ],
+        },
+        badgeAwards: { edges: [] },
+        legacyEndorsements: { edges: [] },
+      },
+    })
+    const out = await hydrateFeedEvents(events)
+    const payload = out[0].payload
+    if (payload?.kind === "collection.create") {
+      expect(payload.record.value.type).toBe("endorsement-list")
+    } else {
+      throw new Error("Expected collection.create payload")
+    }
+  })
+})

--- a/src/lib/atproto/__tests__/follower-events.test.ts
+++ b/src/lib/atproto/__tests__/follower-events.test.ts
@@ -37,7 +37,6 @@ const sampleNode = {
     handle: "alice.test",
     displayName: "Alice",
     avatarCid: null,
-    pds: null,
   },
 }
 
@@ -152,7 +151,6 @@ describe("hydrateFeedEvents", () => {
         handle: "x.test",
         displayName: "X",
         avatarCid: null,
-        pds: null,
       },
     }
   }

--- a/src/lib/atproto/follower-events.ts
+++ b/src/lib/atproto/follower-events.ts
@@ -1,0 +1,418 @@
+/**
+ * Home-timeline feed client — magic-indexer #122.
+ *
+ * Two responsibilities:
+ *
+ *   1. `fetchFollowerEvents` — wraps the `FollowerEvents` server proxy
+ *      op. Returns a paginated list of `FeedEvent`s (the union of the
+ *      viewer's relevant lexicon-level create events across the
+ *      follow set). Each event carries its denormalised `actor` so
+ *      the renderer doesn't need a per-row profile lookup.
+ *
+ *   2. `hydrateFeedEvents` — wraps the `HydrateFeedPage` server proxy
+ *      op. Takes the events from a page, buckets them by `kind`, and
+ *      fetches the headline-render record for each kind in one
+ *      GraphQL round-trip. Unknown kinds skip hydration (payload =
+ *      null) — the dispatch site falls back to a generic actor +
+ *      subjectUri card.
+ *
+ * Coded errors from the indexer (per the issue's contract) surface as
+ * `FollowerEventsError` with a typed `code`:
+ *
+ *   - AUTHORS_REQUIRED          (defensive — proxy rejects first)
+ *   - AUTHORS_FILTER_TOO_LARGE  (>500 unique DIDs after server-side
+ *                                dedupe; client should pre-truncate)
+ *   - INVALID_CURSOR            (opaque cursor failed to decode)
+ *
+ * Network / non-GraphQL errors throw plain `Error`.
+ */
+
+import type { ActivityRecord } from "./activity-types"
+import type { CollectionRecord } from "./collection"
+import {
+  INDEXER_PROXY_URL,
+  type ActivityGraphQLNode,
+  type CollectionGraphQLNode,
+  nodeToActivityRecord,
+  nodeToCollectionRecord,
+} from "./indexer"
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Server-enforced cap on `authors`. Client truncates to this before sending. */
+export const MAX_AUTHORS_FILTER_SIZE = 500
+/** Server-enforced cap on `first`. */
+export const MAX_FEED_PAGE_SIZE = 50
+export const DEFAULT_FEED_PAGE_SIZE = 20
+/** Polling cadence when the tab is visible. */
+export const FOREGROUND_POLL_MS = 30_000
+/** Polling cadence when the tab is hidden (per issue's load planning). */
+export const BACKGROUND_POLL_MS = 5 * 60_000
+
+/**
+ * Documented kinds in v1 of the FollowerEvents API. The wire type
+ * `FeedEvent.kind` stays `string` (open union) because a new
+ * server-side mapping may ship before the client updates — the
+ * dispatch site narrows to a known kind or falls through to the
+ * fallback card.
+ */
+export const KNOWN_FEED_EVENT_KINDS = [
+  "cert.create",
+  "collection.create",
+  "badge.award",
+  "legacy.endorsement",
+] as const
+export type KnownFeedEventKind = (typeof KNOWN_FEED_EVENT_KINDS)[number]
+
+// ============================================================================
+// Wire types
+// ============================================================================
+
+export interface FeedActor {
+  did: string
+  handle: string | null
+  displayName: string | null
+  avatarCid: string | null
+  pds: string | null
+}
+
+export interface FeedEvent {
+  /** at:// URI — stable across refreshes; use as React key. */
+  id: string
+  kind: string
+  subjectUri: string
+  /** RFC3339Nano, same clock-skew-clamped value as the record's sort_at. */
+  sortAt: string
+  actor: FeedActor
+}
+
+export interface FeedEventPage {
+  events: FeedEvent[]
+  endCursor: string | null
+  hasNextPage: boolean
+}
+
+// ============================================================================
+// Coded errors
+// ============================================================================
+
+export type FollowerEventsErrorCode =
+  | "AUTHORS_REQUIRED"
+  | "AUTHORS_FILTER_TOO_LARGE"
+  | "INVALID_CURSOR"
+
+export class FollowerEventsError extends Error {
+  readonly code: FollowerEventsErrorCode | null
+  constructor(message: string, code: FollowerEventsErrorCode | null) {
+    super(message)
+    this.name = "FollowerEventsError"
+    this.code = code
+  }
+}
+
+const KNOWN_ERROR_CODES: ReadonlySet<string> = new Set([
+  "AUTHORS_REQUIRED",
+  "AUTHORS_FILTER_TOO_LARGE",
+  "INVALID_CURSOR",
+])
+
+function parseErrorCode(raw: string | undefined | null): FollowerEventsErrorCode | null {
+  if (!raw) return null
+  return KNOWN_ERROR_CODES.has(raw) ? (raw as FollowerEventsErrorCode) : null
+}
+
+// ============================================================================
+// fetchFollowerEvents
+// ============================================================================
+
+export interface FetchFollowerEventsOptions {
+  /**
+   * Deduped, client-pre-truncated to MAX_AUTHORS_FILTER_SIZE. Empty
+   * array is valid (and load-bearing): the upstream returns an empty
+   * connection rather than an error.
+   */
+  authors: string[]
+  first?: number
+  after?: string
+  kinds?: string[]
+  signal?: AbortSignal
+}
+
+interface FollowerEventsResponse {
+  data?: {
+    followerEvents?: {
+      edges: {
+        cursor: string
+        node: {
+          id: string
+          kind: string
+          subjectUri: string
+          sortAt: string
+          actor: FeedActor
+        } | null
+      }[]
+      pageInfo: { hasNextPage: boolean; endCursor: string | null }
+    } | null
+  } | null
+  errors?: { message: string; extensions?: { code?: string } }[]
+}
+
+export async function fetchFollowerEvents(
+  options: FetchFollowerEventsOptions,
+): Promise<FeedEventPage> {
+  const { authors, first = DEFAULT_FEED_PAGE_SIZE, after, kinds, signal } = options
+
+  const res = await fetch(INDEXER_PROXY_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      operationName: "FollowerEvents",
+      variables: {
+        authors,
+        first,
+        after: after ?? null,
+        kinds: kinds && kinds.length > 0 ? kinds : null,
+      },
+    }),
+    signal,
+  })
+
+  if (!res.ok) {
+    throw new FollowerEventsError(
+      `Indexer proxy returned ${res.status}`,
+      null,
+    )
+  }
+
+  const json = (await res.json()) as FollowerEventsResponse
+
+  if (json.errors?.length) {
+    const first = json.errors[0]
+    throw new FollowerEventsError(
+      first.message,
+      parseErrorCode(first.extensions?.code),
+    )
+  }
+
+  if (!json.data?.followerEvents) {
+    throw new FollowerEventsError(
+      "Indexer returned no followerEvents payload",
+      null,
+    )
+  }
+
+  const conn = json.data.followerEvents
+  const events: FeedEvent[] = []
+  for (const edge of conn.edges) {
+    if (!edge.node) continue
+    events.push({
+      id: edge.node.id,
+      kind: edge.node.kind,
+      subjectUri: edge.node.subjectUri,
+      sortAt: edge.node.sortAt,
+      actor: edge.node.actor,
+    })
+  }
+
+  return {
+    events,
+    endCursor: conn.pageInfo.endCursor,
+    hasNextPage: conn.pageInfo.hasNextPage,
+  }
+}
+
+// ============================================================================
+// Hydration
+// ============================================================================
+
+export interface HydratedPayloadActivity {
+  kind: "cert.create"
+  record: ActivityRecord
+}
+
+export interface HydratedPayloadCollection {
+  kind: "collection.create"
+  record: CollectionRecord
+}
+
+export interface HydratedPayloadBadgeAward {
+  kind: "badge.award"
+  subjectDid: string
+  note: string | null
+  createdAt: string
+}
+
+export interface HydratedPayloadLegacyEndorsement {
+  kind: "legacy.endorsement"
+  subjectDid: string
+  createdAt: string
+}
+
+export type HydratedPayload =
+  | HydratedPayloadActivity
+  | HydratedPayloadCollection
+  | HydratedPayloadBadgeAward
+  | HydratedPayloadLegacyEndorsement
+
+export interface HydratedFeedEvent {
+  event: FeedEvent
+  /** null when the by-URI lookup 404'd OR when the kind is unknown. */
+  payload: HydratedPayload | null
+}
+
+interface BadgeAwardGraphQLNode {
+  uri: string
+  cid: string
+  did: string
+  createdAt: string
+  note: string | null
+  subject: { did: string } | null
+}
+
+interface LegacyEndorsementGraphQLNode {
+  uri: string
+  did: string
+  createdAt: string
+  subject: { did: string } | null
+}
+
+interface CollectionWithTypeGraphQLNode extends CollectionGraphQLNode {
+  type?: string | null
+}
+
+interface HydrateFeedPageResponse {
+  data?: {
+    activities?: { edges: { node: ActivityGraphQLNode | null }[] } | null
+    collections?: {
+      edges: { node: CollectionWithTypeGraphQLNode | null }[]
+    } | null
+    badgeAwards?: { edges: { node: BadgeAwardGraphQLNode | null }[] } | null
+    legacyEndorsements?: {
+      edges: { node: LegacyEndorsementGraphQLNode | null }[]
+    } | null
+  } | null
+  errors?: { message: string }[]
+}
+
+/**
+ * One request hydrates one page. Events with unknown `kind` are
+ * preserved in the output with `payload: null` so the dispatch site
+ * can render the fallback card.
+ */
+export async function hydrateFeedEvents(
+  events: FeedEvent[],
+  signal?: AbortSignal,
+): Promise<HydratedFeedEvent[]> {
+  if (events.length === 0) return []
+
+  const activityUris: string[] = []
+  const collectionUris: string[] = []
+  const badgeAwardUris: string[] = []
+  const legacyEndorsementUris: string[] = []
+
+  for (const ev of events) {
+    switch (ev.kind) {
+      case "cert.create":
+        activityUris.push(ev.subjectUri)
+        break
+      case "collection.create":
+        collectionUris.push(ev.subjectUri)
+        break
+      case "badge.award":
+        badgeAwardUris.push(ev.subjectUri)
+        break
+      case "legacy.endorsement":
+        legacyEndorsementUris.push(ev.subjectUri)
+        break
+      // Unknown kinds skip hydration.
+    }
+  }
+
+  const haveAny =
+    activityUris.length +
+      collectionUris.length +
+      badgeAwardUris.length +
+      legacyEndorsementUris.length >
+    0
+  if (!haveAny) {
+    // Every event is an unknown kind; the dispatch site renders the
+    // fallback card for each, no hydration round-trip needed.
+    return events.map((event) => ({ event, payload: null }))
+  }
+
+  const res = await fetch(INDEXER_PROXY_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      operationName: "HydrateFeedPage",
+      variables: {
+        activityUris,
+        collectionUris,
+        badgeAwardUris,
+        legacyEndorsementUris,
+      },
+    }),
+    signal,
+  })
+
+  if (!res.ok) {
+    throw new Error(`Hydration request failed: ${res.status}`)
+  }
+
+  const json = (await res.json()) as HydrateFeedPageResponse
+
+  if (json.errors?.length) {
+    // GraphQL can return partial data alongside errors. Log and keep
+    // going — events whose hydration failed will fall through to the
+    // fallback card via `payload: null`.
+    console.warn(
+      "[follower-events] HydrateFeedPage error:",
+      json.errors[0].message,
+    )
+  }
+
+  const payloadByUri = new Map<string, HydratedPayload>()
+
+  for (const edge of json.data?.activities?.edges ?? []) {
+    if (!edge.node) continue
+    payloadByUri.set(edge.node.uri, {
+      kind: "cert.create",
+      record: nodeToActivityRecord(edge.node),
+    })
+  }
+  for (const edge of json.data?.collections?.edges ?? []) {
+    if (!edge.node) continue
+    const record = nodeToCollectionRecord(edge.node)
+    if (edge.node.type) {
+      record.value.type = edge.node.type
+    }
+    payloadByUri.set(edge.node.uri, {
+      kind: "collection.create",
+      record,
+    })
+  }
+  for (const edge of json.data?.badgeAwards?.edges ?? []) {
+    if (!edge.node || !edge.node.subject) continue
+    payloadByUri.set(edge.node.uri, {
+      kind: "badge.award",
+      subjectDid: edge.node.subject.did,
+      note: edge.node.note,
+      createdAt: edge.node.createdAt,
+    })
+  }
+  for (const edge of json.data?.legacyEndorsements?.edges ?? []) {
+    if (!edge.node || !edge.node.subject) continue
+    payloadByUri.set(edge.node.uri, {
+      kind: "legacy.endorsement",
+      subjectDid: edge.node.subject.did,
+      createdAt: edge.node.createdAt,
+    })
+  }
+
+  return events.map((event) => ({
+    event,
+    payload: payloadByUri.get(event.subjectUri) ?? null,
+  }))
+}

--- a/src/lib/atproto/follower-events.ts
+++ b/src/lib/atproto/follower-events.ts
@@ -75,7 +75,6 @@ export interface FeedActor {
   handle: string | null
   displayName: string | null
   avatarCid: string | null
-  pds: string | null
 }
 
 export interface FeedEvent {
@@ -385,8 +384,16 @@ export async function hydrateFeedEvents(
   for (const edge of json.data?.collections?.edges ?? []) {
     if (!edge.node) continue
     const record = nodeToCollectionRecord(edge.node)
-    if (edge.node.type) {
+    // nodeToCollectionRecord hardcodes `type: "project"` because the
+    // existing UserProjects op pre-filters by type. HydrateFeedPage
+    // queries by URI and returns any collection type, so override —
+    // but only when the indexer actually returned a non-empty string.
+    // For null / undefined / empty-string, strip the default rather
+    // than letting renderers silently mislabel a typeless collection.
+    if (typeof edge.node.type === "string" && edge.node.type.length > 0) {
       record.value.type = edge.node.type
+    } else {
+      delete record.value.type
     }
     payloadByUri.set(edge.node.uri, {
       kind: "collection.create",

--- a/src/lib/atproto/indexer.ts
+++ b/src/lib/atproto/indexer.ts
@@ -30,9 +30,9 @@ import { getBlobRefLink } from "./types"
  * accepts `labels` / `excludeLabels` filter args on the records
  * query, so this hook makes a single GraphQL call per page.
  */
-const INDEXER_PROXY_URL = "/api/indexer"
+export const INDEXER_PROXY_URL = "/api/indexer"
 
-interface GraphQLNode {
+export interface ActivityGraphQLNode {
   uri: string
   cid: string
   did: string
@@ -50,14 +50,14 @@ interface GraphQLResponse {
   data?: {
     orgHypercertsClaimActivity?: {
       totalCount: number | null
-      edges: { cursor: string; node: GraphQLNode | null }[]
+      edges: { cursor: string; node: ActivityGraphQLNode | null }[]
       pageInfo: { hasNextPage: boolean; endCursor: string | null }
     } | null
   } | null
   errors?: { message: string }[]
 }
 
-function nodeToActivityRecord(node: GraphQLNode): ActivityRecord {
+export function nodeToActivityRecord(node: ActivityGraphQLNode): ActivityRecord {
   // Map the indexer image union into a shape resolveActivityImageUrl can handle.
   // The indexer may return partial data (null uri on OrgHypercertsDefsUri due
   // to a schema bug), so we guard each branch carefully.
@@ -683,7 +683,7 @@ export async function fetchNetworkCounts(): Promise<NetworkCounts> {
 // whose type discriminator is "project" (case-insensitive via eqi).
 // ============================================================================
 
-interface UserProjectsNode {
+export interface CollectionGraphQLNode {
   uri: string
   cid: string
   did: string
@@ -704,14 +704,14 @@ interface UserProjectsGraphQLResponse {
   data?: {
     orgHypercertsCollection?: {
       totalCount: number | null
-      edges: { cursor: string; node: UserProjectsNode | null }[]
+      edges: { cursor: string; node: CollectionGraphQLNode | null }[]
       pageInfo: { hasNextPage: boolean; endCursor: string | null }
     } | null
   } | null
   errors?: { message: string }[]
 }
 
-function nodeToCollectionRecord(node: UserProjectsNode): CollectionRecord {
+export function nodeToCollectionRecord(node: CollectionGraphQLNode): CollectionRecord {
   // Re-shape the indexer's typed banner union back into the loose
   // `{ uri }` / `{ image: { ref, mimeType } }` blob that
   // resolveActivityImageUrl already understands. The blob ref comes


### PR DESCRIPTION
## Summary

Adopts magic-indexer's new `followerEvents` GraphQL field for a home-timeline feed mounted at `/feed`, leaving the existing `/home` activity timeline (built in parallel on this branch) untouched. Two surfaces coexist:

- **`/home`** — your GitHub-style activity timeline (unchanged from upstream)
- **`/feed`** — new card-based feed driven by `followerEvents` + `HydrateFeedPage` batched hydration

## What landed (11 commits)

1. **Server proxy ops** (`src/app/api/indexer/route.ts`) — adds `FollowerEvents` and `HydrateFeedPage` operations. Enforces `MaxAuthorsFilterSize = 500`, `MaxFeedPageSize = 50`, accepts empty `authors: []` (load-bearing). `MAX_BODY_SIZE` bumped 16KB → 32KB for the worst-case hydration payload.
2. **Client module** (`src/lib/atproto/follower-events.ts`) — `fetchFollowerEvents`, `hydrateFeedEvents`, `FollowerEventsError` with the three coded errors (`AUTHORS_REQUIRED`, `AUTHORS_FILTER_TOO_LARGE`, `INVALID_CURSOR`). Reuses extracted `nodeToActivityRecord` / `nodeToCollectionRecord` mappers from `indexer.ts`.
3. **`useBlueskyFollows.truncated`** — small additive change so the contract matches `useFollowing` and `useHomeFeedAuthors` can surface `truncatedBySource`.
4. **`useHomeFeedAuthors`** — composes Bluesky + Certified follows into a deduped, alphabetically-sorted, cap-truncated array.
5. **`useFollowerEventsFeed`** (`src/hooks/use-follower-events-feed.ts`) — paged + visibility-aware-polled feed driver. 30s foreground, 5min background. Refresh merges by `event.id`, preserves load-more history. Renamed from `useHomeFeed` to avoid collision with the upstream hook of the same name.
6. **`FeedEventCard`** — one card with internal kind dispatch (`cert.create` / `collection.create` / `badge.award` / `legacy.endorsement`) plus a degraded-known-kind card for 404 hydration and a generic fallback for unknown kinds (per issue #88's "Unknown-kind contract").
7. **`HomeFeed`** shell — three-variant empty state (signed-out / no-follows / no-events), error state with `AUTHORS_FILTER_TOO_LARGE`-specific copy, warning banner for `isOversized` / `truncatedBySource`, IntersectionObserver infinite scroll.
8. **`/feed` wire-up** — replaces the legacy `HomeClient` redirector.
9. **Desktop nav** — adds a `/feed` entry to `desktop-left-rail.tsx` (was reachable only via the mobile bottom-nav before).

## Process

Full plan → review → implement → review cycle per CLAUDE.md, all under `docs/follower-events-feed/`:

- `discovery.md` — repo orientation
- `plan.md` → `review-spec.md` + `review-build.md` + `review-integration.md` → `review-decisions.md` → `plan-v2.md`
- `implementation.md` — track log + deferred items
- `review-impl-correctness.md` + `review-impl-quality.md` + `review-impl-integration.md` (round 2 reviews after implementation)

The fix commit (`98dc0b1`) integrates round-2 feedback: CSS tokens, three-variant empty states, race-condition guards on filter-key change, hydration-404 degraded cards, dropped unused `actor.pds`, desktop nav entry.

## Test plan

- [ ] **Schema probe (must verify pre-merge)**: confirm magic-indexer-dev supports `where: { uri: { in: $uris } }` on the four `*ByUri` connections in `HydrateFeedPage`. See `docs/follower-events-feed/implementation.md` § "Schema probe". If unsupported, hydration for those kinds falls through to the unknown-kind fallback card.
- [ ] Sign in. Verify `/feed` renders the new card-based feed.
- [ ] Sign out. Verify `/feed` shows the "Sign in to see your feed" empty state.
- [ ] Sign in as a user with zero follows. Verify the "You're not following anyone yet" empty state.
- [ ] Verify the desktop left rail's new "Feed" entry navigates to `/feed`.
- [ ] Visit `/home`. Verify the existing activity timeline still renders (untouched by this PR).
- [ ] Verify the polling pauses when the tab is hidden (background cadence is 5min).

## Notes on what's NOT in this PR

- **Last night's 15 refactor commits on `feat/positioning-redesign`** (the `code-quality-audit/` work) are parked on `backup/positioning-redesign-overnight` locally. They were superseded in part by upstream work and the rebase would have surfaced substantial conflicts. Let me know how you'd like to handle them.
- **Polling cadence + visibility tests** — fake-timer + React-effect + visibility-API mocking is brittle. Covered by manual smoke.
- **Migrating `ActivityFeed.following`** to the new feed — deferred. Separate surface.
- **Recent-interaction author ranking, endorsement-vs-other-badge-type distinction, per-kind skeletons, batched `resolve-did`** — deferred per plan-v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)