### PR TITLE
fix(profile): guard follow/endorse while acting as a group

### DIFF
--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -2615,6 +2615,52 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   min-height: 36px;
 }
 
+/* Acting-as-group guard shown in place of the Follow/Endorse cluster on
+   foreign profiles while the viewer is acting as a group. Those actions
+   write to the personal repo, so we explain the state instead of letting
+   a click misattribute the record. */
+.profile-sidebar__acting-note {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+}
+
+.profile-sidebar__acting-note-text {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--fg-muted);
+}
+
+.profile-sidebar__acting-note-text strong {
+  color: var(--fg-secondary);
+  font-weight: 600;
+}
+
+.profile-sidebar__acting-note-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 10px;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.profile-sidebar__acting-note-switch:hover {
+  background: var(--bg-sunken);
+  border-color: var(--border-hover);
+}
+
 .profile-sidebar__action-primary {
   display: inline-flex;
   align-items: center;

--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link"
 import { useEffect, useRef, useState } from "react"
 import {
+  ArrowLeftRight,
   Calendar,
   Camera,
   Check,
@@ -26,6 +27,7 @@ import { getInitials } from "@/lib/utils/initials"
 import { formatMonthYear } from "@/lib/utils/format-date"
 import { useProfilePds } from "@/hooks/use-profile-pds"
 import { useAuth } from "@/lib/auth/auth-context"
+import { useOrg } from "@/lib/groups/org-context"
 import { useFollowing } from "@/hooks/use-following"
 import { useFollowers } from "@/hooks/use-followers"
 import { useGivenEndorsements } from "@/hooks/use-endorsements"
@@ -172,6 +174,14 @@ export default function ProfileSidebar({
   // when the viewer is signed out or when they're looking at their
   // own profile (no Follow button to render in either case).
   const { did: viewerDid, isAuthenticated } = useAuth()
+  // Acting-as-group context. Follow / Endorse / Add-to-list write to the
+  // viewer's PERSONAL repo (createFollow + createEndorsementAward are
+  // keyed to the signed-in DID, and there is no group endorse path nor a
+  // group *unfollow* route). So while acting as a group we must NOT render
+  // the live buttons — doing so silently authored personal-repo records
+  // while the rest of the UI claimed the user was the group. Guard them
+  // and offer a one-tap return to personal instead.
+  const { activeOrg, switchOrg } = useOrg()
   const isOwnProfile = !!viewerDid && viewerDid === did
   const viewerFollowing = useFollowing(
     isAuthenticated && !isOwnProfile ? viewerDid : null,
@@ -259,6 +269,11 @@ export default function ProfileSidebar({
             <Pencil size={14} strokeWidth={1.75} aria-hidden />
             Edit profile
           </Link>
+        ) : isAuthenticated && viewerDid && activeOrg ? (
+          <ActingAsGroupNotice
+            groupName={activeOrg.displayName || activeOrg.handle}
+            onSwitchToPersonal={() => switchOrg(null)}
+          />
         ) : isAuthenticated && viewerDid ? (
           <>
             <FollowButton
@@ -664,6 +679,39 @@ function AvatarEditOverlay({ onFile, isUploading, hasPending }: AvatarEditOverla
  * while the write is in flight; the parent's `onAfterWrite` re-pages
  * the viewer's follow list so the true state catches up.
  */
+
+/**
+ * Shown in the action slot of a foreign profile while the viewer is
+ * acting as a group. Follow / Endorse / Add-to-list are personal-only
+ * actions (no group write path exists for them), so rather than letting
+ * a click misattribute a record to the personal repo, we explain the
+ * state and offer a one-tap return to personal. Mirrors the personal-only
+ * nav-gating philosophy in lib/groups/personal-only.ts.
+ */
+function ActingAsGroupNotice({
+  groupName,
+  onSwitchToPersonal,
+}: {
+  groupName: string
+  onSwitchToPersonal: () => void
+}) {
+  return (
+    <div className="profile-sidebar__acting-note" role="note">
+      <p className="profile-sidebar__acting-note-text">
+        Acting as <strong>{groupName}</strong>. Follow and endorse are
+        personal actions.
+      </p>
+      <button
+        type="button"
+        className="profile-sidebar__acting-note-switch"
+        onClick={onSwitchToPersonal}
+      >
+        <ArrowLeftRight size={14} strokeWidth={1.75} aria-hidden />
+        Switch to personal
+      </button>
+    </div>
+  )
+}
 
 interface FollowButtonProps {
   viewerDid: string


### PR DESCRIPTION
## What

While **acting as a group**, the profile sidebar's **Follow / Endorse / Add-to-list** actions wrote to the viewer's **personal** repo. `createFollow` and `createEndorsementAward` are keyed to the signed-in DID and never read `activeOrg`, so a record was silently authored as the personal account while the rest of the UI (avatar, name, handle, feed, create flows) claimed the user was the group.

For an app whose whole value is verifiable attribution, a mis-attributed follow/endorsement is a correctness and trust bug, not a cosmetic one.

## Why guard rather than route to the group

There is **no group write path** for these actions today:
- the group follow route (`/api/groups/[did]/follow`) is **POST-only** (no unfollow), and `deleteFollow` writes to the personal repo via XRPC;
- endorsements have **no group route** at all (`createEndorsementAward` runs `ensureEndorsementDefinition(ownDid)` and writes to `ownDid`).

Wiring "act as group" here would ship a half-feature (a follow you can't undo; an endorse with no backend). So this PR takes the safe, consistent path: while `activeOrg` is set, the foreign-profile action cluster is replaced with a short note plus a one-tap **"Switch to personal"**, mirroring the existing personal-only nav gating in `lib/groups/personal-only.ts`. No more silent wrong-identity writes.

## Changes
- `src/components/profile/profile-sidebar.tsx` — read `useOrg()`; when acting as a group, render `ActingAsGroupNotice` instead of the live Follow/Endorse/Add-to-list buttons.
- `src/app/styles/layout.css` — tokenized styles for the notice (no raw hex, `--radius`, semantic tokens).

## Out of scope
- The larger switcher redesign (persistent "Acting as" bar vs. per-action identity). Two mockups live in `docs/switcher-mockups/` for that decision; not part of this PR.
- Enabling group follow/endorse as real group writes (needs new backend routes).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files (no new warnings)
- [x] `vitest` 519/519 pass
- [ ] Manual: acting as a group, open a foreign profile, confirm the guard + "Switch to personal" shows and no follow/endorse record is written to the personal repo
- [ ] Manual: as personal, confirm Follow / Endorse / Add-to-list behave exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
