### PR TITLE
fix(nav): brandmark and /home route signed-out visitors to /welcome

### DIFF
--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -1,14 +1,15 @@
 "use client"
 
+import { useEffect } from "react"
 import Link from "next/link"
-import { FolderGit2, LogIn, User, Users } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { FolderGit2, User, Users } from "lucide-react"
 import CertIcon from "@/components/ui/cert-icon"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useOrg } from "@/lib/groups/org-context"
 import { useUserProjects } from "@/hooks/use-user-projects"
 import { useUserActivities } from "@/hooks/use-user-activities"
 import { usePageTitle } from "@/lib/navbar-context"
-import EmptyState from "@/components/ui/empty-state"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import Avatar from "@/components/ui/avatar"
 import HomeFeed from "@/components/home/home-feed"
@@ -46,6 +47,7 @@ const SIDEBAR_PREVIEW_LIMIT = 5
  */
 export default function Home() {
   usePageTitle("Home")
+  const router = useRouter()
   const { isLoading: authLoading, isAuthenticated, did: personalDid } = useAuth()
   const { activeOrg } = useOrg()
 
@@ -56,29 +58,27 @@ export default function Home() {
   // useOrg() further down, which always reflects the signed-in user).
   const activeDid = activeOrg?.groupDid || personalDid
 
-  // While the auth check is in flight `isAuthenticated` is still
-  // false. Show a spinner instead of the sign-in CTA so the page
-  // doesn't flash a "sign in" message every reload before the auth
-  // state resolves.
-  if (authLoading) {
+  // /home is a signed-in-only surface. Once auth resolves to
+  // signed-out, redirect to the marketing landing rather than showing
+  // a sign-in empty state. Runs in an effect because router.replace
+  // can't fire during render. The brandmark links already aim straight
+  // at /welcome when they know the viewer is signed out; this guard
+  // backstops the remaining paths into /home — direct navigation, the
+  // bottom-nav Home tab, or a click during the auth-loading tick.
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace("/welcome")
+    }
+  }, [authLoading, isAuthenticated, router])
+
+  // Show a spinner while auth is still resolving, while the signed-out
+  // redirect above is in flight, or while an authenticated viewer's
+  // acting-as DID is still resolving — never flash the feed or a CTA.
+  if (authLoading || !isAuthenticated || !activeDid) {
     return (
       <div className="home-page">
         <div className="home__loading">
           <LoadingSpinner size="md" />
-        </div>
-      </div>
-    )
-  }
-
-  if (!isAuthenticated || !activeDid) {
-    return (
-      <div className="home-page">
-        <div className="home__signed-out">
-          <EmptyState
-            icon={LogIn}
-            title="Sign in to see your home"
-            description="Once signed in, you'll see the groups, projects, and certs you own — plus a feed of activity from the people you follow."
-          />
         </div>
       </div>
     )

--- a/src/components/layout/desktop-left-rail.tsx
+++ b/src/components/layout/desktop-left-rail.tsx
@@ -74,7 +74,7 @@ function formatPendingBadge(count: number | null): string | null {
 export default function DesktopLeftRail() {
   const pathname = usePathname();
   const router = useRouter();
-  const { isAuthenticated, did, openSignIn, signOut } = useAuth();
+  const { isLoading, isAuthenticated, did, openSignIn, signOut } = useAuth();
   const { profile, avatarUrl } = useProfile();
   const { handle } = useSession();
   const { activeOrg, groups, switchOrg } = useOrg();
@@ -196,11 +196,12 @@ export default function DesktopLeftRail() {
   // personal-handle path uses `handle` (from useSession) rather than
   // `identity.handle`, which is the *group* handle when activeOrg is
   // set and would otherwise send us to /profile/<group-handle>.
-  // Brand mark always links to /home. The /home page handles its
-  // own unauth state (sign-in empty state). Org-switch acting-as
-  // state is no longer load-bearing here — the user's mental model
-  // is "brand = home", not "brand = my current profile".
-  const brandHref = "/home";
+  // Brand mark links to /home for signed-in viewers and to /welcome
+  // once auth resolves to signed-out. While auth is still loading we
+  // keep /home, whose own guard bounces an unauthenticated viewer to
+  // /welcome. Org-switch acting-as state is not load-bearing here —
+  // the user's mental model is "brand = home", not "brand = my profile".
+  const brandHref = !isLoading && !isAuthenticated ? "/welcome" : "/home";
 
   // Personal-only visibility (Create, Endorsements, Groups) is decided
   // by lib/groups/personal-only.ts — same source of truth used by the

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -362,10 +362,11 @@ export default function DesktopTopBar() {
     return qs ? `${pathname}?${qs}` : pathname;
   };
 
-  // Brandmark always navigates to /home, regardless of auth or
-  // active identity. The /home page itself handles the signed-out
-  // empty state. Mirrors the navbar + left-rail brand link.
-  const brandHref = "/home"
+  // Brandmark navigates to /home for signed-in viewers and to /welcome
+  // once we know the viewer is signed out. isLoading already returned
+  // null above (line ~353), so !isAuthenticated here means definitively
+  // signed out. Mirrors the navbar + left-rail brand link.
+  const brandHref = isAuthenticated ? "/home" : "/welcome"
   const brandAriaLabel = "Certified home"
 
   return (

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -314,10 +314,13 @@ const Navbar: React.FC = () => {
           )}
         </div>
 
-        {/* Center: brandmark — always links to /home. The /home page
-            handles the unauthenticated state itself (sign-in empty
-            state) so we don't need to branch the href here. */}
-        <Link href="/home" className="navbar__logo">
+        {/* Center: brandmark — links to /home for signed-in viewers and
+            straight to /welcome once we know the viewer is signed out.
+            While auth is still resolving we keep /home; its own guard
+            redirects an unauthenticated viewer to /welcome, so the worst
+            case is a one-tick bounce rather than stranding a signed-in
+            viewer on the marketing page during the loading flash. */}
+        <Link href={!isLoading && !isAuthenticated ? "/welcome" : "/home"} className="navbar__logo">
           <Brandmark className="navbar__logo-img" title="Certified" />
         </Link>
 

--- a/src/components/layout/site-drawer.tsx
+++ b/src/components/layout/site-drawer.tsx
@@ -27,7 +27,7 @@ export default function SiteDrawer({
   onClose: () => void
 }) {
   const pathname = usePathname()
-  const { isAuthenticated } = useAuth()
+  const { isLoading, isAuthenticated } = useAuth()
   const { handle: personalHandle } = useSession()
   const { activeOrg } = useOrg()
   // The "My profile" item — and any future identity-bound link added
@@ -98,7 +98,7 @@ export default function SiteDrawer({
       >
         <header className="site-drawer__head">
           <Link
-            href="/home"
+            href={!isLoading && !isAuthenticated ? "/welcome" : "/home"}
             className="site-drawer__brand"
             onClick={onClose}
             aria-label="Certified home"


### PR DESCRIPTION
## What

Signed-out visitors are now routed to `/welcome` instead of `/home`:

- **Brandmark → /welcome when signed out.** Every brandmark variant (mobile navbar, desktop top bar, desktop left rail, site-drawer wordmark) links to `/home` for signed-in viewers and to `/welcome` once auth resolves to signed-out.
- **/home redirects signed-out viewers to /welcome** (via `router.replace` in an effect, mirroring the existing `page.tsx` / `auth-guard.tsx` convention) instead of rendering the "Sign in to see your home" empty state.

## Why the loading-flash guard

The brandmark only diverts to `/welcome` when the viewer is **definitively** signed out (`!isLoading && !isAuthenticated`). While auth is still resolving it keeps `/home`, whose own redirect is the backstop. This avoids stranding an authenticated viewer on the marketing page during the brief auth-loading window (`/welcome` does not bounce authenticated users back).

## Changes
- `src/components/layout/navbar.tsx`, `desktop-top-bar.tsx`, `desktop-left-rail.tsx`, `site-drawer.tsx` — auth-aware brandmark href.
- `src/components/home/home.tsx` — redirect signed-out → `/welcome`; removed the now-unused sign-in empty state and its imports.

## Notes
- `desktop-left-rail.tsx` is currently dead code (not mounted anywhere); updated for consistency.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (no new warnings)
- [x] `vitest` 519/519 pass
- [x] Browser (signed out): `/home` redirects to `/welcome`; navbar / top-bar / drawer brand href is `/welcome`; `/welcome` stays put (no loop)
- [ ] Manual (signed in): brandmark still goes to `/home`; `/home` renders the feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
