### PR TITLE
feat(resolve-did): optional indexer actorProfile fast-path (flag-gated)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -40,6 +40,21 @@ INDEXER_DID=
 # INDEXER_URL above and leave this unset on new deploys.
 # NEXT_PUBLIC_INDEXER_URL=
 
+# Optional indexer fast-path for /api/resolve-did (default false). When
+# "true", resolve-did reads identity (handle + the Bluesky profile block)
+# from the indexer's actorProfile(did) query instead of fanning out to
+# resolveHandle + app.bsky.actor.getProfile for DIDs the indexer has
+# backfilled. Falls back to the legacy path per-field on any indexer miss,
+# so it's safe to leave off until the actorProfile query is deployed on the
+# targeted indexer. Leave unset (or "false") to keep today's behaviour.
+# RESOLVE_DID_USE_INDEXER=false
+
+# Optional rate-limit bypass key for the server-side actorProfile query
+# above. Must match the indexer's GRAPHQL_RATE_LIMIT_BYPASS_KEY. Only set
+# the header is sent when this is non-empty; only needed once the indexer
+# enables its GraphQL rate limiter.
+# INDEXER_RATELIMIT_BYPASS_KEY=
+
 # Optional: Group service URL and DID (CGS). Defaults to the production CGS.
 # NEXT_PUBLIC_GROUP_SERVICE_URL=https://groups.certified.app
 # NEXT_PUBLIC_GROUP_SERVICE_DID=did:web:groups.certified.app

--- a/src/app/api/resolve-did/__tests__/indexer-fastpath.test.ts
+++ b/src/app/api/resolve-did/__tests__/indexer-fastpath.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { NextRequest } from "next/server"
+
+/**
+ * Tests for the optional indexer fast-path on GET /api/resolve-did
+ * (RESOLVE_DID_USE_INDEXER). The route can read identity (handle + the
+ * Bluesky profile block) from the magic-indexer's `actorProfile(did)`
+ * GraphQL query instead of fanning out to resolveHandle +
+ * app.bsky.actor.getProfile. The certs lookup ALWAYS runs in parallel
+ * and its precedence (certs → bsky) is unchanged.
+ *
+ * Approach: mirror the rate-limit suite — let the real limiter run with
+ * a stubbed Redis backend that always allows (incr → 1), stub the
+ * atproto/session deps, and mock global fetch. We dispatch fetches by
+ * URL so the same mock serves the indexer GraphQL endpoint, the public
+ * appView, and the certs PDS getRecord. The route reads
+ * RESOLVE_DID_USE_INDEXER at module load, so each test stubs the env
+ * and re-imports via vi.resetModules().
+ */
+
+const incr = vi.fn().mockResolvedValue(1)
+const expire = vi.fn().mockResolvedValue(1)
+
+vi.mock("@/lib/auth/stores", () => ({
+  getRedis: () => ({ incr, expire }),
+}))
+
+vi.mock("@/lib/auth/session", () => ({
+  getSessionDid: vi.fn(async () => null),
+}))
+
+const resolveHandle = vi.fn(async () => "legacy-handle.test")
+const resolvePdsUrl = vi.fn(async () => null)
+
+vi.mock("@/lib/atproto/did", () => ({
+  resolveHandle: (...args: unknown[]) => resolveHandle(...args),
+  resolveHandleToDid: vi.fn(async () => null),
+  resolvePdsUrl: (...args: unknown[]) => resolvePdsUrl(...args),
+}))
+
+const VALID_DID = "did:plc:abcdefghijklmnopqrstuvwx"
+const INDEXER_URL = "https://magic-indexer-prod.up.railway.app/graphql"
+
+const mockFetch = vi.fn()
+const originalFetch = globalThis.fetch
+
+/** Fresh JSON Response per call — bodies are single-use streams. */
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+beforeEach(() => {
+  incr.mockReset().mockResolvedValue(1)
+  expire.mockReset().mockResolvedValue(1)
+  resolveHandle.mockReset().mockResolvedValue("legacy-handle.test")
+  resolvePdsUrl.mockReset().mockResolvedValue(null)
+  globalThis.fetch = mockFetch as unknown as typeof fetch
+  mockFetch.mockReset()
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.unstubAllEnvs()
+})
+
+async function getResolve(did: string): Promise<Response> {
+  vi.resetModules()
+  const { GET } = await import("../route")
+  const req = new NextRequest(
+    `http://localhost/api/resolve-did?did=${encodeURIComponent(did)}`,
+    { headers: { "x-real-ip": "203.0.113.7" } },
+  )
+  return GET(req)
+}
+
+/** True if any fetch call targeted the public bsky appView. */
+function appViewWasCalled(): boolean {
+  return mockFetch.mock.calls.some((c) =>
+    String(c[0]).includes("public.api.bsky.app"),
+  )
+}
+
+/** True if any fetch call targeted the indexer GraphQL endpoint. */
+function indexerWasCalled(): boolean {
+  return mockFetch.mock.calls.some((c) => String(c[0]) === INDEXER_URL)
+}
+
+describe("/api/resolve-did indexer fast-path", () => {
+  describe("flag ON", () => {
+    beforeEach(() => {
+      vi.stubEnv("RESOLVE_DID_USE_INDEXER", "true")
+      vi.stubEnv("INDEXER_URL", INDEXER_URL)
+    })
+
+    it("(a) full indexer profile → handle/displayName/avatar/banner come from the indexer; appView NOT called", async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (String(url) === INDEXER_URL) {
+          return Promise.resolve(
+            jsonResponse({
+              data: {
+                actorProfile: {
+                  did: VALID_DID,
+                  handle: "indexed.test",
+                  displayName: "Indexed Name",
+                  description: "from the indexer",
+                  avatarCid: "avatarcid123",
+                  bannerCid: "bannercid456",
+                },
+              },
+            }),
+          )
+        }
+        // certs PDS getRecord — no certs profile (resolvePdsUrl→null
+        // means getCertsProfile bails before any fetch, but be safe).
+        return Promise.resolve(new Response("", { status: 404 }))
+      })
+
+      const res = await getResolve(VALID_DID)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      expect(body.handle).toBe("indexed.test")
+      expect(body.displayName).toBe("Indexed Name")
+      expect(body.description).toBe("from the indexer")
+      // avatar / banner are the buildAvatarUrlFromCid getBlob URLs.
+      expect(body.avatar).toBe(
+        "/api/xrpc/com/atproto/sync/getBlob?did=" +
+          encodeURIComponent(VALID_DID) +
+          "&cid=avatarcid123",
+      )
+      expect(body.banner).toBe(
+        "/api/xrpc/com/atproto/sync/getBlob?did=" +
+          encodeURIComponent(VALID_DID) +
+          "&cid=bannercid456",
+      )
+      // The indexer supplied a bsky block, so the onboarding seed +
+      // hasBlueskyProfile derive from it.
+      expect(body.hasBlueskyProfile).toBe(true)
+      expect(body.blueskyProfile.displayName).toBe("Indexed Name")
+
+      expect(indexerWasCalled()).toBe(true)
+      // The whole point: no fan-out to the appView.
+      expect(appViewWasCalled()).toBe(false)
+      // The indexer carried the handle, so resolveHandle is skipped too.
+      expect(resolveHandle).not.toHaveBeenCalled()
+    })
+
+    it("(b) indexer returns handle-only (null bsky fields) → falls back to the appView for the bsky block", async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (String(url) === INDEXER_URL) {
+          return Promise.resolve(
+            jsonResponse({
+              data: {
+                actorProfile: {
+                  did: VALID_DID,
+                  handle: "handleonly.test",
+                  displayName: null,
+                  description: null,
+                  avatarCid: null,
+                  bannerCid: null,
+                },
+              },
+            }),
+          )
+        }
+        if (String(url).includes("public.api.bsky.app")) {
+          return Promise.resolve(
+            jsonResponse({
+              displayName: "AppView Name",
+              description: "from the appview",
+              avatar: "https://cdn.bsky.app/avatar.jpg",
+              banner: "https://cdn.bsky.app/banner.jpg",
+            }),
+          )
+        }
+        return Promise.resolve(new Response("", { status: 404 }))
+      })
+
+      const res = await getResolve(VALID_DID)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      // Handle still came from the indexer.
+      expect(body.handle).toBe("handleonly.test")
+      // bsky block fell back to the appView.
+      expect(body.displayName).toBe("AppView Name")
+      expect(body.avatar).toBe("https://cdn.bsky.app/avatar.jpg")
+      expect(body.banner).toBe("https://cdn.bsky.app/banner.jpg")
+      expect(body.hasBlueskyProfile).toBe(true)
+      expect(body.blueskyProfile.displayName).toBe("AppView Name")
+
+      expect(indexerWasCalled()).toBe(true)
+      expect(appViewWasCalled()).toBe(true)
+    })
+
+    it("(c) indexer query errors → full legacy fallback still produces a correct response", async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (String(url) === INDEXER_URL) {
+          // Upstream 500 — fetchIndexerActorProfile returns null → the
+          // route must fall back to the full legacy path.
+          return Promise.resolve(new Response("boom", { status: 500 }))
+        }
+        if (String(url).includes("public.api.bsky.app")) {
+          return Promise.resolve(
+            jsonResponse({
+              displayName: "Legacy AppView",
+              avatar: "https://cdn.bsky.app/legacy.jpg",
+            }),
+          )
+        }
+        return Promise.resolve(new Response("", { status: 404 }))
+      })
+
+      const res = await getResolve(VALID_DID)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      // Legacy fan-out: handle from resolveHandle, bsky from appView.
+      expect(body.handle).toBe("legacy-handle.test")
+      expect(body.displayName).toBe("Legacy AppView")
+      expect(body.avatar).toBe("https://cdn.bsky.app/legacy.jpg")
+      expect(body.hasBlueskyProfile).toBe(true)
+
+      expect(indexerWasCalled()).toBe(true)
+      expect(appViewWasCalled()).toBe(true)
+      expect(resolveHandle).toHaveBeenCalled()
+    })
+
+    it("certs precedence still wins over the indexer bsky block", async () => {
+      // A certified profile exists with a displayName → it must win the
+      // merge even though the indexer supplied a bsky displayName.
+      resolvePdsUrl.mockResolvedValue("https://pds.example")
+      mockFetch.mockImplementation((url: string) => {
+        if (String(url) === INDEXER_URL) {
+          return Promise.resolve(
+            jsonResponse({
+              data: {
+                actorProfile: {
+                  did: VALID_DID,
+                  handle: "indexed.test",
+                  displayName: "Indexed Name",
+                  avatarCid: "avatarcid123",
+                },
+              },
+            }),
+          )
+        }
+        if (String(url).includes("com.atproto.repo.getRecord")) {
+          return Promise.resolve(
+            jsonResponse({
+              value: {
+                displayName: "Certified Name",
+                description: "certified bio",
+              },
+            }),
+          )
+        }
+        return Promise.resolve(new Response("", { status: 404 }))
+      })
+
+      const res = await getResolve(VALID_DID)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      // Certs displayName wins; handle still from the indexer.
+      expect(body.displayName).toBe("Certified Name")
+      expect(body.description).toBe("certified bio")
+      expect(body.handle).toBe("indexed.test")
+      expect(body.hasCertifiedProfile).toBe(true)
+      // The onboarding seed still reflects the bsky/indexer block.
+      expect(body.blueskyProfile.displayName).toBe("Indexed Name")
+    })
+  })
+
+  describe("flag OFF (default)", () => {
+    // No RESOLVE_DID_USE_INDEXER stub → defaults to off.
+    it("(d) behaviour identical to today: the indexer is NEVER queried", async () => {
+      vi.stubEnv("INDEXER_URL", INDEXER_URL)
+      mockFetch.mockImplementation((url: string) => {
+        if (String(url).includes("public.api.bsky.app")) {
+          return Promise.resolve(
+            jsonResponse({
+              displayName: "AppView Name",
+              avatar: "https://cdn.bsky.app/avatar.jpg",
+            }),
+          )
+        }
+        return Promise.resolve(new Response("", { status: 404 }))
+      })
+
+      const res = await getResolve(VALID_DID)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      // Legacy fan-out: handle from resolveHandle, bsky from appView.
+      expect(body.handle).toBe("legacy-handle.test")
+      expect(body.displayName).toBe("AppView Name")
+      expect(body.avatar).toBe("https://cdn.bsky.app/avatar.jpg")
+
+      expect(appViewWasCalled()).toBe(true)
+      expect(resolveHandle).toHaveBeenCalled()
+      // The flag is off — the indexer must never be queried.
+      expect(indexerWasCalled()).toBe(false)
+    })
+  })
+})

--- a/src/app/api/resolve-did/route.ts
+++ b/src/app/api/resolve-did/route.ts
@@ -5,9 +5,89 @@ import { extractRouteError } from "@/lib/utils/api"
 import { getSessionDid } from "@/lib/auth/session"
 import { enforceRateLimitMulti, makeLimiter } from "@/lib/auth/rate-limit"
 import { clientIp } from "@/lib/utils/ip"
+import {
+  buildAvatarUrlFromCid,
+  buildBannerUrlFromCid,
+} from "@/lib/atproto/profile"
 
 const CERTS_PROFILE_COLLECTION = "app.certified.actor.profile"
 const CERTS_PROFILE_RKEY = "self"
+
+/**
+ * Optional indexer fast-path (default OFF). When enabled, the route
+ * reads identity (handle + the bsky profile block) from the magic-
+ * indexer's `actorProfile(did)` query instead of fanning out to
+ * `resolveHandle` + `app.bsky.actor.getProfile` for DIDs the indexer
+ * has already backfilled. The certs lookup is unchanged and always runs
+ * in parallel. Fully backward-compatible: with the flag off the route is
+ * byte-identical to the legacy three-upstream fan-out, and even with the
+ * flag on every indexer miss falls back to the legacy path per-field, so
+ * resolve-did never regresses against an un-deployed / un-indexed
+ * upstream. See magic-indexer #151 / #153 / #154.
+ */
+const USE_INDEXER = process.env.RESOLVE_DID_USE_INDEXER === "true"
+
+/**
+ * Upstream indexer GraphQL endpoint. Mirrors the resolution in
+ * `/api/indexer` (INDEXER_URL → NEXT_PUBLIC_INDEXER_URL → the railway
+ * prod fallback) so the server-side `actorProfile` query targets the
+ * same instance as the proxied client ops.
+ */
+const UPSTREAM_INDEXER_URL =
+  process.env.INDEXER_URL ||
+  process.env.NEXT_PUBLIC_INDEXER_URL ||
+  "https://magic-indexer-prod.up.railway.app/graphql"
+
+const RESOLVE_ACTOR_PROFILE_QUERY = `query ResolveActorProfile($did:String!){ actorProfile(did:$did){ did handle displayName description avatarCid bannerCid } }`
+
+type IndexerActorProfile = {
+  did?: string | null
+  handle?: string | null
+  displayName?: string | null
+  description?: string | null
+  avatarCid?: string | null
+  bannerCid?: string | null
+}
+
+/**
+ * Server-side `actorProfile(did)` lookup against the magic-indexer.
+ * POSTs the fixed GraphQL query with an 8s timeout, attaching the
+ * rate-limit bypass header only when `INDEXER_RATELIMIT_BYPASS_KEY` is
+ * set. Returns the `actorProfile` object or null on any error, non-OK
+ * status, GraphQL error, or empty payload — every failure mode collapses
+ * to null so the caller cleanly falls back to the legacy path.
+ */
+async function fetchIndexerActorProfile(
+  did: string
+): Promise<IndexerActorProfile | null> {
+  try {
+    const bypassKey = process.env.INDEXER_RATELIMIT_BYPASS_KEY
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    }
+    if (bypassKey) headers["X-RateLimit-Bypass"] = bypassKey
+
+    const res = await fetch(UPSTREAM_INDEXER_URL, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        operationName: "ResolveActorProfile",
+        query: RESOLVE_ACTOR_PROFILE_QUERY,
+        variables: { did },
+      }),
+      signal: AbortSignal.timeout(8_000),
+    })
+    if (!res.ok) return null
+    const data = (await res.json()) as {
+      data?: { actorProfile?: IndexerActorProfile | null }
+      errors?: unknown
+    }
+    if (data.errors) return null
+    return data.data?.actorProfile ?? null
+  } catch {
+    return null
+  }
+}
 
 // 60/min. Mirrors search-actors (judgment-002): this route is
 // unauthenticated and issues up to 3 outbound fetches per request, so
@@ -151,6 +231,86 @@ async function fetchBskyAppViewProfile(did: string): Promise<{
   }
 }
 
+/** The bsky identity block fed into the downstream per-field merge —
+ *  the same shape whether it originated from the indexer's
+ *  `actorProfile` or the appView's `app.bsky.actor.getProfile`. */
+type BskyIdentity = {
+  displayName?: string
+  description?: string
+  avatar?: string
+  banner?: string
+}
+
+/**
+ * Resolve the `{ handle, bsky }` identity for a DID — the part of the
+ * lookup the indexer fast-path can replace. Two modes:
+ *
+ *   - Legacy (flag OFF, or the indexer query failed entirely): the
+ *     original `resolveHandle(did)` + `fetchBskyAppViewProfile(did)`
+ *     fan-out, run in parallel.
+ *   - Indexer (flag ON + a non-null `actorProfile`): handle comes from
+ *     `actorProfile.handle ?? resolveHandle(did)`; the bsky block is
+ *     built from the indexer's denormalised fields when the indexer
+ *     HAS a bsky profile for this DID (signalled by a displayName or
+ *     avatarCid), otherwise it falls back to `fetchBskyAppViewProfile`
+ *     for an un-backfilled / un-observed DID.
+ *
+ * The certs lookup is intentionally NOT handled here — it always runs
+ * in parallel in the GET handler and its precedence (certs → bsky) is
+ * unchanged.
+ */
+async function resolveIdentity(did: string): Promise<{
+  handle: string | null
+  bsky: BskyIdentity | null
+}> {
+  // Legacy fan-out, also the universal fallback when the flag is off.
+  const legacy = async (): Promise<{
+    handle: string | null
+    bsky: BskyIdentity | null
+  }> => {
+    const [handleResult, bskyResult] = await Promise.allSettled([
+      resolveHandle(did),
+      fetchBskyAppViewProfile(did),
+    ])
+    return {
+      handle: handleResult.status === "fulfilled" ? handleResult.value : null,
+      bsky: bskyResult.status === "fulfilled" ? bskyResult.value : null,
+    }
+  }
+
+  if (!USE_INDEXER) return legacy()
+
+  const actor = await fetchIndexerActorProfile(did)
+  // Indexer query failed / returned nothing → full legacy fallback so
+  // the route never regresses against an un-deployed indexer schema.
+  if (!actor) return legacy()
+
+  // handle: prefer the indexer's denormalised handle, else resolve it.
+  const handle =
+    actor.handle ??
+    (await resolveHandle(did).catch(() => null))
+
+  // The indexer HAS a bsky profile for this DID when it carries a
+  // displayName or an avatarCid — build the bsky block from its
+  // denormalised fields. Otherwise the DID is un-backfilled / not
+  // observed, so fall back to the appView for the bsky block only.
+  const indexerHasBsky = !!(actor.displayName || actor.avatarCid)
+  if (indexerHasBsky) {
+    return {
+      handle,
+      bsky: {
+        displayName: actor.displayName ?? undefined,
+        description: actor.description ?? undefined,
+        avatar: buildAvatarUrlFromCid(did, actor.avatarCid) ?? undefined,
+        banner: buildBannerUrlFromCid(did, actor.bannerCid) ?? undefined,
+      },
+    }
+  }
+
+  const bsky = await fetchBskyAppViewProfile(did)
+  return { handle, bsky }
+}
+
 /**
  * GET /api/resolve-did?did=<did>
  * GET /api/resolve-did?handle=<handle>
@@ -205,21 +365,27 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Invalid DID" }, { status: 400 })
     }
 
-    // Run handle resolution and both profile lookups in parallel.
-    // Each is independently allowed to fail — we combine whatever
-    // succeeds.
-    const [handleResult, certsResult, bskyResult] = await Promise.allSettled([
-      resolveHandle(did),
+    // Run the certs lookup and the identity (handle + bsky) resolution
+    // in parallel. `resolveIdentity` is the adaptive layer: with the
+    // indexer flag off it's the original `resolveHandle` +
+    // `fetchBskyAppViewProfile` fan-out; with the flag on it reads
+    // identity from the indexer's `actorProfile(did)` with per-field
+    // fallback. Certs ALWAYS comes from its own PDS lookup and its
+    // precedence over bsky below is unchanged. Each branch is allowed
+    // to fail independently — we combine whatever succeeds.
+    const [identityResult, certsResult] = await Promise.allSettled([
+      resolveIdentity(did),
       getCertsProfile(did),
-      fetchBskyAppViewProfile(did),
     ])
 
-    const handle =
-      handleResult.status === "fulfilled" ? handleResult.value : null
+    const identity =
+      identityResult.status === "fulfilled"
+        ? identityResult.value
+        : { handle: null, bsky: null }
+    const handle = identity.handle
+    const bsky = identity.bsky
     const certs =
       certsResult.status === "fulfilled" ? certsResult.value : null
-    const bsky =
-      bskyResult.status === "fulfilled" ? bskyResult.value : null
 
     const displayName = certs?.displayName || bsky?.displayName || undefined
     const description = certs?.description || bsky?.description || undefined

--- a/src/lib/atproto/profile.ts
+++ b/src/lib/atproto/profile.ts
@@ -259,6 +259,21 @@ export function buildAvatarUrlFromCid(
 }
 
 /**
+ * Build a banner URL from the indexer's denormalised `(did, bannerCid)`
+ * pair. A banner blob is fetched through the exact same getBlob-by-cid
+ * proxy path as an avatar — the only difference is which CID — so this
+ * delegates to `buildAvatarUrlFromCid` and exists purely for naming
+ * clarity at call sites that resolve a banner (e.g. the resolve-did
+ * indexer fast-path consuming `actorProfile(did) { bannerCid }`).
+ */
+export function buildBannerUrlFromCid(
+  did: string | null | undefined,
+  cid: string | null | undefined,
+): string | null {
+  return buildAvatarUrlFromCid(did, cid)
+}
+
+/**
  * Get the URL for a profile banner
  * @param profile - The profile record
  * @param did - The DID of the user


### PR DESCRIPTION
## `resolve-did`: optional indexer `actorProfile` fast-path (A, app half)

Wires `/api/resolve-did` to read identity from the magic-indexer `actorProfile(did)` query, cutting its outbound fan-out — **flag-gated and fully backward-compatible**. This is the app half of the cross-repo "D" work (indexer side: #151 D1, #153 D2, #154 banner).

### Behaviour
- **`RESOLVE_DID_USE_INDEXER` (default `false`)** — when off, behaviour is **byte-identical** to today (the indexer is never queried). Safe to merge now, before the indexer redeploys.
- When on, **adaptive**:
  - Queries `actorProfile(did) { handle displayName description avatarCid bannerCid }` server-to-server (8s timeout), sending `X-RateLimit-Bypass: $INDEXER_RATELIMIT_BYPASS_KEY` (only when set) so the app egress is exempt from the indexer's per-IP limiter (#152).
  - `handle` ← indexer, else `resolveHandle`. bsky block ← indexer when it has a profile (`displayName || avatarCid`), with `avatar`/`banner` built from the CIDs via the existing `buildAvatarUrlFromCid` / new `buildBannerUrlFromCid` (the `/api/xrpc/.../getBlob` proxy, same as the feed renders indexer avatars). 
  - Falls back to `fetchBskyAppViewProfile` when the indexer lacks a profile for the DID (un-backfilled / un-indexed), and to the **full legacy path** if the indexer query errors. So it **never regresses**, and auto-improves as D2 backfills.
  - `getCertsProfile` (PDS) is unchanged and always runs in parallel; the per-field merge (certs → bsky → undefined), `hasCertifiedProfile`/`hasBlueskyProfile`, the onboarding `blueskyProfile` seed, the rate limiter, and the response shape are all untouched.

### Rollout (after the indexer side is deployed)
1. Merge #154 → indexer exposes `bannerCid`.
2. `BSKY_PROFILE_BACKFILL_ENABLED=true` on the indexer (D2 populates profiles).
3. Shared secret: indexer `GRAPHQL_RATE_LIMIT_BYPASS_KEY` == app `INDEXER_RATELIMIT_BYPASS_KEY` (optionally enable the indexer limiter).
4. `RESOLVE_DID_USE_INDEXER=true` on the app.

### Verification
- `npx tsc --noEmit` 0 errors · `npm run lint` 0 errors / 67 warnings (baseline) · `npm test` **505 passing** (72 files).
- New `indexer-fastpath.test.ts` (5): flag-on full-profile (indexer fields used, appview + resolveHandle NOT called), flag-on handle-only (appview fallback for bsky), flag-on indexer-500 (full legacy fallback), certs-precedence-wins, flag-off (indexer never queried). Fail-first confirmed on the flag-off no-fetch assertion. No existing test modified.

Opened as **Draft** — not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
