### PR TITLE
fix(explore): stop URL→local search-input sync from stomping keystrokes

### DIFF
--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -484,11 +484,27 @@ export default function Explore() {
 
   // Local search debounce: keep typing snappy, hit indexer once typing stops.
   const [localQuery, setLocalQuery] = useState(search)
-  useEffect(() => setLocalQuery(search), [search])
+  // Remember the value we last wrote to the URL so the URL→local
+  // sync below can tell our own debounce writes apart from external
+  // URL changes (back/forward, filter switch that clears `q`). Without
+  // this, the sync effect fires every time we write — and if the user
+  // typed an extra keystroke between scheduling the write and the URL
+  // commit, that keystroke gets stomped (it shows on screen briefly,
+  // then the URL→local sync overwrites localQuery with the older URL
+  // value). Symptom: "not all keystrokes are recognised when results
+  // come in."
+  const lastWroteToUrlRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (search === lastWroteToUrlRef.current) return
+    setLocalQuery(search)
+  }, [search])
   useEffect(() => {
     const t = setTimeout(() => {
-      if (localQuery !== search) setUrl({ q: localQuery || null })
-    }, 250)
+      if (localQuery !== search) {
+        lastWroteToUrlRef.current = localQuery
+        setUrl({ q: localQuery || null })
+      }
+    }, 350)
     return () => clearTimeout(t)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [localQuery])


### PR DESCRIPTION
## Summary

Typing into the explore search bar drops characters once results start coming in. The drop isn't a render-perf issue — it's the URL→local sync effect overwriting \`localQuery\` with the older URL value during the URL-write round-trip.

### Sequence (typing \"hello\" then \"w\" quickly)

1. \`setLocalQuery(\"hellow\")\`
2. Debounce fires → \`setUrl({ q: \"hello\" })\` (the previous local value at the time the debounce scheduled)
3. URL commits, \`search\` becomes \`\"hello\"\`
4. \`useEffect([search])\` runs → \`setLocalQuery(\"hello\")\` → localQuery snaps back, \`\"w\"\` is lost.

The sync effect itself is doing honest work — it's there so back/forward navigation and filter-clear (e.g. switching kind, which writes \`q=null\`) propagate into the input. But it has no way to distinguish \"the URL changed externally\" from \"the URL changed because we just wrote it ourselves.\"

## Fix

Track the last value we wrote to the URL in a ref; the sync effect skips when \`search\` matches that ref. External URL changes still flow through unchanged.

Also bumped the debounce from **250ms → 350ms**. Keystrokes coming in within ~300ms of the previous one are clearly still part of the same typing burst, and the extra breathing room reduces per-burst URL/state churn while results are mid-fetch.

## Test plan

- [ ] Open \`/explore?kind=certs\`. Type \"hello world\" continuously at normal speed. Every character should appear (was: occasional drop once the first batch of results lands).
- [ ] Type quickly, pause, then press backspace several times. Input deletes correctly; no snap-back to stale URL value.
- [ ] Use the browser back button after typing — input reverts to previous URL value (sync still works for external changes).
- [ ] Switch kind (Certs → Projects → Accounts) — \`q\` clears in the URL and the input clears (sync still works).
- [ ] Paste a long string — debounce fires once 350ms after paste; URL updates once.