### PR TITLE
feat(groups/create): circular avatar + banner on shared header row; tighter validators

### DIFF
--- a/src/app/groups/create/page.tsx
+++ b/src/app/groups/create/page.tsx
@@ -96,6 +96,10 @@ export default function CreateGroupPage() {
       setNameError("Name is required")
       return false
     }
+    if (value.trim().length < 5) {
+      setNameError("Name must be at least 5 characters")
+      return false
+    }
     if (value.length > 64) {
       setNameError("Name must be 64 characters or fewer")
       return false
@@ -109,8 +113,8 @@ export default function CreateGroupPage() {
       setHandleError("Handle is required")
       return false
     }
-    if (value.length < 2) {
-      setHandleError("Handle must be at least 2 characters")
+    if (value.length < 5) {
+      setHandleError("Handle must be at least 5 characters")
       return false
     }
     if (value.length > 32) {
@@ -319,38 +323,78 @@ export default function CreateGroupPage() {
     <form onSubmit={handleSubmit}>
       <article className="project-detail-page project-detail--wide create-project">
         <div className="project-detail">
-          {/* Banner image at top — same hero treatment + aspect
-              ratios as the project create form. */}
-          <div
-            className={
-              bannerPreviewUrl
-                ? "project-detail__hero create-project__hero"
-                : "project-detail__hero project-detail__hero--placeholder create-project__hero"
-            }
-          >
-            {bannerPreviewUrl ? (
-              <Image
-                src={bannerPreviewUrl}
-                alt=""
-                fill
-                className="project-detail__hero-img"
-                unoptimized
+          {/* Avatar (circular) on the left, banner image on the
+              right — both pickers sit on a single header row so the
+              identity inputs are introduced before the text fields.
+              The avatar is square-aspect inside its tile and given
+              `border-radius: 50%` so the preview reads as a circle
+              that matches how the avatar will render everywhere else
+              in the app. The banner keeps the project-form hero
+              aspect via `flex: 1`. */}
+          <div className="create-group__identity-row">
+            <div
+              className={
+                avatarPreviewUrl
+                  ? "create-group__avatar-tile"
+                  : "create-group__avatar-tile create-group__avatar-tile--placeholder"
+              }
+            >
+              {avatarPreviewUrl ? (
+                <Image
+                  src={avatarPreviewUrl}
+                  alt=""
+                  fill
+                  className="create-group__avatar-img"
+                  unoptimized
+                />
+              ) : (
+                <Building2
+                  size={36}
+                  strokeWidth={1.25}
+                  aria-hidden
+                  className="create-group__avatar-placeholder-icon"
+                />
+              )}
+              <ImageEditOverlay
+                onFile={handleAvatarFile}
+                hasPending={!!avatarFile}
+                variant="with-remove"
+                onRemove={handleAvatarRemove}
+                hasImage={!!avatarFile}
               />
-            ) : (
-              <Building2
-                size={56}
-                strokeWidth={1.25}
-                aria-hidden
-                className="project-detail__hero-placeholder-icon"
+            </div>
+
+            <div
+              className={
+                bannerPreviewUrl
+                  ? "project-detail__hero create-project__hero create-group__banner-tile"
+                  : "project-detail__hero project-detail__hero--placeholder create-project__hero create-group__banner-tile"
+              }
+            >
+              {bannerPreviewUrl ? (
+                <Image
+                  src={bannerPreviewUrl}
+                  alt=""
+                  fill
+                  className="project-detail__hero-img"
+                  unoptimized
+                />
+              ) : (
+                <Building2
+                  size={48}
+                  strokeWidth={1.25}
+                  aria-hidden
+                  className="project-detail__hero-placeholder-icon"
+                />
+              )}
+              <ImageEditOverlay
+                onFile={handleBannerFile}
+                hasPending={!!bannerFile}
+                variant="with-remove"
+                onRemove={handleBannerRemove}
+                hasImage={!!bannerFile}
               />
-            )}
-            <ImageEditOverlay
-              onFile={handleBannerFile}
-              hasPending={!!bannerFile}
-              variant="with-remove"
-              onRemove={handleBannerRemove}
-              hasImage={!!bannerFile}
-            />
+            </div>
           </div>
 
           <header className="cert-detail__headline">
@@ -474,44 +518,6 @@ export default function CreateGroupPage() {
                 placeholder="e.g. non-profit, cooperative, DAO (comma-separated)"
                 value={organizationType}
                 onChange={(e) => setOrganizationType(e.target.value)}
-              />
-            </div>
-          </section>
-
-          {/* Avatar — small square preview slot. Sits below the
-              meta strip so it doesn't compete with the wide banner
-              at the top; visually parallels the cert image slot on
-              the cert create page. */}
-          <section className="cert-detail__section">
-            <div className="cert-detail__section-header">
-              <h2 className="cert-detail__section-title">Avatar</h2>
-            </div>
-            <div
-              className="cert-detail__image cert-detail__image--editing"
-              style={{ maxWidth: 200 }}
-            >
-              {avatarPreviewUrl ? (
-                <Image
-                  src={avatarPreviewUrl}
-                  alt=""
-                  fill
-                  className="cert-detail__image-img"
-                  unoptimized
-                />
-              ) : (
-                <Building2
-                  size={48}
-                  strokeWidth={1.25}
-                  aria-hidden
-                  className="cert-detail__image-placeholder-icon"
-                />
-              )}
-              <ImageEditOverlay
-                onFile={handleAvatarFile}
-                hasPending={!!avatarFile}
-                variant="with-remove"
-                onRemove={handleAvatarRemove}
-                hasImage={!!avatarFile}
               />
             </div>
           </section>

--- a/src/app/styles/project-detail.css
+++ b/src/app/styles/project-detail.css
@@ -860,3 +860,69 @@
   background: var(--overlay-weak);
   outline: none;
 }
+
+/* =====================================================================
+   /groups/create — identity row (avatar circle + banner side-by-side)
+   ===================================================================== */
+
+/* Top row that introduces the group visually: a square-aspect avatar
+   tile on the left (rendered as a circle via border-radius: 50%), and
+   the wide banner tile to the right that fills the remaining width.
+   Stacks vertically on narrow viewports so the banner doesn't compress
+   into a sliver. */
+.create-group__identity-row {
+  display: flex;
+  gap: 20px;
+  align-items: stretch;
+  margin-bottom: 24px;
+}
+
+.create-group__avatar-tile {
+  position: relative;
+  flex: 0 0 auto;
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: var(--bg-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.create-group__avatar-tile--placeholder {
+  border: 1px dashed var(--border-subtle);
+  background: var(--bg-subtle);
+}
+
+.create-group__avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.create-group__avatar-placeholder-icon {
+  color: var(--fg-muted);
+}
+
+/* The banner tile inherits .project-detail__hero metrics from the
+   project-create form; this rule just lets it grow into the row's
+   remaining width and zeroes the bottom margin so the headline below
+   sits flush with the identity row. */
+.create-group__banner-tile {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+}
+
+@media (max-width: 599px) {
+  .create-group__identity-row {
+    flex-direction: column;
+    gap: 12px;
+  }
+  .create-group__avatar-tile {
+    width: 120px;
+    height: 120px;
+  }
+}


### PR DESCRIPTION
## Summary

Three changes to the new-group form (`/groups/create`).

### 1. New identity header row — avatar circle + banner side-by-side

Banner used to be full-width at the top with the avatar in its own section below the meta strip. The avatar was almost invisible until you scrolled past the form chrome. Now both pickers share a single row at the top of the form:

- **Avatar** — 140×140 square tile, rendered as a circle via `border-radius: 50%`, with the same image-edit overlay the banner uses. The preview reads as a circle, which matches how the avatar will render everywhere else in the app.
- **Banner** — grows into the row's remaining width via `flex: 1`, reuses the project-detail hero metrics.

Stacks vertically below 600px so the banner doesn't collapse to a sliver next to the circle.

### 2. Display-name requires at least 5 characters

Previously: only "is required" + 64-char max. Now: 5 ≤ name ≤ 64. Same error-display path the empty/over-cap rules already used.

### 3. Handle requires at least 5 characters

Previously: 2 ≤ handle ≤ 32. Now: 5 ≤ handle ≤ 32. The lowercase-alphanumeric-with-hyphens rule and 32-char max are unchanged.

## Note on the layout interpretation

The original request read "avatar on the top right, to the right of that have the banner image," but a thing to the right of the top-right element is physically impossible — I assumed that's a typo and went with the natural composition (avatar **left**, banner to the right of it). If you actually wanted avatar overlay top-right of the banner (Twitter-style hero+pfp), say the word and I'll swap.

## Test plan

- [ ] Navigate to `/groups/create`. Top of the form shows a circular avatar tile on the left and the banner tile on the right.
- [ ] Click the avatar tile → file picker → preview renders as a circle.
- [ ] Click the banner tile → file picker → preview fills the rectangle.
- [ ] Type a 4-char name + submit → "Name must be at least 5 characters".
- [ ] Type a 5-char name → no error.
- [ ] Type a 4-char handle + submit → "Handle must be at least 5 characters".
- [ ] Type a 5-char handle (lowercase, alphanumeric) → no error.
- [ ] Below 600px the identity row stacks vertically.
- [ ] Existing flow (handle conflict, registerGroup failure, etc.) still surfaces the right error copy.