### PR TITLE
Wider left pane (335px) + consistent top inset + single-row navbar border

### DIFF
--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -53,7 +53,7 @@
 
 .explore__layout {
   display: grid;
-  grid-template-columns: 220px 1fr;
+  grid-template-columns: 335px 1fr;
   gap: 0;
   align-items: start;
 }
@@ -69,7 +69,7 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 220px;
+  left: 335px;
   width: 1px;
   background: var(--border-medium);
   pointer-events: none;
@@ -91,9 +91,10 @@
   /* Scrolls with the page (matches the top bar's no-sticky
      behavior). Flush-left to the viewport, with breathing room at
      the top + right so the active filter pill doesn't touch the
-     vertical divider. Bottom padding gives the rail air above the
-     footer's border. */
-  padding: 20px 12px 32px 12px;
+     vertical divider. Top padding shared with /home and /settings
+     so first-line-of-text sits at the same vertical position on
+     every page-frame route. */
+  padding: 32px 12px 32px 12px;
 }
 
 /* Filter list rows need their own right padding now that the

--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -44,7 +44,7 @@
 
 .home__layout {
   display: grid;
-  grid-template-columns: 220px 1fr;
+  grid-template-columns: 335px 1fr;
   gap: 0;
   align-items: start;
 }
@@ -57,7 +57,7 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 220px;
+  left: 335px;
   width: 1px;
   background: var(--border-medium);
   pointer-events: none;
@@ -81,8 +81,10 @@
   gap: 28px;
   /* Extra breathing room on the left so the sidebar doesn't hug the
      viewport edge — matches the inset the main pane reserves on the
-     right side of the page-frame divider. */
-  padding: 20px 16px 32px 28px;
+     right side of the page-frame divider. Top padding is shared
+     with /explore and /settings so the first line of text sits at
+     the same vertical position on every page-frame route. */
+  padding: 32px 16px 32px 28px;
   min-width: 0;
 }
 

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -1960,6 +1960,18 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   gap: 24px;
 }
 
+/* Single-row navbar (pages without a tabs row, e.g. /home) needs
+   its own bottom border — the two-row case carries the same border
+   on row-2. Without this rule, /home's navbar ends with only the
+   subtle ambient box-shadow on `.desktop-top-bar`, which reads as
+   "no border" against the page background and breaks the page-frame
+   continuity (top bar → sidebar divider → footer). `:last-child`
+   covers the case cleanly because row-chrome is always followed by
+   row-tabs when row-tabs is present. */
+.desktop-top-bar__row--chrome:last-child {
+  border-bottom: 1px solid var(--border-medium);
+}
+
 .desktop-top-bar__row--tabs {
   height: var(--top-bar-row2);
   gap: 20px;

--- a/src/app/styles/settings-page.css
+++ b/src/app/styles/settings-page.css
@@ -100,7 +100,7 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 220px;
+  left: 335px;
   width: 1px;
   background: var(--border-medium);
   pointer-events: none;
@@ -112,7 +112,7 @@
    ------------------------------------------------------------------------ */
 .sx__layout {
   display: grid;
-  grid-template-columns: 220px 1fr;
+  grid-template-columns: 335px 1fr;
   gap: 0;
   align-items: start;
 }
@@ -138,9 +138,10 @@
   /* Scrolls with the page (matches the top bar's no-sticky
      behaviour). Flush-left to the viewport, with breathing room at
      the top + right so the active filter pill doesn't touch the
-     vertical divider. Bottom padding gives the rail air above the
-     footer's border. */
-  padding: 20px 12px 32px 12px;
+     vertical divider. Top padding shared with /home and /explore
+     so first-line-of-text sits at the same vertical position on
+     every page-frame route. */
+  padding: 32px 12px 32px 12px;
 }
 
 .sx-menu {


### PR DESCRIPTION
## Summary

- Left pane on /home, /explore, /settings widens from **220px → 335px**. Vertical page-frame divider moves with it (\`left: 335px\`).
- Sidebar top padding **20px → 32px**, identical on all three pages. First line of text now sits at the same vertical position across the page-frame routes and gets a little more breathing room from the navbar's bottom border.
- Single-row navbar (the chrome row alone, e.g. /home) gains a \`border-bottom\` of the same weight the two-row case carries on row-tabs. Without this, /home's navbar ended on only the subtle ambient \`box-shadow\` and broke the page-frame continuity (navbar bottom → sidebar divider → footer top).

## Files

- \`src/app/styles/home.css\`
- \`src/app/styles/explore.css\`
- \`src/app/styles/settings-page.css\`
- \`src/app/styles/layout.css\` (single-row navbar border)

## Test plan

- [ ] /home (signed in): sidebar is 335px wide; first \"Groups\" / \"Projects\" heading lands with comfortable space below the navbar; navbar has a single-row bottom border that visually continues into the sidebar divider and footer top border.
- [ ] /explore (any tab): sidebar is 335px wide; \"Recently viewed\" sits at the same vertical position as /home's first heading; tabs row already carries the bottom border.
- [ ] /settings (signed in): sidebar is 335px wide; \"Appearance\" sits at the same vertical position as the other two.
- [ ] At <760px the layout still collapses to a single column (no regression in the responsive breakpoint).