### PR TITLE
chore(indexer): default UPSTREAM_INDEXER_URL to magic-indexer-prod

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -24,17 +24,16 @@ COOKIE_SECRET=dev-secret-change-in-production
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
-# Required in production: Magic Indexer GraphQL endpoint and DID.
+# Magic Indexer GraphQL endpoint and DID.
 #
 # INDEXER_URL is consumed by the server-side /api/indexer and /api/notifications
 # proxies. If unset, the code falls back to NEXT_PUBLIC_INDEXER_URL, and then to
-# a hardcoded dev URL (magic-indexer-dev.up.railway.app). A production deploy
-# with INDEXER_URL unset will silently route every feed/notifications query at
-# the dev indexer — set this explicitly in prod.
+# a hardcoded fallback (magic-indexer-prod.up.railway.app). For local dev
+# against the dev indexer, set this to magic-indexer-dev.up.railway.app.
 #
 # INDEXER_DID is required for the notifications JWT `aud` claim. Without it,
 # /api/notifications returns 503 and logs a module-load warning.
-INDEXER_URL=https://magic-indexer-dev.up.railway.app/graphql
+INDEXER_URL=https://magic-indexer-prod.up.railway.app/graphql
 INDEXER_DID=
 
 # Deprecated alias for INDEXER_URL; still read for backwards-compat. Prefer

--- a/src/app/api/indexer/route.ts
+++ b/src/app/api/indexer/route.ts
@@ -31,19 +31,22 @@ import { logSafe } from "@/lib/utils/log-safe"
 const UPSTREAM_INDEXER_URL =
   process.env.INDEXER_URL ||
   process.env.NEXT_PUBLIC_INDEXER_URL ||
-  "https://magic-indexer-dev.up.railway.app/graphql"
+  "https://magic-indexer-prod.up.railway.app/graphql"
 
-// Mirror the module-load warning the notifications route has — without
-// this a production deploy that forgets to set INDEXER_URL silently
-// routes every feed query at the dev indexer.
+// Mirror the module-load warning the notifications route has — flags
+// the case where neither INDEXER_URL nor NEXT_PUBLIC_INDEXER_URL is
+// set so the fallback default is silent in dev too. Production used
+// to fall back to the dev indexer here; the default now points at
+// prod so an unset env doesn't break the feed.
 if (
   process.env.NODE_ENV === "production" &&
   !process.env.INDEXER_URL &&
   !process.env.NEXT_PUBLIC_INDEXER_URL
 ) {
   console.warn(
-    "[indexer] no INDEXER_URL set in production — falling back to the dev " +
-      "instance. Set INDEXER_URL in the Vercel project env.",
+    "[indexer] no INDEXER_URL set in production — using the built-in " +
+      "fallback (magic-indexer-prod). Set INDEXER_URL in the Vercel project " +
+      "env to override.",
   )
 }
 


### PR DESCRIPTION
Follow-up to #93 — the one commit that landed on \`feat/89-feed-enhancements\` after #93 was already merged.

## Summary

Flips the hardcoded fallback in \`src/app/api/indexer/route.ts\` from \`magic-indexer-dev\` → \`magic-indexer-prod\`. The dev indexer doesn't yet expose \`followerEvents\` (magic-indexer #125 is live on prod, hasn't deployed to dev), so an unset \`INDEXER_URL\` env was silently breaking the home/feed surfaces.

\`.env.local.example\` updated to match and to drop the "required in production" wording that's no longer accurate (the default is now functional).

## Vercel env

Already set out of band:
- \`INDEXER_URL\` = \`https://magic-indexer-prod.up.railway.app/graphql\` on **Production**
- Same value on **Preview (feat/positioning-redesign)**

So Vercel preview/prod deploys are already hitting prod even without this commit. This PR just makes the code default match, so local dev + any future deploys without an explicit env override hit prod too.

## Test plan

- [ ] Local dev without \`INDEXER_URL\` set hits magic-indexer-prod (verify in network panel on /home).
- [ ] CI green: typecheck 0 errors, 204 tests passing on the underlying branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)