### PR TITLE
fix(explore): replace projects' generic Filter with Account-quality popover

### DIFF
--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -377,18 +377,6 @@ export default function Explore() {
     [setUrl],
   )
 
-  const onAttrToggle = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const key = e.currentTarget.dataset.attrKey
-      if (!key) return
-      const next = new Set(attrs)
-      if (e.currentTarget.checked) next.add(key)
-      else next.delete(key)
-      setUrl({ attrs: next.size > 0 ? Array.from(next).join(",") : null })
-    },
-    [attrs, setUrl],
-  )
-
   const onQualityToggle = useCallback(
     (slug: HyperlabelTier | UnlabeledSlug) => {
       const next = new Set(qualityIncluded)
@@ -453,9 +441,13 @@ export default function Explore() {
     // Org-quality filter — used on accounts (filters the actor list)
     // and certs (filters certs whose author org carries the tier).
     excludeOrgLabels:
-      kind === "accounts" || kind === "certs" ? excludeOrgLabels : undefined,
+      kind === "accounts" || kind === "certs" || kind === "projects"
+        ? excludeOrgLabels
+        : undefined,
     includeOrgLabels:
-      kind === "accounts" || kind === "certs" ? includeOrgLabels : undefined,
+      kind === "accounts" || kind === "certs" || kind === "projects"
+        ? includeOrgLabels
+        : undefined,
   })
 
   const onDegreeButtonClick = useCallback(
@@ -510,7 +502,6 @@ export default function Explore() {
   }, [localQuery])
 
   const [sortOpen, setSortOpen] = useState(false)
-  const [filtersOpen, setFiltersOpen] = useState(false)
   const [qualityOpen, setQualityOpen] = useState(false)
   const [subPrefixOpen, setSubPrefixOpen] = useState(false)
 
@@ -659,46 +650,13 @@ export default function Explore() {
                 )}
               </Popover>
 
-              {/* The generic attr-based Filter popover stays for
-                  projects only; on certs + accounts it's replaced
-                  by the labeler-tier Quality popover below. */}
-              {kind === "projects" ? (
-                <Popover
-                  open={filtersOpen}
-                  onClose={() => setFiltersOpen(false)}
-                  trigger={
-                    <button
-                      type="button"
-                      className="explore__chrome-btn"
-                      onClick={() => setFiltersOpen((v) => !v)}
-                      aria-expanded={filtersOpen}
-                    >
-                      <FilterIcon size={13} strokeWidth={1.75} aria-hidden />
-                      Filter{attrs.size ? ` (${attrs.size})` : ""}
-                    </button>
-                  }
-                >
-                  {attrOptions(kind).map((opt) => {
-                    const on = attrs.has(opt.key)
-                    return (
-                      <label
-                        key={opt.key}
-                        className="popover__item popover__item--check"
-                      >
-                        <input
-                          type="checkbox"
-                          checked={on}
-                          data-attr-key={opt.key}
-                          onChange={onAttrToggle}
-                        />
-                        {opt.label}
-                      </label>
-                    )
-                  })}
-                </Popover>
-              ) : null}
-
-              {kind === "certs" || kind === "accounts" ? (
+              {/* Labeler-tier quality popover. On certs, shows both
+                  Cert quality (Hyperlabel tiers) and Account quality
+                  (Orglabeler tiers). On accounts + projects, shows
+                  Account quality only — projects' record-tier
+                  filtering is keyed off the author's org label, not
+                  the project itself. */}
+              {kind === "certs" || kind === "accounts" || kind === "projects" ? (
                 <Popover
                   open={qualityOpen}
                   onClose={() => setQualityOpen(false)}
@@ -752,6 +710,8 @@ export default function Explore() {
                       <hr className="popover__divider" aria-hidden="true" />
                       <p className="popover__section-heading">Account quality</p>
                     </>
+                  ) : kind === "projects" ? (
+                    <p className="popover__section-heading">Account quality</p>
                   ) : null}
                   {ORG_TIER_SLUGS.map((slug) => (
                     <label
@@ -983,23 +943,6 @@ function searchPlaceholder(kind: ExploreKind): string {
   if (kind === "accounts") return "Search accounts by name…"
   if (kind === "projects") return "Search projects…"
   return "Search certs…"
-}
-
-function attrOptions(kind: ExploreKind): { key: string; label: string }[] {
-  if (kind === "accounts")
-    return [
-      { key: "has-avatar", label: "Has avatar" },
-      { key: "has-description", label: "Has description" },
-    ]
-  if (kind === "projects")
-    return [
-      { key: "has-banner", label: "Has banner" },
-      { key: "has-items", label: "Has at least one cert" },
-    ]
-  return [
-    { key: "has-image", label: "Has image" },
-    { key: "has-shortDescription", label: "Has description" },
-  ]
 }
 
 function Popover({


### PR DESCRIPTION
## Summary

The projects tab carried a labelled \"Filter\" button that opened a generic attribute-toggle popover (\"Has banner\" / \"Has at least one cert\"). Certs + Accounts already use an unlabelled icon-only button with a labeler-tier quality popover. Projects now matches that pattern, but with the orglabeler \"Account quality\" section in place of cert quality.

## Changes

- Drop the kind=projects-only attr-toggle popover and the dead code it supported (\`onAttrToggle\`, \`attrOptions\`, \`filtersOpen\` state).
- Extend the existing Quality popover trigger to render on \`kind === \"projects\"\` as well as certs + accounts.
- Inside the popover, projects renders an **\"Account quality\"** heading + the orglabeler tier checkboxes (plus unlabeled). The cert-quality block stays gated on \`kind === \"certs\"\`.
- Thread \`excludeOrgLabels\` / \`includeOrgLabels\` through to \`useExploreData\` for the projects kind. \`loadProjectsPage\` was already consuming both — the call site just needed to stop dropping them.

URL state for the now-unused \`?attrs=…\` param is preserved on read — old bookmarks keep applying the client-side filters via \`ResultsArea\` — but the UI no longer exposes the toggles.

## Test plan

- [ ] On \`/explore?kind=projects\`, the right-most chrome button is the icon-only filter button (no \"Filter\" word). Same visual as on Certs + Accounts.
- [ ] Clicking it opens a popover with \"Account quality\" heading + the orglabeler tier checkboxes (high quality, standard, likely test, unlabeled).
- [ ] Toggling a checkbox writes \`?orgQuality=…\` to the URL and re-filters the result list. Default (all selected) keeps the URL clean.
- [ ] Pairs cleanly with #101 (deselect-all sentinel): unchecking every checkbox writes \`?orgQuality=-\` and shows an empty list; re-checking brings results back.
- [ ] Old URL with \`?attrs=has-banner\` still client-side filters the result list, even though the toggle is no longer in the UI.