### PR TITLE
fix(settings): adopt page-layout grid for org settings + tighten sticky offset

### DIFF
--- a/src/app/styles/settings-page.css
+++ b/src/app/styles/settings-page.css
@@ -81,16 +81,20 @@
      left edge so the rounded background flows from the grid track. */
   padding: 0;
   /* Travel with the scroll: pin the nav to the top of the
-     viewport (offset by the sticky top bar's full height plus
-     a small breathing gap) so the section anchors are always
-     reachable while the main panel scrolls past them. The grid
+     viewport (offset by the desktop top-bar's resolved height
+     plus a small breathing gap) so the section anchors are
+     always reachable while the main panel scrolls past them.
+     `--top-bar-total` is row 1 by default and bumps to row 1 +
+     row 2 on pages that render the tabs row — settings has no
+     tabs row, so the previous `row1 + row2` sum overshot by
+     ~44px and left a visible gap below the navbar. The grid
      parent has `align-items: start`, so sticky resolves against
      the page scroll context rather than the row's height. */
   position: sticky;
-  top: calc(var(--top-bar-row1) + var(--top-bar-row2) + 16px);
+  top: calc(var(--top-bar-total) + 16px);
   /* Cap the rail's height so a long menu can scroll internally
      without ever clipping past the viewport bottom. */
-  max-height: calc(100vh - var(--top-bar-row1) - var(--top-bar-row2) - 32px);
+  max-height: calc(100vh - var(--top-bar-total) - 32px);
   overflow-y: auto;
 }
 

--- a/src/components/groups/org-settings.tsx
+++ b/src/components/groups/org-settings.tsx
@@ -301,10 +301,10 @@ export default function OrgSettings({ groupDid, org }: OrgSettingsProps) {
   )
 
   return (
-    <div className="sx sx--wide">
+    <div className="sx">
       <h1 className="sx__heading sr-only">Group settings</h1>
 
-      <div className="sx__layout">
+      <div className="page-layout">
         <aside className="sx__menu">
           <nav aria-label="Group settings sections">
             <ul className="sx-menu">
@@ -331,7 +331,7 @@ export default function OrgSettings({ groupDid, org }: OrgSettingsProps) {
           </nav>
         </aside>
 
-        <div className="sx__panel">
+        <div className="page-layout__main sx__panel">
           {/* Handle — read-only; group service doesn't support
               handle changes after registration. */}
           <section


### PR DESCRIPTION
## Summary

Two related fixes for the broken /settings layout:

### 1. OrgSettings was missing its grid parent

`OrgSettings` (the panel shown when the viewer is acting as a group) wrapped its content in `<div className="sx__layout">`, but `.sx__layout` was deleted when the personal settings panel migrated to the shared `.page-layout` grid. Without a grid parent the aside (which still carries `position: sticky` + full width) ended up block-level and visually overlaid the panel during scroll — "left pane and main pane overlap."

Fix: switch the wrapper to the same `.page-layout` / `.page-layout__main` chrome the personal panel uses. Both settings entry points now share one layout.

Also dropped `sx--wide` — it had no CSS; the `:has(.sx)` width override in `settings-page.css` already widens the shell.

### 2. Sticky offset overshot by row-2's height

`.sx__menu` used `top: calc(var(--top-bar-row1) + var(--top-bar-row2) + 16px) = 112px`, but the settings page renders only the chrome row (no tabs row). The 44px row-2 padding left a visible gap between the navbar's bottom border and the pinned nav.

Fix: use `--top-bar-total + 16px`. That token resolves to row 1 only on pages without a tabs row and row 1 + row 2 on pages with one. Same change applied to the rail's `max-height` cap.

## Test plan

- [ ] Sign in. Visit `/settings` — left rail sits 16px below the navbar bottom border, right pane next to it (296px + 1fr grid).
- [ ] Scroll the right pane down. Left rail stays pinned (no scroll-away), no longer overlaps the right pane.
- [ ] Switch into a group via the account switcher. `/settings` now renders `OrgSettings` — same layout: aside on left, panel on right, sticky behaviour matches.
- [ ] Click a left-rail item. Section flashes; URL hash updates; page scrolls cleanly with the nav still in view.
- [ ] On <800px both panels stack vertically (responsive single-column from `page-layout`).