### PR TITLE
fix(profile): stop avatar data-loss (inline-edit preserve + swapRecord, sign-in clobber, resolve-did fallback)

### DIFF
--- a/src/app/api/auth/callback-handler/__tests__/seed-anti-clobber.test.ts
+++ b/src/app/api/auth/callback-handler/__tests__/seed-anti-clobber.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+/**
+ * Tests for the sign-in profile seeding in the OAuth callback handler
+ * (avatar-data-loss bug, item B1+C).
+ *
+ * Two guarantees under test:
+ *
+ *   B1 (INVARIANT): certified-app NEVER writes `app.bsky.actor.profile`.
+ *       Sign-in only ever seeds `app.certified.actor.profile`.
+ *
+ *   C  (anti-clobber): the surviving app.certified seed only runs on a
+ *       GENUINE record-not-found. On any other getRecord failure (5xx /
+ *       network / timeout / rate-limit) we must NOT putRecord, because we
+ *       can't prove the record is absent and seeding could clobber it.
+ *       When the record already exists, we also must not putRecord.
+ *
+ * The route builds an Agent from the restored OAuth session at request
+ * time, so we mock `@atproto/api`'s Agent to expose controllable
+ * getRecord/putRecord mocks. Session, rate-limit, IP and log-safe are
+ * mocked so the handler reaches the seeding path without real I/O.
+ */
+
+const getRecord = vi.fn()
+const putRecord = vi.fn()
+const restore = vi.fn()
+const createSession = vi.fn()
+const deleteSession = vi.fn()
+
+vi.mock("@atproto/api", () => ({
+  // The handler does `new Agent(oauthSession)` then calls
+  // `agent.com.atproto.repo.getRecord / putRecord`. Use a `function`
+  // implementation so `new Agent()` returns this object (an arrow fn as a
+  // constructor returns a fresh instance, dropping our `com` stub).
+  Agent: vi.fn().mockImplementation(function () {
+    return { com: { atproto: { repo: { getRecord, putRecord } } } }
+  }),
+}))
+
+vi.mock("@/lib/auth/oauth-client", () => ({
+  getOAuthClient: vi.fn(async () => ({
+    callback: vi.fn(async () => ({ session: { did: DID } })),
+    restore,
+  })),
+}))
+
+vi.mock("@/lib/auth/session", () => ({
+  createSession,
+  deleteSession,
+}))
+
+vi.mock("@/lib/utils/log-safe", () => ({ logSafe: vi.fn() }))
+
+vi.mock("@/lib/auth/rate-limit", () => ({
+  makeLimiter: vi.fn(() => ({})),
+  // No rate denial — return null so the handler proceeds.
+  enforceRateLimit: vi.fn(async () => null),
+}))
+
+vi.mock("@/lib/utils/ip", () => ({ clientIp: vi.fn(() => "127.0.0.1") }))
+
+const DID = "did:plc:seeduser000000000000000000"
+
+/** XRPCError-shaped genuine record-not-found: discriminator on `.error`. */
+function recordNotFoundError(): Error & { error: string; status: number } {
+  const e = new Error("Could not locate record") as Error & {
+    error: string
+    status: number
+  }
+  e.name = "XRPCError"
+  e.error = "RecordNotFound"
+  e.status = 400
+  return e
+}
+
+/** A non-not-found upstream failure (5xx / network style). */
+function upstreamError(): Error & { status: number } {
+  const e = new Error("Internal Server Error") as Error & { status: number }
+  e.status = 502
+  return e
+}
+
+function makeRequest(): import("next/server").NextRequest {
+  // The handler only reads `request.nextUrl.searchParams`; a minimal stub
+  // is enough since getOAuthClient().callback is mocked.
+  return {
+    nextUrl: { searchParams: new URLSearchParams() },
+  } as unknown as import("next/server").NextRequest
+}
+
+beforeEach(() => {
+  getRecord.mockReset()
+  putRecord.mockReset()
+  restore.mockReset()
+  createSession.mockReset()
+  deleteSession.mockReset()
+  restore.mockResolvedValue({})
+  createSession.mockResolvedValue(undefined)
+  deleteSession.mockResolvedValue(undefined)
+  putRecord.mockResolvedValue({ data: {} })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("auth callback — profile seeding (B1 invariant + C anti-clobber)", () => {
+  it("(i) seeds app.certified on RecordNotFound, and NEVER writes app.bsky", async () => {
+    getRecord.mockRejectedValue(recordNotFoundError())
+    const { GET } = await import("../route")
+
+    const res = await GET(makeRequest())
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ did: DID })
+
+    expect(putRecord).toHaveBeenCalledTimes(1)
+    const input = putRecord.mock.calls[0][0]
+    expect(input.collection).toBe("app.certified.actor.profile")
+    // create-if-absent only (belt-and-suspenders).
+    expect(input.swapRecord).toBeNull()
+
+    // The invariant: app.bsky.actor.profile is never written.
+    const wroteBsky = putRecord.mock.calls.some(
+      (c) => c[0]?.collection === "app.bsky.actor.profile",
+    )
+    expect(wroteBsky).toBe(false)
+  })
+
+  it("(ii) does NOT putRecord when getRecord throws a 5xx/network error", async () => {
+    getRecord.mockRejectedValue(upstreamError())
+    const { GET } = await import("../route")
+
+    const res = await GET(makeRequest())
+
+    // Sign-in still succeeds (seeding is best-effort).
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ did: DID })
+    expect(putRecord).not.toHaveBeenCalled()
+  })
+
+  it("(iii) does NOT putRecord when the record already exists", async () => {
+    getRecord.mockResolvedValue({ data: { uri: "at://exists" } })
+    const { GET } = await import("../route")
+
+    const res = await GET(makeRequest())
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ did: DID })
+    expect(putRecord).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/auth/callback-handler/route.ts
+++ b/src/app/api/auth/callback-handler/route.ts
@@ -6,11 +6,15 @@ import { logSafe } from "@/lib/utils/log-safe"
 import { enforceRateLimit, makeLimiter } from "@/lib/auth/rate-limit"
 import { clientIp } from "@/lib/utils/ip"
 
-/** Collections that should always have a "self" record after sign-in */
-const PROFILE_COLLECTIONS = [
-  "app.certified.actor.profile",
-  "app.bsky.actor.profile",
-]
+/**
+ * Collections that should always have a "self" record after sign-in.
+ *
+ * INVARIANT: certified-app must NEVER write `app.bsky.actor.profile`.
+ * Seeding an empty bsky profile here clobbers the user's existing Bluesky
+ * profile (avatar, banner, display name) — the avatar-data-loss bug. This
+ * array is the loop's only consumer, so it is the sole gate on what we seed.
+ */
+const PROFILE_COLLECTIONS = ["app.certified.actor.profile"]
 
 // 20/min by IP — the OAuth callback completes the PDS handshake;
 // legitimate users hit it once per sign-in. Higher than zero to
@@ -67,22 +71,60 @@ async function ensureProfileRecords(agent: Agent, did: string) {
         rkey: "self",
       })
       // Record exists — nothing to do
-    } catch {
-      // Record missing or error — try to create it
+    } catch (err) {
+      // Only seed on a GENUINE record-not-found. Any other failure
+      // (5xx / network / timeout / rate-limit) leaves the existing-record
+      // question UNKNOWN — seeding then would risk overwriting a record
+      // that's actually present, so we must not putRecord. The atproto SDK
+      // surfaces the discriminator on `err.error` (an XRPCError whose
+      // `.error === "RecordNotFound"`); we match the error-NAME string
+      // rather than `instanceof` so a structurally-equal error from any SDK
+      // layer still counts. See ComAtprotoRepoGetRecord.RecordNotFoundError.
+      if (!isRecordNotFound(err)) {
+        logSafe("[auth] profile getRecord failed (not seeding)", err, {
+          did,
+          collection,
+        })
+        continue
+      }
+      // Record genuinely absent — create an empty one.
       try {
         const input: ComAtprotoRepoPutRecord.InputSchema = {
           repo: did,
           collection,
           rkey: "self",
+          // Belt-and-suspenders: create-if-absent only. `swapRecord: null`
+          // tells the PDS to reject the write if a record already exists at
+          // (collection, rkey), so a TOCTOU race or a misclassified error
+          // can never clobber existing profile data.
+          swapRecord: null,
           record: {
             $type: collection,
             createdAt: now,
           },
         }
         await agent.com.atproto.repo.putRecord(input)
-      } catch {
-        // Silently ignore — best effort
+      } catch (putErr) {
+        logSafe("[auth] profile putRecord failed", putErr, { did, collection })
       }
     }
   }
+}
+
+/**
+ * True iff `err` is a genuine "record not found" from the PDS — i.e. the
+ * record really is absent and seeding is safe. The atproto SDK throws an
+ * `XRPCError` carrying the lexicon error discriminator on `.error`
+ * (`ComAtprotoRepoGetRecord.RecordNotFoundError` sets `.error ===
+ * "RecordNotFound"`). We match the error-NAME string rather than using
+ * `instanceof`, so an equivalently-shaped error from any SDK/transport layer
+ * still classifies correctly. Everything else (5xx, network, timeout, rate
+ * limit, auth) returns false → caller must NOT seed.
+ */
+function isRecordNotFound(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    (err as { error?: unknown }).error === "RecordNotFound"
+  )
 }

--- a/src/app/api/resolve-did/__tests__/indexer-fastpath.test.ts
+++ b/src/app/api/resolve-did/__tests__/indexer-fastpath.test.ts
@@ -229,6 +229,146 @@ describe("/api/resolve-did indexer fast-path", () => {
       expect(resolveHandle).toHaveBeenCalled()
     })
 
+    it("(e) per-field fallback: displayName set but avatarCid null → avatar comes from the appView, not undefined", async () => {
+      // The read-side amplifier of the data-loss bug: the indexer has a
+      // displayName (so indexerHasBsky is true) but a null avatarCid. The
+      // appView fallback must run per-field and fill the missing avatar
+      // rather than leaving it undefined (a sticky blank avatar).
+      mockFetch.mockImplementation((url: string) => {
+        if (String(url) === INDEXER_URL) {
+          return Promise.resolve(
+            jsonResponse({
+              data: {
+                actorProfile: {
+                  did: VALID_DID,
+                  handle: "indexed.test",
+                  displayName: "Indexed Name",
+                  description: "from the indexer",
+                  avatarCid: null,
+                  bannerCid: null,
+                },
+              },
+            }),
+          )
+        }
+        if (String(url).includes("public.api.bsky.app")) {
+          return Promise.resolve(
+            jsonResponse({
+              displayName: "AppView Name",
+              description: "from the appview",
+              avatar: "https://cdn.bsky.app/recovered-avatar.jpg",
+              banner: "https://cdn.bsky.app/recovered-banner.jpg",
+            }),
+          )
+        }
+        return Promise.resolve(new Response("", { status: 404 }))
+      })
+
+      const res = await getResolve(VALID_DID)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      // displayName is authoritative from the indexer.
+      expect(body.displayName).toBe("Indexed Name")
+      expect(body.description).toBe("from the indexer")
+      // The missing avatar/banner are recovered from the appView — NOT
+      // undefined.
+      expect(body.avatar).toBe("https://cdn.bsky.app/recovered-avatar.jpg")
+      expect(body.banner).toBe("https://cdn.bsky.app/recovered-banner.jpg")
+      expect(body.handle).toBe("indexed.test")
+
+      expect(indexerWasCalled()).toBe(true)
+      // The missing-field condition gated a single appView fetch.
+      expect(appViewWasCalled()).toBe(true)
+    })
+
+    it("(f) avatarCid + bannerCid present → appView is NOT fetched; avatar from the CID", async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (String(url) === INDEXER_URL) {
+          return Promise.resolve(
+            jsonResponse({
+              data: {
+                actorProfile: {
+                  did: VALID_DID,
+                  handle: "indexed.test",
+                  displayName: "Indexed Name",
+                  avatarCid: "avatarcid123",
+                  bannerCid: "bannercid456",
+                },
+              },
+            }),
+          )
+        }
+        return Promise.resolve(new Response("", { status: 404 }))
+      })
+
+      const res = await getResolve(VALID_DID)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      // avatar is built from the indexer CID.
+      expect(body.avatar).toBe(
+        "/api/xrpc/com/atproto/sync/getBlob?did=" +
+          encodeURIComponent(VALID_DID) +
+          "&cid=avatarcid123",
+      )
+      expect(body.banner).toBe(
+        "/api/xrpc/com/atproto/sync/getBlob?did=" +
+          encodeURIComponent(VALID_DID) +
+          "&cid=bannercid456",
+      )
+
+      expect(indexerWasCalled()).toBe(true)
+      // The fast path stays fast: both image CIDs present → no appView.
+      expect(appViewWasCalled()).toBe(false)
+    })
+
+    it("(g) neither displayName nor avatarCid → the full legacy appView fallback path is used", async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (String(url) === INDEXER_URL) {
+          return Promise.resolve(
+            jsonResponse({
+              data: {
+                actorProfile: {
+                  did: VALID_DID,
+                  handle: "handleonly.test",
+                  displayName: null,
+                  description: null,
+                  avatarCid: null,
+                  bannerCid: null,
+                },
+              },
+            }),
+          )
+        }
+        if (String(url).includes("public.api.bsky.app")) {
+          return Promise.resolve(
+            jsonResponse({
+              displayName: "AppView Name",
+              description: "from the appview",
+              avatar: "https://cdn.bsky.app/avatar.jpg",
+              banner: "https://cdn.bsky.app/banner.jpg",
+            }),
+          )
+        }
+        return Promise.resolve(new Response("", { status: 404 }))
+      })
+
+      const res = await getResolve(VALID_DID)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      // indexerHasBsky is false → the existing full legacy fallback path
+      // produces the entire bsky block from the appView.
+      expect(body.handle).toBe("handleonly.test")
+      expect(body.displayName).toBe("AppView Name")
+      expect(body.avatar).toBe("https://cdn.bsky.app/avatar.jpg")
+      expect(body.banner).toBe("https://cdn.bsky.app/banner.jpg")
+
+      expect(indexerWasCalled()).toBe(true)
+      expect(appViewWasCalled()).toBe(true)
+    })
+
     it("certs precedence still wins over the indexer bsky block", async () => {
       // A certified profile exists with a displayName → it must win the
       // merge even though the indexer supplied a bsky displayName.

--- a/src/app/api/resolve-did/__tests__/profile-fallback-precedence.test.ts
+++ b/src/app/api/resolve-did/__tests__/profile-fallback-precedence.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { NextRequest } from "next/server"
+
+/**
+ * Tests for the ALL-OR-NOTHING Bluesky fallback rule on
+ * GET /api/resolve-did.
+ *
+ * Product decision: the Bluesky profile is a wholesale fallback, used
+ * ONLY when the certs (app.certified.actor.profile) record is absent or
+ * completely empty. The moment the certs profile carries ANY meaningful
+ * content, its fields are authoritative and we do NOT backfill blanks
+ * per-field from Bluesky — an empty field in a partly-filled certs
+ * profile is assumed INTENTIONALLY empty.
+ *
+ * Harness mirrors indexer-fastpath.test.ts: real limiter with a stubbed
+ * Redis backend that always allows, stubbed atproto/session deps, and a
+ * mocked global fetch dispatched by URL. The flag stays OFF here so the
+ * bsky block resolves via the public appView fan-out; the merge
+ * precedence under test is independent of how the bsky block is fetched.
+ */
+
+const incr = vi.fn().mockResolvedValue(1)
+const expire = vi.fn().mockResolvedValue(1)
+
+vi.mock("@/lib/auth/stores", () => ({
+  getRedis: () => ({ incr, expire }),
+}))
+
+vi.mock("@/lib/auth/session", () => ({
+  getSessionDid: vi.fn(async () => null),
+}))
+
+const resolveHandle = vi.fn(async () => "legacy-handle.test")
+const resolvePdsUrl = vi.fn(async () => "https://pds.example")
+
+vi.mock("@/lib/atproto/did", () => ({
+  resolveHandle: (...args: unknown[]) => resolveHandle(...args),
+  resolveHandleToDid: vi.fn(async () => null),
+  resolvePdsUrl: (...args: unknown[]) => resolvePdsUrl(...args),
+}))
+
+const VALID_DID = "did:plc:abcdefghijklmnopqrstuvwx"
+
+const mockFetch = vi.fn()
+const originalFetch = globalThis.fetch
+
+/** Fresh JSON Response per call — bodies are single-use streams. */
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+beforeEach(() => {
+  incr.mockReset().mockResolvedValue(1)
+  expire.mockReset().mockResolvedValue(1)
+  resolveHandle.mockReset().mockResolvedValue("legacy-handle.test")
+  resolvePdsUrl.mockReset().mockResolvedValue("https://pds.example")
+  globalThis.fetch = mockFetch as unknown as typeof fetch
+  mockFetch.mockReset()
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.unstubAllEnvs()
+})
+
+async function getResolve(did: string): Promise<Response> {
+  vi.resetModules()
+  const { GET } = await import("../route")
+  const req = new NextRequest(
+    `http://localhost/api/resolve-did?did=${encodeURIComponent(did)}`,
+    { headers: { "x-real-ip": "203.0.113.7" } },
+  )
+  return GET(req)
+}
+
+describe("/api/resolve-did all-or-nothing bsky fallback", () => {
+  it("(i) certs has content but NO certs avatar; bsky has an avatar → avatar is undefined (NOT backfilled from bsky)", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (String(url).includes("com.atproto.repo.getRecord")) {
+        // Partly-filled certs profile: a display name, but no avatar.
+        return Promise.resolve(
+          jsonResponse({
+            value: {
+              $type: "app.certified.actor.profile",
+              displayName: "Certified Name",
+            },
+          }),
+        )
+      }
+      if (String(url).includes("public.api.bsky.app")) {
+        return Promise.resolve(
+          jsonResponse({
+            displayName: "Bsky Name",
+            avatar: "https://cdn.bsky.app/avatar.jpg",
+            banner: "https://cdn.bsky.app/banner.jpg",
+          }),
+        )
+      }
+      return Promise.resolve(new Response("", { status: 404 }))
+    })
+
+    const res = await getResolve(VALID_DID)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    // certs is authoritative: its displayName is used...
+    expect(body.displayName).toBe("Certified Name")
+    // ...and the missing avatar/banner are NOT pulled from bsky.
+    expect(body.avatar ?? undefined).toBeUndefined()
+    expect(body.banner ?? undefined).toBeUndefined()
+    expect(body.hasCertifiedProfile).toBe(true)
+  })
+
+  it("(ii) certs absent/empty; bsky has displayName + avatar → result uses the bsky values", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (String(url).includes("com.atproto.repo.getRecord")) {
+        // No certs record at all.
+        return Promise.resolve(new Response("", { status: 404 }))
+      }
+      if (String(url).includes("public.api.bsky.app")) {
+        return Promise.resolve(
+          jsonResponse({
+            displayName: "Bsky Name",
+            description: "bsky bio",
+            avatar: "https://cdn.bsky.app/avatar.jpg",
+            banner: "https://cdn.bsky.app/banner.jpg",
+          }),
+        )
+      }
+      return Promise.resolve(new Response("", { status: 404 }))
+    })
+
+    const res = await getResolve(VALID_DID)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.displayName).toBe("Bsky Name")
+    expect(body.description).toBe("bsky bio")
+    expect(body.avatar).toBe("https://cdn.bsky.app/avatar.jpg")
+    expect(body.banner).toBe("https://cdn.bsky.app/banner.jpg")
+    expect(body.hasCertifiedProfile).toBe(false)
+    expect(body.hasBlueskyProfile).toBe(true)
+  })
+
+  it("(ii-stub) certs record is an empty stub {$type, createdAt}; bsky has values → bsky fallback applies", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (String(url).includes("com.atproto.repo.getRecord")) {
+        // Stub record carrying no displayed profile fields.
+        return Promise.resolve(
+          jsonResponse({
+            value: {
+              $type: "app.certified.actor.profile",
+              createdAt: "2026-01-01T00:00:00.000Z",
+            },
+          }),
+        )
+      }
+      if (String(url).includes("public.api.bsky.app")) {
+        return Promise.resolve(
+          jsonResponse({
+            displayName: "Bsky Name",
+            avatar: "https://cdn.bsky.app/avatar.jpg",
+          }),
+        )
+      }
+      return Promise.resolve(new Response("", { status: 404 }))
+    })
+
+    const res = await getResolve(VALID_DID)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.displayName).toBe("Bsky Name")
+    expect(body.avatar).toBe("https://cdn.bsky.app/avatar.jpg")
+    expect(body.hasCertifiedProfile).toBe(false)
+  })
+
+  it("(iii) certs has ONLY a website set → displayName/avatar are undefined (all-or-nothing, not pulled from bsky)", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (String(url).includes("com.atproto.repo.getRecord")) {
+        return Promise.resolve(
+          jsonResponse({
+            value: {
+              $type: "app.certified.actor.profile",
+              website: "https://example.com",
+            },
+          }),
+        )
+      }
+      if (String(url).includes("public.api.bsky.app")) {
+        return Promise.resolve(
+          jsonResponse({
+            displayName: "Bsky Name",
+            description: "bsky bio",
+            avatar: "https://cdn.bsky.app/avatar.jpg",
+            banner: "https://cdn.bsky.app/banner.jpg",
+          }),
+        )
+      }
+      return Promise.resolve(new Response("", { status: 404 }))
+    })
+
+    const res = await getResolve(VALID_DID)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    // website alone counts as content → certs is authoritative.
+    expect(body.website).toBe("https://example.com")
+    expect(body.hasCertifiedProfile).toBe(true)
+    // None of the bsky-overlappable fields are backfilled.
+    expect(body.displayName ?? undefined).toBeUndefined()
+    expect(body.description ?? undefined).toBeUndefined()
+    expect(body.avatar ?? undefined).toBeUndefined()
+    expect(body.banner ?? undefined).toBeUndefined()
+  })
+
+  it("(iv) hasCertifiedProfile reflects certsHasContent — true when certs has content beyond displayName, false when empty", async () => {
+    // Case A: certs has only a description (no displayName) → still
+    // certsHasContent, so hasCertifiedProfile is true under the new rule
+    // (the old `!!certs?.displayName` would have reported false).
+    mockFetch.mockImplementation((url: string) => {
+      if (String(url).includes("com.atproto.repo.getRecord")) {
+        return Promise.resolve(
+          jsonResponse({
+            value: {
+              $type: "app.certified.actor.profile",
+              description: "certified bio only",
+            },
+          }),
+        )
+      }
+      if (String(url).includes("public.api.bsky.app")) {
+        return Promise.resolve(
+          jsonResponse({
+            displayName: "Bsky Name",
+            avatar: "https://cdn.bsky.app/avatar.jpg",
+          }),
+        )
+      }
+      return Promise.resolve(new Response("", { status: 404 }))
+    })
+
+    const resA = await getResolve(VALID_DID)
+    expect(resA.status).toBe(200)
+    const bodyA = await resA.json()
+    expect(bodyA.hasCertifiedProfile).toBe(true)
+    expect(bodyA.description).toBe("certified bio only")
+    // displayName not backfilled from bsky.
+    expect(bodyA.displayName ?? undefined).toBeUndefined()
+
+    // Case B: certs record present but empty stub → hasCertifiedProfile false.
+    mockFetch.mockReset()
+    mockFetch.mockImplementation((url: string) => {
+      if (String(url).includes("com.atproto.repo.getRecord")) {
+        return Promise.resolve(
+          jsonResponse({
+            value: { $type: "app.certified.actor.profile" },
+          }),
+        )
+      }
+      if (String(url).includes("public.api.bsky.app")) {
+        return Promise.resolve(
+          jsonResponse({
+            displayName: "Bsky Name",
+            avatar: "https://cdn.bsky.app/avatar.jpg",
+          }),
+        )
+      }
+      return Promise.resolve(new Response("", { status: 404 }))
+    })
+
+    const resB = await getResolve(VALID_DID)
+    expect(resB.status).toBe(200)
+    const bodyB = await resB.json()
+    expect(bodyB.hasCertifiedProfile).toBe(false)
+    // Empty certs → bsky fallback in full.
+    expect(bodyB.displayName).toBe("Bsky Name")
+    expect(bodyB.avatar).toBe("https://cdn.bsky.app/avatar.jpg")
+  })
+})

--- a/src/app/api/resolve-did/route.ts
+++ b/src/app/api/resolve-did/route.ts
@@ -402,20 +402,48 @@ export async function GET(request: NextRequest) {
     const certs =
       certsResult.status === "fulfilled" ? certsResult.value : null
 
-    const displayName = certs?.displayName || bsky?.displayName || undefined
-    const description = certs?.description || bsky?.description || undefined
+    // ALL-OR-NOTHING fallback rule (maintainer product decision):
+    // the Bluesky profile is only a wholesale fallback. We use the
+    // Bluesky fields ONLY when the user has no Certified profile, or
+    // a completely empty one. The moment a Certified profile carries
+    // ANY meaningful content, we treat it as authoritative and use
+    // ITS fields exclusively — a blank field in a partly-filled certs
+    // profile is assumed to be INTENTIONALLY blank, so we must NOT
+    // backfill it from Bluesky per-field (e.g. someone who set a
+    // display name but deliberately cleared their avatar should get
+    // no avatar, not their old bsky one).
+    //
+    // `certsHasContent` is the single gate: a certs record exists AND
+    // at least one displayed profile field is non-empty. A stub record
+    // that only carries {$type, createdAt} therefore counts as empty,
+    // so the bsky fallback still applies to it.
+    const certsHasContent = !!(
+      certs &&
+      (certs.displayName ||
+        certs.description ||
+        certs.avatarUrl ||
+        certs.bannerUrl ||
+        certs.pronouns ||
+        certs.website)
+    )
+    const displayName = certsHasContent
+      ? certs?.displayName
+      : bsky?.displayName
+    const description = certsHasContent
+      ? certs?.description
+      : bsky?.description
     const pronouns = certs?.pronouns
     const website = certs?.website
-    const avatar = certs?.avatarUrl ?? bsky?.avatar ?? undefined
-    const banner = certs?.bannerUrl ?? bsky?.banner ?? undefined
+    const avatar = certsHasContent ? certs?.avatarUrl : bsky?.avatar
+    const banner = certsHasContent ? certs?.bannerUrl : bsky?.banner
     const createdAt = certs?.createdAt
-    // True when an app.certified.actor.profile record exists with a
-    // displayName populated. Surfaced to the client so the profile
-    // sidebar / header can render the "Bluesky profile" tag only
-    // when the user has NOT authored a Certified profile (i.e. the
-    // displayName + other fields we're showing all originate from
+    // True when the user has a non-empty app.certified.actor.profile
+    // (the same `certsHasContent` gate above). Surfaced to the client
+    // so the profile sidebar / header can render the "Bluesky profile"
+    // tag only when the user has NOT authored a Certified profile
+    // (i.e. the fields we're showing all originate from
     // app.bsky.actor.profile). Issue #74.
-    const hasCertifiedProfile = !!certs?.displayName
+    const hasCertifiedProfile = certsHasContent
     // True when an app.bsky.actor.profile is reachable + populated.
     // Used by the first-signin onboarding gate so the import modal
     // only opens for users who actually have bsky content worth

--- a/src/app/api/resolve-did/route.ts
+++ b/src/app/api/resolve-did/route.ts
@@ -296,13 +296,28 @@ async function resolveIdentity(did: string): Promise<{
   // observed, so fall back to the appView for the bsky block only.
   const indexerHasBsky = !!(actor.displayName || actor.avatarCid)
   if (indexerHasBsky) {
+    const indexerAvatar = buildAvatarUrlFromCid(did, actor.avatarCid)
+    const indexerBanner = buildBannerUrlFromCid(did, actor.bannerCid)
+
+    // PER-FIELD fallback: a displayName-set-but-avatarCid-null indexer row
+    // used to render a sticky blank avatar (the read-side amplifier of the
+    // data-loss bug) because `indexerHasBsky` skipped the appView wholesale.
+    // When the indexer is missing a needed image field, lazily hit the
+    // appView ONCE and fill ONLY the gaps — the indexer stays authoritative
+    // for whatever it does carry, and the fast path stays fast (no appView
+    // fetch) whenever the avatar+banner CIDs are present.
+    let appView: BskyIdentity | null = null
+    if (!actor.avatarCid || !actor.bannerCid) {
+      appView = await fetchBskyAppViewProfile(did)
+    }
+
     return {
       handle,
       bsky: {
-        displayName: actor.displayName ?? undefined,
-        description: actor.description ?? undefined,
-        avatar: buildAvatarUrlFromCid(did, actor.avatarCid) ?? undefined,
-        banner: buildBannerUrlFromCid(did, actor.bannerCid) ?? undefined,
+        displayName: actor.displayName ?? appView?.displayName ?? undefined,
+        description: actor.description ?? appView?.description ?? undefined,
+        avatar: indexerAvatar ?? appView?.avatar ?? undefined,
+        banner: indexerBanner ?? appView?.banner ?? undefined,
       },
     }
   }

--- a/src/app/api/xrpc/[...method]/route.ts
+++ b/src/app/api/xrpc/[...method]/route.ts
@@ -21,6 +21,8 @@ import {
   RATE_LIMITED_WRITE_COLLECTIONS,
 } from "@/lib/auth/rate-limit"
 
+// INVARIANT: `app.bsky.actor.profile` must NEVER be added to this allowlist
+// (certified-app invariant) — writing it clobbers the user's Bluesky profile.
 const ALLOWED_WRITE_COLLECTIONS = [
   "org.impactindexer.link.attestation",
   "app.certified.actor.profile",

--- a/src/app/profile/[handle]/page.tsx
+++ b/src/app/profile/[handle]/page.tsx
@@ -10,6 +10,8 @@ import {
   useProfileGroupsAvailable,
 } from "@/lib/navbar-context"
 import { useUserProfile } from "@/hooks/use-user-profile"
+import { getProfileWithCid } from "@/lib/atproto/profile"
+import type { CertifiedProfile } from "@/lib/atproto/types"
 import { useUserActivities } from "@/hooks/use-user-activities"
 import { useOrgMarker } from "@/hooks/use-org-marker"
 import { useOrg } from "@/lib/groups/org-context"
@@ -156,6 +158,60 @@ export default function UserProfilePage() {
   const editTargetDid = isActingAsThisGroup ? did : undefined
 
   // -------------------------------------------------------------------
+  // Editable-base source for inline edit.
+  //
+  // `useUserProfile` resolves the DISPLAY profile via /api/resolve-did,
+  // which carries no avatar/banner blob refs (only resolved URLs). If
+  // that avatar-less snapshot were fed to useProfileInlineEdit, a
+  // TEXT-ONLY save (no fresh upload) would write the profile record
+  // WITHOUT the existing avatar/banner blobs — silently deleting them
+  // (the data-loss bug). The /settings/edit-profile surface avoids this
+  // by sourcing its base from the RAW certs record via getProfile(did),
+  // which DOES carry the blob refs; we mirror that here.
+  //
+  // Gated behind `canEditInline` so foreign / read-only views don't pay
+  // for the extra getRecord. A 404 (brand-new user with no certs record)
+  // yields null — fine, there's no avatar to preserve. We also capture
+  // the record CID as the swapRecord precondition (judgment-006 / #71).
+  // State holds the LAST successful fetch for the currently-eligible
+  // (did, canEditInline) pair. We never synchronously reset it inside
+  // the effect (that trips the set-state-in-effect lint rule); instead
+  // we track which DID the held value belongs to and gate consumption
+  // below so a stale value from a previous DID / view is never used.
+  const [editBaseFetch, setEditBaseFetch] = useState<{
+    did: string
+    profile: CertifiedProfile | null
+    cid: string | null
+  } | null>(null)
+  useEffect(() => {
+    if (!canEditInline || !did) return
+    const controller = new AbortController()
+    const targetDid = did
+    getProfileWithCid(targetDid, controller.signal)
+      .then((res) => {
+        if (controller.signal.aborted) return
+        setEditBaseFetch({
+          did: targetDid,
+          profile: res?.value ?? null,
+          cid: res?.cid ?? null,
+        })
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return
+        setEditBaseFetch({ did: targetDid, profile: null, cid: null })
+      })
+    return () => controller.abort()
+  }, [canEditInline, did])
+  // Only honor the held fetch when it matches the currently-viewed DID
+  // and the view is editable — otherwise treat the base as not-yet-known
+  // (null), so a foreign / read-only view never sees a previous editable
+  // record's blob refs or CID.
+  const editBaseValid =
+    canEditInline && !!did && editBaseFetch?.did === did
+  const editBaseProfile = editBaseValid ? editBaseFetch!.profile : null
+  const editBaseProfileCid = editBaseValid ? editBaseFetch!.cid : null
+
+  // -------------------------------------------------------------------
   // Inline edit state — owned by useProfileInlineEdit. The hook holds
   // drafts, pending uploads, post-save local mirrors, the two-write
   // save path (profile + org marker + location), and installs a
@@ -170,7 +226,13 @@ export default function UserProfilePage() {
     canEditInline,
     editTargetDid,
     sidebarIsOrg,
-    profile,
+    // Editable views feed the RAW certs record (carries avatar/banner
+    // blob refs) so a text-only save preserves them; read-only views
+    // keep the resolved useUserProfile snapshot for display. While the
+    // raw fetch is in flight we fall back to the resolved profile so the
+    // edit button isn't disabled (handleEditClick no-ops on a null base).
+    profile: canEditInline ? (editBaseProfile ?? profile) : profile,
+    profileCid: canEditInline ? editBaseProfileCid : null,
     avatarUrl,
     bannerUrl,
     orgMarker,

--- a/src/hooks/__tests__/use-profile-inline-edit-preserve.test.tsx
+++ b/src/hooks/__tests__/use-profile-inline-edit-preserve.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, act, cleanup } from "@testing-library/react"
+
+// --- Module mocks -----------------------------------------------------
+// Spy on `putProfile` to assert which record the text-only save path
+// writes. The data-loss bug (judgment-006) was: an avatar/banner-LESS
+// base profile fed into the hook left `base.avatar` / `base.banner`
+// undefined, so the preserve branches in handleSave were dead and a
+// text-only save wrote the profile record WITHOUT the existing blob
+// refs — deleting them. The page fix sources the base from the RAW
+// certs record (with blob refs); this suite pins that the preserve
+// branches keep the refs when the base carries them, and would drop
+// them when it doesn't (the old, buggy sourcing).
+
+const putProfile = vi.fn(async () => undefined)
+const uploadAvatar = vi.fn()
+const uploadBanner = vi.fn()
+const uploadBlob = vi.fn()
+
+vi.mock("@/lib/atproto/profile", () => ({
+  putProfile: (...args: unknown[]) => putProfile(...args),
+  uploadAvatar: (...args: unknown[]) => uploadAvatar(...args),
+  uploadBanner: (...args: unknown[]) => uploadBanner(...args),
+  uploadBlob: (...args: unknown[]) => uploadBlob(...args),
+}))
+
+vi.mock("@/lib/groups/org-marker", () => ({
+  putOrgMarker: vi.fn(async () => undefined),
+}))
+
+vi.mock("@/lib/atproto/location", () => ({
+  putLocationRecord: vi.fn(async () => ({ uri: "at://x", cid: "c" })),
+  readLocationStrongRef: vi.fn(async () => null),
+  rkeyFromStrongRefUri: vi.fn(() => undefined),
+}))
+
+import { useProfileInlineEdit } from "../use-profile-inline-edit"
+import type {
+  CertifiedProfile,
+  HypercertsSmallImage,
+  HypercertsLargeImage,
+} from "@/lib/atproto/types"
+import type { BlobRef } from "@atproto/api"
+
+// Pull the `$link` out of a profile avatar/banner image, regardless of
+// the (loosely-typed) BlobRef shape. Used to assert which blob the save
+// path persisted.
+function imageLink(
+  field: CertifiedProfile["avatar"] | CertifiedProfile["banner"] | undefined,
+): string | undefined {
+  if (!field || typeof field !== "object" || !("image" in field)) {
+    return undefined
+  }
+  const image = (field as { image?: { ref?: { $link?: string } } }).image
+  return image?.ref?.$link
+}
+
+// A profile that already carries BOTH an avatar (smallImage) and a
+// banner (largeImage) blob ref — the existing record the inline-edit
+// base must preserve across a text-only save.
+const EXISTING_AVATAR: HypercertsSmallImage = {
+  $type: "org.hypercerts.defs#smallImage",
+  image: {
+    $type: "blob",
+    ref: { $link: "EXISTING_AVATAR_CID" },
+    mimeType: "image/png",
+    size: 10,
+  } as unknown as BlobRef,
+}
+
+const EXISTING_BANNER: HypercertsLargeImage = {
+  $type: "org.hypercerts.defs#largeImage",
+  image: {
+    $type: "blob",
+    ref: { $link: "EXISTING_BANNER_CID" },
+    mimeType: "image/png",
+    size: 20,
+  } as unknown as BlobRef,
+}
+
+// The RAW certs-record base (post-fix): carries the blob refs. This is
+// what the page now sources via getProfileWithCid(did) for the editable
+// case, instead of the avatar-less useUserProfile snapshot.
+const baseWithBlobs: CertifiedProfile = {
+  createdAt: "2024-01-01T00:00:00.000Z",
+  displayName: "Old Name",
+  description: "Old bio",
+  avatar: EXISTING_AVATAR,
+  banner: EXISTING_BANNER,
+}
+
+// The avatar/banner-LESS base (pre-fix behavior): the resolved
+// useUserProfile snapshot has no blob refs. Used by the regression
+// assertion below to pin that the OLD sourcing drops the blobs.
+const baseWithoutBlobs: CertifiedProfile = {
+  createdAt: "2024-01-01T00:00:00.000Z",
+  displayName: "Old Name",
+  description: "Old bio",
+}
+
+function inputFor(profile: CertifiedProfile) {
+  return {
+    did: "did:plc:viewer",
+    sessionDid: "did:plc:viewer",
+    isAuthenticated: true,
+    canEditInline: true,
+    editTargetDid: undefined,
+    sidebarIsOrg: false,
+    profile,
+    profileCid: "bafyProfileCid",
+    avatarUrl: "https://cdn/old-avatar.png",
+    bannerUrl: "https://cdn/old-banner.png",
+    orgMarker: null,
+    refreshOrgMarker: vi.fn(),
+    orgUrls: null,
+    additionalUrls: [],
+  }
+}
+
+beforeEach(() => {
+  cleanup()
+  putProfile.mockClear()
+  uploadAvatar.mockReset()
+  uploadBanner.mockReset()
+  uploadBlob.mockReset()
+  // jsdom lacks createObjectURL/revokeObjectURL — stub them so the
+  // synchronous preview-URL bookkeeping in the hook doesn't throw.
+  URL.createObjectURL = vi.fn(() => "blob:preview")
+  URL.revokeObjectURL = vi.fn()
+})
+
+describe("useProfileInlineEdit — text-only save preserves existing avatar/banner", () => {
+  it("keeps the existing avatar AND banner blob refs when the base carries them and no new image is uploaded", async () => {
+    const { result } = renderHook(() =>
+      useProfileInlineEdit(inputFor(baseWithBlobs)),
+    )
+
+    act(() => result.current.handleEditClick())
+
+    // Text-only edit: change the display name; do NOT pick a new
+    // avatar or banner.
+    act(() => result.current.handleDraftChange("displayName", "New Name"))
+
+    await act(async () => {
+      await result.current.handleSave()
+    })
+
+    expect(putProfile).toHaveBeenCalledTimes(1)
+    const next = putProfile.mock.calls[0][1] as CertifiedProfile
+    // The edited text field is written...
+    expect(next.displayName).toBe("New Name")
+    // ...and crucially the existing avatar + banner blob refs survive.
+    expect(imageLink(next.avatar)).toBe("EXISTING_AVATAR_CID")
+    expect(imageLink(next.banner)).toBe("EXISTING_BANNER_CID")
+  })
+
+  it("threads the mount-time profile CID as the swapRecord precondition", async () => {
+    const { result } = renderHook(() =>
+      useProfileInlineEdit(inputFor(baseWithBlobs)),
+    )
+
+    act(() => result.current.handleEditClick())
+    act(() => result.current.handleDraftChange("displayName", "New Name"))
+
+    await act(async () => {
+      await result.current.handleSave()
+    })
+
+    expect(putProfile).toHaveBeenCalledTimes(1)
+    const opts = putProfile.mock.calls[0][2] as
+      | { targetDid?: string; swapRecord?: string }
+      | undefined
+    expect(opts?.swapRecord).toBe("bafyProfileCid")
+  })
+
+  it("regression: an avatar/banner-LESS base (the old sourcing) would DROP both blobs on a text-only save", async () => {
+    // This pins WHY the page must source the base from the raw certs
+    // record. With the avatar-less useUserProfile snapshot, the preserve
+    // branches in handleSave have nothing to copy, so the written record
+    // loses the existing avatar/banner — the data-loss bug.
+    const { result } = renderHook(() =>
+      useProfileInlineEdit(inputFor(baseWithoutBlobs)),
+    )
+
+    act(() => result.current.handleEditClick())
+    act(() => result.current.handleDraftChange("displayName", "New Name"))
+
+    await act(async () => {
+      await result.current.handleSave()
+    })
+
+    expect(putProfile).toHaveBeenCalledTimes(1)
+    const next = putProfile.mock.calls[0][1] as CertifiedProfile
+    expect(next.displayName).toBe("New Name")
+    expect(imageLink(next.avatar)).toBeUndefined()
+    expect(imageLink(next.banner)).toBeUndefined()
+  })
+})

--- a/src/hooks/use-profile-inline-edit.ts
+++ b/src/hooks/use-profile-inline-edit.ts
@@ -170,8 +170,20 @@ export interface UseProfileInlineEditInput {
   editTargetDid: string | undefined
   /** True when the viewed profile is an org (has an org marker). */
   sidebarIsOrg: boolean
-  /** Snapshot of the profile record from useUserProfile. */
+  /** Snapshot of the profile record. For the editable case the caller
+   *  sources this from the RAW certs record via `getProfileWithCid(did)`
+   *  so it carries the existing avatar/banner blob refs — the preserve
+   *  branches in `handleSave` copy them onto `next` when there's no fresh
+   *  upload. The avatar-LESS useUserProfile snapshot must NOT be passed
+   *  here for editable views or a text-only save drops the blobs. */
   profile: CertifiedProfile | null
+  /** CID of the raw profile record at mount, from `getProfileWithCid`.
+   *  Captured as a swap precondition at `handleEditClick` and threaded
+   *  into the putProfile write so a concurrent edit (other tab/device)
+   *  surfaces as an InvalidSwap error instead of silently clobbering.
+   *  `null`/`undefined` when there's no existing record (brand-new user)
+   *  or the CID couldn't be read — the write then proceeds unconditioned. */
+  profileCid?: string | null
   /** Snapshot of the avatar URL from useUserProfile. */
   avatarUrl: string | null
   /** Snapshot of the banner URL from useUserProfile. */
@@ -265,6 +277,7 @@ export function useProfileInlineEdit(
     editTargetDid,
     sidebarIsOrg,
     profile,
+    profileCid,
     avatarUrl,
     bannerUrl,
     orgMarker,
@@ -332,6 +345,14 @@ export function useProfileInlineEdit(
   // record (putRecord) instead of spawning another orphan. Cleared on
   // edit-click / cancel / successful save so a new session starts fresh.
   const mintedLocationRkeyRef = useRef<string | null>(null)
+  // CID of the profile record captured when the edit session opened
+  // (handleEditClick). Threaded as `swapRecord` into the putProfile
+  // write so the PDS rejects the write with InvalidSwap if the record
+  // moved underneath us (another tab/device) since edit-start. Null
+  // when there's no existing record (brand-new user) — the write then
+  // proceeds unconditioned, which is correct. Reset on cancel /
+  // successful save so a fresh session re-snapshots. (judgment-006 / #71)
+  const profileSwapCidRef = useRef<string | null>(null)
   // Local object-URL previews. Created the moment the user picks a
   // file (before the network upload completes) so the edit view shows
   // the new image immediately. On Save these get promoted to
@@ -525,11 +546,19 @@ export function useProfileInlineEdit(
     avatarUploadRef.current = null
     bannerUploadRef.current = null
     mintedLocationRkeyRef.current = null
+    // Snapshot the record CID at edit-start as the swap precondition.
+    profileSwapCidRef.current = profileCid ?? null
     setPendingBannerRemoved(false)
     setSaveError(null)
     setHasInteracted(false)
     setIsEditing(true)
-  }, [effectiveProfile, effectiveOrgMarker, effectiveOrgUrls, resolvedLocationRef])
+  }, [
+    effectiveProfile,
+    effectiveOrgMarker,
+    effectiveOrgUrls,
+    resolvedLocationRef,
+    profileCid,
+  ])
 
   const handleCancelEdit = useCallback(() => {
     setIsEditing(false)
@@ -538,6 +567,7 @@ export function useProfileInlineEdit(
     avatarUploadRef.current = null
     bannerUploadRef.current = null
     mintedLocationRkeyRef.current = null
+    profileSwapCidRef.current = null
     if (pendingAvatarPreviewUrl) URL.revokeObjectURL(pendingAvatarPreviewUrl)
     if (pendingBannerPreviewUrl) URL.revokeObjectURL(pendingBannerPreviewUrl)
     setPendingAvatarPreviewUrl(null)
@@ -696,25 +726,20 @@ export function useProfileInlineEdit(
       // `isSaving` / `saveError` were already set before awaiting the
       // in-flight uploads above; the record-write phase continues under
       // the same flags.
-      // TODO(#71-profile-swap): plumb swapRecord through the
-      // profile + org-marker + location writes here. Blocked on
-      // useUserProfile / useOrgMarker exposing the underlying
-      // record CIDs (they currently synthesize via /api/resolve-did
-      // which doesn't surface the CID). Once that lands:
-      //   - take `profileCid` + `orgMarkerCid` (+ `locationCid`?)
-      //     as additional UseProfileInlineEditInput fields
-      //   - capture them as the mountSnapshot at handleEditClick
-      //   - use saveWithSwap (lib/atproto/save-with-swap.ts) here
-      //     with the same hybrid C+A conflict UX as project-detail
-      //     and activity-detail.
-      // The dual-path write helpers (putProfile, putOrgMarker,
-      // putLocationRecord) already accept opts.swapRecord; only
-      // the caller wiring is missing. Tracked as a follow-up.
-      await putProfile(
-        sessionDid,
-        next,
-        editTargetDid ? { targetDid: editTargetDid } : undefined,
-      )
+      // Thread the mount-time profile CID as `swapRecord` so the PDS
+      // rejects the write with InvalidSwap when the record moved
+      // underneath us since edit-start (another tab / device). The
+      // generic catch below surfaces that as `saveError`. When there's
+      // no snapshot CID (brand-new user / unreadable CID) the write
+      // proceeds unconditioned. The org-marker + location writes below
+      // are still unconditioned — only the profile record (the avatar/
+      // banner carrier, i.e. the data-loss surface) is guarded here.
+      // (judgment-006 / #71)
+      const profileSwapCid = profileSwapCidRef.current
+      await putProfile(sessionDid, next, {
+        ...(editTargetDid ? { targetDid: editTargetDid } : {}),
+        ...(profileSwapCid ? { swapRecord: profileSwapCid } : {}),
+      })
 
       let nextMarker: GroupMetadata | null = null
       if (sidebarIsOrg) {
@@ -820,6 +845,7 @@ export function useProfileInlineEdit(
       avatarUploadRef.current = null
       bannerUploadRef.current = null
       mintedLocationRkeyRef.current = null
+      profileSwapCidRef.current = null
       setPendingBannerRemoved(false)
       setHasInteracted(false)
       setIsEditing(false)

--- a/src/lib/atproto/profile.ts
+++ b/src/lib/atproto/profile.ts
@@ -33,6 +33,26 @@ export async function getProfile(
   did: string,
   signal?: AbortSignal
 ): Promise<CertifiedProfile | null> {
+  const res = await getProfileWithCid(did, signal);
+  return res ? res.value : null;
+}
+
+/**
+ * Get a user's profile record together with the record CID.
+ *
+ * The `com.atproto.repo.getRecord` response carries both the record
+ * `value` and its `cid`. `getProfile` (above) discards the CID for the
+ * common read path; this sibling preserves it so inline-edit can capture
+ * a mount-time CID snapshot and thread it as the `swapRecord`
+ * precondition on the subsequent putProfile (judgment-006 / #71).
+ *
+ * @param did - The DID of the user whose profile to fetch
+ * @returns `{ value, cid }` or null when the record doesn't exist.
+ */
+export async function getProfileWithCid(
+  did: string,
+  signal?: AbortSignal
+): Promise<{ value: CertifiedProfile; cid: string | null } | null> {
   const res = await authFetch(
     xrpcGetRecordPath({ repo: did, collection: COLLECTION, rkey: RKEY }),
     { signal }
@@ -41,8 +61,11 @@ export async function getProfile(
     if (res.status === 400 || res.status === 404) return null;
     throw new Error(`Failed to get profile: ${res.statusText}`);
   }
-  const data = await res.json();
-  return data.value as CertifiedProfile;
+  const data = (await res.json()) as { value?: CertifiedProfile; cid?: string };
+  return {
+    value: data.value as CertifiedProfile,
+    cid: typeof data.cid === "string" ? data.cid : null,
+  };
 }
 
 /**


### PR DESCRIPTION
## Fix avatar data-loss + Bluesky-fallback precedence

Root-causes the "avatar vanished ~30 min later, gone on both apps, only fixed by re-adding" report, and tightens how the Bluesky profile is used as a fallback. Four commits. The group-create `app.bsky` stub write is intentionally **kept** (per maintainer).

### A — Inline-edit no longer deletes your avatar/banner *(the primary data-loss fix)* — `cb0d99d`
The `/profile/[handle]` inline editor sourced its base from the avatar-**less** `useUserProfile` snapshot, so the "preserve existing avatar" branch was dead — a **text-only save re-wrote `app.certified.actor.profile` without the avatar/banner blob refs**, deleting them. Now, for editable views, the base is sourced from the **raw certs record** (`getProfileWithCid`, which carries the blob refs — mirroring `/settings/edit-profile`). Also threads **`swapRecord`** (the record CID captured at edit-open) so concurrent edits surface a conflict instead of silently clobbering (closes the held judgment-006 / #71).

### B1+C — Sign-in stops clobbering profiles — `14f7dcd`
`ensureProfileRecords` seeded profiles on every sign-in with a **bare `catch {}`** that treated *any* `getRecord` error (network/5xx/timeout) as "missing" and `putRecord`'d an empty `{$type, createdAt}` record — wiping a real profile. Now: **removed `app.bsky.actor.profile` from the sign-in seed entirely** (certified-app no longer writes the per-user bsky stub), and the surviving `app.certified` seed only writes on a **genuine `RecordNotFound`** (else log + skip) with **`swapRecord: null`** (create-if-absent). Added a never-re-add comment on the XRPC write allow-list.

### D — `resolve-did` resolves the Bluesky block per-field — `334eef5`
The indexer fast-path (#114) treated the indexer as authoritative and **skipped the appview fallback** when it had a display name but a null `avatarCid` → sticky blank. Now, *when the Bluesky block is used*, a null indexer `avatarCid`/`bannerCid` falls back **per field** to the appview avatar/banner.

### Precedence — Bluesky is an all-or-nothing fallback — `a07651a`
Per maintainer rule: the Bluesky profile is used **only** when the user has **no `app.certified.actor.profile` or a completely empty one**. A single gate — `certsHasContent` (a certs record exists *and* any of displayName/description/avatar/banner/pronouns/website is set) — drives the merge: if true, the displayed displayName/description/avatar/banner come from **certs only** (blank certs fields stay blank — assumed intentional, no Bluesky backfill); if false, they come from Bluesky. `hasCertifiedProfile` is aligned to this gate. The raw `blueskyProfile` onboarding seed is untouched.
*(How D + precedence fit: precedence decides **whether** the Bluesky block is used; D decides **how** it's resolved when it is — so D now only matters for users with no/empty Certified profile.)*

### Not changed (deliberately)
The **group-create `app.bsky.actor.profile` stub** write is **retained** — you confirmed it should be allowed (an earlier commit removing it was dropped from this branch).

### Verification
- `npm test` **519 passing** (75 files; new tests for preserve, sign-in anti-clobber, per-field fallback, and all-or-nothing precedence) · `tsc --noEmit` **0 errors** · lint **0 errors / 67 warnings**. No baseline test modified/weakened.

Pairs with magic-indexer #156 (last-writer guard) and maearth #16 (sign-in clobber guard). Draft — not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
