### PR TITLE
fix(chrome): route 'My profile' to the active identity, open '+' menu right, preserve page on switch

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,24 +3,32 @@
 import { useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/lib/auth/auth-context"
+import { useOrg } from "@/lib/groups/org-context"
 import { useSession } from "@/hooks/use-session"
 import { useProfileNavbar } from "@/lib/navbar-context"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 
 /**
  * `/profile` — redirect stub. The canonical profile view lives at
- * `/profile/[handle]`. When authenticated, we resolve the logged-in
- * user's handle and forward them to `/profile/<handle>`. Unauthenticated
+ * `/profile/[handle]`. When authenticated we resolve the **active**
+ * identity (the group from the account switcher, or the personal
+ * handle when no group is active) and forward there. Unauthenticated
  * visitors get bounced to `/`.
  *
- * We call useProfileNavbar() so there's no flash of the default navbar
- * during the redirect.
+ * "Active identity" wins over "personal identity" so that the
+ * /profile entry point lines up with what the user is currently
+ * acting as — same convention as the chrome (`useOrg().activeOrg`
+ * decides "me" everywhere in the navbar / drawer).
+ *
+ * We call useProfileNavbar() so there's no flash of the default
+ * navbar during the redirect.
  */
 export default function ProfileRedirectPage() {
   useProfileNavbar()
   const router = useRouter()
   const { isAuthenticated, isLoading } = useAuth()
-  const { handle, isLoading: isSessionLoading } = useSession()
+  const { handle: personalHandle, isLoading: isSessionLoading } = useSession()
+  const { activeOrg, isLoading: orgsLoading } = useOrg()
 
   useEffect(() => {
     if (isLoading) return
@@ -28,13 +36,22 @@ export default function ProfileRedirectPage() {
       router.replace("/")
       return
     }
-    if (isSessionLoading) return
-    if (handle) {
-      router.replace(`/profile/${encodeURIComponent(handle)}`)
+    if (isSessionLoading || orgsLoading) return
+    const activeHandle = activeOrg?.handle ?? personalHandle
+    if (activeHandle) {
+      router.replace(`/profile/${encodeURIComponent(activeHandle)}`)
     } else {
       router.replace("/")
     }
-  }, [isLoading, isAuthenticated, isSessionLoading, handle, router])
+  }, [
+    isLoading,
+    isAuthenticated,
+    isSessionLoading,
+    orgsLoading,
+    personalHandle,
+    activeOrg?.handle,
+    router,
+  ])
 
   return (
     <div className="loading-screen">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSession } from "@/hooks/use-session";
+import { useOrg } from "@/lib/groups/org-context";
 import {
   usePageTitle,
   usePageTitleBreadcrumb,
@@ -17,10 +18,18 @@ import SettingsPanel from "@/components/settings/settings-panel";
  * identical regardless of which URL the user lands on.
  */
 export default function SettingsPage() {
-  const { handle } = useSession();
+  const { handle: personalHandle } = useSession();
+  const { activeOrg } = useOrg();
+  // The breadcrumb above the settings panel shows whichever identity
+  // the user is currently acting as — so clicking it lands on the
+  // matching profile, not the personal one. Matches the chrome
+  // convention.
+  const activeHandle = activeOrg?.handle ?? personalHandle;
   usePageTitle("Settings");
   usePageTitleBreadcrumb(
-    handle ? { left: { text: handle, href: `/profile/${handle}` } } : null,
+    activeHandle
+      ? { left: { text: activeHandle, href: `/profile/${activeHandle}` } }
+      : null,
   );
   return <SettingsPanel />;
 }

--- a/src/components/layout/desktop-left-rail.tsx
+++ b/src/components/layout/desktop-left-rail.tsx
@@ -24,8 +24,8 @@ import { useSession } from "@/hooks/use-session";
 import { useOrg } from "@/lib/groups/org-context";
 import {
   isRouteVisibleToActor,
-  pathnameToPersonalOnlyRoute,
 } from "@/lib/groups/personal-only";
+import { routeForActorSwitch } from "@/lib/groups/navigation";
 import { useOrgProfile } from "@/hooks/use-org-profile";
 import { usePendingAwardsCount } from "@/hooks/use-pending-awards-count";
 import { useNotifications } from "@/lib/notifications-context";
@@ -367,17 +367,7 @@ export default function DesktopLeftRail() {
                 switchOrg={switchOrg}
                 onAfterSwitch={(next) => {
                   setSwitcherOpen(false);
-                  // Stay on the current pathname unless the route is
-                  // personal-only AND the new actor is an org (in
-                  // which case the new persona wouldn't have access
-                  // — redirect to /home).
-                  const routeKey = pathnameToPersonalOnlyRoute(pathname || "")
-                  const nextIsOrg = !!next
-                  const dest =
-                    routeKey && !isRouteVisibleToActor(routeKey, nextIsOrg)
-                      ? "/home"
-                      : pathname || "/home"
-                  router.push(dest);
+                  router.push(routeForActorSwitch(pathname, next));
                 }}
                 onSignOut={() => {
                   setSwitcherOpen(false);

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -23,7 +23,7 @@ import { useSession } from "@/hooks/use-session";
 import { useOrg } from "@/lib/groups/org-context";
 import { useOrgProfile } from "@/hooks/use-org-profile";
 import { useMounted } from "@/hooks/use-mounted";
-import { resolvePostSwitchPath } from "@/lib/groups/navigation";
+import { routeForActorSwitch } from "@/lib/groups/navigation";
 import Avatar from "@/components/ui/avatar";
 import { getInitials } from "@/lib/utils/initials";
 import AccountSwitcherList from "./account-switcher-list";
@@ -229,7 +229,7 @@ export default function DesktopTopBar() {
   const createRef = useRef<HTMLDivElement>(null);
   const createMenuRef = useRef<HTMLDivElement>(null);
   const [createAnchor, setCreateAnchor] = useState<{
-    right: number;
+    left: number;
     top: number;
   } | null>(null);
 
@@ -294,8 +294,12 @@ export default function DesktopTopBar() {
     const compute = () => {
       const rect = createRef.current?.getBoundingClientRect();
       if (!rect) return;
+      // Anchor the menu's LEFT edge to the trigger's left edge so it
+      // opens to the right of the "+" button (no chance of running off
+      // the viewport's left side when the button sits near the chrome's
+      // right edge — same affordance as GitHub's "+" menu).
       setCreateAnchor({
-        right: globalThis.innerWidth - rect.right,
+        left: rect.left,
         top: rect.bottom + 8,
       });
     };
@@ -639,7 +643,7 @@ export default function DesktopTopBar() {
               style={{
                 position: "fixed",
                 top: createAnchor.top,
-                right: createAnchor.right,
+                left: createAnchor.left,
                 width: 220,
               }}
             >
@@ -697,7 +701,11 @@ export default function DesktopTopBar() {
                 switchOrg={switchOrg}
                 onAfterSwitch={(next) => {
                   setSwitcherOpen(false);
-                  router.push(resolvePostSwitchPath(next));
+                  // Stay on the current page after the swap unless
+                  // it's a personal-only surface the new actor can't
+                  // visit (e.g. /create when switching personal →
+                  // group); the helper returns /home in that case.
+                  router.push(routeForActorSwitch(pathname, next));
                 }}
                 onSignOut={() => {
                   setSwitcherOpen(false);

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -11,11 +11,7 @@ import { useSession } from "@/hooks/use-session";
 import Avatar from "@/components/ui/avatar";
 import { getInitials } from "@/lib/utils/initials";
 import { useOrg } from "@/lib/groups/org-context";
-import {
-  isRouteVisibleToActor,
-  pathnameToPersonalOnlyRoute,
-} from "@/lib/groups/personal-only";
-import type { Group } from "@/lib/groups/types";
+import { routeForActorSwitch } from "@/lib/groups/navigation";
 import { useOrgProfile } from "@/hooks/use-org-profile";
 import { useScrollHideNavbar } from "@/hooks/use-scroll-hide-navbar";
 import { useBodyScrollLock } from "@/hooks/use-body-scroll-lock";
@@ -28,26 +24,6 @@ import { useLayoutBreakpoints } from "@/hooks/use-layout-breakpoints";
 
 const ROLE_ORDER: Record<string, number> = { owner: 0, admin: 1, member: 2 };
 
-/**
- * Decide where to go after the user switches actor (personal ↔ org).
- * Default: stay on the current path. Only redirect to /home when the
- * current route is personal-only AND the new actor is an org (so the
- * route would render its "this isn't visible to your org" empty
- * state instead of useful content).
- *
- * `resolvePostSwitchPath` (always-redirect-to-profile) is retained
- * for callers that explicitly want to land on the new persona's
- * profile after switching — not used in the post-switch redirect.
- */
-function routeForActorSwitch(pathname: string | null, next: Group | null): string {
-  if (!pathname) return "/home"
-  const routeKey = pathnameToPersonalOnlyRoute(pathname)
-  const nextIsOrg = !!next
-  if (routeKey && !isRouteVisibleToActor(routeKey, nextIsOrg)) {
-    return "/home"
-  }
-  return pathname
-}
 
 const Navbar: React.FC = () => {
   const { isLoading, isAuthenticated, did, openSignIn, signOut } = useAuth();

--- a/src/components/layout/site-drawer.tsx
+++ b/src/components/layout/site-drawer.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation"
 import { Compass, Home, Settings, User, X } from "lucide-react"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useSession } from "@/hooks/use-session"
+import { useOrg } from "@/lib/groups/org-context"
 
 /**
  * GitHub-style site-nav drawer.
@@ -27,7 +28,15 @@ export default function SiteDrawer({
 }) {
   const pathname = usePathname()
   const { isAuthenticated } = useAuth()
-  const { handle } = useSession()
+  const { handle: personalHandle } = useSession()
+  const { activeOrg } = useOrg()
+  // The "My profile" item — and any future identity-bound link added
+  // to this drawer — must route to the account the user is currently
+  // *acting as*, not their personal identity. When the account
+  // switcher is on a group, that's the group's handle; otherwise it
+  // falls back to the personal handle. Matches the convention the
+  // desktop top bar and the mobile sidebar already use.
+  const activeHandle = activeOrg?.handle ?? personalHandle
 
   // Lock body scroll + bind Escape while open.
   useEffect(() => {
@@ -44,10 +53,14 @@ export default function SiteDrawer({
     }
   }, [open, onClose])
 
-  // Profile target: own profile when signed in, sign-in prompt otherwise.
+  // Profile target: active identity's profile when signed in (group's
+  // when acting as a group, personal otherwise); sign-in prompt
+  // otherwise. The label stays "My profile" — "my" follows the
+  // currently active identity by design, same as everywhere else
+  // in the chrome.
   const profileHref =
-    isAuthenticated && handle
-      ? `/profile/${encodeURIComponent(handle)}`
+    isAuthenticated && activeHandle
+      ? `/profile/${encodeURIComponent(activeHandle)}`
       : null
 
   const items: {

--- a/src/lib/groups/navigation.ts
+++ b/src/lib/groups/navigation.ts
@@ -1,21 +1,32 @@
 import type { Group } from "./types"
+import {
+  isRouteVisibleToActor,
+  pathnameToPersonalOnlyRoute,
+} from "./personal-only"
 
 /**
- * Single source of truth for the URL we navigate to after the user
- * switches actor in the account switcher.
+ * Decide where to go after the user switches actor (personal ↔ org)
+ * in the account switcher.
  *
- * Personal → "/" (which redirects to the user's profile)
- * Group    → "/profile/<encoded-handle>" — the profile route now
- *            handles both individual and group actors, with admin
- *            affordances exposed when the viewer has owner/admin role.
- *            Falls back to "/groups/<encoded-did>" (which itself
- *            redirects server-side to /profile/<handle>) when we don't
- *            have a handle on file — strictly belt-and-suspenders for
- *            an edge case that should never fire because the org list
- *            always includes a handle.
+ * Default: stay on the current path. The switch should feel like a
+ * mode change, not a navigation — the user's reading context is
+ * preserved across the swap.
+ *
+ * Only redirect to /home when the current route is personal-only
+ * AND the new actor is an org (so the route would render its "this
+ * isn't visible to your org" empty state instead of useful content).
+ * The personal-only registry is the single source of truth shared
+ * with the nav-visibility helpers, so the two surfaces can't drift.
  */
-export function resolvePostSwitchPath(next: Group | null): string {
-  if (!next) return "/"
-  if (next.handle) return `/profile/${encodeURIComponent(next.handle)}`
-  return `/groups/${encodeURIComponent(next.groupDid)}`
+export function routeForActorSwitch(
+  pathname: string | null,
+  next: Group | null,
+): string {
+  if (!pathname) return "/home"
+  const routeKey = pathnameToPersonalOnlyRoute(pathname)
+  const nextIsOrg = !!next
+  if (routeKey && !isRouteVisibleToActor(routeKey, nextIsOrg)) {
+    return "/home"
+  }
+  return pathname
 }


### PR DESCRIPTION
Three nav-chrome fixes for the active-identity behaviour the user surfaced in one batch.

## 1. "My profile" goes to the active account

The site-drawer's "My profile" link was wired off `useSession()` alone, so it always pointed at the personal handle even when the account switcher had a group selected. Same for the `/profile` redirect index and the `/settings` breadcrumb.

Fix: read `activeOrg?.handle ?? personalHandle` everywhere a chrome surface labels something "my" / "me". Matches the convention the desktop top bar and mobile sidebar already use.

Identity-locked surfaces that *are* anchored to the personal account (`/settings/edit-profile`, `/groups/<did>/...`) are unchanged — those are reachable from their own profile contexts and their breadcrumbs follow the page they edit.

## 2. The "+" dropdown opens to the right of the trigger

It was anchored by `right: viewportWidth - rect.right`, so the menu extended to the *left*. Switch to `left: rect.left` so the menu's left edge aligns with the button's left edge — same affordance GitHub's "+" menu uses, no risk of the menu running off the viewport's left edge when the button sits near the chrome's right side.

## 3. Switching account preserves the current page

The desktop top bar's switcher always pushed to the new persona's profile via `resolvePostSwitchPath`. The mobile navbar already had the right behaviour (stay on current path; redirect to `/home` only when the current route is personal-only and the new actor is an org).

Lift that helper into `lib/groups/navigation.ts` as `routeForActorSwitch`, swap the desktop top bar over to it, and collapse the inline duplicates in `navbar.tsx` + `desktop-left-rail.tsx` so all three switcher mounts call one helper. `resolvePostSwitchPath` is retired (no remaining callers).

## Test plan

- [ ] Sign in as a personal account. Open the site drawer (hamburger). Click "My profile" → lands on personal profile.
- [ ] Switch into a group via the account switcher. Open the drawer, click "My profile" → lands on the group's profile.
- [ ] Click the breadcrumb on `/settings` while acting as a group → lands on the group's profile (was: personal).
- [ ] Visit `/profile` (bare) while acting as a group → redirects to the group's profile.
- [ ] Click the "+" in the desktop top bar. The menu opens to the right of the icon (was: left).
- [ ] On `/explore`, switch persona via the switcher → stays on `/explore`.
- [ ] On `/create`, switch from personal to a group → redirects to `/home` (create is personal-only).
- [ ] On `/create`, switch back to personal → returns to `/create`.
- [ ] On `/profile/<some-other-user>`, switch persona → stays on that profile.