### PR TITLE
fix(settings): adopt the profile-page layout shell

### DIFF
--- a/src/app/styles/settings-page.css
+++ b/src/app/styles/settings-page.css
@@ -26,7 +26,11 @@
    ======================================================================== */
 
 .sx {
-  padding: 24px 16px 64px;
+  /* No outer padding — `.page-layout` (the profile-page grid we
+     reuse) carries its own 24px of padding on desktop and 24px /
+     16px on mobile. Stacking another layer here would push the
+     sidebar away from the page-frame border. */
+  padding: 0 0 64px;
 }
 
 /* Visually-hidden heading. The navbar breadcrumb already carries the
@@ -43,12 +47,25 @@
   border: 0;
 }
 
-/* Settings page now sits inside the standard .app-shell width
-   constraint and uses the shared .page-layout grid (296px sidebar
-   + flexible main pane) — same base layout as the profile page.
-   The full-viewport hack + custom vertical divider that used to
-   live here were removed when the page was aligned with the
-   profile shell. */
+/* Widen the app-shell content slot to the profile/cert-detail max
+   (1280px) and drop its 600/720px reading cap + 32px lateral
+   padding. The settings page is a two-pane editor surface, not a
+   reading column, and it should land at the same width as the
+   profile page so navigating between the two doesn't visibly
+   resize the canvas. Mirrors the `.app-shell:has(.cert-detail--wide)`
+   pattern in cert-detail.css. */
+.app-shell:has(.sx) .app-shell__content {
+  /* Zero ALL `.app-shell__content` padding so the page-frame
+     borders meet flush. Top spacing comes from `.page-layout`'s
+     own 24px padding on desktop. */
+  padding: 0;
+}
+
+@media (min-width: 800px) {
+  .app-shell:has(.sx) .app-shell__content {
+    max-width: 1280px;
+  }
+}
 
 /* ------------------------------------------------------------------------
    Left pane — scroll-spy nav.
@@ -58,13 +75,11 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  /* Scrolls with the page (matches the top bar's no-sticky
-     behaviour). Flush-left to the viewport, with breathing room at
-     the top + right so the active filter pill doesn't touch the
-     vertical divider. Top padding shared with /home and /explore
-     so first-line-of-text sits at the same vertical position on
-     every page-frame route. */
-  padding: 32px 12px 32px 12px;
+  /* No own top padding — `.page-layout` (the parent grid) handles
+     it with 24px on desktop, matching the profile sidebar's
+     starting offset. The filter pills hug the sidebar column's
+     left edge so the rounded background flows from the grid track. */
+  padding: 0;
 }
 
 .sx-menu {
@@ -152,24 +167,11 @@
    bar.
    ------------------------------------------------------------------------ */
 .sx__panel {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
+  /* `.page-layout__main` already supplies min-width:0 +
+     flex-direction:column. Layered class. We only bump the section
+     gap (default page-layout__main gap is 24px; settings sections
+     need more air to read as distinct units). */
   gap: 48px;
-  /* Center the content in the space right of the sidebar. The grid
-     cell takes the full remaining width; the inner content is
-     bounded + auto-margined so it sits in the middle of the cell.
-     Matches .explore__main exactly. */
-  width: 100%;
-  max-width: 1400px;
-  margin: 0 auto;
-  padding: 20px 24px 32px;
-}
-
-@media (max-width: 760px) {
-  .sx__panel {
-    padding: 0;
-  }
 }
 
 .sx-section {
@@ -255,14 +257,11 @@
 }
 
 /* ------------------------------------------------------------------------
-   Mobile tweaks. Match the explore page's breakpoint (760px) — under
-   that, menu and panel stack vertically.
+   Mobile tweaks. Match the profile-page breakpoint (800px) — under
+   that, .page-layout collapses to a single stack and the sidebar
+   sits on top of the panel.
    ------------------------------------------------------------------------ */
-@media (max-width: 760px) {
-  .sx {
-    padding: 16px 0 48px;
-  }
-
+@media (max-width: 799px) {
   .sx-panel__title {
     font-size: 1.25rem;
   }


### PR DESCRIPTION
## Summary

\`/settings\` now uses the exact same canvas as \`/profile/<handle>\`: a 1280px-max content slot containing a 296px sidebar + flexible main pane via \`.page-layout\`.

Before this change, \`SettingsPanel\` already wrapped its content in \`.page-layout\`, but the surrounding \`.app-shell__content\` was capped at 600px (the default reading column for non-profile pages). That made the 296px sidebar + main grid squeeze into a narrow column. Stacked \`.sx\` paddings on top of \`.page-layout\`'s own 24px padding also pushed the sidebar items out of alignment with the profile sidebar.

## Changes (all in \`src/app/styles/settings-page.css\`)

- **New \`.app-shell:has(.sx) .app-shell__content\` rule**: widens the content slot to **1280px** on desktop and zeros its lateral padding. Mirrors the \`.app-shell:has(.cert-detail--wide)\` pattern in \`cert-detail.css\` — both \`/cert/...\` and \`/settings\` now share the profile page's canvas.
- **Drop redundant outer paddings**: removed \`.sx { padding: 24px 16px 64px }\`, \`.sx__menu { padding: 32px 12px 32px 12px }\`, and the inner \`.sx__panel { max-width: 1400px; margin: 0 auto; padding: 20px 24px 32px }\`. Those came from a previous full-viewport variant and fought with \`.page-layout\`'s own padding. \`.sx__panel\` now only bumps the inter-section \`gap\` to 48px on top of what \`.page-layout__main\` already supplies.
- **Mobile breakpoint** moved from 760px to **799px** so the single-column collapse fires at the same width as the profile page's \`.page-layout\`.

## Test plan

- [ ] Navigate from \`/profile/<handle>\` → \`/settings\` and back: canvas width does not change. Sidebar lines up vertically across both pages.
- [ ] \`/settings\` sidebar (\"Appearance\", \"Sync social graph\", \"Username\", etc.) sits with **24px** breathing room from the top of the canvas and from the left edge — same gutter as the profile page sidebar.
- [ ] Clicking a sidebar entry scrolls to the right section; flash highlight still triggers on the section heading.
- [ ] Below 800px the sidebar stacks on top of the panel (was: 760px).
- [ ] Dark-mode + light-mode both render without unwanted borders or wash changes.