### PR TITLE
fix(filters): let 'deselect all' actually show nothing (feed + explore)

### DIFF
--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -120,23 +120,37 @@ type Degree = 1 | 2 | 3
 const ALL_DEGREES: readonly Degree[] = [1, 2, 3] as const
 
 /**
- * Parse the URL into a non-empty `Set<Degree>` of selected endorsement
- * rings. The control is a multi-select of three tags — direct, 2nd-hop,
+ * Sentinel for an explicitly-empty selection. Without this, a writer
+ * that puts `""` into the URL would be normalised away by setUrl
+ * (which deletes empty values), and the next read would resolve to
+ * the default set — making "deselect all" indistinguishable from "no
+ * preference" for the user. We pick `-` because it never collides
+ * with a legitimate value across degrees / quality / orgQuality.
+ */
+const EMPTY_SELECTION_SENTINEL = "-"
+
+/**
+ * Parse the URL into a `Set<Degree>` of selected endorsement rings.
+ * The control is a multi-select of three tags — direct, 2nd-hop,
  * 3rd-hop — and the URL serialises the active subset as a sorted
  * comma-separated list (`?degrees=1,3`).
+ *
+ * Special values:
+ *   - missing param → default `{1}` (direct endorsements only)
+ *   - `degrees=-`   → empty set (user explicitly deselected every
+ *                     ring; result list renders empty until they
+ *                     re-add at least one)
  *
  * Migration shim: a legacy `?degree=N` (single integer, cumulative
  * up to N — the old segmented-control semantics) is read as
  * `{1, …, N}`. Preferred form is `degrees=...`; the migration keeps
  * existing bookmarks meaningful.
- *
- * Returns `{1}` (default — direct endorsements only) when neither
- * param is present, matching the old default-degree behaviour.
  */
 function parseDegrees(
   rawDegrees: string | null,
   legacyDegree: string | null,
 ): Set<Degree> {
+  if (rawDegrees === EMPTY_SELECTION_SENTINEL) return new Set<Degree>()
   if (rawDegrees) {
     const out = new Set<Degree>()
     for (const part of rawDegrees.split(",")) {
@@ -152,8 +166,10 @@ function parseDegrees(
 }
 
 /** Serialise a degree set for URL storage — sorted, comma-joined.
- *  Returns null for the `{1}` default so the URL stays clean. */
+ *  Returns null for the `{1}` default so the URL stays clean, and
+ *  the explicit-empty sentinel when the user deselected every ring. */
 function serializeDegrees(degrees: Set<Degree>): string | null {
+  if (degrees.size === 0) return EMPTY_SELECTION_SENTINEL
   if (degrees.size === 1 && degrees.has(1)) return null
   return ALL_DEGREES.filter((d) => degrees.has(d)).join(",")
 }
@@ -237,6 +253,9 @@ export default function Explore() {
         UNLABELED_SLUG,
       ])
     }
+    if (qualityParam === EMPTY_SELECTION_SENTINEL) {
+      return new Set<HyperlabelTier | UnlabeledSlug>()
+    }
     const valid = new Set<string>([...HYPERLABEL_TIERS, UNLABELED_SLUG])
     return new Set(
       qualityParam
@@ -287,6 +306,9 @@ export default function Explore() {
         ...DEFAULT_ORG_TIER_SLUGS,
         UNLABELED_SLUG,
       ])
+    }
+    if (orgQualityParam === EMPTY_SELECTION_SENTINEL) {
+      return new Set<OrgTierSlug | UnlabeledSlug>()
     }
     const valid = new Set<string>([...ORG_TIER_SLUGS, UNLABELED_SLUG])
     return new Set(
@@ -405,12 +427,18 @@ export default function Explore() {
         next.size === defaultSlugs.size &&
         Array.from(defaultSlugs).every((s) => next.has(s))
       // URL preserves slug order matching the popover render order
-      // (named tiers first, then unlabeled).
+      // (named tiers first, then unlabeled). Empty set writes the
+      // sentinel so deselect-all isn't normalised back to default.
       const ordered: (HyperlabelTier | UnlabeledSlug)[] = [
         ...HYPERLABEL_TIERS.filter((t) => next.has(t)),
         ...(next.has(UNLABELED_SLUG) ? [UNLABELED_SLUG] : []),
       ]
-      setUrl({ quality: isDefault ? null : ordered.join(",") })
+      const value = isDefault
+        ? null
+        : ordered.length === 0
+          ? EMPTY_SELECTION_SENTINEL
+          : ordered.join(",")
+      setUrl({ quality: value })
     },
     [qualityIncluded, setUrl],
   )
@@ -431,7 +459,12 @@ export default function Explore() {
         ...ORG_TIER_SLUGS.filter((s) => next.has(s)),
         ...(next.has(UNLABELED_SLUG) ? [UNLABELED_SLUG] : []),
       ]
-      setUrl({ orgQuality: isDefault ? null : ordered.join(",") })
+      const value = isDefault
+        ? null
+        : ordered.length === 0
+          ? EMPTY_SELECTION_SENTINEL
+          : ordered.join(",")
+      setUrl({ orgQuality: value })
     },
     [orgQualityIncluded, setUrl],
   )
@@ -446,6 +479,10 @@ export default function Explore() {
     // stale `?degrees=…` on a non-endorsement filter doesn't perturb
     // caching keys / loader behaviour.
     degree: showsDegreeControl ? maxDegree(degrees) : undefined,
+    // Signals "user deselected every endorsement ring on the
+    // endorsement-graph filter" — the loader short-circuits to an
+    // empty page in that state instead of defaulting back to {1}.
+    noEndorsementRings: showsDegreeControl && degrees.size === 0,
     // Cert-quality filter — only meaningful for the certs kind, but
     // passing it for other kinds is a no-op at the load-page level.
     excludeCertLabels: kind === "certs" ? excludeCertLabels : undefined,
@@ -464,16 +501,14 @@ export default function Explore() {
       const key =
         raw === "1" ? 1 : raw === "2" ? 2 : raw === "3" ? 3 : null
       if (!key) return
-      // Toggle: deselect if already active, select otherwise. Block
-      // the move that would leave the set empty — at least one ring
-      // must stay active so the result list isn't filtered to zero.
+      // Toggle: deselect if already active, select otherwise.
+      // Deselecting the last ring is allowed — the result list
+      // renders empty until the user re-adds a ring. serializeDegrees
+      // encodes the empty set as the explicit sentinel so the round-
+      // trip through the URL doesn't collapse it back to the default.
       const next = new Set<Degree>(degrees)
-      if (next.has(key)) {
-        if (next.size === 1) return
-        next.delete(key)
-      } else {
-        next.add(key)
-      }
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
       // Clear the legacy `degree=` param while we're patching so it
       // doesn't outlive a multi-select edit and re-take precedence
       // on the next read.

--- a/src/hooks/use-explore.ts
+++ b/src/hooks/use-explore.ts
@@ -189,6 +189,11 @@ export function useExploreData(opts: {
   /** Orglabeler tier labels to require (analog of
    *  includeCertLabels). */
   includeOrgLabels?: readonly string[]
+  /** Set by the explore page when the active filter consumes the
+   *  endorsement-graph closure and the user has deselected every
+   *  ring (degrees set is empty). The hook short-circuits to an
+   *  empty result list instead of defaulting back to degree=1. */
+  noEndorsementRings?: boolean
 }): ExploreData {
   const {
     kind,
@@ -201,6 +206,7 @@ export function useExploreData(opts: {
     includeOrgLabels,
   } = opts
   const degree: 1 | 2 | 3 = opts.degree ?? 1
+  const noEndorsementRings: boolean = opts.noEndorsementRings ?? false
   // Stable key so the load effect can refetch when the exclude list
   // changes without retriggering when an identical-content array
   // arrives by reference.
@@ -278,6 +284,7 @@ export function useExploreData(opts: {
           cursor: null,
           signal: controller.signal,
           degree,
+          noEndorsementRings,
           excludeCertLabels: excludeCertLabels ?? null,
           includeCertLabels: includeCertLabels ?? null,
           excludeOrgLabels: excludeOrgLabels ?? null,
@@ -315,6 +322,7 @@ export function useExploreData(opts: {
     followedDids,
     myGroupDids,
     degree,
+    noEndorsementRings,
     closureVersion,
     excludeKey,
     includeKey,
@@ -346,10 +354,11 @@ export function useExploreData(opts: {
             cursor,
             signal: null,
             degree,
+            noEndorsementRings,
             excludeCertLabels: excludeCertLabels ?? null,
-          includeCertLabels: includeCertLabels ?? null,
-          excludeOrgLabels: excludeOrgLabels ?? null,
-          includeOrgLabels: includeOrgLabels ?? null,
+            includeCertLabels: includeCertLabels ?? null,
+            excludeOrgLabels: excludeOrgLabels ?? null,
+            includeOrgLabels: includeOrgLabels ?? null,
           })
           if (generation !== generationRef.current) return
           setState((current) => {
@@ -405,6 +414,7 @@ export function useExploreData(opts: {
     followedDids,
     myGroupDids,
     degree,
+    noEndorsementRings,
     closureVersion,
     excludeKey,
     includeKey,
@@ -468,6 +478,11 @@ interface LoadArgs {
   cursor: string | null
   signal: AbortSignal | null
   degree: 1 | 2 | 3
+  /** True when the active filter consumes the endorsement-graph
+   *  closure and the user has deselected every ring. The loader
+   *  short-circuits to an empty page in that state instead of
+   *  defaulting back to degree=1. */
+  noEndorsementRings: boolean
   /** Forwarded to `fetchIndexerActivities` when loading the certs
    *  page; null on other kinds. */
   excludeCertLabels: readonly string[] | null
@@ -479,9 +494,44 @@ interface LoadArgs {
 }
 
 async function loadPage(args: LoadArgs): Promise<LoadedPage> {
+  // Explicit-empty "include" filter = the user deselected every
+  // option in that filter's popover. The indexer's HTTP proxy
+  // normalises empty arrays to `null` (i.e. "no filter"), which would
+  // silently show every record — masking what should look like an
+  // empty result set. Short-circuit at the loader level so deselecting
+  // all options reads as "nothing matches", which is the natural
+  // affordance for re-adding a selection.
+  if (
+    (args.kind === "certs" || args.kind === "projects") &&
+    isExplicitlyEmpty(args.includeCertLabels)
+  ) {
+    return EMPTY_PAGE
+  }
+  if (
+    (args.kind === "accounts" || args.kind === "certs") &&
+    isExplicitlyEmpty(args.includeOrgLabels)
+  ) {
+    return EMPTY_PAGE
+  }
+  // Endorsement-degree multi-select: zero rings selected = "show no
+  // endorsement matches" (only applies to endorsement-graph filters).
+  if (
+    args.noEndorsementRings &&
+    (
+      (args.kind === "accounts" && args.filter === "endorsed") ||
+      ((args.kind === "certs" || args.kind === "projects") &&
+        args.filter === "by-endorsed")
+    )
+  ) {
+    return EMPTY_PAGE
+  }
   if (args.kind === "accounts") return loadAccountsPage(args)
   if (args.kind === "projects") return loadProjectsPage(args)
   return loadCertsPage(args)
+}
+
+function isExplicitlyEmpty(v: readonly string[] | null | undefined): boolean {
+  return Array.isArray(v) && v.length === 0
 }
 
 /**

--- a/src/hooks/use-home-feed.ts
+++ b/src/hooks/use-home-feed.ts
@@ -250,6 +250,17 @@ export function useHomeFeed(
       setState({ ...EMPTY_STATE, isLoading: false })
       return
     }
+    // Explicit-empty include filter — the user deselected every tier
+    // in the quality popover. The indexer's HTTP proxy normalises
+    // empty arrays to "no filter", so without this short-circuit we'd
+    // silently show every cert (i.e. the opposite of what the user
+    // asked for). Render an empty feed; re-selecting at least one
+    // tier re-enables the fetch.
+    const inc = includeCertLabelsRef.current
+    if (Array.isArray(inc) && inc.length === 0) {
+      setState({ ...EMPTY_STATE, isLoading: false })
+      return
+    }
     try {
       const page = await fetchFollowerEvents({
         authors,
@@ -296,6 +307,10 @@ export function useHomeFeed(
     }
     const authors = Array.from(followedRef.current)
     if (authors.length === 0) return
+    // Same explicit-empty guard the initial loader uses — if the user
+    // deselected every quality tier mid-scroll, don't keep paginating.
+    const inc = includeCertLabelsRef.current
+    if (Array.isArray(inc) && inc.length === 0) return
 
     setState((prev) => ({ ...prev, isLoadingMore: true }))
     ;(async () => {


### PR DESCRIPTION
## Summary

Deselecting every option in any of the multi-select filters silently reverted to the default selection, so users couldn't reach an empty result list. After this change, **deselect-all = nothing**; re-adding any option brings results back.

Affected filters:
- **Explore**: cert quality, org quality, endorsement-graph degrees
- **Home feed**: cert quality

## Why it was happening

Two failure modes were combining:

1. The explore page encodes filters in the URL. \`setUrl\` deletes any key set to \`\"\"\` (correct for everything else), so serialising an empty selection as \`\"\"\` made the URL look like \"no preference\" — and the reader interpreted that as \"apply default\".
2. The indexer HTTP proxy normalises empty \`labels\` / \`authors\` arrays to \`null\` (i.e. \"no filter\"). So even when the parent passed an empty include-array straight to the loader, the request that reached the indexer carried no filter — every record came back, masking what should have looked like an empty result list.

## Fix

- New \`EMPTY_SELECTION_SENTINEL = \"-\"\` for the explore URL params. The quality / orgQuality / degrees toggles write the sentinel when their set is empty; the readers recognise it and return an empty Set, distinct from the missing-param default.
- Dropped the \"deselecting the last degree ring is blocked\" guard.
- \`useExploreData\` accepts \`noEndorsementRings\`; the explore page sets it when the user has emptied the degree multi-select on an endorsement-graph filter.
- \`loadPage\` short-circuits to \`EMPTY_PAGE\` when an \`include*Labels\` arg is the empty array OR \`noEndorsementRings\` is true for the active filter — so the indexer's empty-array normalisation can't override the user's intent.
- \`useHomeFeed.load\` / \`useHomeFeed.loadMore\` short-circuit on the same explicit-empty signal for \`includeCertLabels\`.

## Test plan

- [ ] On \`/explore?kind=certs\`, open quality popover, uncheck every tier. Result list goes empty. Re-check one tier → results come back.
- [ ] Same on org-quality popover for \`/explore?kind=accounts\` and \`/explore?kind=certs\`.
- [ ] On \`/explore?kind=accounts&filter=endorsed\`, deselect all degree pills. Result list goes empty. Re-add 1st → results come back.
- [ ] Reload the page after deselecting all — empty state persists (URL carries \`?quality=-\` / \`?orgQuality=-\` / \`?degrees=-\`).
- [ ] On \`/home\`, deselect every tier in the cert-quality popover. Feed goes empty. Re-add → results come back.
- [ ] Default (no URL params, fresh visit) still shows the default selection — sentinel is only emitted on intentional deselect-all.