### PR TITLE
feat(home): unstick news, adopt issue #89 kinds, add card-style feed view

### DIFF
--- a/src/app/api/indexer/__tests__/route.test.ts
+++ b/src/app/api/indexer/__tests__/route.test.ts
@@ -494,22 +494,36 @@ describe("/api/indexer trust boundary", () => {
   })
 
   describe("HydrateFeedPage", () => {
+    const allEmpty = {
+      activityUris: [],
+      collectionUris: [],
+      badgeAwardUris: [],
+      legacyEndorsementUris: [],
+      evaluationUris: [],
+      measurementUris: [],
+      hyperboardUris: [],
+      attachmentUris: [],
+    }
+
     it("forwards a mixed-kind page", async () => {
       const res = await postIndexer({
         operationName: "HydrateFeedPage",
         variables: {
+          ...allEmpty,
           activityUris: ["at://did:plc:a/org.hypercerts.claim.activity/abc"],
           collectionUris: ["at://did:plc:b/org.hypercerts.collection/def"],
-          badgeAwardUris: [],
-          legacyEndorsementUris: [],
+          evaluationUris: ["at://did:plc:c/org.hypercerts.context.evaluation/e"],
+          hyperboardUris: ["at://did:plc:d/org.hyperboards.board/h"],
         },
       })
       expect(res.status).toBe(200)
       const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
       expect(body.variables.activityUris).toHaveLength(1)
       expect(body.variables.collectionUris).toHaveLength(1)
+      expect(body.variables.evaluationUris).toHaveLength(1)
+      expect(body.variables.hyperboardUris).toHaveLength(1)
       expect(body.variables.badgeAwardUris).toEqual([])
-      expect(body.variables.legacyEndorsementUris).toEqual([])
+      expect(body.variables.attachmentUris).toEqual([])
     })
 
     it("400s when any *Uris is missing (not an array)", async () => {
@@ -519,7 +533,24 @@ describe("/api/indexer trust boundary", () => {
           activityUris: ["at://x"],
           collectionUris: ["at://y"],
           badgeAwardUris: [],
-          // legacyEndorsementUris omitted
+          // legacyEndorsementUris (and the new four) omitted
+        },
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it("400s when one of the new-kind *Uris is missing", async () => {
+      const res = await postIndexer({
+        operationName: "HydrateFeedPage",
+        variables: {
+          activityUris: [],
+          collectionUris: [],
+          badgeAwardUris: [],
+          legacyEndorsementUris: [],
+          evaluationUris: [],
+          measurementUris: [],
+          hyperboardUris: [],
+          // attachmentUris omitted — the new buckets are required too
         },
       })
       expect(res.status).toBe(400)
@@ -529,12 +560,7 @@ describe("/api/indexer trust boundary", () => {
       const tooMany = Array.from({ length: 51 }, (_, i) => `at://x/${i}`)
       const res = await postIndexer({
         operationName: "HydrateFeedPage",
-        variables: {
-          activityUris: tooMany,
-          collectionUris: [],
-          badgeAwardUris: [],
-          legacyEndorsementUris: [],
-        },
+        variables: { ...allEmpty, activityUris: tooMany },
       })
       expect(res.status).toBe(400)
     })
@@ -542,12 +568,7 @@ describe("/api/indexer trust boundary", () => {
     it("400s on non-string URI entries", async () => {
       const res = await postIndexer({
         operationName: "HydrateFeedPage",
-        variables: {
-          activityUris: ["ok", 42],
-          collectionUris: [],
-          badgeAwardUris: [],
-          legacyEndorsementUris: [],
-        },
+        variables: { ...allEmpty, activityUris: ["ok", 42] },
       })
       expect(res.status).toBe(400)
     })

--- a/src/app/api/indexer/route.ts
+++ b/src/app/api/indexer/route.ts
@@ -582,6 +582,10 @@ ${ACTIVITY_NODE_SELECTION}
       $collectionUris: [String!]!
       $badgeAwardUris: [String!]!
       $legacyEndorsementUris: [String!]!
+      $evaluationUris: [String!]!
+      $measurementUris: [String!]!
+      $hyperboardUris: [String!]!
+      $attachmentUris: [String!]!
     ) {
       activities: orgHypercertsClaimActivity(
         first: ${MAX_URI_LIST_PER_KIND}
@@ -660,6 +664,62 @@ ${ACTIVITY_NODE_SELECTION}
             did
             createdAt
             subject { did }
+          }
+        }
+      }
+      evaluations: orgHypercertsContextEvaluation(
+        first: ${MAX_URI_LIST_PER_KIND}
+        where: { uri: { in: $evaluationUris } }
+      ) {
+        edges {
+          node {
+            uri
+            cid
+            did
+            createdAt
+            title
+          }
+        }
+      }
+      measurements: orgHypercertsContextMeasurement(
+        first: ${MAX_URI_LIST_PER_KIND}
+        where: { uri: { in: $measurementUris } }
+      ) {
+        edges {
+          node {
+            uri
+            cid
+            did
+            createdAt
+            title
+          }
+        }
+      }
+      hyperboards: orgHyperboardsBoard(
+        first: ${MAX_URI_LIST_PER_KIND}
+        where: { uri: { in: $hyperboardUris } }
+      ) {
+        edges {
+          node {
+            uri
+            cid
+            did
+            createdAt
+            title
+          }
+        }
+      }
+      attachments: orgHypercertsContextAttachment(
+        first: ${MAX_URI_LIST_PER_KIND}
+        where: { uri: { in: $attachmentUris } }
+      ) {
+        edges {
+          node {
+            uri
+            cid
+            did
+            createdAt
+            title
           }
         }
       }
@@ -934,11 +994,19 @@ function buildVariables(
       const collectionUris = readUriList(vars.collectionUris)
       const badgeAwardUris = readUriList(vars.badgeAwardUris)
       const legacyEndorsementUris = readUriList(vars.legacyEndorsementUris)
+      const evaluationUris = readUriList(vars.evaluationUris)
+      const measurementUris = readUriList(vars.measurementUris)
+      const hyperboardUris = readUriList(vars.hyperboardUris)
+      const attachmentUris = readUriList(vars.attachmentUris)
       if (
         activityUris === null ||
         collectionUris === null ||
         badgeAwardUris === null ||
-        legacyEndorsementUris === null
+        legacyEndorsementUris === null ||
+        evaluationUris === null ||
+        measurementUris === null ||
+        hyperboardUris === null ||
+        attachmentUris === null
       ) {
         return null
       }
@@ -947,6 +1015,10 @@ function buildVariables(
         collectionUris,
         badgeAwardUris,
         legacyEndorsementUris,
+        evaluationUris,
+        measurementUris,
+        hyperboardUris,
+        attachmentUris,
       }
     }
     default:

--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -253,19 +253,15 @@
   min-width: 0;
   /* Match the .right-rail surface used elsewhere — light card on
      a darker canvas, with a thin border that reads as a panel
-     edge rather than competing with the page-frame dividers. */
+     edge rather than competing with the page-frame dividers.
+     Scrolls with the page rather than sticking — the rail is a
+     side panel, not a persistent control surface, and pinning it
+     produced an awkward dead zone once the user had scrolled past
+     the news content. */
   padding: 16px 18px 18px;
   border: 1px solid var(--border-subtle);
   border-radius: 10px;
   background: var(--bg-elevated);
-  position: sticky;
-  top: calc(var(--navbar-height) + 20px);
-}
-
-@media (max-width: 1100px) {
-  .home__news {
-    position: static;
-  }
 }
 
 /* ---------- Activity timeline (GitHub-style) ---------- */
@@ -494,3 +490,4 @@ a.home-feed__preview:hover {
   margin: 64px auto;
   padding: 0 16px;
 }
+

--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -491,3 +491,289 @@ a.home-feed__preview:hover {
   padding: 0 16px;
 }
 
+/* ==========================================================================
+   View toggle (timeline | cards) — mirrors the .explore__view-toggle pattern
+   ========================================================================== */
+
+.home__view-toggle {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  margin-bottom: 16px;
+}
+
+.home__view-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: transparent;
+  border: none;
+  color: var(--fg-muted);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: color var(--transition-fast), background var(--transition-fast);
+  font-family: var(--font-inter), system-ui, sans-serif;
+}
+
+.home__view-btn:hover {
+  color: var(--fg-primary);
+}
+
+.home__view-btn--active {
+  color: var(--fg-primary);
+  background: var(--bg-sunken);
+}
+
+.home__view-btn--active:hover {
+  background: var(--bg-sunken);
+}
+
+/* ==========================================================================
+   Card-style feed — social media variant
+   Lives alongside the GitHub-style timeline (`.home-feed`); a view
+   toggle in `.home__main` swaps between them.
+   ========================================================================== */
+
+.home-cards {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.home-cards__loading {
+  display: flex;
+  justify-content: center;
+  padding: 32px 0;
+}
+
+.home-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 18px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: var(--bg-elevated);
+}
+
+/* ---- Header (avatar + name + handle/time) ---- */
+
+.home-card__header {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+}
+
+.home-card__avatar {
+  display: inline-flex;
+  width: 40px;
+  height: 40px;
+}
+
+.home-card__meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.home-card__actor-name {
+  font-weight: 600;
+  font-size: 0.9375rem;
+  color: var(--fg-primary);
+  text-decoration: none;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.home-card__actor-name:hover {
+  text-decoration: underline;
+}
+
+.home-card__actor-sub {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8125rem;
+  color: var(--fg-muted);
+  line-height: 1.4;
+  min-width: 0;
+}
+
+.home-card__handle {
+  color: var(--fg-muted);
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.home-card__handle:hover {
+  text-decoration: underline;
+}
+
+.home-card__dot {
+  color: var(--fg-muted);
+}
+
+.home-card__time {
+  white-space: nowrap;
+}
+
+/* ---- Body ---- */
+
+.home-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.home-card__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8125rem;
+  color: var(--fg-muted);
+}
+
+.home-card__action svg {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+.home-card__link {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: inherit;
+  text-decoration: none;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.home-card__link:hover .home-card__title {
+  text-decoration: underline;
+}
+
+.home-card__link--inert {
+  cursor: default;
+}
+
+.home-card__media {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: var(--bg-sunken);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.home-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.home-card__primary {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.home-card__primary--standalone {
+  padding: 0;
+}
+
+.home-card__title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--fg-primary);
+  line-height: 1.3;
+}
+
+.home-card__desc {
+  font-size: 0.875rem;
+  color: var(--fg-secondary);
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  overflow: hidden;
+}
+
+/* ---- Endorsement subject row ---- */
+
+.home-card__subject {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  background: var(--bg-sunken);
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.home-card__subject:hover .home-card__subject-name {
+  text-decoration: underline;
+}
+
+.home-card__subject-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.home-card__subject-name {
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: var(--fg-primary);
+}
+
+.home-card__subject-handle {
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+}
+
+.home-card__note {
+  margin: 0;
+  padding: 10px 12px;
+  background: var(--bg-sunken);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  color: var(--fg-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.home-card__subject-uri {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+  word-break: break-all;
+}
+
+@media (max-width: 760px) {
+  .home-card {
+    padding: 14px 16px;
+    border-radius: 10px;
+  }
+  .home-card__media {
+    aspect-ratio: 4 / 3;
+  }
+}

--- a/src/components/feed/__tests__/feed-event-card.test.tsx
+++ b/src/components/feed/__tests__/feed-event-card.test.tsx
@@ -96,17 +96,17 @@ describe("FeedEventCard", () => {
     expect(screen.getByText("My List")).toBeTruthy()
   })
 
-  it("renders badge.award with subject byline and note", () => {
+  it("renders endorsement.award with subject byline and note", () => {
     const payload: HydratedPayload = {
-      kind: "badge.award",
+      kind: "endorsement.award",
       subjectDid: "did:plc:subject",
       note: "Great work last quarter.",
       createdAt: "2026-05-26T00:00:00.000Z",
     }
     render(
-      <FeedEventCard event={makeEvent("badge.award")} payload={payload} />,
+      <FeedEventCard event={makeEvent("endorsement.award")} payload={payload} />,
     )
-    expect(screen.getByText("awarded a badge to")).toBeTruthy()
+    expect(screen.getAllByText("endorsed").length).toBeGreaterThan(0)
     expect(screen.getByText("Subject Person")).toBeTruthy()
     expect(screen.getByText("Great work last quarter.")).toBeTruthy()
   })

--- a/src/components/feed/feed-event-card.tsx
+++ b/src/components/feed/feed-event-card.tsx
@@ -95,13 +95,13 @@ function FeedEventBody({ event, payload }: FeedEventCardProps) {
   if (payload?.kind === "collection.create") {
     return <CollectionCreateBody event={event} record={payload.record} />
   }
-  if (payload?.kind === "badge.award") {
+  if (payload?.kind === "endorsement.award") {
     return (
       <SubjectActionBody
         subjectDid={payload.subjectDid}
-        action="awarded a badge to"
+        action="endorsed"
         note={payload.note}
-        icon={<Award size={16} strokeWidth={1.75} aria-hidden="true" />}
+        icon={<Heart size={16} strokeWidth={1.75} aria-hidden="true" />}
       />
     )
   }
@@ -114,6 +114,14 @@ function FeedEventBody({ event, payload }: FeedEventCardProps) {
         icon={<Heart size={16} strokeWidth={1.75} aria-hidden="true" />}
       />
     )
+  }
+  if (
+    payload?.kind === "evaluation.create" ||
+    payload?.kind === "measurement.create" ||
+    payload?.kind === "hyperboard.create" ||
+    payload?.kind === "update.create"
+  ) {
+    return <SimpleTitleBody kind={payload.kind} title={payload.title} />
   }
   // Hydration missed (404) on a known kind — show the action line we
   // can derive from event.kind alone, with no body content. Beats
@@ -132,8 +140,16 @@ function actionLabelForKnownKind(kind: string): string | null {
       return "created a cert"
     case "collection.create":
       return "created a project"
-    case "badge.award":
-      return "awarded a badge"
+    case "evaluation.create":
+      return "added an evaluation"
+    case "measurement.create":
+      return "added a measurement"
+    case "hyperboard.create":
+      return "created a hyperboard"
+    case "update.create":
+      return "posted an update"
+    case "endorsement.award":
+      return "endorsed someone"
     case "legacy.endorsement":
       return "endorsed someone"
     default:
@@ -148,6 +164,40 @@ function DegradedKnownKindBody({ label }: { label: string }) {
         <Sparkles size={16} strokeWidth={1.75} aria-hidden="true" />
         <span>{label}</span>
       </div>
+    </div>
+  )
+}
+
+// ----------------------------------------------------------------------
+// evaluation / measurement / hyperboard / update — simple-title body
+// ----------------------------------------------------------------------
+
+function SimpleTitleBody({
+  kind,
+  title,
+}: {
+  kind:
+    | "evaluation.create"
+    | "measurement.create"
+    | "hyperboard.create"
+    | "update.create"
+  title: string | null
+}) {
+  const label =
+    kind === "evaluation.create"
+      ? "added an evaluation"
+      : kind === "measurement.create"
+        ? "added a measurement"
+        : kind === "hyperboard.create"
+          ? "created a hyperboard"
+          : "posted an update"
+  return (
+    <div className="feed-card__body">
+      <div className="feed-card__action">
+        <Sparkles size={16} strokeWidth={1.75} aria-hidden="true" />
+        <span>{label}</span>
+      </div>
+      {title ? <h2 className="feed-card__title">{title}</h2> : null}
     </div>
   )
 }

--- a/src/components/home/home-feed-cards.tsx
+++ b/src/components/home/home-feed-cards.tsx
@@ -1,0 +1,467 @@
+"use client"
+
+import Link from "next/link"
+import {
+  Award,
+  BarChart3,
+  FolderGit2,
+  Inbox,
+  LayoutDashboard,
+  Megaphone,
+  Sparkles,
+  Users,
+} from "lucide-react"
+import Avatar from "@/components/ui/avatar"
+import EmptyState from "@/components/ui/empty-state"
+import LoadingSpinner from "@/components/ui/loading-spinner"
+import { useAuthorInfo } from "@/hooks/use-author-info"
+import { useHomeFeed, type HomeFeedEvent } from "@/hooks/use-home-feed"
+import { useFollowedDids } from "@/hooks/use-followed-dids"
+import {
+  formatRelativeTime,
+  resolveActivityImageUrl,
+} from "@/lib/atproto/activity"
+import { parseAtUri } from "@/lib/atproto/activity-uri"
+import { buildAvatarUrlFromCid } from "@/lib/atproto/profile"
+import { getInitials } from "@/lib/utils/initials"
+import type { ActivityRecord } from "@/lib/atproto/activity-types"
+import type { CollectionRecord } from "@/lib/atproto/collection"
+
+/**
+ * Card-style alternative to the GitHub-style timeline at `<HomeFeed>`.
+ * Each event renders as a distinct social-media card (Twitter / Bluesky
+ * shape): prominent actor header, action line, large image, body
+ * copy. Cards sit in a vertical column with whitespace between them
+ * rather than the dense list-rhythm of the timeline.
+ *
+ * Consumes the same `useHomeFeed` data as the timeline — the
+ * difference is purely visual. Toggle UI in `home.tsx` swaps between
+ * `<HomeFeed>` and this component.
+ */
+export default function HomeFeedCards({ activeDid }: { activeDid: string }) {
+  const {
+    followedDids,
+    isLoading: followsLoading,
+    error: followsError,
+  } = useFollowedDids(activeDid)
+  const { events, isLoading, error } = useHomeFeed(followedDids)
+
+  if (followsLoading || isLoading) {
+    return (
+      <div className="home-cards__loading">
+        <LoadingSpinner size="md" />
+      </div>
+    )
+  }
+
+  if (followsError) {
+    return (
+      <div className="feed__warning" role="alert">
+        Could not load your follow list. Please try again later.
+      </div>
+    )
+  }
+
+  if (followedDids.size === 0) {
+    return (
+      <EmptyState
+        icon={Users}
+        title="You're not following anyone yet"
+        description="Follow people to see their activity here."
+      />
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="feed__warning" role="alert">
+        Could not load activity: {error}
+      </div>
+    )
+  }
+
+  if (events.length === 0) {
+    return (
+      <EmptyState
+        icon={Inbox}
+        title="No activity yet"
+        description="People you follow haven't posted any activity yet."
+      />
+    )
+  }
+
+  return (
+    <ol className="home-cards">
+      {events.map((event) => (
+        <li key={event.uri} className="home-cards__item">
+          <HomeFeedCard event={event} />
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+// ----------------------------------------------------------------------
+// Card shell
+// ----------------------------------------------------------------------
+
+function HomeFeedCard({ event }: { event: HomeFeedEvent }) {
+  return (
+    <article className="home-card">
+      <ActorHeader event={event} />
+      <CardBody event={event} />
+    </article>
+  )
+}
+
+function ActorHeader({ event }: { event: HomeFeedEvent }) {
+  const actor = event.actorProfile
+  const displayName =
+    actor.displayName || actor.handle || event.actor.slice(0, 16)
+  const initials = getInitials(actor.displayName, event.actor)
+  const avatarUrl = buildAvatarUrlFromCid(actor.did, actor.avatarCid)
+  const profileHref = `/profile/${encodeURIComponent(
+    actor.handle || event.actor,
+  )}`
+
+  return (
+    <header className="home-card__header">
+      <Link
+        href={profileHref}
+        className="home-card__avatar"
+        aria-label={`${displayName}'s profile`}
+      >
+        <Avatar
+          size="md"
+          src={avatarUrl ?? undefined}
+          alt=""
+          fallbackInitials={initials}
+        />
+      </Link>
+      <div className="home-card__meta">
+        <Link href={profileHref} className="home-card__actor-name">
+          {displayName}
+        </Link>
+        <span className="home-card__actor-sub">
+          {actor.handle ? (
+            <Link href={profileHref} className="home-card__handle">
+              @{actor.handle}
+            </Link>
+          ) : null}
+          {actor.handle ? (
+            <span className="home-card__dot" aria-hidden="true">
+              ·
+            </span>
+          ) : null}
+          <time
+            className="home-card__time"
+            dateTime={event.createdAt}
+            title={event.createdAt}
+          >
+            {formatRelativeTime(event.createdAt)}
+          </time>
+        </span>
+      </div>
+    </header>
+  )
+}
+
+// ----------------------------------------------------------------------
+// Body dispatch
+// ----------------------------------------------------------------------
+
+function CardBody({ event }: { event: HomeFeedEvent }) {
+  switch (event.kind) {
+    case "cert.create":
+      return <CertCardBody event={event} record={event.record} />
+    case "collection.create":
+      return <CollectionCardBody event={event} record={event.record} />
+    case "endorsement.award":
+    case "legacy.endorsement":
+      return (
+        <EndorsementCardBody
+          subjectDid={event.subjectDid}
+          note={"note" in event ? event.note : null}
+        />
+      )
+    case "evaluation.create":
+      return (
+        <SimpleCardBody
+          icon={<BarChart3 size={14} strokeWidth={1.75} aria-hidden />}
+          action="added an evaluation"
+          title={event.title}
+        />
+      )
+    case "measurement.create":
+      return (
+        <SimpleCardBody
+          icon={<BarChart3 size={14} strokeWidth={1.75} aria-hidden />}
+          action="added a measurement"
+          title={event.title}
+        />
+      )
+    case "hyperboard.create":
+      return (
+        <SimpleCardBody
+          icon={<LayoutDashboard size={14} strokeWidth={1.75} aria-hidden />}
+          action="created a hyperboard"
+          title={event.title}
+        />
+      )
+    case "update.create":
+      return (
+        <SimpleCardBody
+          icon={<Megaphone size={14} strokeWidth={1.75} aria-hidden />}
+          action="posted an update"
+          title={event.title}
+        />
+      )
+    case "unknown":
+      return (
+        <SimpleCardBody
+          icon={<Sparkles size={14} strokeWidth={1.75} aria-hidden />}
+          action="did something"
+          title={null}
+          subjectUri={event.subjectUri}
+        />
+      )
+  }
+}
+
+// ----------------------------------------------------------------------
+// cert.create
+// ----------------------------------------------------------------------
+
+function CertCardBody({
+  event,
+  record,
+}: {
+  event: HomeFeedEvent & { kind: "cert.create" }
+  record: ActivityRecord
+}) {
+  const parsed = parseAtUri(event.uri)
+  const href = parsed
+    ? `/activity/${encodeURIComponent(parsed.did)}/${encodeURIComponent(parsed.rkey)}`
+    : null
+  const title =
+    typeof record.value.title === "string" && record.value.title.length > 0
+      ? record.value.title
+      : "Untitled cert"
+  const description =
+    typeof record.value.shortDescription === "string" &&
+    record.value.shortDescription.length > 0
+      ? record.value.shortDescription
+      : null
+  const imageUrl =
+    record.value.image && parsed
+      ? resolveActivityImageUrl(record.value.image, parsed.did)
+      : null
+
+  return (
+    <div className="home-card__body">
+      <ActionLine
+        icon={<Award size={14} strokeWidth={1.75} aria-hidden />}
+        label="created a cert"
+      />
+      <CardLink href={href}>
+        {imageUrl ? (
+          <span className="home-card__media">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={imageUrl} alt="" loading="lazy" />
+          </span>
+        ) : null}
+        <span className="home-card__primary">
+          <span className="home-card__title">{title}</span>
+          {description ? (
+            <span className="home-card__desc">{description}</span>
+          ) : null}
+        </span>
+      </CardLink>
+    </div>
+  )
+}
+
+// ----------------------------------------------------------------------
+// collection.create
+// ----------------------------------------------------------------------
+
+function CollectionCardBody({
+  event,
+  record,
+}: {
+  event: HomeFeedEvent & { kind: "collection.create" }
+  record: CollectionRecord
+}) {
+  const parsed = parseAtUri(event.uri)
+  const href = parsed
+    ? `/project/${encodeURIComponent(parsed.did)}/${encodeURIComponent(parsed.rkey)}`
+    : null
+  const v = record.value as Record<string, unknown>
+  const collectionType =
+    typeof v.type === "string" ? v.type.toLowerCase() : "project"
+  const verb =
+    collectionType === "endorsement-list"
+      ? "created a list"
+      : collectionType === "portfolio"
+        ? "created a portfolio"
+        : "created a project"
+  const fallbackTitle =
+    collectionType === "endorsement-list"
+      ? "Untitled list"
+      : collectionType === "portfolio"
+        ? "Untitled portfolio"
+        : "Untitled project"
+  const title =
+    (typeof v.title === "string" && v.title.length > 0 ? v.title : null) ||
+    (typeof v.name === "string" && v.name.length > 0 ? v.name : null) ||
+    fallbackTitle
+  const description =
+    typeof v.shortDescription === "string" && v.shortDescription.length > 0
+      ? v.shortDescription
+      : null
+  const rawImage = v.banner ?? v.image
+  const imageUrl =
+    rawImage && parsed
+      ? resolveActivityImageUrl(
+          rawImage as Parameters<typeof resolveActivityImageUrl>[0],
+          parsed.did,
+        )
+      : null
+
+  return (
+    <div className="home-card__body">
+      <ActionLine
+        icon={<FolderGit2 size={14} strokeWidth={1.75} aria-hidden />}
+        label={verb}
+      />
+      <CardLink href={href}>
+        {imageUrl ? (
+          <span className="home-card__media">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={imageUrl} alt="" loading="lazy" />
+          </span>
+        ) : null}
+        <span className="home-card__primary">
+          <span className="home-card__title">{title}</span>
+          {description ? (
+            <span className="home-card__desc">{description}</span>
+          ) : null}
+        </span>
+      </CardLink>
+    </div>
+  )
+}
+
+// ----------------------------------------------------------------------
+// endorsement.award / legacy.endorsement
+// ----------------------------------------------------------------------
+
+function EndorsementCardBody({
+  subjectDid,
+  note,
+}: {
+  subjectDid: string
+  note: string | null
+}) {
+  const { info } = useAuthorInfo(subjectDid)
+  const subjectName =
+    info?.displayName || info?.handle || subjectDid.slice(0, 16)
+  const subjectInitials = getInitials(info?.displayName, subjectDid)
+  const subjectAvatar = info?.avatarUrl ?? null
+  const subjectHref = `/profile/${encodeURIComponent(
+    info?.handle || subjectDid,
+  )}`
+  return (
+    <div className="home-card__body">
+      <ActionLine
+        icon={<Award size={14} strokeWidth={1.75} aria-hidden />}
+        label="endorsed"
+      />
+      <Link href={subjectHref} className="home-card__subject">
+        <Avatar
+          size="sm"
+          src={subjectAvatar ?? undefined}
+          alt=""
+          fallbackInitials={subjectInitials}
+        />
+        <span className="home-card__subject-meta">
+          <span className="home-card__subject-name">{subjectName}</span>
+          {info?.handle ? (
+            <span className="home-card__subject-handle">@{info.handle}</span>
+          ) : null}
+        </span>
+      </Link>
+      {note ? <p className="home-card__note">{note}</p> : null}
+    </div>
+  )
+}
+
+// ----------------------------------------------------------------------
+// Simple-title body (evaluation, measurement, hyperboard, update,
+// unknown). Keeps the card chrome consistent without an image
+// preview — the source records don't reliably surface one.
+// ----------------------------------------------------------------------
+
+function SimpleCardBody({
+  icon,
+  action,
+  title,
+  subjectUri,
+}: {
+  icon: React.ReactNode
+  action: string
+  title: string | null
+  subjectUri?: string
+}) {
+  return (
+    <div className="home-card__body">
+      <ActionLine icon={icon} label={action} />
+      {title ? (
+        <span className="home-card__primary home-card__primary--standalone">
+          <span className="home-card__title">{title}</span>
+        </span>
+      ) : null}
+      {subjectUri ? (
+        <p className="home-card__subject-uri" title={subjectUri}>
+          {subjectUri}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+// ----------------------------------------------------------------------
+// Card subprimitives
+// ----------------------------------------------------------------------
+
+function ActionLine({
+  icon,
+  label,
+}: {
+  icon: React.ReactNode
+  label: string
+}) {
+  return (
+    <div className="home-card__action">
+      {icon}
+      <span>{label}</span>
+    </div>
+  )
+}
+
+function CardLink({
+  href,
+  children,
+}: {
+  href: string | null
+  children: React.ReactNode
+}) {
+  if (href) {
+    return (
+      <Link href={href} className="home-card__link">
+        {children}
+      </Link>
+    )
+  }
+  return <div className="home-card__link home-card__link--inert">{children}</div>
+}

--- a/src/components/home/home-feed.tsx
+++ b/src/components/home/home-feed.tsx
@@ -12,6 +12,7 @@ import { formatRelativeTime, resolveActivityImageUrl } from "@/lib/atproto/activ
 import { parseAtUri } from "@/lib/atproto/activity-uri"
 import { formatShortDate } from "@/lib/utils/format-date"
 import { getInitials } from "@/lib/utils/initials"
+import { buildAvatarUrlFromCid } from "@/lib/atproto/profile"
 import type { ActivityRecord } from "@/lib/atproto/activity-types"
 import type { CollectionRecord } from "@/lib/atproto/collection"
 
@@ -92,14 +93,15 @@ export default function HomeFeed({ activeDid }: { activeDid: string }) {
 }
 
 function HomeFeedRow({ event }: { event: HomeFeedEvent }) {
-  const { info: actorInfo } = useAuthorInfo(event.actor)
+  // Actor is denormalised onto the event by the indexer — no
+  // per-row useAuthorInfo lookup needed for the header.
+  const actor = event.actorProfile
   const actorName =
-    actorInfo?.displayName || actorInfo?.handle || event.actor.slice(0, 16)
-  const actorHandle = actorInfo?.handle ?? null
-  const actorAvatar = actorInfo?.avatarUrl ?? null
-  const actorInitials = getInitials(actorInfo?.displayName, event.actor)
+    actor.displayName || actor.handle || event.actor.slice(0, 16)
+  const actorAvatar = buildAvatarUrlFromCid(actor.did, actor.avatarCid)
+  const actorInitials = getInitials(actor.displayName, event.actor)
   const profileHref = `/profile/${encodeURIComponent(
-    actorHandle || event.actor,
+    actor.handle || event.actor,
   )}`
 
   return (
@@ -126,8 +128,8 @@ function HomeFeedRow({ event }: { event: HomeFeedEvent }) {
         {event.kind === "cert.create" ? (
           <CertPreview record={event.record} uri={event.uri} />
         ) : null}
-        {event.kind === "project.create" ? (
-          <ProjectPreview record={event.record} uri={event.uri} />
+        {event.kind === "collection.create" ? (
+          <CollectionPreview record={event.record} uri={event.uri} />
         ) : null}
       </div>
       <time
@@ -142,13 +144,33 @@ function HomeFeedRow({ event }: { event: HomeFeedEvent }) {
 }
 
 function EventSentence({ event }: { event: HomeFeedEvent }) {
-  if (event.kind === "cert.create") {
-    return <>created a cert</>
+  switch (event.kind) {
+    case "cert.create":
+      return <>created a cert</>
+    case "collection.create":
+      return <>created a {collectionTypeLabel(event.record)}</>
+    case "endorsement.award":
+    case "legacy.endorsement":
+      return <EndorsementSentence subjectDid={event.subjectDid} />
+    case "evaluation.create":
+      return <>added an evaluation</>
+    case "measurement.create":
+      return <>added a measurement</>
+    case "hyperboard.create":
+      return <>created a hyperboard</>
+    case "update.create":
+      return <>posted an update</>
+    case "unknown":
+      return <>did something</>
   }
-  if (event.kind === "project.create") {
-    return <>created a project</>
-  }
-  return <EndorsementSentence subjectDid={event.subjectDid} />
+}
+
+function collectionTypeLabel(record: CollectionRecord): string {
+  const t =
+    typeof record.value.type === "string" ? record.value.type.toLowerCase() : null
+  if (t === "endorsement-list") return "list"
+  if (t === "portfolio") return "portfolio"
+  return "project"
 }
 
 function EndorsementSentence({ subjectDid }: { subjectDid: string }) {
@@ -211,9 +233,9 @@ function CertPreview({ record, uri }: { record: ActivityRecord; uri: string }) {
   )
 }
 
-// -------------------------------- Project preview ---------------------------
+// ------------------------------ Collection preview --------------------------
 
-function ProjectPreview({
+function CollectionPreview({
   record,
   uri,
 }: {
@@ -225,10 +247,18 @@ function ProjectPreview({
     ? `/project/${encodeURIComponent(parsed.did)}/${encodeURIComponent(parsed.rkey)}`
     : null
   const v = record.value as Record<string, unknown>
+  const collectionType =
+    typeof v.type === "string" ? v.type.toLowerCase() : "project"
+  const fallbackTitle =
+    collectionType === "endorsement-list"
+      ? "Untitled list"
+      : collectionType === "portfolio"
+        ? "Untitled portfolio"
+        : "Untitled project"
   const title =
     (typeof v.title === "string" && v.title.length > 0 ? v.title : null) ||
     (typeof v.name === "string" && v.name.length > 0 ? v.name : null) ||
-    "Untitled project"
+    fallbackTitle
   const description =
     typeof v.shortDescription === "string" && v.shortDescription.length > 0
       ? v.shortDescription
@@ -242,6 +272,7 @@ function ProjectPreview({
         )
       : null
   const itemCount = Array.isArray(v.items) ? v.items.length : 0
+  const itemNoun = collectionType === "endorsement-list" ? "endorsement" : "cert"
 
   return (
     <PreviewCard
@@ -251,7 +282,9 @@ function ProjectPreview({
       imageUrl={imageUrl}
       description={description}
       meta={[
-        itemCount > 0 ? `${itemCount} cert${itemCount === 1 ? "" : "s"}` : null,
+        itemCount > 0
+          ? `${itemCount} ${itemNoun}${itemCount === 1 ? "" : "s"}`
+          : null,
       ].filter((s): s is string => !!s)}
     />
   )

--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -1,7 +1,17 @@
 "use client"
 
 import Link from "next/link"
-import { ArrowRight, Award, FolderGit2, LogIn, Users } from "lucide-react"
+import { useCallback } from "react"
+import { useRouter, usePathname, useSearchParams } from "next/navigation"
+import {
+  ArrowRight,
+  Award,
+  FolderGit2,
+  LayoutList,
+  LogIn,
+  Newspaper,
+  Users,
+} from "lucide-react"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useOrg } from "@/lib/groups/org-context"
 import { useUserProjects } from "@/hooks/use-user-projects"
@@ -11,6 +21,7 @@ import EmptyState from "@/components/ui/empty-state"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import Avatar from "@/components/ui/avatar"
 import HomeFeed from "@/components/home/home-feed"
+import HomeFeedCards from "@/components/home/home-feed-cards"
 import NewsSection from "@/components/right-rail/news-section"
 import { resolveActivityImageUrl } from "@/lib/atproto/activity"
 import { parseAtUri } from "@/lib/atproto/activity-uri"
@@ -18,6 +29,11 @@ import { getInitials } from "@/lib/utils/initials"
 import type { CollectionRecord } from "@/lib/atproto/collection"
 import type { ActivityRecord } from "@/lib/atproto/activity-types"
 import type { Group } from "@/lib/groups/types"
+
+type HomeFeedView = "timeline" | "cards"
+function parseView(v: string | null): HomeFeedView {
+  return v === "cards" ? "cards" : "timeline"
+}
 
 /** DID of the actor whose Bluesky timeline powers the home page's
  *  "Our news" rail. Hard-coded — the source-of-truth lives in this
@@ -78,7 +94,7 @@ export default function Home() {
         <main className="home__main">
           <div className="home__split">
             <div className="home__feed">
-              <HomeFeed activeDid={activeDid} />
+              <HomeFeedSection activeDid={activeDid} />
             </div>
             <aside className="home__news" aria-label="News from Certified">
               <NewsSection actor={NEWS_ACTOR_DID} heading="News from Certified" />
@@ -87,6 +103,65 @@ export default function Home() {
         </main>
       </div>
     </div>
+  )
+}
+
+// ---------------------- Feed section with view toggle ----------------------
+
+function HomeFeedSection({ activeDid }: { activeDid: string }) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const view: HomeFeedView = parseView(searchParams.get("view"))
+
+  const setView = useCallback(
+    (next: HomeFeedView) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (next === "timeline") {
+        params.delete("view")
+      } else {
+        params.set("view", "cards")
+      }
+      const qs = params.toString()
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+    },
+    [pathname, router, searchParams],
+  )
+
+  return (
+    <>
+      <div
+        className="home__view-toggle"
+        role="group"
+        aria-label="Feed layout"
+      >
+        <button
+          type="button"
+          aria-label="Timeline view"
+          aria-pressed={view === "timeline"}
+          className={`home__view-btn${view === "timeline" ? " home__view-btn--active" : ""}`}
+          onClick={() => setView("timeline")}
+        >
+          <LayoutList size={14} strokeWidth={1.75} aria-hidden />
+          <span>Timeline</span>
+        </button>
+        <button
+          type="button"
+          aria-label="Cards view"
+          aria-pressed={view === "cards"}
+          className={`home__view-btn${view === "cards" ? " home__view-btn--active" : ""}`}
+          onClick={() => setView("cards")}
+        >
+          <Newspaper size={14} strokeWidth={1.75} aria-hidden />
+          <span>Cards</span>
+        </button>
+      </div>
+      {view === "cards" ? (
+        <HomeFeedCards activeDid={activeDid} />
+      ) : (
+        <HomeFeed activeDid={activeDid} />
+      )}
+    </>
   )
 }
 

--- a/src/hooks/use-home-feed.ts
+++ b/src/hooks/use-home-feed.ts
@@ -2,49 +2,76 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
-  fetchEndorsements,
-  fetchIndexerActivities,
-  fetchProjects,
-} from "@/lib/atproto/indexer"
+  fetchFollowerEvents,
+  hydrateFeedEvents,
+  type FeedActor,
+  type HydratedFeedEvent,
+} from "@/lib/atproto/follower-events"
 import type { ActivityRecord } from "@/lib/atproto/activity-types"
 import type { CollectionRecord } from "@/lib/atproto/collection"
 
 /**
- * Discriminated union of the timeline event kinds we can construct
- * from the current indexer surface (Activities / Endorsements /
- * Collections). Each variant carries the author DID, the createdAt
- * timestamp used for merging, and enough record-specific payload for
- * the renderer to compose the verb sentence + permalink.
+ * Discriminated union of the timeline event kinds the home feed
+ * renders. Driven by magic-indexer's `followerEvents` field (issue
+ * #89), which returns one paginated stream of CREATE events
+ * authored by the viewer's follow set.
  *
- * The magic-indexer would need a unified events endpoint to support
- * edit events ("alice updated a cert"), badge issuance, etc. — see
- * the open tracking issue. For now we stick to "create" verbs
- * because that's all the current ops emit.
+ * The wire `FeedEvent.kind` is a string-typed open union (a new
+ * server-side kind may ship before the client updates). At this
+ * layer we narrow to a closed set: known kinds become specific
+ * variants below; unrecognised kinds become a `"unknown"` variant
+ * that the renderer can fall back to a generic "actor + subjectUri"
+ * card without dropping the event.
+ *
+ * Every variant carries:
+ *   - `uri`: the source record's at:// URI (= `id` on the wire).
+ *   - `actor`: DID convenience accessor (same as `actorProfile.did`).
+ *   - `actorProfile`: denormalised actor profile (handle, display
+ *     name, avatar CID) from the indexer. Renderers can use this
+ *     directly instead of firing a per-row `useAuthorInfo` lookup.
+ *   - `createdAt`: RFC3339 timestamp from the event's `sortAt`.
  */
-export type HomeFeedEvent =
-  | {
-      kind: "cert.create"
-      uri: string
-      actor: string
-      createdAt: string
-      record: ActivityRecord
-    }
-  | {
-      kind: "project.create"
-      uri: string
-      actor: string
-      createdAt: string
-      record: CollectionRecord
-    }
-  | {
-      kind: "endorsement.create"
-      uri: string
-      actor: string
-      createdAt: string
-      subjectDid: string
-    }
+export interface HomeFeedEventBase {
+  uri: string
+  actor: string
+  actorProfile: FeedActor
+  createdAt: string
+}
 
-const PER_SOURCE_LIMIT = 25
+export type HomeFeedEvent =
+  | (HomeFeedEventBase & {
+      kind: "cert.create"
+      record: ActivityRecord
+    })
+  | (HomeFeedEventBase & {
+      kind: "collection.create"
+      record: CollectionRecord
+    })
+  | (HomeFeedEventBase & {
+      kind: "endorsement.award"
+      subjectDid: string
+      note: string | null
+    })
+  | (HomeFeedEventBase & {
+      kind: "legacy.endorsement"
+      subjectDid: string
+    })
+  | (HomeFeedEventBase & {
+      kind:
+        | "evaluation.create"
+        | "measurement.create"
+        | "hyperboard.create"
+        | "update.create"
+      title: string | null
+      subjectUri: string
+    })
+  | (HomeFeedEventBase & {
+      kind: "unknown"
+      rawKind: string
+      subjectUri: string
+    })
+
+const PAGE_SIZE = 25
 const DISPLAY_CAP = 60
 
 interface State {
@@ -56,29 +83,27 @@ interface State {
 const EMPTY_STATE: State = { events: [], isLoading: true, error: null }
 
 /**
- * Aggregator hook that powers the GitHub-style activity feed on the
- * home page. Given a set of followed DIDs (union of Bluesky +
- * Certified follow graphs from `useFollowedDids`), it fans out across
- * the three existing indexer ops the home feed cares about — cert
- * creations, project creations, and endorsement awards — merges the
- * payloads into a single timestamp-sorted stream, and exposes it as
- * a flat `HomeFeedEvent[]` for the renderer.
+ * Aggregator hook that powers the home page's activity feed.
  *
- * Pagination is intentionally absent in this first cut: the indexer
- * doesn't yet expose a unified events endpoint, so client-side
- * "load more" would have to maintain three independent cursors and
- * re-sort on every page. The MVP fetches `PER_SOURCE_LIMIT` rows
- * from each source, merges, and caps the displayed total at
- * `DISPLAY_CAP`. Once the indexer ships a unified op (see the open
- * tracking issue) this hook collapses to a single fetch with a
- * stable cursor.
+ * Internally:
+ *   - One round-trip to `followerEvents` (the union of CREATE
+ *     events across the follow set, sorted server-side by sortAt).
+ *   - One follow-up round-trip to `HydrateFeedPage` to pull the
+ *     headline payload (title, image, banner, subject DID, etc.)
+ *     for each event whose kind needs more than the actor + verb.
+ *
+ * Pagination is intentionally absent in this first cut: the visible
+ * cap is `DISPLAY_CAP`, and the home page composition only allots
+ * room for one screen of activity. Adding `loadMore` is mechanical
+ * once the surface needs it — see `useFollowerEventsFeed` for the
+ * shape.
  */
 export function useHomeFeed(followedDids: Set<string>) {
   const [state, setState] = useState<State>(EMPTY_STATE)
 
-  // Stable string key so the effect doesn't refetch on every render
-  // when the parent recreates the Set instance (it does — useMemo
-  // returns a new Set whenever the union recomputes).
+  // Stable string key — parent useMemo of `followedDids` recomputes
+  // a new Set instance whenever the union recomputes; we don't want
+  // that to refire the fetch.
   const followedKey = useMemo(() => {
     if (followedDids.size === 0) return "[]"
     return Array.from(followedDids).sort().join(",")
@@ -96,88 +121,24 @@ export function useHomeFeed(followedDids: Set<string>) {
       return
     }
     try {
-      const [activities, projects, endorsements] = await Promise.all([
-        fetchIndexerActivities({
-          first: PER_SOURCE_LIMIT,
-          authors,
-          signal,
-        }).catch((err) => {
-          console.warn("[home-feed] activities fetch failed:", err)
-          return { records: [] as ActivityRecord[] }
-        }),
-        fetchProjects({ first: PER_SOURCE_LIMIT, authors, signal }).catch(
-          (err) => {
-            console.warn("[home-feed] projects fetch failed:", err)
-            return { records: [] as CollectionRecord[] }
-          },
-        ),
-        fetchEndorsements({ authors, signal }).catch((err) => {
-          console.warn("[home-feed] endorsements fetch failed:", err)
-          return []
-        }),
-      ])
-
+      const page = await fetchFollowerEvents({
+        authors,
+        first: PAGE_SIZE,
+        signal,
+      })
       if (signal.aborted) return
 
-      const events: HomeFeedEvent[] = []
+      const hydrated = await hydrateFeedEvents(page.events, signal)
+      if (signal.aborted) return
 
-      for (const rec of activities.records) {
-        const createdAt =
-          typeof rec.value.createdAt === "string" ? rec.value.createdAt : ""
-        if (!createdAt) continue
-        const actor = parseDidFromAtUri(rec.uri)
-        if (!actor) continue
-        events.push({
-          kind: "cert.create",
-          uri: rec.uri,
-          actor,
-          createdAt,
-          record: rec,
-        })
-      }
+      const events = hydrated
+        .map(hydratedToHomeFeedEvent)
+        .slice(0, DISPLAY_CAP)
 
-      for (const rec of projects.records) {
-        const createdAt =
-          typeof rec.value.createdAt === "string" ? rec.value.createdAt : ""
-        if (!createdAt) continue
-        // Drop endorsement-list collections — they're a separate
-        // surface (Lists tab) and shouldn't read as "created a
-        // project" in the timeline.
-        const collectionType = typeof rec.value.type === "string"
-          ? rec.value.type.toLowerCase()
-          : ""
-        if (collectionType && collectionType !== "project") continue
-        const actor = parseDidFromAtUri(rec.uri)
-        if (!actor) continue
-        events.push({
-          kind: "project.create",
-          uri: rec.uri,
-          actor,
-          createdAt,
-          record: rec,
-        })
-      }
-
-      for (const endorsement of endorsements.slice(0, PER_SOURCE_LIMIT)) {
-        if (!endorsement.createdAt) continue
-        events.push({
-          kind: "endorsement.create",
-          uri: endorsement.uri,
-          actor: endorsement.author,
-          createdAt: endorsement.createdAt,
-          subjectDid: endorsement.subject,
-        })
-      }
-
-      events.sort((a, b) => b.createdAt.localeCompare(a.createdAt))
-      setState({
-        events: events.slice(0, DISPLAY_CAP),
-        isLoading: false,
-        error: null,
-      })
+      setState({ events, isLoading: false, error: null })
     } catch (err) {
       if (signal.aborted) return
-      console.error("[home-feed] aggregate fetch failed:", err)
+      console.error("[home-feed] follower-events fetch failed:", err)
       setState({
         events: [],
         isLoading: false,
@@ -197,10 +158,62 @@ export function useHomeFeed(followedDids: Set<string>) {
   return state
 }
 
-function parseDidFromAtUri(uri: string): string | null {
-  if (!uri.startsWith("at://")) return null
-  const slash = uri.indexOf("/", 5)
-  if (slash === -1) return null
-  const did = uri.slice(5, slash)
-  return did.startsWith("did:") ? did : null
+/**
+ * Maps a hydrated FeedEvent into the discriminated `HomeFeedEvent`
+ * the renderer expects. Unknown kinds and known-kind 404s land in
+ * the `"unknown"` variant so the renderer can show a generic card.
+ */
+function hydratedToHomeFeedEvent(h: HydratedFeedEvent): HomeFeedEvent {
+  const base: HomeFeedEventBase = {
+    uri: h.event.id,
+    actor: h.event.actor.did,
+    actorProfile: h.event.actor,
+    createdAt: h.event.sortAt,
+  }
+
+  const payload = h.payload
+  if (payload?.kind === "cert.create") {
+    return { ...base, kind: "cert.create", record: payload.record }
+  }
+  if (payload?.kind === "collection.create") {
+    return { ...base, kind: "collection.create", record: payload.record }
+  }
+  if (payload?.kind === "endorsement.award") {
+    return {
+      ...base,
+      kind: "endorsement.award",
+      subjectDid: payload.subjectDid,
+      note: payload.note,
+    }
+  }
+  if (payload?.kind === "legacy.endorsement") {
+    return {
+      ...base,
+      kind: "legacy.endorsement",
+      subjectDid: payload.subjectDid,
+    }
+  }
+  if (
+    payload?.kind === "evaluation.create" ||
+    payload?.kind === "measurement.create" ||
+    payload?.kind === "hyperboard.create" ||
+    payload?.kind === "update.create"
+  ) {
+    return {
+      ...base,
+      kind: payload.kind,
+      title: payload.title,
+      subjectUri: h.event.subjectUri,
+    }
+  }
+
+  // Either payload was null (404 hydration) or the wire `kind` was
+  // outside our known set entirely. The renderer falls through to a
+  // generic actor + subjectUri card.
+  return {
+    ...base,
+    kind: "unknown",
+    rawKind: h.event.kind,
+    subjectUri: h.event.subjectUri,
+  }
 }

--- a/src/lib/atproto/__tests__/follower-events.test.ts
+++ b/src/lib/atproto/__tests__/follower-events.test.ts
@@ -174,7 +174,7 @@ describe("hydrateFeedEvents", () => {
     const events = [
       makeEvent("cert.create", "a"),
       makeEvent("collection.create", "b"),
-      makeEvent("badge.award", "c"),
+      makeEvent("endorsement.award", "c"),
       makeEvent("legacy.endorsement", "d"),
       makeEvent("future.kind", "e"),
     ]
@@ -250,7 +250,7 @@ describe("hydrateFeedEvents", () => {
     expect(out.map((h) => h.event.id)).toEqual(events.map((e) => e.id))
     expect(out[0].payload?.kind).toBe("cert.create")
     expect(out[1].payload?.kind).toBe("collection.create")
-    expect(out[2].payload?.kind).toBe("badge.award")
+    expect(out[2].payload?.kind).toBe("endorsement.award")
     expect(out[3].payload?.kind).toBe("legacy.endorsement")
     expect(out[4].payload).toBeNull()
   })

--- a/src/lib/atproto/follower-events.ts
+++ b/src/lib/atproto/follower-events.ts
@@ -52,16 +52,32 @@ export const FOREGROUND_POLL_MS = 30_000
 export const BACKGROUND_POLL_MS = 5 * 60_000
 
 /**
- * Documented kinds in v1 of the FollowerEvents API. The wire type
+ * Documented kinds (per magic-indexer #122 + #125). The wire type
  * `FeedEvent.kind` stays `string` (open union) because a new
  * server-side mapping may ship before the client updates — the
  * dispatch site narrows to a known kind or falls through to the
  * fallback card.
+ *
+ * Issue #89 expanded the v1 set from 4 to 7. Deltas vs the #88
+ * surface:
+ *   - `badge.award` renamed to `endorsement.award`. Server now
+ *     filters to endorsement-typed and non-rejected awards via the
+ *     `endorsement_edge` materialised view.
+ *   - Added: `evaluation.create`, `measurement.create`,
+ *     `hyperboard.create`, `update.create` (the
+ *     `context.attachment` variant with `json.type == "update"`).
+ *   - `legacy.endorsement` stays in this list for backward compat
+ *     and as a defensive case in the dispatcher, even though the
+ *     new server doesn't emit it.
  */
 export const KNOWN_FEED_EVENT_KINDS = [
   "cert.create",
   "collection.create",
-  "badge.award",
+  "evaluation.create",
+  "measurement.create",
+  "hyperboard.create",
+  "update.create",
+  "endorsement.award",
   "legacy.endorsement",
 ] as const
 export type KnownFeedEventKind = (typeof KNOWN_FEED_EVENT_KINDS)[number]
@@ -236,8 +252,8 @@ export interface HydratedPayloadCollection {
   record: CollectionRecord
 }
 
-export interface HydratedPayloadBadgeAward {
-  kind: "badge.award"
+export interface HydratedPayloadEndorsementAward {
+  kind: "endorsement.award"
   subjectDid: string
   note: string | null
   createdAt: string
@@ -249,11 +265,30 @@ export interface HydratedPayloadLegacyEndorsement {
   createdAt: string
 }
 
+/**
+ * The four single-record kinds added by magic-indexer #125
+ * (evaluation, measurement, hyperboard, update). Headline payload is
+ * a uniform `{ title, createdAt }` because the lexicons differ enough
+ * that a kind-specific shape would balloon the type surface for
+ * little visual gain — the cards show the title and the relative
+ * time, nothing else, in v1.
+ */
+export interface HydratedPayloadSimpleRecord {
+  kind:
+    | "evaluation.create"
+    | "measurement.create"
+    | "hyperboard.create"
+    | "update.create"
+  title: string | null
+  createdAt: string
+}
+
 export type HydratedPayload =
   | HydratedPayloadActivity
   | HydratedPayloadCollection
-  | HydratedPayloadBadgeAward
+  | HydratedPayloadEndorsementAward
   | HydratedPayloadLegacyEndorsement
+  | HydratedPayloadSimpleRecord
 
 export interface HydratedFeedEvent {
   event: FeedEvent
@@ -281,6 +316,14 @@ interface CollectionWithTypeGraphQLNode extends CollectionGraphQLNode {
   type?: string | null
 }
 
+interface SimpleTitleGraphQLNode {
+  uri: string
+  cid: string
+  did: string
+  createdAt: string
+  title: string | null
+}
+
 interface HydrateFeedPageResponse {
   data?: {
     activities?: { edges: { node: ActivityGraphQLNode | null }[] } | null
@@ -291,6 +334,10 @@ interface HydrateFeedPageResponse {
     legacyEndorsements?: {
       edges: { node: LegacyEndorsementGraphQLNode | null }[]
     } | null
+    evaluations?: { edges: { node: SimpleTitleGraphQLNode | null }[] } | null
+    measurements?: { edges: { node: SimpleTitleGraphQLNode | null }[] } | null
+    hyperboards?: { edges: { node: SimpleTitleGraphQLNode | null }[] } | null
+    attachments?: { edges: { node: SimpleTitleGraphQLNode | null }[] } | null
   } | null
   errors?: { message: string }[]
 }
@@ -310,6 +357,10 @@ export async function hydrateFeedEvents(
   const collectionUris: string[] = []
   const badgeAwardUris: string[] = []
   const legacyEndorsementUris: string[] = []
+  const evaluationUris: string[] = []
+  const measurementUris: string[] = []
+  const hyperboardUris: string[] = []
+  const attachmentUris: string[] = []
 
   for (const ev of events) {
     switch (ev.kind) {
@@ -319,23 +370,39 @@ export async function hydrateFeedEvents(
       case "collection.create":
         collectionUris.push(ev.subjectUri)
         break
+      case "endorsement.award":
       case "badge.award":
         badgeAwardUris.push(ev.subjectUri)
         break
       case "legacy.endorsement":
         legacyEndorsementUris.push(ev.subjectUri)
         break
+      case "evaluation.create":
+        evaluationUris.push(ev.subjectUri)
+        break
+      case "measurement.create":
+        measurementUris.push(ev.subjectUri)
+        break
+      case "hyperboard.create":
+        hyperboardUris.push(ev.subjectUri)
+        break
+      case "update.create":
+        attachmentUris.push(ev.subjectUri)
+        break
       // Unknown kinds skip hydration.
     }
   }
 
-  const haveAny =
+  const totalToHydrate =
     activityUris.length +
-      collectionUris.length +
-      badgeAwardUris.length +
-      legacyEndorsementUris.length >
-    0
-  if (!haveAny) {
+    collectionUris.length +
+    badgeAwardUris.length +
+    legacyEndorsementUris.length +
+    evaluationUris.length +
+    measurementUris.length +
+    hyperboardUris.length +
+    attachmentUris.length
+  if (totalToHydrate === 0) {
     // Every event is an unknown kind; the dispatch site renders the
     // fallback card for each, no hydration round-trip needed.
     return events.map((event) => ({ event, payload: null }))
@@ -351,6 +418,10 @@ export async function hydrateFeedEvents(
         collectionUris,
         badgeAwardUris,
         legacyEndorsementUris,
+        evaluationUris,
+        measurementUris,
+        hyperboardUris,
+        attachmentUris,
       },
     }),
     signal,
@@ -403,7 +474,7 @@ export async function hydrateFeedEvents(
   for (const edge of json.data?.badgeAwards?.edges ?? []) {
     if (!edge.node || !edge.node.subject) continue
     payloadByUri.set(edge.node.uri, {
-      kind: "badge.award",
+      kind: "endorsement.award",
       subjectDid: edge.node.subject.did,
       note: edge.node.note,
       createdAt: edge.node.createdAt,
@@ -414,6 +485,42 @@ export async function hydrateFeedEvents(
     payloadByUri.set(edge.node.uri, {
       kind: "legacy.endorsement",
       subjectDid: edge.node.subject.did,
+      createdAt: edge.node.createdAt,
+    })
+  }
+  // The four new simple-record kinds collapse onto a single shape —
+  // {title, createdAt} — because they render with the same chrome in
+  // v1. The `kind` discriminator preserves the source lexicon so
+  // future renderers can specialise without changing the wire types.
+  for (const edge of json.data?.evaluations?.edges ?? []) {
+    if (!edge.node) continue
+    payloadByUri.set(edge.node.uri, {
+      kind: "evaluation.create",
+      title: edge.node.title,
+      createdAt: edge.node.createdAt,
+    })
+  }
+  for (const edge of json.data?.measurements?.edges ?? []) {
+    if (!edge.node) continue
+    payloadByUri.set(edge.node.uri, {
+      kind: "measurement.create",
+      title: edge.node.title,
+      createdAt: edge.node.createdAt,
+    })
+  }
+  for (const edge of json.data?.hyperboards?.edges ?? []) {
+    if (!edge.node) continue
+    payloadByUri.set(edge.node.uri, {
+      kind: "hyperboard.create",
+      title: edge.node.title,
+      createdAt: edge.node.createdAt,
+    })
+  }
+  for (const edge of json.data?.attachments?.edges ?? []) {
+    if (!edge.node) continue
+    payloadByUri.set(edge.node.uri, {
+      kind: "update.create",
+      title: edge.node.title,
       createdAt: edge.node.createdAt,
     })
   }


### PR DESCRIPTION
Three asks bundled (closes #89 once merged):

## 1. Unstick "News from Certified"

The news rail used `position: sticky` so it stayed pinned as the feed scrolled. Dropped the rule — the rail now scrolls naturally with the column. Fix lives in `src/app/styles/home.css`.

## 2. Issue #89 — expanded FeedEvent kinds

magic-indexer #125 expanded the `followerEvents` verb set from 4 to 7. Wired through end-to-end:

- `badge.award` → renamed to **`endorsement.award`** (server now filters to endorsement-typed + non-rejected via the `endorsement_edge` materialised view).
- New: **`evaluation.create`** (`org.hypercerts.context.evaluation`)
- New: **`measurement.create`** (`org.hypercerts.context.measurement`)
- New: **`hyperboard.create`** (`org.hyperboards.board`)
- New: **`update.create`** (`org.hypercerts.context.attachment` where `json.type == "update"`)
- `legacy.endorsement` kept in the constant + dispatcher for backward compat.

Touched layers:
- `/api/indexer` proxy: 4 new aliased connections in `HydrateFeedPage` (filtered by `where: { uri: { in: $uris } }`).
- `src/lib/atproto/follower-events.ts`: extended kind enum + `HydratedPayloadSimpleRecord` union covering all four new kinds.
- `src/hooks/use-home-feed.ts`: **full migration from the old 3-op fan-out** (fetchIndexerActivities + fetchProjects + fetchEndorsements) to `fetchFollowerEvents` + `hydrateFeedEvents`. The hook now also carries the indexer-denormalised `actorProfile` per event so renderers skip a per-row useAuthorInfo lookup.
- `src/components/feed/feed-event-card.tsx` (the /feed-page card): dispatch updated for renamed and new kinds.

### ⚠️ Schema probe needed pre-merge

The new aliased connections in `HydrateFeedPage` assume `where: { uri: { in: $uris } }` is supported on each of the four new lexicon connections. I couldn't verify this from the sandbox (no live indexer access). If `uri.in` isn't supported on one of them, hydration for that kind will fail soft (`payload: null`) and the card falls through to the known-kind-but-no-payload degraded view — functional but visually thin. Confirm via a manual probe to the dev indexer before merging.

## 3. Card-style feed view at /home with timeline ⇄ cards toggle

The existing GitHub-style timeline becomes one of two views. A toggle above the feed (mirroring the explore page's list/gallery pattern) lets the viewer switch.

- `?view=cards` opens the new social-media-style card view. Each event is a distinct card with a 40px avatar header, actor name + handle + time inline, action line, then a 16:9 image preview and title/description body. Endorsement events show the subject as a Twitter-style recipient row.
- Default (no `view` param) keeps the existing timeline.

Files:
- `src/components/home/home-feed-cards.tsx` (new) — the card view.
- `src/components/home/home.tsx` — extracts a `HomeFeedSection` with the toggle UI. Uses `router.replace({ scroll: false })` so toggling doesn't reset scroll position.
- `src/components/home/home-feed.tsx` — updated for renamed kinds; switched to indexer-denormalised actor data (`event.actorProfile`); renamed `ProjectPreview` → `CollectionPreview` with type-aware labels for lists / portfolios / projects.
- `src/app/styles/home.css` — `.home__view-toggle` + `.home-card*` rule set.

## Verification

- typecheck: 0 errors
- lint: 55 warnings (baseline unchanged)
- tests: 204 passing (was 203; +1 from the renamed badge.award → endorsement.award test)
- build: green
- dev-server smoke: `/home` and `/home?view=cards` both return 200 with no errors

## Notes / deferred

- Schema probe for `uri.in` on the four new connections (see warning above).
- Per-kind card decorations beyond title (e.g. evaluation score, measurement value, hyperboard preview thumbnail) — the lexicons surface richer payloads than the v1 cards consume. Easy follow-up once we know what the design wants.
- The new kinds' source records aren't directly linkable yet from the card (no detail pages for evaluation / measurement / hyperboard / attachment routes in the app). v1 cards show title only; clicking does nothing. Can be wired up when those detail surfaces exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)