### PR TITLE
feat(filters): consistent headings + reset buttons across explore + feed

### DIFF
--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -388,6 +388,62 @@
   border-top: 1px solid var(--border-subtle);
 }
 
+/* "Reset to default" link at the bottom of each popover. Sits just
+   under the menu's last divider; rendered as a quiet text button
+   (no border / no fill) so it doesn't compete with the active
+   selection above. Disabled state when already at default keeps it
+   visible but reads as inert. */
+.popover__reset-btn {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 6px 12px;
+  border: 0;
+  border-radius: 4px;
+  background: none;
+  text-align: left;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.popover__reset-btn:hover:not(:disabled) {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.popover__reset-btn:disabled {
+  color: var(--fg-muted, #b7bdc6);
+  cursor: default;
+}
+
+/* Inline reset on the endorsement-degree pill row (the degree
+   control lives in the chrome strip, not a popover, so its reset
+   sits adjacent to the pills rather than below them). */
+.explore__degree-reset {
+  margin-left: 4px;
+  padding: 4px 10px;
+  background: none;
+  border: 0;
+  border-radius: 6px;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.explore__degree-reset:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
 /* ---------- View toggle (certs + projects) ---------- */
 
 .explore__view-toggle {

--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -673,6 +673,39 @@ a.home-feed__preview:hover {
   flex-shrink: 0;
 }
 
+/* "Reset to default" link at the bottom of each filter popover.
+   Quiet text-button styling so it doesn't compete with the active
+   selection above; disabled state when already at default keeps it
+   visible but inert. Mirrors `.popover__reset-btn` in explore.css. */
+.home-feed__filter-reset {
+  display: block;
+  width: calc(100% - 8px);
+  margin: 8px 4px 0;
+  padding: 6px 8px;
+  border: 0;
+  border-top: 1px solid var(--border-subtle);
+  border-radius: 0;
+  background: none;
+  text-align: left;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.home-feed__filter-reset:hover:not(:disabled) {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.home-feed__filter-reset:disabled {
+  color: var(--fg-muted, #b7bdc6);
+  cursor: default;
+}
+
 /* ---------- Trusted-evaluator popover overrides ---------- */
 
 .home-feed__filter-pop--evaluators {

--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -399,6 +399,22 @@ export default function Explore() {
     [setUrl],
   )
 
+  // "Reset to default" buttons clear the URL params they own. The
+  // readers fall back to the canonical default sets when those params
+  // are missing, so a single `setUrl({ key: null })` is enough.
+  const onResetQuality = useCallback(() => {
+    setUrl({ quality: null, orgQuality: null })
+  }, [setUrl])
+
+  const onResetDegrees = useCallback(() => {
+    setUrl({ degrees: null, degree: null })
+  }, [setUrl])
+
+  const onResetSort = useCallback(() => {
+    setUrl({ sort: null })
+    setSortOpen(false)
+  }, [setUrl])
+
   const onQualityToggle = useCallback(
     (slug: HyperlabelTier | UnlabeledSlug) => {
       const next = new Set(qualityIncluded)
@@ -683,6 +699,15 @@ export default function Explore() {
                     </button>
                   ),
                 )}
+                <hr className="popover__divider" aria-hidden="true" />
+                <button
+                  type="button"
+                  className="popover__reset-btn"
+                  onClick={onResetSort}
+                  disabled={sort === "newest"}
+                >
+                  Reset to default
+                </button>
               </Popover>
 
               {/* Labeler-tier quality popover. On certs, shows both
@@ -743,11 +768,13 @@ export default function Explore() {
                         {UNLABELED_LABEL}
                       </label>
                       <hr className="popover__divider" aria-hidden="true" />
-                      <p className="popover__section-heading">Account quality</p>
                     </>
-                  ) : kind === "projects" ? (
-                    <p className="popover__section-heading">Account quality</p>
                   ) : null}
+                  {/* Account-quality heading shows on every kind that
+                      surfaces the orglabeler tiers. On certs it sits
+                      below the divider; on accounts + projects it's
+                      the top of the popover. */}
+                  <p className="popover__section-heading">Account quality</p>
                   {ORG_TIER_SLUGS.map((slug) => (
                     <label
                       key={slug}
@@ -769,6 +796,23 @@ export default function Explore() {
                     />
                     {UNLABELED_LABEL}
                   </label>
+                  {/* Reset returns every section in this popover to
+                      its default selection by clearing the URL params
+                      it owns. Disabled when nothing has been customised
+                      so it doesn't read as an active control on the
+                      default state. */}
+                  <hr className="popover__divider" aria-hidden="true" />
+                  <button
+                    type="button"
+                    className="popover__reset-btn"
+                    onClick={onResetQuality}
+                    disabled={
+                      (kind !== "certs" || qualityIsDefault) &&
+                      orgQualityIsDefault
+                    }
+                  >
+                    Reset to default
+                  </button>
                 </Popover>
               ) : null}
             </div>
@@ -778,6 +822,7 @@ export default function Explore() {
             <EndorsementDegreeBar
               degrees={degrees}
               onSelect={onDegreeButtonClick}
+              onReset={onResetDegrees}
               meta={data.endorsementClosure}
             />
           ) : null}
@@ -838,12 +883,18 @@ const DEGREE_TITLE: Record<Degree, string> = {
 function EndorsementDegreeBar({
   degrees,
   onSelect,
+  onReset,
   meta,
 }: {
   degrees: Set<Degree>
   onSelect: (e: React.MouseEvent<HTMLButtonElement>) => void
+  onReset: () => void
   meta: ReturnType<typeof useExploreData>["endorsementClosure"]
 }) {
+  // Default is {1}. Hide the reset affordance when we're already
+  // there so the inline control doesn't read as "active" on a fresh
+  // visit.
+  const isDefault = degrees.size === 1 && degrees.has(1)
   return (
     <div
       className="explore__degree-bar"
@@ -868,6 +919,16 @@ function EndorsementDegreeBar({
             </button>
           )
         })}
+        {!isDefault ? (
+          <button
+            type="button"
+            className="explore__degree-reset"
+            onClick={onReset}
+            aria-label="Reset endorsement rings to default"
+          >
+            Reset
+          </button>
+        ) : null}
       </div>
       {meta?.truncated ? (
         <p

--- a/src/components/home/home-feed.tsx
+++ b/src/components/home/home-feed.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react"
 import Link from "next/link"
-import { Inbox, MapPin, SlidersHorizontal, UserCheck, Users } from "lucide-react"
+import { Filter as FilterIcon, Inbox, MapPin, UserCheck, Users } from "lucide-react"
 import Avatar from "@/components/ui/avatar"
 import EmptyState from "@/components/ui/empty-state"
 import LoadingSpinner from "@/components/ui/loading-spinner"
@@ -324,10 +324,15 @@ function QualityFilter({
     onChange(next)
   }
 
+  const resetToDefault = () => {
+    onChange(new Set<QualityFilterValue>([...DEFAULT_INCLUDED_TIERS, UNLABELED_SLUG]))
+  }
+
   // "Filtered" badge highlights the button when the popover state
   // diverges from the default (every visible tier + unlabeled).
   // Total filter slots = number of Hyperlabel tiers + 1 for unlabeled.
   const filtered = included.size !== HYPERLABEL_TIERS.length + 1
+  const isDefault = isQualityDefault(included)
 
   return (
     <div className="home-feed__filter" ref={wrapRef}>
@@ -338,12 +343,13 @@ function QualityFilter({
         aria-haspopup="true"
         aria-expanded={open}
         aria-label="Filter feed by cert quality"
+        title="Filter by cert quality"
       >
-        <SlidersHorizontal size={14} strokeWidth={1.75} aria-hidden />
+        <FilterIcon size={14} strokeWidth={1.75} aria-hidden />
       </button>
       {open ? (
         <div className="home-feed__filter-pop" role="dialog" aria-label="Cert quality filters">
-          <p className="home-feed__filter-title">Show certs labeled</p>
+          <p className="home-feed__filter-title">Certs quality</p>
           <ul className="home-feed__filter-list">
             {HYPERLABEL_DISPLAY_ORDER.map((tier) => (
               <li key={tier}>
@@ -368,10 +374,26 @@ function QualityFilter({
               </label>
             </li>
           </ul>
+          <button
+            type="button"
+            className="home-feed__filter-reset"
+            onClick={resetToDefault}
+            disabled={isDefault}
+          >
+            Reset to default
+          </button>
         </div>
       ) : null}
     </div>
   )
+}
+
+function isQualityDefault(included: Set<QualityFilterValue>): boolean {
+  // Default = every tier in DEFAULT_INCLUDED_TIERS, plus unlabeled.
+  if (included.size !== DEFAULT_INCLUDED_TIERS.size + 1) return false
+  if (!included.has(UNLABELED_SLUG)) return false
+  for (const t of DEFAULT_INCLUDED_TIERS) if (!included.has(t)) return false
+  return true
 }
 
 /**
@@ -400,6 +422,10 @@ function EvaluatorFilter({
     if (next.has(did)) next.delete(did)
     else next.add(did)
     onChange(next)
+  }
+
+  const resetToDefault = () => {
+    onChange(new Set(TRUSTED_EVALUATOR_DIDS))
   }
 
   const partial = selected.size !== TRUSTED_EVALUATOR_DIDS.length
@@ -432,6 +458,14 @@ function EvaluatorFilter({
               </li>
             ))}
           </ul>
+          <button
+            type="button"
+            className="home-feed__filter-reset"
+            onClick={resetToDefault}
+            disabled={!partial}
+          >
+            Reset to default
+          </button>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary

Three tightly related filter-UI polish changes:

### 1. "Account quality" heading on the Accounts explore popover

For consistency. The heading was already present on Certs (above the Cert/Account divider) and on Projects; Accounts was the lone outlier.

### 2. Reset-to-default on every filter

- **Explore**: bottom of the Sort popover, bottom of the Quality popover (resets Cert + Account quality together), inline next to the endorsement-degree pills.
- **Home feed**: bottom of the cert-quality popover and the trusted-evaluator popover.

Each reset clears the relevant URL params or local state back to defaults. Disabled state when already at default so the control doesn't read as active on a fresh visit.

### 3. Home-feed cert-quality popover matches the explore filter

- Icon: `SlidersHorizontal` → `Filter` (same lucide icon the explore chrome button uses).
- Heading: "Show certs labeled" → "Certs quality" (mirrors "Cert quality" / "Account quality" elsewhere).

## Test plan

- [ ] `/explore?kind=accounts` — quality popover shows the "Account quality" heading + Reset.
- [ ] `/explore?kind=certs` — both Cert + Account quality headings render with the divider, single Reset clears both sections.
- [ ] `/explore?kind=projects` — Account quality heading + Reset.
- [ ] Sort popover — Reset returns to Newest.
- [ ] On an endorsement-graph filter (`/explore?kind=certs&filter=by-endorsed&degrees=1,2`) — inline "Reset" appears right of the degree pills; clicking it returns to `{1}` and clears `?degrees` from the URL.
- [ ] On `/home` — quality popover uses the Filter icon, heading reads "Certs quality", Reset restores default visible tiers + unlabeled.
- [ ] On `/home` evaluator popover — Reset restores all curated evaluators.
- [ ] Reset buttons are disabled while already at default.