### PR TITLE
feat(org): act-as delegation — orgs can endorse and follow as first-class actors

### DIFF
--- a/docs/switcher-mockups/option-1-desktop.html
+++ b/docs/switcher-mockups/option-1-desktop.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Switcher — Option 1 (desktop): Sticky persona + persistent bar</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Noto+Serif:wght@500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --color-primary:#111111; --color-white:#FFFFFF;
+    --bg-canvas:#f9f9f9; --bg-sunken:#eeeeee; --bg-raised:#f3f3f3; --bg-elevated:#FFFFFF;
+    --fg-primary:#111111; --fg-secondary:#4c4546; --fg-muted:#6b6263;
+    --border-default:rgba(0,0,0,0.08); --border-hover:rgba(0,0,0,0.15); --border-strong:rgba(0,0,0,0.22);
+    --shadow-sm:0 1px 2px rgba(0,0,0,0.05); --shadow-md:0 4px 12px rgba(0,0,0,0.08);
+    --radius:2px; --serif:'Noto Serif',Georgia,serif; --ui:'Inter',system-ui,sans-serif; --stage:#dcdcd8;
+  }
+  .dark{
+    --bg-canvas:#18181b; --bg-sunken:#111114; --bg-raised:#26262b; --bg-elevated:#2d2d33;
+    --fg-primary:#f5f5f7; --fg-secondary:#c7c7cc; --fg-muted:#8e8e93;
+    --border-default:rgba(255,255,255,0.08); --border-hover:rgba(255,255,255,0.18); --border-strong:rgba(255,255,255,0.28);
+    --shadow-md:0 4px 12px rgba(0,0,0,0.5); --stage:#0c0c0e;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0;font-family:var(--ui);background:var(--stage);color:var(--fg-primary);-webkit-font-smoothing:antialiased;}
+  .top{display:flex;align-items:center;justify-content:space-between;padding:16px 28px;}
+  .top .t{font-family:var(--serif);font-weight:600;font-size:17px;}
+  .top .t small{font-family:var(--ui);font-weight:500;font-size:12px;color:var(--fg-muted);margin-left:8px;}
+  .toggle{font-size:12.5px;font-weight:500;color:var(--fg-primary);background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:999px;padding:7px 14px;cursor:pointer;}
+  .wrap{max-width:1340px;margin:0 auto;padding:6px 28px 50px;}
+  .lede{font-size:14px;line-height:1.55;color:var(--fg-secondary);max-width:880px;margin:0 0 20px;}
+
+  /* browser window */
+  .browser{border-radius:12px;overflow:hidden;box-shadow:0 22px 60px rgba(0,0,0,.22);border:1px solid var(--border-hover);background:var(--bg-canvas);}
+  .chrome{height:40px;display:flex;align-items:center;gap:14px;padding:0 14px;background:var(--bg-sunken);border-bottom:1px solid var(--border-default);}
+  .dots{display:flex;gap:7px;} .dots i{width:11px;height:11px;border-radius:50%;display:block;background:#cfcfca;} .dark .dots i{background:#3a3a40;}
+  .url{flex:1;max-width:520px;height:24px;border-radius:999px;background:var(--bg-elevated);border:1px solid var(--border-default);display:flex;align-items:center;padding:0 12px;font-size:12px;color:var(--fg-muted);}
+
+  /* app top bar */
+  .appbar{height:56px;display:flex;align-items:center;gap:18px;padding:0 20px;background:color-mix(in srgb,var(--bg-elevated) 90%,transparent);backdrop-filter:blur(12px);border-bottom:1px solid var(--border-default);position:relative;}
+  .burger{color:var(--fg-secondary);cursor:pointer;}
+  .brand{font-family:var(--serif);font-weight:600;font-size:18px;letter-spacing:-.01em;}
+  .tabs{display:flex;gap:4px;margin-left:14px;}
+  .tabs a{font-size:13px;color:var(--fg-muted);padding:6px 10px;border-radius:var(--radius);text-decoration:none;}
+  .tabs a.on{color:var(--fg-primary);font-weight:600;background:var(--bg-sunken);}
+  .spacer{flex:1;}
+  .switch{display:flex;align-items:center;gap:9px;padding:5px 8px 5px 6px;border:1px solid var(--border-default);border-radius:999px;background:var(--bg-elevated);cursor:pointer;position:relative;}
+  .switch .who{display:flex;flex-direction:column;line-height:1.15;} .switch .who .n{font-size:12.5px;font-weight:600;} .switch .who .h{font-size:11px;color:var(--fg-muted);}
+  .chev{color:var(--fg-muted);font-size:11px;}
+
+  /* the persistent inverted bar */
+  .actbar{display:flex;align-items:center;gap:12px;padding:11px 22px;background:var(--color-primary);color:var(--color-white);}
+  .dark .actbar{background:var(--color-white);color:var(--color-primary);}
+  .actbar .lab{font-size:13px;flex:1;} .actbar .lab .lead{opacity:.6;} .actbar .lab .who{font-weight:600;}
+  .actbar .exit{font-size:12.5px;font-weight:500;color:inherit;background:transparent;border:1px solid rgba(255,255,255,.34);border-radius:999px;padding:5px 12px;cursor:pointer;}
+  .dark .actbar .exit{border-color:rgba(0,0,0,.25);}
+  .actbar .av.ring{box-shadow:0 0 0 2px var(--color-primary),0 0 0 3.5px rgba(255,255,255,.85);}
+  .dark .actbar .av.ring{box-shadow:0 0 0 2px var(--color-white),0 0 0 3.5px rgba(0,0,0,.6);}
+
+  /* avatars */
+  .av{border-radius:50%;display:grid;place-items:center;font-weight:600;color:#fff;flex:none;}
+  .av.green{background:#3d5a45;} .av.blue{background:#3a4a63;} .av.plum{background:#5a3d52;}
+  .av-22{width:22px;height:22px;font-size:9px;} .av-26{width:26px;height:26px;font-size:10px;} .av-28{width:28px;height:28px;font-size:11px;}
+  .av-120{width:120px;height:120px;font-size:42px;}
+  .av.ring{box-shadow:0 0 0 2px var(--bg-canvas),0 0 0 4px var(--fg-primary);}
+
+  /* profile layout */
+  .content{display:grid;grid-template-columns:288px 1fr;gap:0;}
+  .side{padding:26px 22px;border-right:1px solid var(--border-default);display:flex;flex-direction:column;align-items:flex-start;}
+  .side .nm{font-family:var(--serif);font-weight:600;font-size:22px;margin-top:14px;}
+  .side .hd{font-size:13px;color:var(--fg-muted);margin-top:3px;}
+  .side .did{font-size:11.5px;color:var(--fg-muted);margin-top:10px;font-feature-settings:"tnum";}
+  .note{margin-top:18px;display:flex;flex-direction:column;gap:9px;align-items:flex-start;}
+  .note p{margin:0;font-size:12.5px;line-height:1.45;color:var(--fg-muted);}
+  .note p b{color:var(--fg-secondary);font-weight:600;}
+  .note .sw{display:inline-flex;align-items:center;gap:6px;height:32px;padding:0 12px;font-size:12.5px;font-weight:500;color:var(--fg-primary);background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius);cursor:pointer;}
+  .main{padding:24px 26px;}
+  .main h2{font-family:var(--serif);font-weight:600;font-size:18px;margin:0 0 14px;}
+  .card{border:1px solid var(--border-default);border-radius:var(--radius);background:var(--bg-elevated);padding:14px;display:flex;gap:12px;align-items:center;margin-bottom:10px;}
+  .card .thumb{width:42px;height:42px;border-radius:var(--radius);background:var(--bg-sunken);flex:none;display:grid;place-items:center;color:var(--fg-muted);}
+  .card .ct{font-size:14px;font-weight:600;} .card .cs{font-size:12px;color:var(--fg-muted);margin-top:2px;}
+
+  /* split dropdown menu */
+  .menu{position:absolute;top:50px;right:14px;width:290px;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:8px;box-shadow:var(--shadow-md);overflow:hidden;z-index:30;}
+  .menu .sec{font-size:10.5px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:var(--fg-muted);padding:11px 13px 5px;}
+  .menu .mrow{display:flex;align-items:center;gap:10px;padding:8px 13px;cursor:pointer;}
+  .menu .mrow:hover{background:var(--bg-sunken);}
+  .menu .mrow .meta{display:flex;flex-direction:column;line-height:1.25;flex:1;min-width:0;}
+  .menu .mrow .meta .n{font-size:13.5px;font-weight:500;} .menu .mrow .meta .h{font-size:11.5px;color:var(--fg-muted);}
+  .menu .mrow .role{font-size:10px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--fg-muted);background:var(--bg-sunken);padding:2px 6px;border-radius:999px;}
+  .menu .mrow.active{background:var(--bg-sunken);} .menu .mrow.active .ck{margin-left:auto;}
+  .menu .divider{height:1px;background:var(--border-default);margin:5px 0;}
+  .menu .lin{display:flex;align-items:center;gap:9px;padding:9px 13px;font-size:13px;color:var(--fg-secondary);cursor:pointer;} .menu .lin:hover{background:var(--bg-sunken);} .menu .lin svg{color:var(--fg-muted);}
+
+  .annos{display:flex;gap:26px;margin-top:18px;flex-wrap:wrap;}
+  .anno{font-size:12.5px;line-height:1.5;color:var(--fg-secondary);padding-left:15px;position:relative;max-width:380px;}
+  .anno::before{content:"";position:absolute;left:0;top:7px;width:6px;height:6px;border-radius:50%;background:var(--fg-primary);}
+  .anno b{color:var(--fg-primary);font-weight:600;}
+  svg{display:block;}
+</style>
+</head>
+<body>
+  <div class="top">
+    <div class="t">Option 1 — desktop <small>Sticky persona + persistent bar</small></div>
+    <button class="toggle" id="themeBtn">Dark mode</button>
+  </div>
+  <div class="wrap">
+    <p class="lede">Desktop widens the same idea. The switcher lives in the top-right of the desktop top bar and now shows the full name + @handle (not avatar-only). The persistent inverted bar spans the full width directly under the top bar, so it stays in view beside the left identity rail and main column. The split menu opens as a dropdown.</p>
+
+    <div class="browser">
+      <div class="chrome"><div class="dots"><i></i><i></i><i></i></div><div class="url">certified.app/profile/jane.bsky.social</div></div>
+      <div class="appbar">
+        <span class="burger"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M3 12h18M3 18h18"/></svg></span>
+        <span class="brand">Certified</span>
+        <nav class="tabs"><a href="#" class="on">Overview</a><a href="#">Certs</a><a href="#">Projects</a><a href="#">Endorsements</a></nav>
+        <span class="spacer"></span>
+        <div class="switch" id="trig">
+          <div class="av green av-28 ring">AC</div>
+          <div class="who"><span class="n">Acme Collective</span><span class="h">@acme.certified.app</span></div>
+          <span class="chev">&#9662;</span>
+        </div>
+        <div class="menu" id="menu">
+          <div class="sec">Acting as</div>
+          <div class="mrow"><div class="av plum av-28">YO</div><div class="meta"><span class="n">You (personal)</span><span class="h">@holke.certified.app</span></div></div>
+          <div class="mrow active"><div class="av green av-28 ring">AC</div><div class="meta"><span class="n">Acme Collective</span><span class="h">@acme.certified.app</span></div><span class="role">Owner</span><span class="ck">&#10003;</span></div>
+          <div class="mrow"><div class="av blue av-28">RF</div><div class="meta"><span class="n">Rainforest Fund</span><span class="h">@rainforest.certified.app</span></div><span class="role">Admin</span></div>
+          <div class="divider"></div>
+          <div class="lin"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 3h5v5"/><path d="M21 3l-7 7"/><path d="M8 21H3v-5"/><path d="M3 21l7-7"/></svg> Use a different account&hellip;</div>
+          <div class="lin"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="M16 17l5-5-5-5"/><path d="M21 12H9"/></svg> Sign out</div>
+        </div>
+      </div>
+      <div class="actbar">
+        <div class="av green av-26 ring">AC</div>
+        <div class="lab"><span class="lead">Acting as </span><span class="who">Acme Collective</span></div>
+        <button class="exit">&#8617; Switch back to You</button>
+      </div>
+      <div class="content">
+        <div class="side">
+          <div class="av blue av-120">JR</div>
+          <div class="nm">Jane Rivera</div>
+          <div class="hd">@jane.bsky.social</div>
+          <div class="did">did:plc:44ybard66vv44z&hellip;</div>
+          <div class="note">
+            <p>Acting as <b>Acme Collective</b>. Follow and endorse are personal actions.</p>
+            <button class="sw">&#8646; Switch to personal</button>
+          </div>
+        </div>
+        <div class="main">
+          <h2>Certificates</h2>
+          <div class="card"><div class="thumb"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"/><path d="M9 12l-3 8 6-3 6 3-3-8"/></svg></div><div><div class="ct">Reforestation milestone, Q2</div><div class="cs">Issued by Rainforest Fund &middot; endorsed by 12</div></div></div>
+          <div class="card"><div class="thumb"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"/><path d="M9 12l-3 8 6-3 6 3-3-8"/></svg></div><div><div class="ct">Verified contributor 2026</div><div class="cs">Issued by Acme Collective &middot; endorsed by 4</div></div></div>
+          <div class="card"><div class="thumb"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 15a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"/><path d="M9 12l-3 8 6-3 6 3-3-8"/></svg></div><div><div class="ct">Open-source maintainer</div><div class="cs">Self-issued &middot; endorsed by 31</div></div></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="annos">
+      <div class="anno"><b>Switcher in the top bar</b> shows name + @handle on desktop (mobile was avatar-only), so the active identity is legible at rest.</div>
+      <div class="anno"><b>Full-width inverted bar</b> sits above both the identity rail and the main column, persistent on every route. Inversion carries the signal without a brand hue.</div>
+      <div class="anno"><b>Guard in the identity rail:</b> Follow / Endorse are replaced by the note while acting as a group, never silently written to the personal repo.</div>
+    </div>
+  </div>
+<script>
+  document.getElementById('themeBtn').addEventListener('click',e=>{const on=document.body.classList.toggle('dark');e.target.textContent=on?'Light mode':'Dark mode';});
+</script>
+</body>
+</html>

--- a/docs/switcher-mockups/option-1-sticky-bar.html
+++ b/docs/switcher-mockups/option-1-sticky-bar.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Switcher — Option 1: Sticky persona + persistent bar</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Noto+Serif:wght@500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --color-primary:#111111; --color-white:#FFFFFF;
+    --bg-canvas:#f9f9f9; --bg-sunken:#eeeeee; --bg-raised:#f3f3f3; --bg-elevated:#FFFFFF;
+    --fg-primary:#111111; --fg-secondary:#4c4546; --fg-muted:#6b6263;
+    --border-default:rgba(0,0,0,0.08); --border-hover:rgba(0,0,0,0.15); --border-strong:rgba(0,0,0,0.22);
+    --shadow-sm:0 1px 2px rgba(0,0,0,0.05); --shadow-md:0 4px 12px rgba(0,0,0,0.08);
+    --radius:2px;
+    --serif:'Noto Serif',Georgia,serif; --ui:'Inter',system-ui,sans-serif;
+    --stage:#e7e7e4;
+  }
+  .dark{
+    --bg-canvas:#18181b; --bg-sunken:#111114; --bg-raised:#26262b; --bg-elevated:#2d2d33;
+    --fg-primary:#f5f5f7; --fg-secondary:#c7c7cc; --fg-muted:#8e8e93;
+    --border-default:rgba(255,255,255,0.08); --border-hover:rgba(255,255,255,0.18); --border-strong:rgba(255,255,255,0.28);
+    --shadow-md:0 4px 12px rgba(0,0,0,0.5);
+    --stage:#0e0e10;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0;font-family:var(--ui);background:var(--stage);color:var(--fg-primary);-webkit-font-smoothing:antialiased;transition:background .2s;}
+  .topbar{display:flex;align-items:center;justify-content:space-between;padding:18px 28px;border-bottom:1px solid var(--border-default);position:sticky;top:0;background:var(--stage);z-index:5;}
+  .topbar .t{font-family:var(--serif);font-weight:600;font-size:18px;color:var(--fg-primary);}
+  .topbar .t small{font-family:var(--ui);font-weight:500;font-size:12px;color:var(--fg-muted);margin-left:8px;letter-spacing:.02em;}
+  .toggle{font-family:var(--ui);font-size:12.5px;font-weight:500;color:var(--fg-primary);background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:999px;padding:7px 14px;cursor:pointer;}
+  .wrap{max-width:1140px;margin:0 auto;padding:30px 28px 64px;}
+  .lede{font-size:14.5px;line-height:1.6;color:var(--fg-secondary);max-width:780px;margin:0 0 28px;}
+  .row{display:flex;gap:34px;flex-wrap:wrap;align-items:flex-start;}
+  .col{display:flex;flex-direction:column;gap:14px;}
+  .screen-label{font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--fg-muted);}
+
+  .phone{width:368px;background:var(--bg-canvas);border:1px solid var(--border-hover);border-radius:16px;overflow:hidden;box-shadow:0 16px 40px rgba(0,0,0,.18);}
+  .nav{display:flex;align-items:center;justify-content:space-between;height:54px;padding:0 14px;background:color-mix(in srgb,var(--bg-elevated) 86%,transparent);backdrop-filter:blur(12px);border-bottom:1px solid var(--border-default);}
+  .nav-ico{width:30px;height:30px;display:grid;place-items:center;color:var(--fg-secondary);cursor:pointer;}
+  .wordmark{font-family:var(--serif);font-weight:600;font-size:18px;letter-spacing:-.01em;}
+  .trigger{display:flex;align-items:center;gap:5px;cursor:pointer;position:relative;}
+  .chev{color:var(--fg-muted);font-size:11px;}
+
+  .av{border-radius:50%;display:grid;place-items:center;font-weight:600;color:#fff;flex:none;}
+  .av.green{background:#3d5a45;} .av.blue{background:#3a4a63;} .av.plum{background:#5a3d52;}
+  .av-30{width:30px;height:30px;font-size:11px;} .av-22{width:22px;height:22px;font-size:9px;}
+  .av-28{width:28px;height:28px;font-size:11px;} .av-76{width:76px;height:76px;font-size:27px;}
+  .av.ring{box-shadow:0 0 0 2px var(--bg-canvas),0 0 0 4px var(--fg-primary);}
+
+  /* the persistent inverted bar */
+  .actbar{display:flex;align-items:center;gap:10px;padding:10px 12px;background:var(--color-primary);color:var(--color-white);}
+  .dark .actbar{background:var(--color-white);color:var(--color-primary);}
+  .actbar .av.ring{box-shadow:0 0 0 2px var(--color-primary),0 0 0 3.5px rgba(255,255,255,.85);}
+  .dark .actbar .av.ring{box-shadow:0 0 0 2px var(--color-white),0 0 0 3.5px rgba(0,0,0,.65);}
+  .actbar .label{font-size:12.5px;flex:1;min-width:0;line-height:1.25;}
+  .actbar .label .lead{opacity:.6;} .actbar .label .who{font-weight:600;}
+  .actbar .exit{font-size:12px;font-weight:500;color:inherit;background:transparent;border:1px solid rgba(255,255,255,.34);border-radius:999px;padding:5px 11px;cursor:pointer;white-space:nowrap;}
+  .dark .actbar .exit{border-color:rgba(0,0,0,.25);}
+  /* personal mode hides the bar */
+  body[data-actor="personal"] .actbar{display:none;}
+  body[data-actor="personal"] .grpav{display:none;}
+  body[data-actor="personal"] .perav{display:grid !important;}
+  .perav{display:none;}
+
+  .body{padding:18px 16px 22px;}
+  .feedline{font-size:12.5px;color:var(--fg-muted);line-height:1.5;}
+  .prof{display:flex;flex-direction:column;align-items:center;text-align:center;}
+  .prof .nm{font-family:var(--serif);font-weight:600;font-size:20px;margin-top:10px;}
+  .prof .hd{font-size:13px;color:var(--fg-muted);margin-top:2px;}
+  .note{width:100%;margin-top:16px;display:flex;flex-direction:column;gap:9px;align-items:flex-start;}
+  .note p{margin:0;font-size:12.5px;line-height:1.45;color:var(--fg-muted);}
+  .note p b{color:var(--fg-secondary);font-weight:600;}
+  .note .sw{display:inline-flex;align-items:center;gap:6px;height:31px;padding:0 11px;font-size:12.5px;font-weight:500;color:var(--fg-primary);background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius);cursor:pointer;}
+  /* in personal mode, show real follow/endorse */
+  .realactions{display:none;gap:8px;width:100%;margin-top:16px;}
+  body[data-actor="personal"] .realactions{display:flex;}
+  body[data-actor="personal"] .note{display:none;}
+  .btn{flex:1;height:36px;border-radius:var(--radius);font-family:var(--ui);font-size:13px;font-weight:500;display:inline-flex;align-items:center;justify-content:center;gap:6px;cursor:pointer;border:1px solid var(--border-default);background:var(--bg-elevated);color:var(--fg-primary);}
+  .btn.primary{background:var(--color-primary);color:var(--color-white);border-color:var(--color-primary);}
+  .dark .btn.primary{background:var(--color-white);color:var(--color-primary);border-color:var(--color-white);}
+
+  /* split menu */
+  .menu{position:absolute;top:38px;right:0;width:288px;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:8px;box-shadow:var(--shadow-md);overflow:hidden;z-index:20;display:none;}
+  .menu.open{display:block;}
+  .menu .sec{font-size:10.5px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:var(--fg-muted);padding:11px 13px 5px;}
+  .menu .mrow{display:flex;align-items:center;gap:10px;padding:8px 13px;cursor:pointer;}
+  .menu .mrow:hover{background:var(--bg-sunken);}
+  .menu .mrow .meta{display:flex;flex-direction:column;line-height:1.25;min-width:0;flex:1;}
+  .menu .mrow .meta .n{font-size:13.5px;font-weight:500;}
+  .menu .mrow .meta .h{font-size:11.5px;color:var(--fg-muted);}
+  .menu .mrow .role{font-size:10px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--fg-muted);background:var(--bg-sunken);padding:2px 6px;border-radius:999px;}
+  .menu .mrow.active{background:var(--bg-sunken);} .menu .mrow.active .ck{margin-left:auto;}
+  .menu .divider{height:1px;background:var(--border-default);margin:5px 0;}
+  .menu .lin{display:flex;align-items:center;gap:9px;padding:9px 13px;font-size:13px;color:var(--fg-secondary);cursor:pointer;}
+  .menu .lin:hover{background:var(--bg-sunken);} .menu .lin svg{color:var(--fg-muted);}
+
+  .notes{max-width:520px;display:flex;flex-direction:column;gap:12px;margin-top:6px;}
+  .anno{font-size:13px;line-height:1.55;color:var(--fg-secondary);padding-left:16px;position:relative;}
+  .anno::before{content:"";position:absolute;left:0;top:7px;width:6px;height:6px;border-radius:50%;background:var(--fg-primary);}
+  .anno b{color:var(--fg-primary);font-weight:600;}
+  .hint{font-size:12px;color:var(--fg-muted);margin-top:4px;}
+  svg{display:block;}
+</style>
+</head>
+<body data-actor="group">
+  <div class="topbar">
+    <div class="t">Option 1 <small>Sticky persona + persistent bar</small></div>
+    <button class="toggle" id="themeBtn">Dark mode</button>
+  </div>
+  <div class="wrap">
+    <p class="lede">One loud, always-on indicator carries awareness. While acting as a group, an inverted bar is pinned under the navbar on every screen, naming the group with an inline "Switch back". Inversion is the monochrome stand-in for Stripe's orange. Try the avatar menu (top-right of a phone) and the Switch-back button.</p>
+
+    <div class="row">
+      <div class="col">
+        <div class="screen-label">A profile, while acting as a group</div>
+        <div class="phone">
+          <div class="nav">
+            <div class="nav-ico">&#9776;</div>
+            <div class="wordmark">Certified</div>
+            <div class="trigger" data-menu>
+              <div class="av green av-30 ring grpav">AC</div>
+              <div class="av plum av-30 perav">YO</div>
+              <span class="chev">&#9662;</span>
+              <div class="menu" id="menu1">
+                <div class="sec">Acting as</div>
+                <div class="mrow" data-to="personal"><div class="av plum av-28">YO</div><div class="meta"><span class="n">You (personal)</span><span class="h">@holke.certified.app</span></div></div>
+                <div class="mrow active" data-to="group"><div class="av green av-28 ring">AC</div><div class="meta"><span class="n">Acme Collective</span><span class="h">@acme.certified.app</span></div><span class="role">Owner</span><span class="ck">&#10003;</span></div>
+                <div class="mrow"><div class="av blue av-28">RF</div><div class="meta"><span class="n">Rainforest Fund</span><span class="h">@rainforest.certified.app</span></div><span class="role">Admin</span></div>
+                <div class="divider"></div>
+                <div class="lin"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 3h5v5"/><path d="M21 3l-7 7"/><path d="M8 21H3v-5"/><path d="M3 21l7-7"/></svg> Use a different account&hellip;</div>
+                <div class="lin"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="M16 17l5-5-5-5"/><path d="M21 12H9"/></svg> Sign out</div>
+              </div>
+            </div>
+          </div>
+          <div class="actbar">
+            <div class="av green av-22 ring">AC</div>
+            <div class="label"><span class="lead">Acting as </span><span class="who">Acme Collective</span></div>
+            <button class="exit" data-to="personal">&#8617; Switch back</button>
+          </div>
+          <div class="body">
+            <div class="prof">
+              <div class="av blue av-76">JR</div>
+              <div class="nm">Jane Rivera</div>
+              <div class="hd">@jane.bsky.social</div>
+              <div class="note">
+                <p>Acting as <b>Acme Collective</b>. Follow and endorse are personal actions.</p>
+                <button class="sw" data-to="personal">&#8646; Switch to personal</button>
+              </div>
+              <div class="realactions">
+                <button class="btn primary">&#43; Follow</button>
+                <button class="btn">&#9786; Endorse</button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="hint">Switch to personal and the bar disappears, the live Follow / Endorse return.</div>
+      </div>
+
+      <div class="col">
+        <div class="screen-label">Same bar, a different screen (home)</div>
+        <div class="phone">
+          <div class="nav">
+            <div class="nav-ico">&#9776;</div>
+            <div class="wordmark">Certified</div>
+            <div class="trigger"><div class="av green av-30 ring grpav">AC</div><div class="av plum av-30 perav">YO</div><span class="chev">&#9662;</span></div>
+          </div>
+          <div class="actbar">
+            <div class="av green av-22 ring">AC</div>
+            <div class="label"><span class="lead">Acting as </span><span class="who">Acme Collective</span></div>
+            <button class="exit" data-to="personal">&#8617; Switch back</button>
+          </div>
+          <div class="body">
+            <div style="font-family:var(--serif);font-weight:600;font-size:17px;margin-bottom:8px;">Home</div>
+            <p class="feedline">Your feed, projects, certs and any new record are scoped to <b style="color:var(--fg-secondary)">Acme Collective</b>. The bar travels with you, so the mode can't be forgotten after a reload.</p>
+          </div>
+        </div>
+        <div class="hint">Persistence is the point: awareness doesn't decay when you navigate away.</div>
+      </div>
+
+      <div class="col">
+        <div class="notes">
+          <div class="anno"><b>Persistent inverted bar</b> on every screen: ringed avatar, the group name verbatim, and an inline exit. The loudest element in either theme.</div>
+          <div class="anno"><b>Split menu</b> separates persona ("Acting as") from session actions ("Use a different account", "Sign out"), which are labelled text rows, not a bare icon. Group rows show @handle plus a role chip.</div>
+          <div class="anno"><b>Cost:</b> ~40px of persistent chrome. Best when users inhabit a group for a whole session.</div>
+          <div class="anno"><b>Shared baseline</b> (shipped): Follow / Endorse are guarded while acting as a group, never silently written to the personal repo.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+<script>
+  const body=document.body;
+  document.getElementById('themeBtn').addEventListener('click',e=>{
+    const on=body.classList.toggle('dark');
+    e.target.textContent=on?'Light mode':'Dark mode';
+  });
+  // open/close the switcher menu
+  document.querySelectorAll('[data-menu]').forEach(t=>{
+    t.addEventListener('click',ev=>{ev.stopPropagation();document.getElementById('menu1').classList.toggle('open');});
+  });
+  document.addEventListener('click',()=>document.getElementById('menu1')?.classList.remove('open'));
+  // actor switching
+  document.querySelectorAll('[data-to]').forEach(el=>{
+    el.addEventListener('click',ev=>{ev.stopPropagation();body.setAttribute('data-actor',el.getAttribute('data-to'));document.getElementById('menu1')?.classList.remove('open');});
+  });
+</script>
+</body>
+</html>

--- a/docs/switcher-mockups/option-2-desktop.html
+++ b/docs/switcher-mockups/option-2-desktop.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Switcher — Option 2 (desktop): Hybrid, quiet ambient + per-action identity</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Noto+Serif:wght@500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --color-primary:#111111; --color-white:#FFFFFF;
+    --bg-canvas:#f9f9f9; --bg-sunken:#eeeeee; --bg-raised:#f3f3f3; --bg-elevated:#FFFFFF;
+    --fg-primary:#111111; --fg-secondary:#4c4546; --fg-muted:#6b6263;
+    --border-default:rgba(0,0,0,0.08); --border-hover:rgba(0,0,0,0.15); --border-strong:rgba(0,0,0,0.22);
+    --shadow-md:0 4px 12px rgba(0,0,0,0.08); --shadow-lg:0 18px 50px rgba(0,0,0,0.20);
+    --radius:2px; --serif:'Noto Serif',Georgia,serif; --ui:'Inter',system-ui,sans-serif; --stage:#dcdcd8;
+  }
+  .dark{
+    --bg-canvas:#18181b; --bg-sunken:#111114; --bg-raised:#26262b; --bg-elevated:#2d2d33;
+    --fg-primary:#f5f5f7; --fg-secondary:#c7c7cc; --fg-muted:#8e8e93;
+    --border-default:rgba(255,255,255,0.08); --border-hover:rgba(255,255,255,0.18); --border-strong:rgba(255,255,255,0.28);
+    --shadow-lg:0 18px 50px rgba(0,0,0,0.6); --stage:#0c0c0e;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0;font-family:var(--ui);background:var(--stage);color:var(--fg-primary);-webkit-font-smoothing:antialiased;}
+  .top{display:flex;align-items:center;justify-content:space-between;padding:16px 28px;}
+  .top .t{font-family:var(--serif);font-weight:600;font-size:17px;}
+  .top .t small{font-family:var(--ui);font-weight:500;font-size:12px;color:var(--fg-muted);margin-left:8px;}
+  .toggle{font-size:12.5px;font-weight:500;color:var(--fg-primary);background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:999px;padding:7px 14px;cursor:pointer;}
+  .wrap{max-width:1340px;margin:0 auto;padding:6px 28px 50px;}
+  .lede{font-size:14px;line-height:1.55;color:var(--fg-secondary);max-width:880px;margin:0 0 20px;}
+
+  .browser{border-radius:12px;overflow:hidden;box-shadow:0 22px 60px rgba(0,0,0,.22);border:1px solid var(--border-hover);background:var(--bg-canvas);position:relative;}
+  .chrome{height:40px;display:flex;align-items:center;gap:14px;padding:0 14px;background:var(--bg-sunken);border-bottom:1px solid var(--border-default);}
+  .dots{display:flex;gap:7px;} .dots i{width:11px;height:11px;border-radius:50%;display:block;background:#cfcfca;} .dark .dots i{background:#3a3a40;}
+  .url{flex:1;max-width:520px;height:24px;border-radius:999px;background:var(--bg-elevated);border:1px solid var(--border-default);display:flex;align-items:center;padding:0 12px;font-size:12px;color:var(--fg-muted);}
+
+  .appbar{height:56px;display:flex;align-items:center;gap:16px;padding:0 20px;background:color-mix(in srgb,var(--bg-elevated) 90%,transparent);border-bottom:1px solid var(--border-default);}
+  .burger{color:var(--fg-secondary);} .brand{font-family:var(--serif);font-weight:600;font-size:18px;}
+  .tabs{display:flex;gap:4px;margin-left:10px;} .tabs a{font-size:13px;color:var(--fg-muted);padding:6px 10px;text-decoration:none;border-radius:var(--radius);} .tabs a.on{color:var(--fg-primary);font-weight:600;background:var(--bg-sunken);}
+  .spacer{flex:1;}
+  .chip{display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 11px 0 8px;border:1px solid var(--border-strong);border-radius:999px;font-size:12px;font-weight:500;color:var(--fg-secondary);background:var(--bg-raised);}
+  .chip .dot{width:6px;height:6px;border-radius:50%;background:var(--fg-primary);} .chip .who{color:var(--fg-primary);font-weight:600;}
+  .switch{display:flex;align-items:center;gap:9px;padding:5px 8px 5px 6px;border:1px solid var(--border-default);border-radius:999px;background:var(--bg-elevated);cursor:pointer;}
+  .switch .w{display:flex;flex-direction:column;line-height:1.15;} .switch .w .n{font-size:12.5px;font-weight:600;} .switch .w .h{font-size:11px;color:var(--fg-muted);}
+  .chev{color:var(--fg-muted);font-size:11px;}
+
+  .av{border-radius:50%;display:grid;place-items:center;font-weight:600;color:#fff;flex:none;}
+  .av.green{background:#3d5a45;} .av.blue{background:#3a4a63;}
+  .av-22{width:22px;height:22px;font-size:9px;} .av-28{width:28px;height:28px;font-size:11px;} .av-30{width:30px;height:30px;font-size:11px;}
+
+  /* create surface (centered, desktop) */
+  .stagearea{padding:40px 0 56px;display:flex;justify-content:center;}
+  .form{width:560px;}
+  .form h1{font-family:var(--serif);font-weight:600;font-size:24px;margin:0 0 4px;}
+  .form .subtitle{font-size:13px;color:var(--fg-muted);margin:0 0 22px;}
+  .label{font-size:12px;font-weight:600;color:var(--fg-secondary);margin:16px 0 6px;}
+  .field{width:100%;height:42px;border:1px solid var(--border-default);border-radius:var(--radius);background:var(--bg-elevated);display:flex;align-items:center;padding:0 13px;font-size:13.5px;color:var(--fg-muted);}
+  .field.tall{height:88px;align-items:flex-start;padding-top:11px;}
+  .as-btn{margin-top:26px;height:46px;padding:0 22px;border-radius:var(--radius);background:var(--color-primary);color:var(--color-white);border:none;display:inline-flex;align-items:center;gap:9px;font-size:14px;font-weight:600;cursor:pointer;}
+  .dark .as-btn{background:var(--color-white);color:var(--color-primary);}
+  .as-btn .as{display:inline-flex;align-items:center;gap:6px;font-weight:500;opacity:.78;}
+  .as-btn .as .av{box-shadow:0 0 0 1.5px rgba(255,255,255,.55);} .dark .as-btn .as .av{box-shadow:0 0 0 1.5px rgba(0,0,0,.45);}
+
+  /* centered modal confirm (AppDialog style) */
+  .overlay{position:absolute;inset:0;background:rgba(0,0,0,.46);display:flex;align-items:center;justify-content:center;}
+  .dialog{width:420px;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:8px;box-shadow:var(--shadow-lg);padding:22px;}
+  .dialog h3{font-family:var(--serif);font-weight:600;font-size:18px;margin:0 0 6px;}
+  .dialog p{font-size:13px;color:var(--fg-muted);line-height:1.45;margin:0 0 16px;}
+  .idrow{display:flex;align-items:center;gap:11px;padding:12px;border:1px solid var(--border-default);border-radius:var(--radius);background:var(--bg-raised);margin-bottom:20px;}
+  .idrow .meta{flex:1;line-height:1.25;} .idrow .meta .n{font-size:14px;font-weight:600;} .idrow .meta .h{font-size:12px;color:var(--fg-muted);}
+  .idrow .badge{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.04em;color:var(--fg-muted);}
+  .drow{display:flex;justify-content:flex-end;gap:10px;}
+  .btn{height:38px;padding:0 16px;border-radius:var(--radius);font-size:13px;font-weight:500;display:inline-flex;align-items:center;gap:6px;cursor:pointer;border:1px solid var(--border-default);background:var(--bg-elevated);color:var(--fg-primary);}
+  .btn.primary{background:var(--color-primary);color:var(--color-white);border-color:var(--color-primary);} .dark .btn.primary{background:var(--color-white);color:var(--color-primary);border-color:var(--color-white);}
+
+  .annos{display:flex;gap:26px;margin-top:18px;flex-wrap:wrap;}
+  .anno{font-size:12.5px;line-height:1.5;color:var(--fg-secondary);padding-left:15px;position:relative;max-width:380px;}
+  .anno::before{content:"";position:absolute;left:0;top:7px;width:6px;height:6px;border-radius:50%;background:var(--fg-primary);}
+  .anno b{color:var(--fg-primary);font-weight:600;}
+  svg{display:block;}
+  .hint{font-size:12px;color:var(--fg-muted);margin-top:10px;}
+</style>
+</head>
+<body>
+  <div class="top">
+    <div class="t">Option 2 — desktop <small>Hybrid: quiet ambient + per-action identity</small></div>
+    <button class="toggle" id="themeBtn">Dark mode</button>
+  </div>
+  <div class="wrap">
+    <p class="lede">On desktop the ambient chip sits in the top bar next to the switcher, so reading and navigation stay quiet. The identity returns inside the write button on the wide create surface ("Create cert as Acme Collective"), and the high-stakes confirm is a centered modal (desktop convention) that names the author again. Click "Create cert as Acme" to open it.</p>
+
+    <div class="browser" id="browser">
+      <div class="chrome"><div class="dots"><i></i><i></i><i></i></div><div class="url">certified.app/create</div></div>
+      <div class="appbar">
+        <span class="burger"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M3 12h18M3 18h18"/></svg></span>
+        <span class="brand">Certified</span>
+        <nav class="tabs"><a href="#">Home</a><a href="#">Explore</a><a href="#" class="on">Create</a></nav>
+        <span class="spacer"></span>
+        <span class="chip"><span class="dot"></span>Acting as <span class="who">Acme</span></span>
+        <div class="switch"><div class="av green av-30">AC</div><div class="w"><span class="n">Acme Collective</span><span class="h">@acme.certified.app</span></div><span class="chev">&#9662;</span></div>
+      </div>
+
+      <div class="stagearea">
+        <div class="form">
+          <h1>New certificate</h1>
+          <p class="subtitle">Certificates are public, signed records. They can be endorsed by others.</p>
+          <div class="label">Title</div>
+          <div class="field">Reforestation milestone, Q2 2026</div>
+          <div class="label">Recipient</div>
+          <div class="field">@jane.bsky.social</div>
+          <div class="label">Description</div>
+          <div class="field tall">Completed the second-quarter planting target across three sites&hellip;</div>
+          <button class="as-btn" id="createBtn">Create cert <span class="as">as <span class="av green av-22">AC</span> Acme Collective</span></button>
+        </div>
+      </div>
+
+      <div class="overlay" id="overlay" style="display:none;">
+        <div class="dialog">
+          <h3>Publish certificate?</h3>
+          <p>This record will be authored by the group and signed into its repo. It cannot be edited anonymously later.</p>
+          <div class="idrow">
+            <div class="av green av-28">AC</div>
+            <div class="meta"><div class="n">Acme Collective</div><div class="h">@acme.certified.app</div></div>
+            <span class="badge">Author</span>
+          </div>
+          <div class="drow">
+            <button class="btn" id="cancelBtn">Cancel</button>
+            <button class="btn primary">Publish as Acme</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="hint">The same guarded baseline applies on profiles: Follow / Endorse stay personal-only while acting as a group.</div>
+
+    <div class="annos">
+      <div class="anno"><b>Ambient chip in the top bar</b> sits beside the switcher: a quiet, always-present "Acting as Acme" without claiming a full strip of chrome.</div>
+      <div class="anno"><b>Identity in the button</b> on the wide write surface: "Create cert as Acme Collective", reasserted exactly where the record is authored.</div>
+      <div class="anno"><b>Centered modal confirm</b> (desktop convention, not a bottom sheet) names the author one more time before a high-stakes write.</div>
+    </div>
+  </div>
+<script>
+  document.getElementById('themeBtn').addEventListener('click',e=>{const on=document.body.classList.toggle('dark');e.target.textContent=on?'Light mode':'Dark mode';});
+  const ov=document.getElementById('overlay');
+  document.getElementById('createBtn').addEventListener('click',()=>ov.style.display='flex');
+  document.getElementById('cancelBtn').addEventListener('click',()=>ov.style.display='none');
+  ov.addEventListener('click',e=>{if(e.target===ov)ov.style.display='none';});
+</script>
+</body>
+</html>

--- a/docs/switcher-mockups/option-2-hybrid.html
+++ b/docs/switcher-mockups/option-2-hybrid.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Switcher — Option 2: Hybrid (quiet ambient + per-action identity)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Noto+Serif:wght@500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --color-primary:#111111; --color-white:#FFFFFF;
+    --bg-canvas:#f9f9f9; --bg-sunken:#eeeeee; --bg-raised:#f3f3f3; --bg-elevated:#FFFFFF;
+    --fg-primary:#111111; --fg-secondary:#4c4546; --fg-muted:#6b6263;
+    --border-default:rgba(0,0,0,0.08); --border-hover:rgba(0,0,0,0.15); --border-strong:rgba(0,0,0,0.22);
+    --shadow-sm:0 1px 2px rgba(0,0,0,0.05); --shadow-md:0 4px 12px rgba(0,0,0,0.08);
+    --radius:2px;
+    --serif:'Noto Serif',Georgia,serif; --ui:'Inter',system-ui,sans-serif;
+    --stage:#e7e7e4;
+  }
+  .dark{
+    --bg-canvas:#18181b; --bg-sunken:#111114; --bg-raised:#26262b; --bg-elevated:#2d2d33;
+    --fg-primary:#f5f5f7; --fg-secondary:#c7c7cc; --fg-muted:#8e8e93;
+    --border-default:rgba(255,255,255,0.08); --border-hover:rgba(255,255,255,0.18); --border-strong:rgba(255,255,255,0.28);
+    --shadow-md:0 4px 12px rgba(0,0,0,0.5);
+    --stage:#0e0e10;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0;font-family:var(--ui);background:var(--stage);color:var(--fg-primary);-webkit-font-smoothing:antialiased;transition:background .2s;}
+  .topbar{display:flex;align-items:center;justify-content:space-between;padding:18px 28px;border-bottom:1px solid var(--border-default);position:sticky;top:0;background:var(--stage);z-index:5;}
+  .topbar .t{font-family:var(--serif);font-weight:600;font-size:18px;}
+  .topbar .t small{font-family:var(--ui);font-weight:500;font-size:12px;color:var(--fg-muted);margin-left:8px;}
+  .toggle{font-size:12.5px;font-weight:500;color:var(--fg-primary);background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:999px;padding:7px 14px;cursor:pointer;}
+  .wrap{max-width:1140px;margin:0 auto;padding:30px 28px 64px;}
+  .lede{font-size:14.5px;line-height:1.6;color:var(--fg-secondary);max-width:780px;margin:0 0 28px;}
+  .row{display:flex;gap:34px;flex-wrap:wrap;align-items:flex-start;}
+  .col{display:flex;flex-direction:column;gap:14px;}
+  .screen-label{font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--fg-muted);}
+
+  .phone{width:368px;background:var(--bg-canvas);border:1px solid var(--border-hover);border-radius:16px;overflow:hidden;box-shadow:0 16px 40px rgba(0,0,0,.18);position:relative;}
+  .nav{display:flex;align-items:center;justify-content:space-between;height:54px;padding:0 12px;background:color-mix(in srgb,var(--bg-elevated) 86%,transparent);backdrop-filter:blur(12px);border-bottom:1px solid var(--border-default);}
+  .nav-ico{width:30px;height:30px;display:grid;place-items:center;color:var(--fg-secondary);}
+  .trigger{display:flex;align-items:center;gap:5px;}
+  .chev{color:var(--fg-muted);font-size:11px;}
+
+  .av{border-radius:50%;display:grid;place-items:center;font-weight:600;color:#fff;flex:none;}
+  .av.green{background:#3d5a45;} .av.blue{background:#3a4a63;} .av.plum{background:#5a3d52;}
+  .av-30{width:30px;height:30px;font-size:11px;} .av-22{width:22px;height:22px;font-size:9px;}
+  .av-28{width:28px;height:28px;font-size:11px;} .av-76{width:76px;height:76px;font-size:27px;}
+
+  /* the quiet ambient chip */
+  .chip{display:inline-flex;align-items:center;gap:6px;height:27px;padding:0 10px 0 7px;border:1px solid var(--border-strong);border-radius:999px;font-size:11.5px;font-weight:500;color:var(--fg-secondary);background:var(--bg-raised);}
+  .chip .dot{width:6px;height:6px;border-radius:50%;background:var(--fg-primary);}
+  .chip .who{color:var(--fg-primary);font-weight:600;}
+
+  .body{padding:18px 16px 22px;}
+  .prof{display:flex;flex-direction:column;align-items:center;text-align:center;}
+  .prof .nm{font-family:var(--serif);font-weight:600;font-size:20px;margin-top:10px;}
+  .prof .hd{font-size:13px;color:var(--fg-muted);margin-top:2px;}
+  .note{width:100%;margin-top:16px;display:flex;flex-direction:column;gap:9px;align-items:flex-start;}
+  .note p{margin:0;font-size:12.5px;line-height:1.45;color:var(--fg-muted);}
+  .note p b{color:var(--fg-secondary);font-weight:600;}
+  .note .sw{display:inline-flex;align-items:center;gap:6px;height:31px;padding:0 11px;font-size:12.5px;font-weight:500;color:var(--fg-primary);background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius);cursor:pointer;}
+
+  .ttl{font-family:var(--serif);font-weight:600;font-size:17px;margin:0 0 4px;}
+  .field{width:100%;height:38px;border:1px solid var(--border-default);border-radius:var(--radius);background:var(--bg-elevated);display:flex;align-items:center;padding:0 11px;font-size:13px;color:var(--fg-muted);margin-top:10px;}
+  /* identity-in-the-button */
+  .as-btn{width:100%;height:44px;margin-top:14px;border-radius:var(--radius);background:var(--color-primary);color:var(--color-white);border:none;display:inline-flex;align-items:center;justify-content:center;gap:8px;font-size:13.5px;font-weight:600;cursor:pointer;}
+  .dark .as-btn{background:var(--color-white);color:var(--color-primary);}
+  .as-btn .as{display:inline-flex;align-items:center;gap:5px;font-weight:500;opacity:.78;}
+  .as-btn .as .av{box-shadow:0 0 0 1.5px rgba(255,255,255,.55);}
+  .dark .as-btn .as .av{box-shadow:0 0 0 1.5px rgba(0,0,0,.45);}
+
+  /* confirm overlay */
+  .overlay{position:absolute;inset:0;background:rgba(0,0,0,.42);display:none;align-items:flex-end;}
+  .overlay.open{display:flex;}
+  .sheet{width:100%;background:var(--bg-elevated);border-top-left-radius:14px;border-top-right-radius:14px;padding:18px 16px 20px;}
+  .sheet .ct{font-family:var(--serif);font-weight:600;font-size:16px;margin:0 0 3px;}
+  .sheet .cs{font-size:12.5px;color:var(--fg-muted);margin:0 0 12px;line-height:1.45;}
+  .idrow{display:flex;align-items:center;gap:10px;padding:10px;border:1px solid var(--border-default);border-radius:var(--radius);background:var(--bg-raised);margin-bottom:14px;}
+  .idrow .meta{line-height:1.2;flex:1;} .idrow .meta .n{font-size:13.5px;font-weight:600;} .idrow .meta .h{font-size:11.5px;color:var(--fg-muted);}
+  .idrow .badge{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.04em;color:var(--fg-muted);}
+  .row2{display:flex;gap:8px;}
+  .btn{flex:1;height:38px;border-radius:var(--radius);font-size:13px;font-weight:500;display:inline-flex;align-items:center;justify-content:center;gap:6px;cursor:pointer;border:1px solid var(--border-default);background:var(--bg-elevated);color:var(--fg-primary);}
+  .btn.primary{background:var(--color-primary);color:var(--color-white);border-color:var(--color-primary);}
+  .dark .btn.primary{background:var(--color-white);color:var(--color-primary);border-color:var(--color-white);}
+
+  .notes{max-width:520px;display:flex;flex-direction:column;gap:12px;margin-top:6px;}
+  .anno{font-size:13px;line-height:1.55;color:var(--fg-secondary);padding-left:16px;position:relative;}
+  .anno::before{content:"";position:absolute;left:0;top:7px;width:6px;height:6px;border-radius:50%;background:var(--fg-primary);}
+  .anno b{color:var(--fg-primary);font-weight:600;}
+  .hint{font-size:12px;color:var(--fg-muted);}
+  svg{display:block;}
+</style>
+</head>
+<body>
+  <div class="topbar">
+    <div class="t">Option 2 <small>Hybrid: quiet ambient + per-action identity</small></div>
+    <button class="toggle" id="themeBtn">Dark mode</button>
+  </div>
+  <div class="wrap">
+    <p class="lede">A small chip in the chrome handles reading and navigation; the active identity then moves into the verb at every consequential write ("Create cert as Acme Collective"), with a confirm that names the author one more time on high-stakes actions. Lighter than a full bar, and it reasserts identity exactly where a record is authored. Click "Create cert as Acme" to see the confirm.</p>
+
+    <div class="row">
+      <div class="col">
+        <div class="screen-label">Reading / nav — a quiet chip, no bar</div>
+        <div class="phone">
+          <div class="nav">
+            <div class="nav-ico">&#9776;</div>
+            <span class="chip"><span class="dot"></span>Acting as <span class="who">Acme</span></span>
+            <div class="trigger"><div class="av green av-30">AC</div><span class="chev">&#9662;</span></div>
+          </div>
+          <div class="body">
+            <div class="prof">
+              <div class="av blue av-76">JR</div>
+              <div class="nm">Jane Rivera</div>
+              <div class="hd">@jane.bsky.social</div>
+              <div class="note">
+                <p>Acting as <b>Acme</b>. Follow and endorse are personal actions.</p>
+                <button class="sw">&#8646; Switch to personal</button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="hint">Same guarded baseline for personal-only actions.</div>
+      </div>
+
+      <div class="col">
+        <div class="screen-label">A write surface — identity is in the button</div>
+        <div class="phone" id="phone2">
+          <div class="nav">
+            <div class="nav-ico">&#9776;</div>
+            <span class="chip"><span class="dot"></span>Acting as <span class="who">Acme</span></span>
+            <div class="trigger"><div class="av green av-30">AC</div><span class="chev">&#9662;</span></div>
+          </div>
+          <div class="body">
+            <div class="ttl">New certificate</div>
+            <div class="field">Title</div>
+            <div class="field">Recipient</div>
+            <div class="field">Description</div>
+            <button class="as-btn" id="createBtn">Create cert <span class="as">as <span class="av green av-22">AC</span> Acme Collective</span></button>
+          </div>
+          <!-- confirm -->
+          <div class="overlay" id="overlay">
+            <div class="sheet">
+              <p class="ct">Publish certificate?</p>
+              <p class="cs">This record will be authored by the group and signed into its repo.</p>
+              <div class="idrow">
+                <div class="av green av-28">AC</div>
+                <div class="meta"><div class="n">Acme Collective</div><div class="h">@acme.certified.app</div></div>
+                <span class="badge">Author</span>
+              </div>
+              <div class="row2">
+                <button class="btn" id="cancelBtn">Cancel</button>
+                <button class="btn primary">Publish as Acme</button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="hint">High-stakes writes confirm and name the author again.</div>
+      </div>
+
+      <div class="col">
+        <div class="notes">
+          <div class="anno"><b>Quiet ambient chip</b> in the chrome instead of a full bar: lighter, less fatiguing for users who switch often.</div>
+          <div class="anno"><b>Identity in the verb:</b> "Create cert as Acme Collective". The active identity is reasserted exactly where the record is authored, the cheapest defence against mode errors.</div>
+          <div class="anno"><b>Confirm on high-stakes writes</b> names the author one more time. "Create cert as Acme" works today; extending this to Follow / Endorse needs a group write path (separate backend work). Until then those stay guarded.</div>
+          <div class="anno"><b>Trade-off:</b> the ambient signal is quieter than Option 1's bar, so it leans on the per-action labels to carry awareness. Strongest when most risk lives in a few explicit write actions.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+<script>
+  document.getElementById('themeBtn').addEventListener('click',e=>{
+    const on=document.body.classList.toggle('dark');
+    e.target.textContent=on?'Light mode':'Dark mode';
+  });
+  const ov=document.getElementById('overlay');
+  document.getElementById('createBtn').addEventListener('click',()=>ov.classList.add('open'));
+  document.getElementById('cancelBtn').addEventListener('click',()=>ov.classList.remove('open'));
+  ov.addEventListener('click',e=>{if(e.target===ov)ov.classList.remove('open');});
+</script>
+</body>
+</html>

--- a/docs/switcher-mockups/option-3-github-model.html
+++ b/docs/switcher-mockups/option-3-github-model.html
@@ -1,0 +1,292 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Option 3 — GitHub model (no persona mode) with org endorsements</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Noto+Serif:wght@500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --color-primary:#111111; --color-white:#FFFFFF;
+    --bg-canvas:#f9f9f9; --bg-sunken:#eeeeee; --bg-raised:#f3f3f3; --bg-elevated:#FFFFFF;
+    --fg-primary:#111111; --fg-secondary:#4c4546; --fg-muted:#6b6263;
+    --border-default:rgba(0,0,0,0.08); --border-hover:rgba(0,0,0,0.15); --border-strong:rgba(0,0,0,0.22);
+    --shadow-md:0 4px 12px rgba(0,0,0,0.08); --shadow-lg:0 18px 50px rgba(0,0,0,0.20);
+    --radius:2px; --serif:'Noto Serif',Georgia,serif; --ui:'Inter',system-ui,sans-serif; --stage:#dcdcd8;
+  }
+  .dark{
+    --bg-canvas:#18181b; --bg-sunken:#111114; --bg-raised:#26262b; --bg-elevated:#2d2d33;
+    --fg-primary:#f5f5f7; --fg-secondary:#c7c7cc; --fg-muted:#8e8e93;
+    --border-default:rgba(255,255,255,0.08); --border-hover:rgba(255,255,255,0.18); --border-strong:rgba(255,255,255,0.28);
+    --shadow-lg:0 18px 50px rgba(0,0,0,0.6); --stage:#0c0c0e;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0;font-family:var(--ui);background:var(--stage);color:var(--fg-primary);-webkit-font-smoothing:antialiased;}
+  .top{display:flex;align-items:center;justify-content:space-between;padding:20px 30px;}
+  .top h1{font-family:var(--serif);font-weight:600;font-size:21px;margin:0;}
+  .top h1 small{font-family:var(--ui);font-weight:500;font-size:12.5px;color:var(--fg-muted);margin-left:10px;}
+  .toggle{font-size:12.5px;font-weight:500;color:var(--fg-primary);background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:999px;padding:7px 14px;cursor:pointer;}
+  .wrap{max-width:1320px;margin:0 auto;padding:0 30px 60px;}
+  .intro{font-size:14px;line-height:1.6;color:var(--fg-secondary);max-width:920px;margin:0 0 24px;}
+  .intro b{color:var(--fg-primary);}
+  .flabel{font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--fg-muted);margin-bottom:9px;}
+  .rowwrap{display:flex;gap:34px;flex-wrap:wrap;align-items:flex-start;margin-bottom:8px;}
+  .col{display:flex;flex-direction:column;}
+
+  /* avatars */
+  .av{border-radius:50%;display:grid;place-items:center;font-weight:600;color:#fff;flex:none;}
+  .av.green{background:#3d5a45;} .av.blue{background:#3a4a63;} .av.plum{background:#5a3d52;}
+  .av-18{width:18px;height:18px;font-size:8px;} .av-20{width:20px;height:20px;font-size:8px;} .av-24{width:24px;height:24px;font-size:9px;}
+  .av-26{width:26px;height:26px;font-size:10px;} .av-28{width:28px;height:28px;font-size:10px;} .av-72{width:72px;height:72px;font-size:26px;} .av-110{width:110px;height:110px;font-size:38px;}
+
+  /* phone */
+  .phone{width:340px;background:var(--bg-canvas);border:1px solid var(--border-hover);border-radius:15px;overflow:hidden;box-shadow:0 14px 36px rgba(0,0,0,.16);position:relative;}
+  .pnav{height:50px;display:flex;align-items:center;justify-content:space-between;padding:0 13px;background:var(--bg-elevated);border-bottom:1px solid var(--border-default);}
+  .brand{font-family:var(--serif);font-weight:600;font-size:17px;}
+  .you{display:flex;align-items:center;gap:5px;} .you .chev{color:var(--fg-muted);font-size:10px;}
+  .pbody{padding:18px 16px 22px;}
+
+  /* browser */
+  .browser{border:1px solid var(--border-hover);border-radius:11px;overflow:hidden;box-shadow:0 16px 40px rgba(0,0,0,.18);background:var(--bg-canvas);position:relative;width:780px;}
+  .chrome{height:34px;display:flex;align-items:center;gap:11px;padding:0 12px;background:var(--bg-sunken);border-bottom:1px solid var(--border-default);}
+  .dots{display:flex;gap:6px;} .dots i{width:9px;height:9px;border-radius:50%;background:#cfcfca;display:block;} .dark .dots i{background:#3a3a40;}
+  .url{font-size:11px;color:var(--fg-muted);}
+  .abar{height:52px;display:flex;align-items:center;gap:14px;padding:0 18px;background:var(--bg-elevated);border-bottom:1px solid var(--border-default);}
+  .tabs{display:flex;gap:3px;margin-left:8px;} .tabs a{font-size:12px;color:var(--fg-muted);padding:5px 9px;text-decoration:none;border-radius:var(--radius);} .tabs a.on{color:var(--fg-primary);font-weight:600;background:var(--bg-sunken);}
+  .sp{flex:1;}
+  .id2{display:flex;flex-direction:column;line-height:1.15;} .id2 .n{font-size:12px;font-weight:600;} .id2 .h{font-size:10.5px;color:var(--fg-muted);}
+
+  /* profile */
+  .prof{display:flex;flex-direction:column;align-items:center;text-align:center;}
+  .prof .nm{font-family:var(--serif);font-weight:600;font-size:20px;margin-top:10px;} .prof .hd{font-size:13px;color:var(--fg-muted);margin-top:2px;}
+  .pcontent{display:grid;grid-template-columns:250px 1fr;}
+  .pside{padding:24px 20px;border-right:1px solid var(--border-default);display:flex;flex-direction:column;align-items:flex-start;}
+  .pside .nm{font-family:var(--serif);font-weight:600;font-size:19px;margin-top:13px;} .pside .hd{font-size:12.5px;color:var(--fg-muted);margin-top:2px;}
+  .pmain{padding:22px;}
+
+  /* split action button (the core mechanic) */
+  .actions{display:flex;gap:9px;margin-top:16px;width:100%;}
+  .split{display:inline-flex;border:1px solid var(--color-primary);border-radius:var(--radius);overflow:hidden;position:relative;}
+  .dark .split{border-color:var(--color-white);}
+  .split.ghost{border-color:var(--border-strong);}
+  .split .do{background:var(--color-primary);color:#fff;padding:8px 14px;font-size:13px;font-weight:600;display:inline-flex;align-items:center;gap:6px;cursor:pointer;}
+  .dark .split .do{background:var(--color-white);color:var(--color-primary);}
+  .split.ghost .do{background:var(--bg-elevated);color:var(--fg-primary);}
+  .split .pick{padding:8px 9px;display:inline-flex;align-items:center;gap:5px;cursor:pointer;background:var(--bg-elevated);color:var(--fg-secondary);border-left:1px solid var(--border-default);font-size:12px;}
+  .split .pick .chev{font-size:10px;color:var(--fg-muted);}
+
+  /* actor picker menu */
+  .picker{position:absolute;top:42px;right:0;width:248px;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:8px;box-shadow:var(--shadow-md);overflow:hidden;z-index:25;}
+  .picker .ph{font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--fg-muted);padding:10px 12px 5px;}
+  .picker .pr{display:flex;align-items:center;gap:10px;padding:8px 12px;cursor:pointer;} .picker .pr:hover{background:var(--bg-sunken);}
+  .picker .pr .m{flex:1;line-height:1.2;} .picker .pr .m .n{font-size:13px;font-weight:500;} .picker .pr .m .h{font-size:11px;color:var(--fg-muted);}
+  .picker .pr .role{font-size:9.5px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--fg-muted);background:var(--bg-sunken);padding:2px 6px;border-radius:999px;}
+  .picker .pr.on .ck{margin-left:auto;}
+
+  /* confirm (mobile sheet / desktop modal) */
+  .overlay{position:absolute;inset:0;background:rgba(0,0,0,.44);display:flex;z-index:40;}
+  .overlay.sheet-host{align-items:flex-end;} .overlay.modal-host{align-items:center;justify-content:center;}
+  .confirm{background:var(--bg-elevated);border:1px solid var(--border-default);padding:18px 16px 18px;}
+  .sheet-host .confirm{width:100%;border-top-left-radius:14px;border-top-right-radius:14px;}
+  .modal-host .confirm{width:430px;border-radius:8px;box-shadow:var(--shadow-lg);padding:22px;}
+  .confirm h3{font-family:var(--serif);font-weight:600;font-size:17px;margin:0 0 8px;}
+  .confirm .exp{font-size:13px;color:var(--fg-secondary);line-height:1.5;margin:0 0 14px;} .confirm .exp b{color:var(--fg-primary);font-weight:600;}
+  .actrow{display:flex;align-items:center;gap:10px;padding:11px;border:1px solid var(--border-default);border-radius:var(--radius);background:var(--bg-raised);margin-bottom:9px;}
+  .actrow .m{flex:1;line-height:1.2;} .actrow .m .n{font-size:13.5px;font-weight:600;} .actrow .m .h{font-size:11px;color:var(--fg-muted);}
+  .actrow .tag{font-size:9.5px;font-weight:600;text-transform:uppercase;letter-spacing:.04em;color:var(--fg-muted);}
+  .oprow{font-size:11.5px;color:var(--fg-muted);margin-bottom:15px;display:flex;align-items:center;gap:7px;}
+  .drow{display:flex;justify-content:flex-end;gap:9px;}
+  .btn{height:37px;padding:0 15px;border-radius:var(--radius);font-size:13px;font-weight:500;display:inline-flex;align-items:center;gap:6px;cursor:pointer;border:1px solid var(--border-default);background:var(--bg-elevated);color:var(--fg-primary);}
+  .btn.primary{background:var(--color-primary);color:#fff;border-color:var(--color-primary);} .dark .btn.primary{background:var(--color-white);color:var(--color-primary);border-color:var(--color-white);}
+
+  /* owner picker on create */
+  .lab{font-size:12px;font-weight:600;color:var(--fg-secondary);margin:14px 0 6px;}
+  .owner{display:inline-flex;align-items:center;gap:8px;height:38px;padding:0 12px;border:1px solid var(--border-default);border-radius:var(--radius);background:var(--bg-elevated);font-size:13px;font-weight:500;}
+  .owner .chev{color:var(--fg-muted);font-size:11px;margin-left:4px;}
+  .fld{height:38px;border:1px solid var(--border-default);border-radius:var(--radius);background:var(--bg-elevated);display:flex;align-items:center;padding:0 12px;font-size:13px;color:var(--fg-muted);}
+
+  .annos{display:flex;gap:24px;flex-wrap:wrap;margin:20px 0 6px;}
+  .anno{font-size:12.5px;line-height:1.5;color:var(--fg-secondary);padding-left:15px;position:relative;max-width:300px;}
+  .anno::before{content:"";position:absolute;left:0;top:7px;width:6px;height:6px;border-radius:50%;background:var(--fg-primary);}
+  .anno b{color:var(--fg-primary);font-weight:600;}
+
+  .ship{margin-top:30px;border-top:1px solid var(--border-hover);padding-top:22px;}
+  .ship h2{font-family:var(--serif);font-weight:600;font-size:18px;margin:0 0 4px;}
+  .ship p.sub{font-size:13px;color:var(--fg-muted);margin:0 0 16px;}
+  .shipgrid{display:grid;grid-template-columns:1fr 1fr;gap:22px;}
+  .shipcard{border:1px solid var(--border-default);border-radius:8px;background:var(--bg-elevated);padding:16px 18px;}
+  .shipcard .ttl{display:flex;align-items:center;gap:9px;font-size:14px;font-weight:600;margin-bottom:4px;}
+  .pctpill{font-size:10px;font-weight:700;letter-spacing:.03em;padding:2px 8px;border-radius:999px;border:1px solid var(--border-strong);color:var(--fg-secondary);}
+  .pctpill.half{background:var(--bg-sunken);} .pctpill.zero{background:var(--color-primary);color:#fff;border-color:var(--color-primary);} .dark .pctpill.zero{background:var(--color-white);color:var(--color-primary);}
+  .shipcard ul{margin:8px 0 0;padding-left:16px;} .shipcard li{font-size:12px;line-height:1.55;color:var(--fg-secondary);margin-bottom:5px;} .shipcard li b{color:var(--fg-primary);font-weight:600;}
+  .shipcard .have{color:var(--fg-muted);font-size:11.5px;margin-bottom:6px;}
+  @media(max-width:900px){.shipgrid{grid-template-columns:1fr;}}
+  svg{display:block;}
+</style>
+</head>
+<body>
+  <div class="top">
+    <h1>Option 3 — the GitHub model <small>no persona mode &middot; per-action identity &middot; orgs can endorse</small></h1>
+    <button class="toggle" id="themeBtn">Dark mode</button>
+  </div>
+  <div class="wrap">
+    <p class="intro">You are <b>always you</b> in the chrome, your feed, and your profile. There is no "acting as" mode to enter or forget. Identity is chosen <b>per action</b> via a split button: the primary side acts as you by default; the chevron opens a small menu of the orgs you own or admin. The default is <b>always You</b> (never last-used), so the sticky-mode bug class is gone by construction. Because endorsing is high-stakes and core to Certified, choosing a group as the endorser triggers a confirm that names all three parties. Managing a group happens on the group's own page.</p>
+
+    <!-- ===================== MOBILE ===================== -->
+    <div class="flabel">Mobile</div>
+    <div class="rowwrap">
+      <div class="col">
+        <div class="flabel" style="font-weight:500;text-transform:none;letter-spacing:0;color:var(--fg-secondary);">Foreign profile &mdash; split actions, picker open</div>
+        <div class="phone">
+          <div class="pnav"><span class="brand">Certified</span><div class="you"><div class="av plum av-26">YO</div><span class="chev">&#9662;</span></div></div>
+          <div class="pbody">
+            <div class="prof">
+              <div class="av blue av-72">JR</div>
+              <div class="nm">Jane Rivera</div>
+              <div class="hd">@jane.bsky.social</div>
+              <div class="actions">
+                <div class="split ghost" style="flex:1;"><span class="do" style="flex:1;justify-content:center;">&#43; Follow</span><span class="pick"><div class="av plum av-18">YO</div><span class="chev">&#9662;</span></span></div>
+                <div class="split" style="flex:1;position:relative;"><span class="do" style="flex:1;justify-content:center;">&#9786; Endorse</span><span class="pick" id="mpick"><div class="av plum av-18">YO</div><span class="chev">&#9662;</span></span>
+                  <div class="picker" id="mpicker" style="display:none;">
+                    <div class="ph">Endorse as</div>
+                    <div class="pr on"><div class="av plum av-24">YO</div><div class="m"><div class="n">You</div><div class="h">@holke</div></div><span class="ck">&#10003;</span></div>
+                    <div class="pr"><div class="av green av-24">AC</div><div class="m"><div class="n">Acme Collective</div><div class="h">@acme</div></div><span class="role">Owner</span></div>
+                    <div class="pr"><div class="av blue av-24">RF</div><div class="m"><div class="n">Rainforest Fund</div><div class="h">@rainforest</div></div><span class="role">Admin</span></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- confirm sheet -->
+          <div class="overlay sheet-host" id="msheet" style="display:none;">
+            <div class="confirm">
+              <h3>Endorse as Acme Collective?</h3>
+              <p class="exp">This records that <b>Acme Collective</b> certifies <b>Jane Rivera</b>. It is a public, durable vouch.</p>
+              <div class="actrow"><div class="av green av-28">AC</div><div class="m"><div class="n">Acme Collective</div><div class="h">@acme.certified.app</div></div><span class="tag">Endorser</span></div>
+              <div class="oprow"><div class="av plum av-18">YO</div>On behalf of Acme as <b style="color:var(--fg-secondary);font-weight:600;">you (@holke)</b>, an admin.</div>
+              <div class="drow"><button class="btn" id="mcancel">Cancel</button><button class="btn primary">Endorse as Acme</button></div>
+            </div>
+          </div>
+        </div>
+        <p style="font-size:12px;color:var(--fg-muted);margin-top:10px;max-width:340px;">Tap the <b style="color:var(--fg-secondary)">Endorse&nbsp;&#9662;</b> chevron to open the actor menu, then "Acme" to see the confirm.</p>
+      </div>
+
+      <div class="col" style="max-width:300px;">
+        <div class="flabel">How it behaves</div>
+        <div class="annos" style="flex-direction:column;gap:13px;">
+          <div class="anno"><b>Split button</b> on the action itself: primary acts as you; the chevron picks a different endorser for this one action. Identity stays on the button (Facebook's pattern, not LinkedIn's misplaced corner).</div>
+          <div class="anno"><b>Default is always You.</b> The menu resets to you each time, so you can't drift into endorsing as the wrong org.</div>
+          <div class="anno"><b>Only orgs you own/admin</b> appear, with the role shown. The server re-checks the role on write.</div>
+          <div class="anno"><b>Follow as org</b> is one click (low-stakes). <b>Endorse as org</b> gets the confirm, because it is the product's core trust record.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===================== DESKTOP ===================== -->
+    <div class="flabel" style="margin-top:26px;">Desktop</div>
+    <div class="rowwrap">
+      <div class="col">
+        <div class="flabel" style="font-weight:500;text-transform:none;letter-spacing:0;color:var(--fg-secondary);">Foreign profile &mdash; endorse confirm names all three parties</div>
+        <div class="browser">
+          <div class="chrome"><div class="dots"><i></i><i></i><i></i></div><span class="url">certified.app/profile/jane.bsky.social</span></div>
+          <div class="abar"><span class="brand">Certified</span><nav class="tabs"><a href="#" class="on">Overview</a><a href="#">Certs</a><a href="#">Endorsements</a></nav><span class="sp"></span><div class="you"><div class="av plum av-26">YO</div><div class="id2"><span class="n">You</span><span class="h">@holke.certified.app</span></div><span class="chev">&#9662;</span></div></div>
+          <div class="pcontent">
+            <div class="pside">
+              <div class="av blue av-110">JR</div>
+              <div class="nm">Jane Rivera</div>
+              <div class="hd">@jane.bsky.social</div>
+              <div class="actions" style="flex-direction:column;gap:8px;">
+                <div class="split ghost" style="width:100%;"><span class="do" style="flex:1;justify-content:center;">&#43; Follow</span><span class="pick"><div class="av plum av-18">YO</div>as You<span class="chev">&#9662;</span></span></div>
+                <div class="split" style="width:100%;"><span class="do" style="flex:1;justify-content:center;">&#9786; Endorse</span><span class="pick"><div class="av green av-18">AC</div>as Acme<span class="chev">&#9662;</span></span></div>
+              </div>
+            </div>
+            <div class="pmain">
+              <div style="font-family:var(--serif);font-weight:600;font-size:16px;margin-bottom:10px;">Endorsed by 14</div>
+              <div style="font-size:12.5px;color:var(--fg-muted);line-height:1.6;">A foreign profile. The chrome and your tabs stay "You". Only the action's endorser is chosen, here pre-set to Acme via the split button.</div>
+            </div>
+          </div>
+          <!-- modal confirm -->
+          <div class="overlay modal-host" id="dmodal">
+            <div class="confirm">
+              <h3>Endorse Jane Rivera as Acme Collective?</h3>
+              <p class="exp">This records that <b>Acme Collective</b> certifies <b>Jane Rivera</b>. Endorsements are public and durable.</p>
+              <div class="actrow"><div class="av green av-28">AC</div><div class="m"><div class="n">Acme Collective</div><div class="h">@acme.certified.app</div></div><span class="tag">Endorser</span></div>
+              <div class="oprow"><div class="av plum av-18">YO</div>Authored by <b style="color:var(--fg-secondary);font-weight:600;">you (@holke)</b> as an admin of Acme &middot; kept in the group's audit log.</div>
+              <div class="drow"><button class="btn" id="dcancel">Cancel</button><button class="btn primary">Endorse as Acme</button></div>
+            </div>
+          </div>
+        </div>
+        <p style="font-size:12px;color:var(--fg-muted);margin-top:10px;">The confirm names the <b style="color:var(--fg-secondary)">endorser</b> (Acme), the <b style="color:var(--fg-secondary)">operator</b> (you), and the <b style="color:var(--fg-secondary)">subject</b> (Jane). <a href="#" id="reopen" style="color:var(--fg-secondary);">Reopen confirm</a></p>
+      </div>
+
+      <div class="col">
+        <div class="flabel" style="font-weight:500;text-transform:none;letter-spacing:0;color:var(--fg-secondary);">Create &mdash; an "Owner" picker (GitHub's dropdown)</div>
+        <div class="browser" style="width:430px;">
+          <div class="chrome"><div class="dots"><i></i><i></i><i></i></div><span class="url">certified.app/create</span></div>
+          <div class="abar"><span class="brand">Certified</span><span class="sp"></span><div class="you"><div class="av plum av-26">YO</div><div class="id2"><span class="n">You</span><span class="h">@holke.certified.app</span></div></div></div>
+          <div style="padding:20px;">
+            <div style="font-family:var(--serif);font-weight:600;font-size:18px;">New certificate</div>
+            <div class="lab">Owner</div>
+            <div class="owner"><div class="av green av-20">AC</div>Acme Collective<span class="chev">&#9662;</span></div>
+            <div class="lab">Title</div><div class="fld">Reforestation milestone, Q2</div>
+            <div class="lab">Recipient</div><div class="fld">@jane.bsky.social</div>
+            <button class="btn primary" style="margin-top:18px;height:42px;">Create certificate</button>
+          </div>
+        </div>
+        <div class="annos" style="flex-direction:column;gap:11px;margin-top:14px;">
+          <div class="anno"><b>Authoring</b> (certs, projects) uses the same idea as a plain owner dropdown, defaulting to you.</div>
+          <div class="anno"><b>Browsing/managing</b> a group lives on <b>/groups/acme</b>, not by re-skinning your home. Your home is always yours.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===================== SHIP ===================== -->
+    <div class="ship">
+      <h2>What it takes to ship (grounded in the backend trace)</h2>
+      <p class="sub">Unlike Options 1 &amp; 2, this needs real backend work, because "endorse as org" does not exist yet. The UI above is the target; here is the gap.</p>
+      <div class="shipgrid">
+        <div class="shipcard">
+          <div class="ttl">Follow as org <span class="pctpill half">~50% built</span></div>
+          <div class="have">Have: group follow <b>create</b> (POST /api/groups/[did]/follow, createFollow via writeToRepo targetDid).</div>
+          <ul>
+            <li><b>Add DELETE</b> to the group follow route (it is POST-only today, so a group can't unfollow).</li>
+            <li><b>deleteFollow</b> must take a targetDid and route via writeToRepo (currently hardwired to the personal proxy).</li>
+            <li>Thread targetDid into the 2 unfollow call sites; wire the profile Follow button's actor picker.</li>
+          </ul>
+        </div>
+        <div class="shipcard">
+          <div class="ttl">Endorse as org <span class="pctpill zero">0% built</span></div>
+          <div class="have">Endorse is hardwired to the personal DID; no group badge route exists, and the XRPC proxy blocks group writes (repo === session).</div>
+          <ul>
+            <li><b>New group badge route</b> (POST + DELETE for app.certified.badge.award) modeled on the follow POST + project DELETE.</li>
+            <li><b>Per-group endorsement definition</b>: ensure an app.certified.badge.definition on the group repo (the lazy ensure can only target the personal repo today).</li>
+            <li><b>Refactor</b> createEndorsementAward / deleteEndorsementAward to accept targetDid via writeToRepo; thread it through the 5 award call sites.</li>
+            <li>Revisit the "endorsements = personal-only" classification; mirror the badge.award rate-limit on the group route.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="annos" style="margin-top:16px;">
+        <div class="anno"><b>Permission</b> is already enforceable: group writes go through createGroupAgent, which the group service authorizes for owner/admin only and rejects for members. The picker just mirrors that role gate in the UI.</div>
+        <div class="anno"><b>Accountability:</b> the public endorser is the group DID, but the authoring admin's DID is retained in the group's audit log, so "who endorsed as Acme" is always answerable.</div>
+      </div>
+    </div>
+  </div>
+
+<script>
+  document.getElementById('themeBtn').addEventListener('click',e=>{const on=document.body.classList.toggle('dark');e.target.textContent=on?'Light mode':'Dark mode';});
+  // mobile picker -> sheet
+  const mp=document.getElementById('mpicker'), msheet=document.getElementById('msheet');
+  document.getElementById('mpick').addEventListener('click',e=>{e.stopPropagation();mp.style.display=mp.style.display==='none'?'block':'none';});
+  mp.querySelectorAll('.pr').forEach((r,i)=>r.addEventListener('click',()=>{mp.style.display='none';if(i>0)msheet.style.display='flex';}));
+  document.getElementById('mcancel').addEventListener('click',()=>msheet.style.display='none');
+  document.addEventListener('click',()=>{mp.style.display='none';});
+  // desktop modal
+  const dm=document.getElementById('dmodal');
+  document.getElementById('dcancel').addEventListener('click',()=>dm.style.display='none');
+  document.getElementById('reopen').addEventListener('click',e=>{e.preventDefault();dm.style.display='flex';});
+  dm.addEventListener('click',e=>{if(e.target===dm)dm.style.display='none';});
+</script>
+</body>
+</html>

--- a/docs/switcher-mockups/pattern-gallery.html
+++ b/docs/switcher-mockups/pattern-gallery.html
@@ -1,0 +1,416 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Identity-switching patterns — applied to Certified (mobile + desktop)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Noto+Serif:wght@500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --color-primary:#111111; --color-white:#FFFFFF;
+    --bg-canvas:#f9f9f9; --bg-sunken:#eeeeee; --bg-raised:#f3f3f3; --bg-elevated:#FFFFFF;
+    --fg-primary:#111111; --fg-secondary:#4c4546; --fg-muted:#6b6263;
+    --border-default:rgba(0,0,0,0.08); --border-hover:rgba(0,0,0,0.15); --border-strong:rgba(0,0,0,0.22);
+    --shadow-md:0 4px 12px rgba(0,0,0,0.08);
+    --radius:2px; --serif:'Noto Serif',Georgia,serif; --ui:'Inter',system-ui,sans-serif; --stage:#dcdcd8;
+  }
+  .dark{
+    --bg-canvas:#18181b; --bg-sunken:#111114; --bg-raised:#26262b; --bg-elevated:#2d2d33;
+    --fg-primary:#f5f5f7; --fg-secondary:#c7c7cc; --fg-muted:#8e8e93;
+    --border-default:rgba(255,255,255,0.08); --border-hover:rgba(255,255,255,0.18); --border-strong:rgba(255,255,255,0.28);
+    --stage:#0c0c0e;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0;font-family:var(--ui);background:var(--stage);color:var(--fg-primary);-webkit-font-smoothing:antialiased;}
+  .top{display:flex;align-items:center;justify-content:space-between;padding:20px 30px;}
+  .top h1{font-family:var(--serif);font-weight:600;font-size:22px;margin:0;}
+  .top h1 small{font-family:var(--ui);font-weight:500;font-size:12.5px;color:var(--fg-muted);margin-left:10px;}
+  .toggle{font-size:12.5px;font-weight:500;color:var(--fg-primary);background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:999px;padding:7px 14px;cursor:pointer;}
+  .wrap{max-width:1320px;margin:0 auto;padding:0 30px 70px;}
+  .intro{font-size:14px;line-height:1.6;color:var(--fg-secondary);max-width:900px;margin:0 0 8px;}
+  .intro b{color:var(--fg-primary);}
+
+  .pat{border-top:1px solid var(--border-hover);padding:26px 0 30px;}
+  .pat-head{display:flex;align-items:center;gap:12px;margin-bottom:4px;}
+  .pat-head .idx{font-family:var(--serif);font-weight:600;font-size:15px;color:var(--fg-muted);width:26px;}
+  .pat-head h2{font-family:var(--serif);font-weight:600;font-size:19px;margin:0;}
+  .verdict{margin-left:6px;font-size:10.5px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;padding:3px 9px;border-radius:999px;border:1px solid var(--border-strong);color:var(--fg-secondary);}
+  .verdict.cur{background:var(--color-primary);color:var(--color-white);border-color:var(--color-primary);}
+  .dark .verdict.cur{background:var(--color-white);color:var(--color-primary);}
+  .verdict.strong{border-color:var(--fg-primary);color:var(--fg-primary);}
+  .verdict.weak{opacity:.7;}
+  .pat-desc{font-size:13px;line-height:1.5;color:var(--fg-secondary);margin:2px 0 16px;max-width:900px;}
+  .pat-desc b{color:var(--fg-primary);font-weight:600;}
+
+  .frames{display:grid;grid-template-columns:248px 1fr 270px;gap:24px;align-items:start;}
+  .flabel{font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--fg-muted);margin-bottom:8px;}
+
+  /* phone */
+  .phone{width:240px;background:var(--bg-canvas);border:1px solid var(--border-hover);border-radius:13px;overflow:hidden;box-shadow:0 10px 26px rgba(0,0,0,.14);}
+  .pnav{height:46px;display:flex;align-items:center;justify-content:space-between;padding:0 11px;background:var(--bg-elevated);border-bottom:1px solid var(--border-default);}
+  .pbody{padding:12px 11px 14px;min-height:96px;}
+
+  /* browser */
+  .win{border:1px solid var(--border-hover);border-radius:10px;overflow:hidden;box-shadow:0 12px 30px rgba(0,0,0,.15);background:var(--bg-canvas);}
+  .wchrome{height:30px;display:flex;align-items:center;gap:10px;padding:0 11px;background:var(--bg-sunken);border-bottom:1px solid var(--border-default);}
+  .wdots{display:flex;gap:5px;} .wdots i{width:8px;height:8px;border-radius:50%;background:#cfcfca;display:block;} .dark .wdots i{background:#3a3a40;}
+  .wurl{font-size:10.5px;color:var(--fg-muted);}
+  .wbar{height:46px;display:flex;align-items:center;gap:12px;padding:0 14px;background:var(--bg-elevated);border-bottom:1px solid var(--border-default);}
+  .wbody{padding:14px;min-height:92px;}
+
+  .brand{font-family:var(--serif);font-weight:600;font-size:15px;}
+  .brand.sm{font-size:14px;}
+  .burger{color:var(--fg-secondary);display:grid;place-items:center;}
+  .spacer{flex:1;}
+  .wtabs{display:flex;gap:3px;} .wtabs a{font-size:11.5px;color:var(--fg-muted);padding:4px 8px;text-decoration:none;border-radius:var(--radius);} .wtabs a.on{color:var(--fg-primary);font-weight:600;background:var(--bg-sunken);}
+  .chev{color:var(--fg-muted);font-size:10px;}
+
+  .av{border-radius:50%;display:grid;place-items:center;font-weight:600;color:#fff;flex:none;}
+  .av.green{background:#3d5a45;} .av.blue{background:#3a4a63;} .av.plum{background:#5a3d52;}
+  .av-20{width:20px;height:20px;font-size:8px;} .av-24{width:24px;height:24px;font-size:9px;} .av-26{width:26px;height:26px;font-size:10px;} .av-28{width:28px;height:28px;font-size:10px;}
+  .av.ring{box-shadow:0 0 0 1.5px var(--bg-elevated),0 0 0 3px var(--fg-primary);}
+
+  .trig{display:flex;align-items:center;gap:5px;}
+  .id2{display:flex;flex-direction:column;line-height:1.15;} .id2 .n{font-size:11.5px;font-weight:600;} .id2 .h{font-size:10px;color:var(--fg-muted);}
+
+  /* generic helpers */
+  .pill{display:inline-flex;align-items:center;gap:5px;height:23px;padding:0 9px 0 6px;border:1px solid var(--border-strong);border-radius:999px;font-size:10.5px;font-weight:500;color:var(--fg-secondary);background:var(--bg-raised);}
+  .pill .dot{width:5px;height:5px;border-radius:50%;background:var(--fg-primary);} .pill .who{color:var(--fg-primary);font-weight:600;}
+  .invbar{display:flex;align-items:center;gap:8px;padding:7px 11px;background:var(--color-primary);color:var(--color-white);font-size:11px;}
+  .dark .invbar{background:var(--color-white);color:var(--color-primary);}
+  .invbar .who{font-weight:600;} .invbar .lead{opacity:.6;} .invbar .x{margin-left:auto;border:1px solid rgba(255,255,255,.34);border-radius:999px;padding:2px 7px;font-size:10px;}
+  .dark .invbar .x{border-color:rgba(0,0,0,.25);}
+  .acct{display:flex;align-items:center;gap:9px;padding:7px 9px;border-radius:var(--radius);}
+  .acct.on{background:var(--bg-sunken);} .acct .m{flex:1;line-height:1.2;} .acct .m .n{font-size:12px;font-weight:600;} .acct .m .h{font-size:10px;color:var(--fg-muted);}
+  .badge{font-size:9px;font-weight:700;color:#fff;background:#b33;border-radius:999px;min-width:16px;height:16px;display:grid;place-items:center;padding:0 4px;}
+  .dark .badge{background:#c55;}
+  .sectit{font-size:9.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--fg-muted);padding:3px 2px 5px;}
+  .menucard{border:1px solid var(--border-default);border-radius:8px;background:var(--bg-elevated);box-shadow:var(--shadow-md);padding:5px;}
+  .scopebtn{display:inline-flex;align-items:center;gap:6px;height:30px;padding:0 10px;border:1px solid var(--border-default);border-radius:var(--radius);background:var(--bg-elevated);font-size:12px;font-weight:500;}
+  .scopebtn .lab{color:var(--fg-muted);font-weight:400;}
+  .fld{height:30px;border:1px solid var(--border-default);border-radius:var(--radius);background:var(--bg-elevated);display:flex;align-items:center;padding:0 9px;font-size:11px;color:var(--fg-muted);margin-top:7px;}
+  .gobtn{margin-top:9px;height:34px;border-radius:var(--radius);background:var(--color-primary);color:var(--color-white);display:inline-flex;align-items:center;justify-content:center;gap:7px;font-size:12px;font-weight:600;padding:0 14px;}
+  .dark .gobtn{background:var(--color-white);color:var(--color-primary);}
+  .gobtn .as{font-weight:500;opacity:.78;display:inline-flex;align-items:center;gap:4px;}
+  .splitbtn{display:inline-flex;border:1px solid var(--color-primary);border-radius:var(--radius);overflow:hidden;font-size:12px;font-weight:600;}
+  .splitbtn .main{background:var(--color-primary);color:#fff;padding:6px 11px;} .splitbtn .as{padding:6px 8px;color:var(--fg-primary);background:var(--bg-elevated);border-left:1px solid var(--border-default);display:flex;align-items:center;gap:4px;}
+  .leftrail{width:44px;background:var(--bg-sunken);border-right:1px solid var(--border-default);display:flex;flex-direction:column;align-items:center;gap:9px;padding:10px 0;}
+  .leftrail .ri{position:relative;} .leftrail .ri.on::before{content:"";position:absolute;left:-10px;top:2px;bottom:2px;width:3px;border-radius:0 2px 2px 0;background:var(--fg-primary);}
+  .h2serif{font-family:var(--serif);font-weight:600;font-size:14px;margin:0 0 6px;}
+  .muted{font-size:11px;color:var(--fg-muted);line-height:1.45;}
+
+  .cap{font-size:12px;line-height:1.5;}
+  .cap .r{margin-bottom:8px;} .cap .r b{color:var(--fg-primary);font-weight:600;}
+  .cap .pro b{color:var(--fg-primary);}
+  svg{display:block;}
+  @media(max-width:1000px){.frames{grid-template-columns:1fr;}}
+
+  /* --- candidates / insight / recommendation --- */
+  .bigsec{border-top:2px solid var(--fg-primary);margin-top:40px;padding-top:10px;}
+  .bigsec .kicker{font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--fg-muted);}
+  .bigsec h2.big{font-family:var(--serif);font-weight:600;font-size:24px;margin:4px 0 6px;}
+  .cands{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;margin-top:18px;}
+  .optcard{border:1px solid var(--border-default);border-radius:10px;background:var(--bg-elevated);overflow:hidden;display:flex;flex-direction:column;}
+  .optcard .ohead{padding:15px 16px 12px;}
+  .optcard .obadge{font-size:10.5px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;color:#fff;background:var(--color-primary);padding:3px 9px;border-radius:999px;}
+  .dark .optcard .obadge{background:var(--color-white);color:var(--color-primary);}
+  .optcard h3{font-family:var(--serif);font-weight:600;font-size:16.5px;margin:9px 0 5px;}
+  .optcard .od{font-size:12.5px;line-height:1.5;color:var(--fg-secondary);}
+  .optcard .ofig{background:var(--bg-canvas);border-top:1px solid var(--border-default);border-bottom:1px solid var(--border-default);padding:16px;display:flex;justify-content:center;}
+  .optcard .ofoot{padding:11px 16px;font-size:11.5px;}
+  .optcard .ofoot a{color:var(--fg-secondary);} .optcard .verdict2{color:var(--fg-muted);}
+  @media(max-width:980px){.cands{grid-template-columns:1fr;}}
+
+  .insight .grid2{display:grid;grid-template-columns:1fr 1fr;gap:22px;margin-top:14px;}
+  .insight .ibox{border:1px solid var(--border-default);border-radius:10px;background:var(--bg-elevated);padding:18px 20px;}
+  .insight .ibox h4{font-family:var(--serif);font-weight:600;font-size:15px;margin:0 0 8px;}
+  .insight .ibox p{font-size:13px;line-height:1.55;color:var(--fg-secondary);margin:0;} .insight .ibox p b{color:var(--fg-primary);}
+  @media(max-width:980px){.insight .grid2{grid-template-columns:1fr;}}
+
+  .rec{margin-top:40px;border:1.5px solid var(--fg-primary);border-radius:12px;padding:26px;background:var(--bg-elevated);}
+  .rec .kicker{font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--fg-muted);}
+  .rec h2{font-family:var(--serif);font-weight:600;font-size:23px;margin:4px 0 8px;}
+  .rec .lede2{font-size:14px;line-height:1.6;color:var(--fg-secondary);max-width:840px;margin:0;} .rec .lede2 b{color:var(--fg-primary);}
+  .conds{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:14px;}
+  .cond{border:1px solid var(--border-default);border-radius:8px;padding:14px 15px;background:var(--bg-raised);}
+  .cond .cn{font-size:13px;font-weight:600;margin-bottom:5px;} .cond .cb{font-size:12px;line-height:1.5;color:var(--fg-secondary);}
+  @media(max-width:980px){.conds{grid-template-columns:1fr;}}
+</style>
+</head>
+<body>
+  <div class="top">
+    <h1>Identity-switching patterns <small>applied to Certified &middot; mobile + desktop</small></h1>
+    <button class="toggle" id="themeBtn">Dark mode</button>
+  </div>
+  <div class="wrap">
+    <p class="intro">How should one person act for the orgs they own or admin? This is the whole picture in one place: <b>the design space</b> (seven patterns, immediately below), <b>the three candidates we built</b>, <b>the deciding insight</b>, and <b>the recommendation</b>. (e) is what the app does today. Toggle dark mode to check the monochrome behaviour.</p>
+
+    <!-- (a) -->
+    <section class="pat">
+      <div class="pat-head"><span class="idx">(a)</span><h2>Separate logins</h2><span class="verdict weak">Weak fit</span></div>
+      <p class="pat-desc">No in-app switch at all. One identity per session; each group would be its own login you sign out and into. <b>Hard isolation, high friction.</b></p>
+      <div class="frames">
+        <div><div class="flabel">Mobile</div>
+          <div class="phone">
+            <div class="pnav"><span class="brand sm">Certified</span><div class="trig"><div class="av plum av-24">YO</div><span class="chev">&#9662;</span></div></div>
+            <div class="pbody"><div class="menucard">
+              <div class="acct on"><div class="av plum av-28">YO</div><div class="m"><div class="n">You</div><div class="h">@holke.certified.app</div></div></div>
+              <div style="height:1px;background:var(--border-default);margin:4px 0;"></div>
+              <div class="acct"><span style="color:var(--fg-secondary);font-size:11.5px;">&#9099; Sign out</span></div>
+            </div><p class="muted" style="margin-top:8px;">Groups are separate accounts. Sign out to switch.</p></div>
+          </div>
+        </div>
+        <div><div class="flabel">Desktop</div>
+          <div class="win">
+            <div class="wchrome"><div class="wdots"><i></i><i></i><i></i></div><span class="wurl">certified.app/home</span></div>
+            <div class="wbar"><span class="brand">Certified</span><span class="spacer"></span><div class="trig"><div class="av plum av-26">YO</div><div class="id2"><span class="n">You</span><span class="h">@holke.certified.app</span></div><span class="chev">&#9662;</span></div></div>
+            <div class="wbody"><p class="muted">No "act as" concept. The whole session is one DID. To operate a group you sign in as that group. Closest to raw atproto, but groups stop feeling like shared entities.</p></div>
+          </div>
+        </div>
+        <div class="cap"><div class="flabel">Trade-off</div>
+          <div class="r pro"><b>+</b> Zero cross-post risk; one principal per session.</div>
+          <div class="r"><b>&minus;</b> Re-auth to switch; groups become separate accounts, not memberships.</div>
+          <div class="r"><b>Fit:</b> wrong model for a membership-based group feature.</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- (b) -->
+    <section class="pat">
+      <div class="pat-head"><span class="idx">(b)</span><h2>Multi-account switcher</h2><span class="verdict">Workable</span></div>
+      <p class="pat-desc">Personal and each group are <b>peers</b> in one list, switched instantly with per-account unread badges (Slack / Google style). On desktop, a left icon rail keeps all identities partly visible.</p>
+      <div class="frames">
+        <div><div class="flabel">Mobile</div>
+          <div class="phone">
+            <div class="pnav"><span class="brand sm">Certified</span><div class="trig"><div class="av green av-24">AC</div><span class="chev">&#9662;</span></div></div>
+            <div class="pbody"><div class="menucard">
+              <div class="acct"><div class="av plum av-28">YO</div><div class="m"><div class="n">You</div><div class="h">@holke</div></div><span class="badge">2</span></div>
+              <div class="acct on"><div class="av green av-28">AC</div><div class="m"><div class="n">Acme Collective</div><div class="h">@acme</div></div><span class="badge">5</span></div>
+              <div class="acct"><div class="av blue av-28">RF</div><div class="m"><div class="n">Rainforest Fund</div><div class="h">@rainforest</div></div></div>
+            </div></div>
+          </div>
+        </div>
+        <div><div class="flabel">Desktop</div>
+          <div class="win"><div class="wchrome"><div class="wdots"><i></i><i></i><i></i></div><span class="wurl">certified.app/home</span></div>
+            <div style="display:flex;">
+              <div class="leftrail"><div class="ri"><div class="av plum av-28">YO</div></div><div class="ri on"><div class="av green av-28">AC</div></div><div class="ri"><div class="av blue av-28">RF</div></div></div>
+              <div style="flex:1;"><div class="wbar" style="border-bottom:1px solid var(--border-default);"><span class="brand">Certified</span><span class="muted" style="margin-left:6px;">&middot; Acme Collective</span></div><div class="wbody"><p class="muted">Each identity is its own "account" with its own badges. Switching swaps the whole app. The active one is marked on the rail.</p></div></div>
+            </div>
+          </div>
+        </div>
+        <div class="cap"><div class="flabel">Trade-off</div>
+          <div class="r pro"><b>+</b> Fast; aggregated awareness via badges; great for many identities.</div>
+          <div class="r"><b>&minus;</b> Frames "me" and "the org" as equals, weakening the "I am acting FOR a group" idea; heavier model.</div>
+          <div class="r"><b>Fit:</b> good if a user juggles many groups daily.</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- (c) -->
+    <section class="pat">
+      <div class="pat-head"><span class="idx">(c)</span><h2>Workspace switcher</h2><span class="verdict">Workable</span></div>
+      <p class="pat-desc">You are always <b>inside exactly one space</b>; the space name is the switcher (top-left), and the whole app is scoped to it. Personal is just another space (Notion / Linear style).</p>
+      <div class="frames">
+        <div><div class="flabel">Mobile</div>
+          <div class="phone">
+            <div class="pnav"><div class="trig"><div class="av green av-24">AC</div><span class="brand sm" style="font-size:13px;">Acme Collective</span><span class="chev">&#9662;</span></div><div class="av plum av-20">YO</div></div>
+            <div class="pbody"><div class="muted">Feed, certs, projects &mdash; all Acme's. The space name in the corner is both the label and the switcher.</div></div>
+          </div>
+        </div>
+        <div><div class="flabel">Desktop</div>
+          <div class="win"><div class="wchrome"><div class="wdots"><i></i><i></i><i></i></div><span class="wurl">certified.app</span></div>
+            <div class="wbar"><div class="trig"><div class="av green av-26">AC</div><span class="brand" style="font-size:15px;">Acme Collective</span><span class="chev">&#9662;</span></div><span class="spacer"></span><div class="av plum av-26">YO</div></div>
+            <div class="wbody"><p class="muted">The space name replaces the brandmark as the primary anchor. Clicking it lists spaces (You, Acme, Rainforest). Strong, unambiguous scoping.</p></div>
+          </div>
+        </div>
+        <div class="cap"><div class="flabel">Trade-off</div>
+          <div class="r pro"><b>+</b> Crystal-clear scope; symmetric treatment of personal + groups; no separate "mode".</div>
+          <div class="r"><b>&minus;</b> "Personal as a workspace" is slightly odd for a social identity; brandmark gives way to the space name.</div>
+          <div class="r"><b>Fit:</b> strong if groups become the primary unit of work.</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- (d) -->
+    <section class="pat">
+      <div class="pat-head"><span class="idx">(d)</span><h2>Namespace scope dropdown</h2><span class="verdict strong">Strong fit</span></div>
+      <p class="pat-desc">No global mode. You stay <b>you</b> everywhere; a small scope selector on the relevant surface sets who a record is for (GitHub "owner" dropdown). Your feed and profile never change identity.</p>
+      <div class="frames">
+        <div><div class="flabel">Mobile</div>
+          <div class="phone">
+            <div class="pnav"><span class="brand sm">New cert</span><div class="av plum av-24">YO</div></div>
+            <div class="pbody"><div class="muted" style="margin-bottom:6px;">Owner</div><div class="scopebtn"><div class="av green av-20">AC</div>Acme Collective<span class="chev">&#9662;</span></div><div class="fld">Title</div><div class="gobtn" style="margin-top:8px;">Create</div></div>
+          </div>
+        </div>
+        <div><div class="flabel">Desktop</div>
+          <div class="win"><div class="wchrome"><div class="wdots"><i></i><i></i><i></i></div><span class="wurl">certified.app/create</span></div>
+            <div class="wbar"><span class="brand">Certified</span><span class="spacer"></span><div class="trig"><div class="av plum av-26">YO</div><div class="id2"><span class="n">You</span><span class="h">@holke.certified.app</span></div></div></div>
+            <div class="wbody"><div class="muted" style="margin-bottom:6px;">Owner of this certificate</div><div class="scopebtn"><div class="av green av-20">AC</div>Acme Collective<span class="chev">&#9662;</span></div><p class="muted" style="margin-top:10px;">Chrome stays "You". Only this record's owner is scoped. No sticky mode to forget.</p></div>
+          </div>
+        </div>
+        <div class="cap"><div class="flabel">Trade-off</div>
+          <div class="r pro"><b>+</b> No global mode &rarr; no stale-mode errors; your feed/profile stay yours.</div>
+          <div class="r"><b>&minus;</b> Set the scope per surface; doesn't give you the group's feed/library in one move.</div>
+          <div class="r"><b>Fit:</b> strong if "acting as a group" mostly means authoring records, not browsing as them.</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- (e) -->
+    <section class="pat">
+      <div class="pat-head"><span class="idx">(e)</span><h2>Act-as persona <span style="font-weight:400;color:var(--fg-muted);font-size:13px;">(today &middot; Options 1 &amp; 2)</span></h2><span class="verdict cur">Current</span></div>
+      <p class="pat-desc">A sticky, app-wide "acting as &lt;group&gt;" mode that re-scopes reads and writes. This is what Certified does now; Options 1 (persistent bar) and 2 (per-action identity) make the mode legible. <b>See the dedicated files.</b></p>
+      <div class="frames">
+        <div><div class="flabel">Mobile</div>
+          <div class="phone">
+            <div class="pnav"><span class="brand sm">Certified</span><div class="trig"><div class="av green av-24 ring">AC</div><span class="chev">&#9662;</span></div></div>
+            <div class="invbar"><div class="av green av-20 ring">AC</div><span class="lead">Acting as </span><span class="who">Acme</span><span class="x">Switch back</span></div>
+            <div class="pbody"><div class="muted">Whole app scoped to Acme until you switch back.</div></div>
+          </div>
+        </div>
+        <div><div class="flabel">Desktop</div>
+          <div class="win"><div class="wchrome"><div class="wdots"><i></i><i></i><i></i></div><span class="wurl">certified.app/home</span></div>
+            <div class="wbar"><span class="brand">Certified</span><span class="spacer"></span><div class="trig"><div class="av green av-26 ring">AC</div><div class="id2"><span class="n">Acme Collective</span><span class="h">@acme.certified.app</span></div><span class="chev">&#9662;</span></div></div>
+            <div class="invbar" style="padding:8px 14px;"><div class="av green av-24 ring">AC</div><span class="lead">Acting as </span><span class="who">Acme Collective</span><span class="x">&#8617; Switch back to You</span></div>
+            <div class="wbody"><p class="muted">Persistent bar = Option 1. Per-action "as Acme" buttons = Option 2.</p></div>
+          </div>
+        </div>
+        <div class="cap"><div class="flabel">Trade-off</div>
+          <div class="r pro"><b>+</b> One move re-scopes the whole app to the group; natural for "I run this group".</div>
+          <div class="r"><b>&minus;</b> Sticky mode can be forgotten; needs a loud indicator (the whole point of Options 1/2).</div>
+          <div class="r"><b>Fit:</b> good with the safety recipe; today's bare-avatar version is the risk.</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- (f) -->
+    <section class="pat">
+      <div class="pat-head"><span class="idx">(f)</span><h2>Per-action identity picker</h2><span class="verdict strong">Strong fit</span></div>
+      <p class="pat-desc">No ambient mode whatsoever. Chrome is always <b>you</b>; each write action carries its own inline "as &#9662;" picker (LinkedIn post-as, Buffer). Option 2 is a hybrid of this with a light ambient chip.</p>
+      <div class="frames">
+        <div><div class="flabel">Mobile</div>
+          <div class="phone">
+            <div class="pnav"><span class="brand sm">Jane Rivera</span><div class="av plum av-24">YO</div></div>
+            <div class="pbody"><div class="muted" style="margin-bottom:7px;">Follow this profile</div><div class="splitbtn"><span class="main">Follow</span><span class="as"><div class="av plum av-20">YO</div>as You &#9662;</span></div><p class="muted" style="margin-top:9px;">Tap "as" to follow as Acme instead.</p></div>
+          </div>
+        </div>
+        <div><div class="flabel">Desktop</div>
+          <div class="win"><div class="wchrome"><div class="wdots"><i></i><i></i><i></i></div><span class="wurl">certified.app/create</span></div>
+            <div class="wbar"><span class="brand">Certified</span><span class="spacer"></span><div class="trig"><div class="av plum av-26">YO</div><div class="id2"><span class="n">You</span><span class="h">@holke.certified.app</span></div></div></div>
+            <div class="wbody"><div class="muted" style="margin-bottom:6px;">Author</div><div class="scopebtn"><div class="av plum av-20">YO</div>You <span class="lab">&mdash; change &#9662;</span></div><p class="muted" style="margin-top:10px;">Default is you; pick a group per action. The chrome never enters a "mode".</p></div>
+          </div>
+        </div>
+        <div class="cap"><div class="flabel">Trade-off</div>
+          <div class="r pro"><b>+</b> Impossible to be in a stale mode; identity is reasserted at every write.</div>
+          <div class="r"><b>&minus;</b> Friction per action; your feed/library never show the group's view.</div>
+          <div class="r"><b>Fit:</b> strong, and composes with a light ambient cue (that's Option 2).</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- (g) -->
+    <section class="pat">
+      <div class="pat-head"><span class="idx">(g)</span><h2>Profile-as-place</h2><span class="verdict">Niche</span></div>
+      <p class="pat-desc">No switching anywhere. You are always you. Group actions live <b>on the group's own page</b> ("Manage", "+ Post as this group"); there is no global persona to enter or exit.</p>
+      <div class="frames">
+        <div><div class="flabel">Mobile</div>
+          <div class="phone">
+            <div class="pnav"><span class="brand sm">Acme Collective</span><div class="av plum av-24">YO</div></div>
+            <div class="pbody"><div style="display:flex;align-items:center;gap:9px;"><div class="av green av-28">AC</div><div><div style="font-size:12px;font-weight:600;">Acme Collective</div><div class="muted">You're an owner</div></div></div>
+              <div style="display:flex;gap:6px;margin-top:10px;"><div class="gobtn" style="margin:0;flex:1;">+ Post as Acme</div><div class="scopebtn" style="height:34px;">Manage</div></div></div>
+          </div>
+        </div>
+        <div><div class="flabel">Desktop</div>
+          <div class="win"><div class="wchrome"><div class="wdots"><i></i><i></i><i></i></div><span class="wurl">certified.app/groups/acme</span></div>
+            <div class="wbar"><span class="brand">Certified</span><span class="spacer"></span><div class="trig"><div class="av plum av-26">YO</div><div class="id2"><span class="n">You</span><span class="h">@holke.certified.app</span></div></div></div>
+            <div class="wbody"><div style="display:flex;align-items:center;gap:11px;"><div class="av green av-28">AC</div><div style="flex:1;"><div style="font-size:14px;font-weight:600;font-family:var(--serif);">Acme Collective</div><div class="muted">You are an owner of this group</div></div><div class="scopebtn">Manage</div><div class="gobtn" style="margin:0;">+ Post as Acme</div></div><p class="muted" style="margin-top:11px;">Everywhere else you're simply you. Group power lives on its page.</p></div>
+          </div>
+        </div>
+        <div class="cap"><div class="flabel">Trade-off</div>
+          <div class="r pro"><b>+</b> Simplest mental model; no mode, no mis-attribution surface.</div>
+          <div class="r"><b>&minus;</b> Group actions only reachable from the group page; clumsy for heavy admins.</div>
+          <div class="r"><b>Fit:</b> niche; fine if group activity is occasional, weak for power users.</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ======================= CANDIDATES ======================= -->
+    <section class="bigsec">
+      <div class="kicker">The three we built and evaluated</div>
+      <h2 class="big">Candidates</h2>
+      <p class="intro" style="margin-bottom:0;">All three refine the design space above. Options 1 and 2 keep the act-as model (pattern e) and make it legible; Option 3 drops the global mode for GitHub-style per-action identity (d + f). Full interactive mocks are in the sibling files.</p>
+      <div class="cands">
+        <div class="optcard">
+          <div class="ohead"><span class="obadge">Option 1</span><h3>Act-as + persistent bar</h3><div class="od">The sticky mode made loud: an inverted bar on every screen names the group with an inline exit.</div></div>
+          <div class="ofig">
+            <div class="phone" style="width:212px;">
+              <div class="pnav"><span class="brand sm">Certified</span><div class="trig"><div class="av green av-24">AC</div><span class="chev">&#9662;</span></div></div>
+              <div class="invbar"><div class="av green av-20">AC</div><span class="lead">Acting as </span><span class="who">Acme</span><span class="x">Switch back</span></div>
+              <div class="pbody" style="min-height:48px;"><div class="muted">Whole app scoped to Acme.</div></div>
+            </div>
+          </div>
+          <div class="ofoot"><span class="verdict2">Ships on UI alone; mitigates the mode risk</span><br><a href="option-1-sticky-bar.html">mobile</a> &middot; <a href="option-1-desktop.html">desktop</a></div>
+        </div>
+        <div class="optcard">
+          <div class="ohead"><span class="obadge">Option 2</span><h3>Act-as + per-action labels</h3><div class="od">A quiet chip, plus the identity inside each write button ("Create cert as Acme") and a confirm on high-stakes writes.</div></div>
+          <div class="ofig">
+            <div class="phone" style="width:212px;">
+              <div class="pnav"><span class="pill"><span class="dot"></span>Acting as <span class="who">Acme</span></span><div class="av green av-24">AC</div></div>
+              <div class="pbody" style="min-height:72px;"><div class="muted" style="margin-bottom:9px;">New certificate</div><div class="gobtn" style="font-size:11px;height:30px;margin-top:0;">Create cert as &#9737; Acme</div></div>
+            </div>
+          </div>
+          <div class="ofoot"><span class="verdict2">Reasserts identity at the write</span><br><a href="option-2-hybrid.html">mobile</a> &middot; <a href="option-2-desktop.html">desktop</a></div>
+        </div>
+        <div class="optcard">
+          <div class="ohead"><span class="obadge">Option 3</span><h3>GitHub model</h3><div class="od">No global mode. You are always you; a split button picks the actor per action ("Endorse as &#9662;"), default You.</div></div>
+          <div class="ofig">
+            <div class="phone" style="width:212px;">
+              <div class="pnav"><span class="brand sm">Certified</span><div class="trig"><div class="av plum av-24">YO</div><span class="chev">&#9662;</span></div></div>
+              <div class="pbody" style="min-height:72px;"><div class="muted" style="margin-bottom:9px;">Jane Rivera</div><div class="splitbtn"><span class="main">Endorse</span><span class="as">as You &#9662;</span></div></div>
+            </div>
+          </div>
+          <div class="ofoot"><span class="verdict2">Kills the mode bug; needs org-endorse backend</span><br><a href="option-3-github-model.html">mobile + desktop</a></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ======================= INSIGHT ======================= -->
+    <section class="bigsec insight">
+      <div class="kicker">The deciding insight</div>
+      <h2 class="big">An org is a full account, not a namespace</h2>
+      <p class="intro" style="margin-bottom:0;">Two kinds of "org" run through these patterns, and they take opposite models.</p>
+      <div class="grid2">
+        <div class="ibox"><h4>Namespace-orgs &rarr; per-action scope</h4><p>A GitHub org or a Medium publication can't be logged into. They are containers you attach records to. Per-action scoping (Option 3) fits because there is no account to "be".</p></div>
+        <div class="ibox"><h4>Account-orgs &rarr; act-as / delegation</h4><p>An <b>atproto org is its own account</b>: its own DID, handle, repo, profile, follow graph. You could log into Bluesky <i>as</i> Acme directly. X and YouTube brand accounts work the same way, and both use "operate the account", not a per-action tag.</p></div>
+      </div>
+      <p style="font-size:13.5px;line-height:1.6;color:var(--fg-secondary);margin-top:16px;max-width:900px;">A Certified org is the second kind. So Option 3, by framing the org as an owner you tag onto a record, <b style="color:var(--fg-primary)">hides what the org actually is</b> and breaks consistency with the rest of atproto. The act-as model tells the truth: the org is an account you operate. And doing it in-app is <b style="color:var(--fg-primary)">delegation</b>, which beats "log in as Acme" directly: no credential sharing, you stay accountable as the operator, and you never log out of yourself. That delegation gap is exactly what raw atproto lacks and Certified can fill.</p>
+    </section>
+
+    <!-- ======================= RECOMMENDATION ======================= -->
+    <section class="rec">
+      <div class="kicker">Suggestion</div>
+      <h2>Act-as, framed as delegation</h2>
+      <p class="lede2">Keep the act-as model (it is the honest one for an account-org and it bridges to Bluesky), but treat the safety layer as mandatory, not optional. One line states who you are operating and who you are:</p>
+      <div style="margin:16px 0;">
+        <div class="invbar" style="border-radius:var(--radius);padding:12px 16px;max-width:540px;">
+          <div class="av green av-26">AC</div>
+          <span>Operating <span class="who">Acme Collective</span> as @holke <span style="opacity:.62;">(admin)</span></span>
+          <span class="x" style="margin-left:auto;">Switch to personal</span>
+        </div>
+      </div>
+      <div class="conds">
+        <div class="cond"><div class="cn">1 &middot; Persistent indicator</div><div class="cb">That bar on every screen, with the inline exit. It names the org (the account) and you (the operator) at once.</div></div>
+        <div class="cond"><div class="cn">2 &middot; Confirm the high-stakes write</div><div class="cb">Endorsing as the org gets a confirm naming endorser, operator, and subject. Following is one click.</div></div>
+        <div class="cond"><div class="cn">3 &middot; Session-scoped, not forever</div><div class="cb">The mode lasts the session, not indefinitely in localStorage, so you cannot be silently delegated days later.</div></div>
+      </div>
+      <p style="font-size:13px;line-height:1.6;color:var(--fg-secondary);margin-top:18px;max-width:900px;">Why not Option 3: it is safest by construction, but it buys that safety by pretending the org is a namespace. For an atproto identity product, telling the truth that the org is a real account matters more, and the mis-attribution risk is answerable with the three conditions above. The org-endorse backend (group badge route + per-group endorsement definition + unfollow route) is needed either way, so it is not a reason to prefer one model over the other.</p>
+    </section>
+
+  </div>
+<script>
+  document.getElementById('themeBtn').addEventListener('click',e=>{const on=document.body.classList.toggle('dark');e.target.textContent=on?'Light mode':'Dark mode';});
+</script>
+</body>
+</html>

--- a/src/app/api/groups/[groupDid]/endorse/route.ts
+++ b/src/app/api/groups/[groupDid]/endorse/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest, NextResponse } from "next/server"
+import {
+  getAuthenticatedAgent,
+  createGroupAgent,
+} from "@/lib/groups/proxy-agent"
+import { checkCsrf } from "@/lib/auth/csrf"
+import { isValidDid } from "@/lib/utils/did"
+import { extractRecordRef, extractRouteError, parseJsonBody } from "@/lib/utils/api"
+
+const BADGE_AWARD_COLLECTION = "app.certified.badge.award"
+
+/** Max byte length we'll allow on `note` from the client. Mirrors the
+ *  client-side `createEndorsementAward` cap so a write never gets
+ *  rejected at the PDS for going over (badges.ts BADGE_AWARD_NOTE_MAX). */
+const BADGE_AWARD_NOTE_MAX = 500
+
+/**
+ * POST /api/groups/[groupDid]/endorse
+ *
+ * Create an `app.certified.badge.award` record on a GROUP's repo so the
+ * group itself endorses a foreign account. Used when an owner/admin acts
+ * as a group — without this BFF route the client-side
+ * `createEndorsementAward` writes the award to the personal repo instead.
+ *
+ * Body shape:
+ *   { subject: string (DID), badge: { uri: string, cid: string }, note?: string }
+ *
+ * The award `subject` is wrapped in the canonical `app.certified.defs#did`
+ * object form (object with a `did` property) — the magic-indexer's
+ * `subject_did` generated column only extracts the DID from the object
+ * form, so bare-string subjects are invisible to the "endorsements
+ * received" filter. `note` is trimmed and truncated to 500 chars; an
+ * empty/whitespace note is omitted entirely.
+ *
+ * Returns `{ uri, cid }` so the client can mirror the new commit locally
+ * without a re-read.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupDid: string }> },
+) {
+  const csrfError = checkCsrf(request)
+  if (csrfError) return csrfError
+
+  try {
+    const { groupDid } = await params
+    if (!isValidDid(groupDid)) {
+      return NextResponse.json({ error: "Invalid group DID" }, { status: 400 })
+    }
+    const auth = await getAuthenticatedAgent()
+    if (!auth) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+    }
+
+    const parsed = await parseJsonBody(request, "[groups/endorse]")
+    if (!parsed.ok) return parsed.response
+    const body = (parsed.body ?? {}) as Record<string, unknown>
+
+    const subjectDid = typeof body.subject === "string" ? body.subject : null
+    if (!subjectDid || !isValidDid(subjectDid)) {
+      return NextResponse.json(
+        { error: "subject is required and must be a valid DID" },
+        { status: 400 },
+      )
+    }
+
+    // The badge strongRef points at the group's endorsement definition.
+    // Validate the `{ uri, cid }` shape before forwarding so a malformed
+    // award returns a clean 400 instead of trusting upstream to reject.
+    const badgeRaw = body.badge
+    const badge =
+      badgeRaw && typeof badgeRaw === "object"
+        ? (badgeRaw as Record<string, unknown>)
+        : null
+    const badgeUri = badge && typeof badge.uri === "string" ? badge.uri : null
+    const badgeCid = badge && typeof badge.cid === "string" ? badge.cid : null
+    if (!badgeUri || !badgeCid) {
+      return NextResponse.json(
+        { error: "badge is required and must be a { uri, cid } strong ref" },
+        { status: 400 },
+      )
+    }
+
+    // Trim + truncate the note. Empty strings are omitted entirely so we
+    // don't store noise that round-trips on every read.
+    const noteRaw = typeof body.note === "string" ? body.note.trim() : ""
+    const note = noteRaw ? noteRaw.slice(0, BADGE_AWARD_NOTE_MAX) : undefined
+
+    const record = {
+      $type: BADGE_AWARD_COLLECTION,
+      badge: { uri: badgeUri, cid: badgeCid },
+      // Canonical `app.certified.defs#did` shape: object with a `did`
+      // property (see badges.ts writeBadgeAward).
+      subject: { $type: "app.certified.defs#did", did: subjectDid },
+      createdAt: new Date().toISOString(),
+      ...(note ? { note } : {}),
+    }
+
+    const groupAgent = createGroupAgent(auth.agent, groupDid)
+    const upstream = await groupAgent.call(
+      "app.certified.group.repo.createRecord",
+      {},
+      {
+        repo: groupDid,
+        collection: BADGE_AWARD_COLLECTION,
+        record,
+      },
+      { encoding: "application/json" },
+    )
+
+    const ref = extractRecordRef(upstream)
+    if (!ref) {
+      return NextResponse.json(
+        { error: "Upstream returned no record reference" },
+        { status: 502 },
+      )
+    }
+    return NextResponse.json(ref)
+  } catch (err: unknown) {
+    const { status, message } = extractRouteError(err)
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+/**
+ * DELETE /api/groups/[groupDid]/endorse
+ *
+ * Removes an `app.certified.badge.award` record from the group's repo via
+ * `app.certified.group.repo.deleteRecord`. The authenticated viewer must
+ * be an owner / admin of the group. Used to retract a group endorsement.
+ *
+ * Body shape: `{ rkey: string }`.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupDid: string }> },
+) {
+  const csrfError = checkCsrf(request)
+  if (csrfError) return csrfError
+
+  try {
+    const { groupDid } = await params
+    if (!isValidDid(groupDid)) {
+      return NextResponse.json({ error: "Invalid group DID" }, { status: 400 })
+    }
+    const auth = await getAuthenticatedAgent()
+    if (!auth) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+    }
+
+    const parsed = await parseJsonBody(request, "[groups/endorse DELETE]")
+    if (!parsed.ok) return parsed.response
+    const body = (parsed.body ?? {}) as Record<string, unknown>
+    const rkey = typeof body.rkey === "string" ? body.rkey : null
+    if (!rkey) {
+      return NextResponse.json(
+        { error: "rkey is required" },
+        { status: 400 },
+      )
+    }
+
+    const groupAgent = createGroupAgent(auth.agent, groupDid)
+    await groupAgent.call(
+      "app.certified.group.repo.deleteRecord",
+      {},
+      { repo: groupDid, collection: BADGE_AWARD_COLLECTION, rkey },
+      { encoding: "application/json" },
+    )
+    return NextResponse.json({ ok: true })
+  } catch (err: unknown) {
+    const { status, message } = extractRouteError(err)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/src/app/api/groups/[groupDid]/endorsement-definition/route.ts
+++ b/src/app/api/groups/[groupDid]/endorsement-definition/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server"
+import {
+  getAuthenticatedAgent,
+  createGroupAgent,
+} from "@/lib/groups/proxy-agent"
+import { checkCsrf } from "@/lib/auth/csrf"
+import { isValidDid } from "@/lib/utils/did"
+import { extractRecordRef, extractRouteError, parseJsonBody } from "@/lib/utils/api"
+
+const BADGE_DEFINITION_COLLECTION = "app.certified.badge.definition"
+const ENDORSEMENT_BADGE_TYPE = "endorsement"
+const ENDORSEMENT_BADGE_TITLE = "Endorsement"
+
+/**
+ * POST /api/groups/[groupDid]/endorsement-definition
+ *
+ * Create the group's default `app.certified.badge.definition` record for
+ * endorsements on the GROUP's repo. Used lazily by the client's
+ * `ensureGroupEndorsementDefinition`: when acting as a group that has no
+ * endorsement definition yet, the client mints one through this route so
+ * subsequent group endorsements have a badge strongRef to point at.
+ *
+ * The body is intentionally ignored — every field is server-pinned to the
+ * canonical endorsement definition shape so this route can only ever mint
+ * an endorsement definition, never an arbitrary badge type.
+ *
+ * Returns `{ uri, cid }` so the client can use the new ref as the award's
+ * `badge` without a re-read.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupDid: string }> },
+) {
+  const csrfError = checkCsrf(request)
+  if (csrfError) return csrfError
+
+  try {
+    const { groupDid } = await params
+    if (!isValidDid(groupDid)) {
+      return NextResponse.json({ error: "Invalid group DID" }, { status: 400 })
+    }
+    const auth = await getAuthenticatedAgent()
+    if (!auth) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+    }
+
+    // Body is ignored — the definition shape is fully server-pinned.
+    const parsed = await parseJsonBody(request, "[groups/endorsement-definition]")
+    if (!parsed.ok) return parsed.response
+
+    const record = {
+      $type: BADGE_DEFINITION_COLLECTION,
+      badgeType: ENDORSEMENT_BADGE_TYPE,
+      title: ENDORSEMENT_BADGE_TITLE,
+      createdAt: new Date().toISOString(),
+    }
+
+    const groupAgent = createGroupAgent(auth.agent, groupDid)
+    const upstream = await groupAgent.call(
+      "app.certified.group.repo.createRecord",
+      {},
+      {
+        repo: groupDid,
+        collection: BADGE_DEFINITION_COLLECTION,
+        record,
+      },
+      { encoding: "application/json" },
+    )
+
+    const ref = extractRecordRef(upstream)
+    if (!ref) {
+      return NextResponse.json(
+        { error: "Upstream returned no record reference" },
+        { status: 502 },
+      )
+    }
+    return NextResponse.json(ref)
+  } catch (err: unknown) {
+    const { status, message } = extractRouteError(err)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/src/app/api/groups/[groupDid]/follow/route.ts
+++ b/src/app/api/groups/[groupDid]/follow/route.ts
@@ -100,3 +100,56 @@ export async function POST(
     return NextResponse.json({ error: message }, { status })
   }
 }
+
+/**
+ * DELETE /api/groups/[groupDid]/follow
+ *
+ * Removes an `app.certified.graph.follow` record from the group's repo via
+ * `app.certified.group.repo.deleteRecord`. Used when an owner/admin acting
+ * as a group unfollows an account — mirrors the POST above on the unfollow
+ * side so the group's social graph is editable without writing to the
+ * personal repo.
+ *
+ * Body shape: `{ rkey: string }`.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupDid: string }> },
+) {
+  const csrfError = checkCsrf(request)
+  if (csrfError) return csrfError
+
+  try {
+    const { groupDid } = await params
+    if (!isValidDid(groupDid)) {
+      return NextResponse.json({ error: "Invalid group DID" }, { status: 400 })
+    }
+    const auth = await getAuthenticatedAgent()
+    if (!auth) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+    }
+
+    const parsed = await parseJsonBody(request, "[groups/follow DELETE]")
+    if (!parsed.ok) return parsed.response
+    const body = (parsed.body ?? {}) as Record<string, unknown>
+    const rkey = typeof body.rkey === "string" ? body.rkey : null
+    if (!rkey) {
+      return NextResponse.json(
+        { error: "rkey is required" },
+        { status: 400 },
+      )
+    }
+
+    const groupAgent = createGroupAgent(auth.agent, groupDid)
+    await groupAgent.call(
+      "app.certified.group.repo.deleteRecord",
+      {},
+      { repo: groupDid, collection: FOLLOW_COLLECTION, rkey },
+      { encoding: "application/json" },
+    )
+    return NextResponse.json({ ok: true })
+  } catch (err: unknown) {
+    const { status, message } = extractRouteError(err)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/src/app/api/groups/[groupDid]/response/route.ts
+++ b/src/app/api/groups/[groupDid]/response/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from "next/server"
+import {
+  getAuthenticatedAgent,
+  createGroupAgent,
+} from "@/lib/groups/proxy-agent"
+import { checkCsrf } from "@/lib/auth/csrf"
+import { isValidDid } from "@/lib/utils/did"
+import { extractRecordRef, extractRouteError, parseJsonBody } from "@/lib/utils/api"
+
+const BADGE_RESPONSE_COLLECTION = "app.certified.badge.response"
+
+/**
+ * POST /api/groups/[groupDid]/response
+ *
+ * Create an `app.certified.badge.response` record on a GROUP's repo so the
+ * group itself accepts/rejects an endorsement it received. Used when an
+ * owner/admin acts as a group — without this BFF route the client-side
+ * `createResponse` writes the response to the personal repo instead, which
+ * would never affect the group's profile.
+ *
+ * Body shape:
+ *   { award: { uri: string, cid: string }, response: "accepted" | "rejected",
+ *     weight?: string }
+ *
+ * Returns `{ uri, cid }` so the client can mirror the new commit locally
+ * without a re-read.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupDid: string }> },
+) {
+  const csrfError = checkCsrf(request)
+  if (csrfError) return csrfError
+
+  try {
+    const { groupDid } = await params
+    if (!isValidDid(groupDid)) {
+      return NextResponse.json({ error: "Invalid group DID" }, { status: 400 })
+    }
+    const auth = await getAuthenticatedAgent()
+    if (!auth) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+    }
+
+    const parsed = await parseJsonBody(request, "[groups/response]")
+    if (!parsed.ok) return parsed.response
+    const body = (parsed.body ?? {}) as Record<string, unknown>
+
+    // Validate the award strongRef `{ uri, cid }` shape before forwarding so
+    // a malformed reference returns a clean 400 instead of trusting upstream.
+    const awardRaw = body.award
+    const award =
+      awardRaw && typeof awardRaw === "object"
+        ? (awardRaw as Record<string, unknown>)
+        : null
+    const awardUri = award && typeof award.uri === "string" ? award.uri : null
+    const awardCid = award && typeof award.cid === "string" ? award.cid : null
+    if (!awardUri || !awardCid) {
+      return NextResponse.json(
+        { error: "award is required and must be a { uri, cid } strong ref" },
+        { status: 400 },
+      )
+    }
+
+    const response = body.response
+    if (response !== "accepted" && response !== "rejected") {
+      return NextResponse.json(
+        { error: 'response must be "accepted" or "rejected"' },
+        { status: 400 },
+      )
+    }
+
+    const weight = typeof body.weight === "string" ? body.weight : undefined
+
+    const record = {
+      $type: BADGE_RESPONSE_COLLECTION,
+      badgeAward: { uri: awardUri, cid: awardCid },
+      response,
+      ...(weight ? { weight } : {}),
+      createdAt: new Date().toISOString(),
+    }
+
+    const groupAgent = createGroupAgent(auth.agent, groupDid)
+    const upstream = await groupAgent.call(
+      "app.certified.group.repo.createRecord",
+      {},
+      {
+        repo: groupDid,
+        collection: BADGE_RESPONSE_COLLECTION,
+        record,
+      },
+      { encoding: "application/json" },
+    )
+
+    const ref = extractRecordRef(upstream)
+    if (!ref) {
+      return NextResponse.json(
+        { error: "Upstream returned no record reference" },
+        { status: 502 },
+      )
+    }
+    return NextResponse.json(ref)
+  } catch (err: unknown) {
+    const { status, message } = extractRouteError(err)
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+/**
+ * DELETE /api/groups/[groupDid]/response
+ *
+ * Removes an `app.certified.badge.response` record from the group's repo
+ * (reset-to-default). The authenticated viewer must be an owner / admin of
+ * the group.
+ *
+ * Body shape: `{ rkey: string }`.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupDid: string }> },
+) {
+  const csrfError = checkCsrf(request)
+  if (csrfError) return csrfError
+
+  try {
+    const { groupDid } = await params
+    if (!isValidDid(groupDid)) {
+      return NextResponse.json({ error: "Invalid group DID" }, { status: 400 })
+    }
+    const auth = await getAuthenticatedAgent()
+    if (!auth) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+    }
+
+    const parsed = await parseJsonBody(request, "[groups/response DELETE]")
+    if (!parsed.ok) return parsed.response
+    const body = (parsed.body ?? {}) as Record<string, unknown>
+    const rkey = typeof body.rkey === "string" ? body.rkey : null
+    if (!rkey) {
+      return NextResponse.json({ error: "rkey is required" }, { status: 400 })
+    }
+
+    const groupAgent = createGroupAgent(auth.agent, groupDid)
+    await groupAgent.call(
+      "app.certified.group.repo.deleteRecord",
+      {},
+      { repo: groupDid, collection: BADGE_RESPONSE_COLLECTION, rkey },
+      { encoding: "application/json" },
+    )
+    return NextResponse.json({ ok: true })
+  } catch (err: unknown) {
+    const { status, message } = extractRouteError(err)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,7 @@ import FeedbackModal from "@/components/ui/feedback-modal";
 import { FeedbackProvider } from "@/lib/feedback-context";
 import { NotificationsProvider } from "@/lib/notifications-context";
 import BottomNav from "@/components/layout/bottom-nav";
+import ActingAsBar from "@/components/layout/acting-as-bar";
 import { Analytics } from "@vercel/analytics/next";
 
 const inter = Inter({
@@ -152,6 +153,7 @@ export default function RootLayout({
               <NavbarProvider>
                 <FeedbackProvider>
                 <a href="#main-content" className="skip-nav">Skip to main content</a>
+                <ActingAsBar />
                 <Navbar />
                 {/* Suspense is required because DesktopTopBar reads
                     useSearchParams() to highlight the active profile tab.

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -1378,6 +1378,57 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   }
 }
 
+/* Acting-as-group delegation bar. Mounted above all page chrome whenever
+   the viewer is operating a group, so the elevated, inverted treatment
+   reads as a persistent "you are not yourself right now" reminder.
+   Mirrors the primary button: dark bg / light text in light theme, and
+   inverts under [data-theme="dark"] via the same --btn-primary-* tokens.
+   Scrolls with the page (no sticky) so it never overlaps fixed chrome. */
+.acting-as-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  width: 100%;
+  padding: 8px 16px;
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-fg);
+}
+
+.acting-as-bar__text {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}
+
+.acting-as-bar__text b {
+  font-weight: 600;
+}
+
+/* Outlined control that stays legible against the inverted bar — borrows
+   the bar's own foreground for border + text so it tracks the theme flip. */
+.acting-as-bar__switch {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  height: 28px;
+  padding: 0 12px;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--btn-primary-fg);
+  background: transparent;
+  border: 1px solid var(--btn-primary-fg);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.acting-as-bar__switch:hover {
+  opacity: 0.8;
+}
+
 /* Logged-out sign-in card. At narrow rail widths (800-1299) the card
    chrome (padding, border, background) collapses away and the title
    + body text are hidden, leaving just the 44×44 icon-only button so
@@ -2613,52 +2664,6 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
      anchored while the user is in edit mode (the "Edit profile" button
      is hidden but its slot remains as whitespace). */
   min-height: 36px;
-}
-
-/* Acting-as-group guard shown in place of the Follow/Endorse cluster on
-   foreign profiles while the viewer is acting as a group. Those actions
-   write to the personal repo, so we explain the state instead of letting
-   a click misattribute the record. */
-.profile-sidebar__acting-note {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 8px;
-  width: 100%;
-}
-
-.profile-sidebar__acting-note-text {
-  margin: 0;
-  font-size: 0.8125rem;
-  line-height: 1.45;
-  color: var(--fg-muted);
-}
-
-.profile-sidebar__acting-note-text strong {
-  color: var(--fg-secondary);
-  font-weight: 600;
-}
-
-.profile-sidebar__acting-note-switch {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  height: 32px;
-  padding: 0 10px;
-  font-family: inherit;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: var(--fg-primary);
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: background var(--transition-fast), border-color var(--transition-fast);
-}
-
-.profile-sidebar__acting-note-switch:hover {
-  background: var(--bg-sunken);
-  border-color: var(--border-hover);
 }
 
 .profile-sidebar__action-primary {

--- a/src/app/styles/profile-endorsements.css
+++ b/src/app/styles/profile-endorsements.css
@@ -1376,6 +1376,25 @@
   line-height: 1.45;
 }
 
+/* Delegation header shown when the viewer endorses AS a group: names
+   the org (endorser), the subject, and the operating admin. Subtle
+   callout so the attribution is unmissable without shouting. */
+.endorse-reason-modal__acting-as {
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--fg-secondary);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  margin: 0;
+}
+
+.endorse-reason-modal__acting-as b {
+  color: var(--fg-primary);
+  font-weight: 600;
+}
+
 .endorse-reason-modal__textarea {
   width: 100%;
   font: inherit;

--- a/src/components/badges/response-buttons.tsx
+++ b/src/components/badges/response-buttons.tsx
@@ -26,6 +26,9 @@ interface ResponseButtonsProps {
    *     accept or reject rather than "show on my profile".
    *  Both write the same `accepted` / `rejected` response record. */
   readonly labelStyle?: "show-hide" | "accept-reject"
+  /** Group DID when the viewer is acting AS that group (the response is
+   *  authored on the group's repo). Undefined for personal responses. */
+  readonly targetDid?: string
   /** Called after a successful write so the parent can invalidate
    *  caches and re-render with the new state. */
   readonly onAfterWrite?: () => void | Promise<void>
@@ -54,6 +57,7 @@ export default function ResponseButtons({
   ownerDid,
   state,
   labelStyle = "show-hide",
+  targetDid,
   onAfterWrite,
 }: ResponseButtonsProps) {
   const labels = labelStyle === "accept-reject"
@@ -72,6 +76,7 @@ export default function ResponseButtons({
           ownerDid,
           { uri: awardUri, cid: awardCid },
           response,
+          { targetDid },
         )
         await onAfterWrite?.()
       } catch (err) {
@@ -80,7 +85,7 @@ export default function ResponseButtons({
         setIsWriting(null)
       }
     },
-    [ownerDid, awardUri, awardCid, onAfterWrite],
+    [ownerDid, awardUri, awardCid, targetDid, onAfterWrite],
   )
 
   // "unknown" — the record on the PDS has a response value we don't

--- a/src/components/badges/response-menu.tsx
+++ b/src/components/badges/response-menu.tsx
@@ -19,6 +19,9 @@ interface ResponseMenuProps {
   /** All of the owner's response records — needed for "Reset to default"
    *  which sweeps every vestigial response targeting this award. */
   readonly allResponses: BadgeResponseRecord[]
+  /** Group DID when the viewer is acting AS that group (responses are
+   *  authored on the group's repo). Undefined for personal responses. */
+  readonly targetDid?: string
   /** Invoked after a write so the parent can refresh state + drop
    *  the row from the visible list when the action was Hide. */
   readonly onAfterWrite?: () => void | Promise<void>
@@ -63,6 +66,7 @@ export default function ResponseMenu({
   ownerDid,
   state,
   allResponses,
+  targetDid,
   onAfterWrite,
 }: ResponseMenuProps) {
   const [isWriting, setIsWriting] = useState(false)
@@ -78,6 +82,7 @@ export default function ResponseMenu({
           ownerDid,
           { uri: awardUri, cid: awardCid },
           resp,
+          { targetDid },
         )
         await onAfterWrite?.()
       } catch (err) {
@@ -86,7 +91,7 @@ export default function ResponseMenu({
         setIsWriting(false)
       }
     },
-    [ownerDid, awardUri, awardCid, onAfterWrite],
+    [ownerDid, awardUri, awardCid, targetDid, onAfterWrite],
   )
 
   const resetToDefault = useCallback(async () => {
@@ -94,14 +99,16 @@ export default function ResponseMenu({
     setIsWriting(true)
     setError(null)
     try {
-      await deleteAllResponsesForAward(ownerDid, awardUri, allResponses)
+      await deleteAllResponsesForAward(ownerDid, awardUri, allResponses, {
+        targetDid,
+      })
       await onAfterWrite?.()
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to reset")
     } finally {
       setIsWriting(false)
     }
-  }, [ownerDid, awardUri, allResponses, onAfterWrite])
+  }, [ownerDid, awardUri, allResponses, targetDid, onAfterWrite])
 
   /** Single-click toggle:
    *    - clicking the currently-active state → reset to default

--- a/src/components/layout/acting-as-bar.tsx
+++ b/src/components/layout/acting-as-bar.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { useOrg } from "@/lib/groups/org-context"
+import { useSession } from "@/hooks/use-session"
+
+/**
+ * Full-width banner pinned above the page chrome whenever the viewer is
+ * acting AS a group (delegation). It names the org being operated, the
+ * operator's own handle, and the role, and offers a one-click escape back
+ * to the personal account. Renders nothing for personal sessions (the
+ * common case), so it never appears on signed-out routes where activeOrg
+ * is always null.
+ */
+export default function ActingAsBar() {
+  const { activeOrg, switchOrg } = useOrg()
+  const { handle } = useSession()
+
+  if (!activeOrg) return null
+
+  return (
+    <div className="acting-as-bar" role="status">
+      <p className="acting-as-bar__text">
+        Operating <b>{activeOrg.displayName || activeOrg.handle}</b> as @{handle} ({activeOrg.role})
+      </p>
+      <button
+        type="button"
+        className="acting-as-bar__switch"
+        onClick={() => switchOrg(null)}
+      >
+        Switch to personal
+      </button>
+    </div>
+  )
+}

--- a/src/components/profile/endorse-reason-modal.tsx
+++ b/src/components/profile/endorse-reason-modal.tsx
@@ -13,11 +13,29 @@ export interface EndorseReasonListOption {
   title: string
 }
 
+/** Naming for the three parties involved when the endorsement is
+ *  delegated — the viewer is acting AS a group rather than themselves.
+ *  When present the modal swaps its prompt for a delegation header and
+ *  hides the list picker (endorsement lists are personal-only). */
+export interface EndorseReasonActingAs {
+  /** Display name of the group authoring the endorsement. */
+  orgName: string
+  /** Handle of the group (without the leading @). */
+  orgHandle: string
+  /** Handle of the signed-in operator acting on the group's behalf. */
+  operatorHandle: string
+}
+
 interface EndorseReasonModalProps {
   /** Display name / handle of the person being endorsed, surfaced in
    *  the subtitle so the issuer is reminded who they're writing
    *  about. */
   readonly subjectLabel: string
+  /** Set when the viewer is acting AS a group. Names all three parties
+   *  (group, operator, subject) in a header line so the delegation is
+   *  explicit, and suppresses the list picker since endorsement lists
+   *  are personal-only. */
+  readonly actingAs?: EndorseReasonActingAs
   /** Optional viewer-owned endorsement lists. When non-empty the
    *  modal surfaces an "Add to list" picker; selecting one appends
    *  the new award to that list after creation. Empty / undefined
@@ -51,6 +69,7 @@ const NOTE_MAX = 500
  */
 export default function EndorseReasonModal({
   subjectLabel,
+  actingAs,
   lists,
   onConfirm,
   onClose,
@@ -86,7 +105,10 @@ export default function EndorseReasonModal({
     [isWriting, note, selectedListRkey, onConfirm],
   )
 
-  const showListPicker = !!lists && lists.length > 0
+  // Endorsement lists are personal-only — never surface the picker
+  // while the viewer is acting as a group, even if their personal repo
+  // has lists.
+  const showListPicker = !actingAs && !!lists && lists.length > 0
 
   const remaining = NOTE_MAX - note.length
 
@@ -105,6 +127,13 @@ export default function EndorseReasonModal({
       />
 
         <form className="signin-modal__body endorse-reason-modal__body" onSubmit={handleSubmit}>
+          {actingAs ? (
+            <p className="endorse-reason-modal__acting-as" role="note">
+              <b>{actingAs.orgName}</b> will endorse {subjectLabel}. You (@
+              {actingAs.operatorHandle}) are acting as an admin.
+            </p>
+          ) : null}
+
           <label className="endorse-reason-modal__field">
             <span className="endorse-reason-modal__prompt">
               Briefly explain your endorsement, e.g. do you know them

--- a/src/components/profile/profile-endorsements.tsx
+++ b/src/components/profile/profile-endorsements.tsx
@@ -23,6 +23,7 @@ import { useAuthorInfo, type AuthorInfo } from "@/hooks/use-author-info"
 import { useAuthorNamesMap } from "@/hooks/use-author-names-map"
 import { buildAvatarUrlFromCid } from "@/lib/atproto/profile"
 import { useAuth } from "@/lib/auth/auth-context"
+import { useOrg } from "@/lib/groups/org-context"
 import {
   createEndorsementAward,
   deleteEndorsementAward,
@@ -88,6 +89,17 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
   const { did: viewerDid } = useAuth()
   const viewerIsOwner = !!viewerDid && viewerDid === did
 
+  // Acting AS this group: when an owner/admin operates a group (delegation)
+  // and is viewing the group's own profile, the GIVE and revoke-given
+  // actions author the award on the GROUP's repo via `giveTargetDid`
+  // instead of the personal one. The Received-side response controls
+  // (accept/reject) stay personal-only for now — group accept/reject is a
+  // separate, not-yet-built recipient flow — so they keep `viewerIsOwner`.
+  const { activeOrg } = useOrg()
+  const actingAsThisGroup = !!activeOrg && activeOrg.groupDid === did
+  const canGive = viewerIsOwner || actingAsThisGroup
+  const giveTargetDid = actingAsThisGroup ? did : undefined
+
   const given = useGivenEndorsements(did)
   // Owner-side surfaces see ALL received endorsements (including
   // the rejected ones) so the filter dropdown below can offer
@@ -151,7 +163,7 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
   // single pass.
   const [isEndorseModalOpen, setIsEndorseModalOpen] = useState(false)
   const ownGivenForModal = useGivenEndorsements(
-    viewerIsOwner ? viewerDid : null,
+    canGive ? did : null,
   )
   const ownAlreadyEndorsedDids = useMemo(
     () => new Set(ownGivenForModal.endorsements.map((e) => e.subjectDid)),
@@ -235,7 +247,7 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
         </nav>
 
         <div className="profile-endorsements-v2__controls">
-          {viewerIsOwner ? (
+          {canGive ? (
             <button
               type="button"
               className="profile-endorsements-v2__endorse-add"
@@ -397,19 +409,22 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
           query={query}
           sort={sort}
           names={names}
-          viewerIsOwner={viewerIsOwner}
+          viewerIsOwner={canGive}
           viewerDid={viewerDid}
+          targetDid={giveTargetDid}
           onAfterRevoke={() => given.refetch()}
         />
       )}
 
-      {isEndorseModalOpen && viewerIsOwner && viewerDid ? (
+      {isEndorseModalOpen && canGive && viewerDid ? (
         <EndorsePeopleModal
           viewerDid={viewerDid}
           alreadyEndorsedDids={ownAlreadyEndorsedDids}
           requireReason
           onEndorse={(subjectDid, note) =>
-            createEndorsementAward(viewerDid, subjectDid, note)
+            createEndorsementAward(viewerDid, subjectDid, note, {
+              targetDid: giveTargetDid,
+            })
           }
           onClose={() => setIsEndorseModalOpen(false)}
           onCompleted={async () => {
@@ -620,6 +635,9 @@ interface GivenGridProps {
    *  issued. Controls whether the per-card revoke `×` renders. */
   viewerIsOwner: boolean
   viewerDid: string | null
+  /** Group DID when the viewer is acting AS this group — revokes route
+   *  to the group repo. Undefined for personal revokes. */
+  targetDid?: string
   onAfterRevoke: () => void | Promise<void>
 }
 
@@ -632,6 +650,7 @@ function GivenGrid({
   names,
   viewerIsOwner,
   viewerDid,
+  targetDid,
   onAfterRevoke,
 }: GivenGridProps) {
   const visible = useMemo(
@@ -680,6 +699,7 @@ function GivenGrid({
           endorsement={e}
           canRevoke={viewerIsOwner && !!viewerDid}
           viewerDid={viewerDid}
+          targetDid={targetDid}
           onAfterRevoke={onAfterRevoke}
         />
       ))}
@@ -691,11 +711,13 @@ function GivenCard({
   endorsement,
   canRevoke,
   viewerDid,
+  targetDid,
   onAfterRevoke,
 }: {
   endorsement: GivenEndorsement
   canRevoke: boolean
   viewerDid: string | null
+  targetDid?: string
   onAfterRevoke: () => void | Promise<void>
 }) {
   const { info, isLoading } = useAuthorInfo(endorsement.subjectDid)
@@ -712,6 +734,7 @@ function GivenCard({
           <RevokeGivenButton
             viewerDid={viewerDid}
             rkey={endorsement.rkey}
+            targetDid={targetDid}
             subjectDisplay={
               info?.displayName || info?.handle || endorsement.subjectDid
             }
@@ -732,11 +755,13 @@ function GivenCard({
 function RevokeGivenButton({
   viewerDid,
   rkey,
+  targetDid,
   subjectDisplay,
   onAfterRevoke,
 }: {
   viewerDid: string
   rkey: string
+  targetDid?: string
   subjectDisplay: string
   onAfterRevoke: () => void | Promise<void>
 }) {
@@ -749,7 +774,7 @@ function RevokeGivenButton({
     setIsRevoking(true)
     setError(null)
     try {
-      await deleteEndorsementAward(viewerDid, rkey)
+      await deleteEndorsementAward(viewerDid, rkey, { targetDid })
       await onAfterRevoke()
       setConfirmOpen(false)
     } catch (err) {

--- a/src/components/profile/profile-endorsements.tsx
+++ b/src/components/profile/profile-endorsements.tsx
@@ -90,15 +90,15 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
   const viewerIsOwner = !!viewerDid && viewerDid === did
 
   // Acting AS this group: when an owner/admin operates a group (delegation)
-  // and is viewing the group's own profile, the GIVE and revoke-given
-  // actions author the award on the GROUP's repo via `giveTargetDid`
-  // instead of the personal one. The Received-side response controls
-  // (accept/reject) stay personal-only for now — group accept/reject is a
-  // separate, not-yet-built recipient flow — so they keep `viewerIsOwner`.
+  // and is viewing the group's own profile, the give, revoke-given, AND
+  // received accept/reject actions author the record on the GROUP's repo
+  // via `manageTargetDid` instead of the personal one. `canManage` gates
+  // every owner-side affordance; foreign viewers (neither owner nor an
+  // admin acting as this group) get the read-only view.
   const { activeOrg } = useOrg()
   const actingAsThisGroup = !!activeOrg && activeOrg.groupDid === did
-  const canGive = viewerIsOwner || actingAsThisGroup
-  const giveTargetDid = actingAsThisGroup ? did : undefined
+  const canManage = viewerIsOwner || actingAsThisGroup
+  const manageTargetDid = actingAsThisGroup ? did : undefined
 
   const given = useGivenEndorsements(did)
   // Owner-side surfaces see ALL received endorsements (including
@@ -106,9 +106,11 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
   // "Show only rejected" / "Show all". Foreign viewers stay on the
   // default (rejected filtered out at the hook).
   const received = useReceivedEndorsements(did, {
-    includeRejected: viewerIsOwner,
+    includeRejected: canManage,
   })
-  const ownStates = useOwnResponseStates()
+  // Read the GROUP's responses when acting as it on its own profile, so the
+  // Received-tab accept/reject state reflects the group, not the operator.
+  const ownStates = useOwnResponseStates(actingAsThisGroup ? did : undefined)
 
   // Toolbar state — default to Received per spec. Declared up here
   // (above the data memos) because `filteredReceived` reads
@@ -149,21 +151,21 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
   // call already strips rejected entries server-side via the
   // `includeRejected: false` default. Default = hide rejected.
   const filteredReceived = useMemo(() => {
-    if (!viewerIsOwner) return displayReceived
+    if (!canManage) return displayReceived
     return displayReceived.filter((e) => {
       const { state } = ownStates.resolve(e.uri)
       if (responseFilter === "show-all") return true
       if (responseFilter === "only-rejected") return state === "rejected"
       return state !== "rejected"
     })
-  }, [displayReceived, viewerIsOwner, ownStates, responseFilter])
+  }, [displayReceived, canManage, ownStates, responseFilter])
 
   // Endorse-people modal (own-profile only). The viewer can search
   // for one or many people and write a batch of endorsements in a
   // single pass.
   const [isEndorseModalOpen, setIsEndorseModalOpen] = useState(false)
   const ownGivenForModal = useGivenEndorsements(
-    canGive ? did : null,
+    canManage ? did : null,
   )
   const ownAlreadyEndorsedDids = useMemo(
     () => new Set(ownGivenForModal.endorsements.map((e) => e.subjectDid)),
@@ -247,7 +249,7 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
         </nav>
 
         <div className="profile-endorsements-v2__controls">
-          {canGive ? (
+          {canManage ? (
             <button
               type="button"
               className="profile-endorsements-v2__endorse-add"
@@ -282,7 +284,7 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
               contains rejected entries (the hook was called with
               `includeRejected: true` for owners) so flipping the
               filter is purely client-side. */}
-          {viewerIsOwner && tab === "received" ? (
+          {canManage && tab === "received" ? (
             <div
               className="profile-endorsements-v2__sort-wrap"
               ref={filterWrapRef}
@@ -377,7 +379,7 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
 
       {tab === "received" ? (
         <>
-          {viewerIsOwner ? (
+          {canManage ? (
             <p className="profile-endorsements-v2__response-note">
               Endorsements with no response are shown on your profile by
               default. Rejected endorsements are hidden from your profile.
@@ -390,8 +392,9 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
             query={query}
             sort={sort}
             names={names}
-            viewerIsOwner={viewerIsOwner}
+            viewerIsOwner={canManage}
             viewerDid={viewerDid}
+            targetDid={manageTargetDid}
             responseFilter={responseFilter}
             resolve={ownStates.resolve}
             allResponses={ownStates.responses}
@@ -409,21 +412,21 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
           query={query}
           sort={sort}
           names={names}
-          viewerIsOwner={canGive}
+          viewerIsOwner={canManage}
           viewerDid={viewerDid}
-          targetDid={giveTargetDid}
+          targetDid={manageTargetDid}
           onAfterRevoke={() => given.refetch()}
         />
       )}
 
-      {isEndorseModalOpen && canGive && viewerDid ? (
+      {isEndorseModalOpen && canManage && viewerDid ? (
         <EndorsePeopleModal
           viewerDid={viewerDid}
           alreadyEndorsedDids={ownAlreadyEndorsedDids}
           requireReason
           onEndorse={(subjectDid, note) =>
             createEndorsementAward(viewerDid, subjectDid, note, {
-              targetDid: giveTargetDid,
+              targetDid: manageTargetDid,
             })
           }
           onClose={() => setIsEndorseModalOpen(false)}
@@ -459,6 +462,9 @@ interface ReceivedGridProps {
   names: Map<string, string>
   viewerIsOwner: boolean
   viewerDid: string | null
+  /** Group DID when acting AS this group — accept/reject responses route
+   *  to the group's repo. Undefined for personal responses. */
+  targetDid?: string
   /** Active response filter — used by the empty-state copy so a
    *  zero-results "Show only rejected" view says "No rejected
    *  endorsements yet" instead of the generic "No endorsements
@@ -478,6 +484,7 @@ function ReceivedGrid({
   names,
   viewerIsOwner,
   viewerDid,
+  targetDid,
   responseFilter,
   resolve,
   allResponses,
@@ -541,6 +548,7 @@ function ReceivedGrid({
           endorsement={e}
           viewerIsOwner={viewerIsOwner}
           viewerDid={viewerDid}
+          targetDid={targetDid}
           resolve={resolve}
           allResponses={allResponses}
           onAfterWrite={onAfterWrite}
@@ -554,6 +562,7 @@ function ReceivedCard({
   endorsement,
   viewerIsOwner,
   viewerDid,
+  targetDid,
   resolve,
   allResponses,
   onAfterWrite,
@@ -561,6 +570,7 @@ function ReceivedCard({
   endorsement: ReceivedEndorsement
   viewerIsOwner: boolean
   viewerDid: string | null
+  targetDid?: string
   resolve: ReturnType<typeof useOwnResponseStates>["resolve"]
   allResponses: ReturnType<typeof useOwnResponseStates>["responses"]
   onAfterWrite: () => void | Promise<void>
@@ -611,6 +621,7 @@ function ReceivedCard({
               info?.displayName || info?.handle || endorsement.issuerDid
             }
             ownerDid={viewerDid}
+            targetDid={targetDid}
             state={resolve(endorsement.uri).state}
             allResponses={allResponses}
             onAfterWrite={onAfterWrite}

--- a/src/components/profile/profile-followers.tsx
+++ b/src/components/profile/profile-followers.tsx
@@ -16,6 +16,7 @@ import { useFollowing } from "@/hooks/use-following"
 import { useAuthorInfo } from "@/hooks/use-author-info"
 import { useAuthorNamesMap } from "@/hooks/use-author-names-map"
 import { useAuth } from "@/lib/auth/auth-context"
+import { useOrg } from "@/lib/groups/org-context"
 import ConfirmDialog from "@/components/ui/confirm-dialog"
 import { deleteFollow } from "@/lib/atproto/follow"
 import PersonCard from "@/components/profile/person-card"
@@ -74,6 +75,11 @@ export default function ProfileFollowers({ did }: ProfileFollowersProps) {
   // the signed-in viewer's DID to the profile's DID to decide
   // whether the per-card × renders on the Following sub-tab.
   const { did: viewerDid } = useAuth()
+  // When acting as a group, follow deletes must route to the group's
+  // repo via the BFF. The unfollow × only renders on the own-profile
+  // Following list (which, when delegating, is the group's profile), so
+  // the records being revoked live in the group's repo.
+  const { activeOrg } = useOrg()
   const isOwnProfile = !!viewerDid && viewerDid === did
 
   // Sub-tab is read from the URL (`?sub=followers|following`) so the
@@ -273,6 +279,7 @@ export default function ProfileFollowers({ did }: ProfileFollowersProps) {
           names={names}
           canUnfollow={isOwnProfile}
           viewerDid={viewerDid}
+          targetDid={activeOrg?.groupDid}
           onAfterUnfollow={() => following.refetch()}
         />
       )}
@@ -376,6 +383,9 @@ interface FollowingGridProps {
    *  — controls whether the per-card × renders. */
   canUnfollow: boolean
   viewerDid: string | null
+  /** When set (acting-as-group), unfollow writes route to the group's
+   *  repo via the BFF instead of the viewer's personal PDS. */
+  targetDid?: string
   onAfterUnfollow: () => void | Promise<void>
 }
 
@@ -388,6 +398,7 @@ function FollowingGrid({
   names,
   canUnfollow,
   viewerDid,
+  targetDid,
   onAfterUnfollow,
 }: FollowingGridProps) {
   const visible = useMemo(
@@ -432,6 +443,7 @@ function FollowingGrid({
           record={r}
           canUnfollow={canUnfollow && !!viewerDid}
           viewerDid={viewerDid}
+          targetDid={targetDid}
           onAfterUnfollow={onAfterUnfollow}
         />
       ))}
@@ -443,11 +455,13 @@ function FollowingCard({
   record,
   canUnfollow,
   viewerDid,
+  targetDid,
   onAfterUnfollow,
 }: {
   record: FollowRecord
   canUnfollow: boolean
   viewerDid: string | null
+  targetDid?: string
   onAfterUnfollow: () => void | Promise<void>
 }) {
   const { info, isLoading } = useAuthorInfo(record.value.subject)
@@ -462,6 +476,7 @@ function FollowingCard({
           <UnfollowButton
             viewerDid={viewerDid}
             rkey={record.rkey}
+            targetDid={targetDid}
             subjectDisplay={
               info?.displayName || info?.handle || record.value.subject
             }
@@ -482,11 +497,13 @@ function FollowingCard({
 function UnfollowButton({
   viewerDid,
   rkey,
+  targetDid,
   subjectDisplay,
   onAfterUnfollow,
 }: {
   viewerDid: string
   rkey: string
+  targetDid?: string
   subjectDisplay: string
   onAfterUnfollow: () => void | Promise<void>
 }) {
@@ -497,7 +514,7 @@ function UnfollowButton({
     if (isRevoking) return
     setIsRevoking(true)
     try {
-      await deleteFollow(viewerDid, rkey)
+      await deleteFollow(viewerDid, rkey, { targetDid })
       await onAfterUnfollow()
       setConfirmOpen(false)
     } catch (err) {

--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link"
 import { useEffect, useRef, useState } from "react"
 import {
-  ArrowLeftRight,
   Calendar,
   Camera,
   Check,
@@ -27,7 +26,9 @@ import { getInitials } from "@/lib/utils/initials"
 import { formatMonthYear } from "@/lib/utils/format-date"
 import { useProfilePds } from "@/hooks/use-profile-pds"
 import { useAuth } from "@/lib/auth/auth-context"
+import { useSession } from "@/hooks/use-session"
 import { useOrg } from "@/lib/groups/org-context"
+import type { Group } from "@/lib/groups/types"
 import { useFollowing } from "@/hooks/use-following"
 import { useFollowers } from "@/hooks/use-followers"
 import { useGivenEndorsements } from "@/hooks/use-endorsements"
@@ -38,7 +39,9 @@ import {
 } from "@/hooks/use-received-endorsements"
 import { useEndorsementLists } from "@/hooks/use-endorsement-lists"
 import { useAuthorInfo } from "@/hooks/use-author-info"
-import EndorseReasonModal from "@/components/profile/endorse-reason-modal"
+import EndorseReasonModal, {
+  type EndorseReasonActingAs,
+} from "@/components/profile/endorse-reason-modal"
 import { runEndorseReasonConfirm } from "@/components/profile/endorse-reason-confirm"
 import { createFollow, deleteFollow, listFollowing } from "@/lib/atproto/follow"
 import {
@@ -174,17 +177,24 @@ export default function ProfileSidebar({
   // when the viewer is signed out or when they're looking at their
   // own profile (no Follow button to render in either case).
   const { did: viewerDid, isAuthenticated } = useAuth()
-  // Acting-as-group context. Follow / Endorse / Add-to-list write to the
-  // viewer's PERSONAL repo (createFollow + createEndorsementAward are
-  // keyed to the signed-in DID, and there is no group endorse path nor a
-  // group *unfollow* route). So while acting as a group we must NOT render
-  // the live buttons — doing so silently authored personal-repo records
-  // while the rest of the UI claimed the user was the group. Guard them
-  // and offer a one-tap return to personal instead.
-  const { activeOrg, switchOrg } = useOrg()
+  const { handle: operatorHandle } = useSession()
+  // Acting-as-group context. With the group BFF write paths in place
+  // (createFollow / createEndorsementAward / deleteFollow all accept a
+  // `targetDid` that routes the write to the group's repo), Follow /
+  // Endorse now act AS the active group: the operator authors the record
+  // on the group's behalf instead of their personal repo. The DID whose
+  // follow / given-endorsement set drives button state therefore tracks
+  // the group when one is active, and the viewer otherwise.
+  const { activeOrg } = useOrg()
   const isOwnProfile = !!viewerDid && viewerDid === did
+  // The repo we're acting as — the active group, or the viewer when
+  // personal. Drives the Follow / Endorse button state below.
+  const actingDid = activeOrg?.groupDid ?? viewerDid
+  // The acting repo's "following" set. Note this is keyed to `actingDid`
+  // (the group when delegating) — NOT the foreign profile — so the
+  // Follow button reflects whether the GROUP already follows the subject.
   const viewerFollowing = useFollowing(
-    isAuthenticated && !isOwnProfile ? viewerDid : null,
+    isAuthenticated && !isOwnProfile ? actingDid : null,
   )
 
   // Local avatar uploading flag — toggled around the parent's upload
@@ -269,38 +279,45 @@ export default function ProfileSidebar({
             <Pencil size={14} strokeWidth={1.75} aria-hidden />
             Edit profile
           </Link>
-        ) : isAuthenticated && viewerDid && activeOrg ? (
-          <ActingAsGroupNotice
-            groupName={activeOrg.displayName || activeOrg.handle}
-            onSwitchToPersonal={() => switchOrg(null)}
-          />
-        ) : isAuthenticated && viewerDid ? (
+        ) : isAuthenticated && viewerDid && actingDid ? (
           <>
             <FollowButton
               viewerDid={viewerDid}
               subjectDid={did}
+              targetDid={activeOrg?.groupDid}
               isFollowing={viewerFollowing.subjects.has(did)}
               isLoading={viewerFollowing.isLoading}
               onFollowed={(uri, cid) => {
-                // Both surfaces update instantly: the viewer's
+                // Both surfaces update instantly: the acting repo's
                 // "following" set gains the subject; the foreign
                 // profile's follower list (count + grid) gains the
-                // viewer. Real server-side data refreshes on the next
-                // tab-mount / focus-revalidate.
+                // acting repo (group when delegating, viewer otherwise).
+                // Real server-side data refreshes on the next tab-mount
+                // / focus-revalidate.
                 viewerFollowing.addFollow(did, uri, cid)
-                viewedFollowers.addFollower(viewerDid, uri, cid)
+                viewedFollowers.addFollower(actingDid, uri, cid)
               }}
               onUnfollowed={() => {
                 viewerFollowing.removeFollow(did)
-                viewedFollowers.removeFollower(viewerDid)
+                viewedFollowers.removeFollower(actingDid)
               }}
             />
-            <EndorseButton viewerDid={viewerDid} subjectDid={did} />
-            <AddToListMenu
-              targetUri={`at://${did}/app.certified.actor.profile/self`}
-              targetCid=""
-              targetType={LIST_ACCOUNTS_TYPE}
+            <EndorseButton
+              viewerDid={viewerDid}
+              subjectDid={did}
+              actingDid={actingDid}
+              activeOrg={activeOrg}
+              operatorHandle={operatorHandle}
             />
+            {/* Endorsement lists are personal-only — the Add-to-list
+                affordance is hidden while acting as a group. */}
+            {activeOrg ? null : (
+              <AddToListMenu
+                targetUri={`at://${did}/app.certified.actor.profile/self`}
+                targetCid=""
+                targetType={LIST_ACCOUNTS_TYPE}
+              />
+            )}
           </>
         ) : (
           <Button variant="primary" size="sm" disabled>
@@ -680,42 +697,12 @@ function AvatarEditOverlay({ onFile, isUploading, hasPending }: AvatarEditOverla
  * the viewer's follow list so the true state catches up.
  */
 
-/**
- * Shown in the action slot of a foreign profile while the viewer is
- * acting as a group. Follow / Endorse / Add-to-list are personal-only
- * actions (no group write path exists for them), so rather than letting
- * a click misattribute a record to the personal repo, we explain the
- * state and offer a one-tap return to personal. Mirrors the personal-only
- * nav-gating philosophy in lib/groups/personal-only.ts.
- */
-function ActingAsGroupNotice({
-  groupName,
-  onSwitchToPersonal,
-}: {
-  groupName: string
-  onSwitchToPersonal: () => void
-}) {
-  return (
-    <div className="profile-sidebar__acting-note" role="note">
-      <p className="profile-sidebar__acting-note-text">
-        Acting as <strong>{groupName}</strong>. Follow and endorse are
-        personal actions.
-      </p>
-      <button
-        type="button"
-        className="profile-sidebar__acting-note-switch"
-        onClick={onSwitchToPersonal}
-      >
-        <ArrowLeftRight size={14} strokeWidth={1.75} aria-hidden />
-        Switch to personal
-      </button>
-    </div>
-  )
-}
-
 interface FollowButtonProps {
   viewerDid: string
   subjectDid: string
+  /** When set (acting-as-group), the follow write routes to the group's
+   *  repo via the BFF instead of the viewer's personal PDS. */
+  targetDid?: string
   isFollowing: boolean
   isLoading: boolean
   /** Fired after a successful createFollow with the new record's
@@ -731,6 +718,7 @@ interface FollowButtonProps {
 function FollowButton({
   viewerDid,
   subjectDid,
+  targetDid,
   isFollowing,
   isLoading,
   onFollowed,
@@ -738,6 +726,10 @@ function FollowButton({
 }: FollowButtonProps) {
   const [isWriting, setIsWriting] = useState(false)
   const disabled = isLoading || isWriting
+  // The repo the follow record lives in — the group when delegating, the
+  // viewer otherwise. Drives both the rkey lookup (list the right repo)
+  // and which repo's follows we delete from.
+  const actingRepo = targetDid ?? viewerDid
 
   const handleClick = async () => {
     if (disabled) return
@@ -745,15 +737,16 @@ function FollowButton({
     setIsWriting(true)
     try {
       if (next) {
-        const result = await createFollow(viewerDid, subjectDid)
-        // Hand the new ref to the parent so the viewer's following
+        const result = await createFollow(viewerDid, subjectDid, { targetDid })
+        // Hand the new ref to the parent so the acting repo's following
         // set and the subject's follower list update instantly.
         onFollowed(result.uri, result.cid)
       } else {
-        // Unfollow path: walk the viewer's follows to find the rkey
+        // Unfollow path: walk the acting repo's follows to find the rkey
         // targeting this subject. Fetched fresh here to handle the
         // duplicate-follow edge case (delete the most recent record).
-        const { records } = await listFollowing(viewerDid, undefined, {
+        // When acting as a group, the records live in the group's repo.
+        const { records } = await listFollowing(actingRepo, undefined, {
           noCache: true,
         })
         const match = records
@@ -762,7 +755,7 @@ function FollowButton({
             a.value.createdAt < b.value.createdAt ? 1 : -1,
           )[0]
         if (match) {
-          await deleteFollow(viewerDid, match.rkey)
+          await deleteFollow(viewerDid, match.rkey, { targetDid })
         }
         onUnfollowed()
       }
@@ -823,11 +816,32 @@ function formatGraphCount(
 interface EndorseButtonProps {
   viewerDid: string
   subjectDid: string
+  /** The DID the endorsement is authored AS — the active group when
+   *  delegating, the viewer otherwise. Drives the given-endorsements
+   *  set that decides Endorse / Endorsed and the revoke rkey lookup. */
+  actingDid: string
+  /** The active group, when the viewer is acting as one. `null` for the
+   *  personal path. Used to route the write to the group's repo and to
+   *  name the parties in the reason modal. */
+  activeOrg: Group | null
+  /** The signed-in operator's handle, surfaced in the delegation header
+   *  of the reason modal. */
+  operatorHandle: string | null
 }
 
-function EndorseButton({ viewerDid, subjectDid }: EndorseButtonProps) {
-  const ownGiven = useGivenEndorsements(viewerDid)
-  const ownLists = useEndorsementLists(viewerDid)
+function EndorseButton({
+  viewerDid,
+  subjectDid,
+  actingDid,
+  activeOrg,
+  operatorHandle,
+}: EndorseButtonProps) {
+  // Acting-as-group flag + the group DID the write routes to.
+  const targetDid = activeOrg?.groupDid
+  const ownGiven = useGivenEndorsements(actingDid)
+  // Endorsement lists are personal-only — never load or surface them
+  // while acting as a group (the reason modal hides the picker too).
+  const ownLists = useEndorsementLists(activeOrg ? null : viewerDid)
   const { info: subjectInfo } = useAuthorInfo(subjectDid)
   const subjectLabel =
     subjectInfo?.displayName || subjectInfo?.handle || subjectDid
@@ -876,16 +890,18 @@ function EndorseButton({ viewerDid, subjectDid }: EndorseButtonProps) {
       await runEndorseReasonConfirm({
         note,
         listRkey,
-        createAward: (n) => createEndorsementAward(viewerDid, subjectDid, n),
+        createAward: (n) =>
+          createEndorsementAward(viewerDid, subjectDid, n, { targetDid }),
         // PR #110: as soon as the award lands, push it into the shared
         // received-endorsements overlay so the subject's "Endorsed by N"
         // counter and the Endorsements tab reflect it immediately, ahead
-        // of the 5-min scan cache / indexer catching up.
+        // of the 5-min scan cache / indexer catching up. The issuer is
+        // the acting repo (the group when delegating).
         onAwardCreated: (award) =>
           addOptimisticReceivedEndorsement(subjectDid, {
             uri: award.uri,
             cid: award.cid,
-            issuerDid: viewerDid,
+            issuerDid: actingDid,
             createdAt: new Date().toISOString(),
             note: note || undefined,
             responseState: null,
@@ -911,7 +927,7 @@ function EndorseButton({ viewerDid, subjectDid }: EndorseButtonProps) {
     setOptimistic(false)
     setIsWriting(true)
     try {
-      await deleteEndorsementAward(viewerDid, existing.rkey)
+      await deleteEndorsementAward(viewerDid, existing.rkey, { targetDid })
       removeOptimisticReceivedEndorsement(subjectDid, existing.uri)
       await ownGiven.refetch()
       setConfirmRevoke(false)
@@ -922,6 +938,17 @@ function EndorseButton({ viewerDid, subjectDid }: EndorseButtonProps) {
       setIsWriting(false)
     }
   }
+
+  // Delegation naming for the reason modal — names the group, the
+  // operator, and the subject when acting as a group. `null` on the
+  // personal path leaves the modal in its default single-party shape.
+  const actingAs: EndorseReasonActingAs | undefined = activeOrg
+    ? {
+        orgName: activeOrg.displayName || activeOrg.handle,
+        orgHandle: activeOrg.handle,
+        operatorHandle: operatorHandle ?? "you",
+      }
+    : undefined
 
   return (
     <>
@@ -942,6 +969,7 @@ function EndorseButton({ viewerDid, subjectDid }: EndorseButtonProps) {
       {reasonOpen ? (
         <EndorseReasonModal
           subjectLabel={subjectLabel}
+          actingAs={actingAs}
           lists={ownLists.lists.map((l) => ({ rkey: l.rkey, title: l.title }))}
           onConfirm={handleReasonConfirm}
           onClose={() => setReasonOpen(false)}

--- a/src/hooks/use-own-response-states.ts
+++ b/src/hooks/use-own-response-states.ts
@@ -23,7 +23,13 @@ import {
  * own profile pages consume it; non-owner profile views don't
  * receive the per-award state at all.
  */
-export function useOwnResponseStates(): {
+export function useOwnResponseStates(
+  /** Override the responder DID. Defaults to the authenticated viewer.
+   *  Pass a group DID when acting AS that group on its own profile so the
+   *  Received-tab response controls reflect the GROUP's accept/reject state,
+   *  not the operator's personal one. */
+  responderDid?: string,
+): {
   /** Returns the latest response state for a given award URI. */
   resolve: (awardUri: string) => {
     state: ResponseState
@@ -41,7 +47,8 @@ export function useOwnResponseStates(): {
    *  drop. Combine: `invalidate(); await refetch();`. */
   refetch: () => Promise<void>
 } {
-  const { did } = useAuth()
+  const { did: authedDid } = useAuth()
+  const did = responderDid ?? authedDid
   const { responses, isLoading, refetch } = useProfileResponses(did)
 
   const resolve = useCallback(

--- a/src/lib/atproto/badges.ts
+++ b/src/lib/atproto/badges.ts
@@ -816,8 +816,35 @@ export async function createResponse(
   ownDid: string,
   badgeAward: StrongRef,
   response: "accepted" | "rejected",
-  weight?: string,
+  opts?: { targetDid?: string; weight?: string },
 ): Promise<{ uri: string; cid: string }> {
+  const weight = opts?.weight
+  // Acting as a group (recipient): route the response to the GROUP's repo
+  // via the BFF so the group's own profile reflects the accept/reject.
+  // Personal path (no targetDid) is unchanged below.
+  if (opts?.targetDid && opts.targetDid !== ownDid) {
+    const res = await authFetch(
+      `/api/groups/${encodeURIComponent(opts.targetDid)}/response`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ award: badgeAward, response, weight }),
+      },
+    )
+    const data = (await res.json().catch(() => ({}))) as {
+      uri?: string
+      cid?: string
+      error?: string
+    }
+    if (!res.ok || !data.uri || !data.cid) {
+      throw new Error(
+        data.error || `Failed to create group badge response: ${res.status}`,
+      )
+    }
+    invalidateEndorsementClosure()
+    return { uri: data.uri, cid: data.cid }
+  }
+
   const body = {
     repo: ownDid,
     collection: BADGE_RESPONSE_COLLECTION,
@@ -865,7 +892,26 @@ export async function createResponse(
 export async function deleteResponse(
   ownDid: string,
   rkey: string,
+  opts?: { targetDid?: string },
 ): Promise<void> {
+  // Acting as a group: delete the response from the GROUP's repo via the BFF.
+  if (opts?.targetDid && opts.targetDid !== ownDid) {
+    const res = await authFetch(
+      `/api/groups/${encodeURIComponent(opts.targetDid)}/response`,
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rkey }),
+      },
+    )
+    if (!res.ok) {
+      const data = (await res.json().catch(() => ({}))) as { error?: string }
+      throw new Error(
+        data.error || `Failed to delete group badge response: ${res.status}`,
+      )
+    }
+    return
+  }
   const res = await authFetch("/api/xrpc/com/atproto/repo/deleteRecord", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -949,12 +995,13 @@ export async function deleteAllResponsesForAward(
   ownDid: string,
   awardUri: string,
   allResponses: BadgeResponseRecord[],
+  opts?: { targetDid?: string },
 ): Promise<number> {
   const matching = allResponses.filter(
     (r) => r.value.badgeAward?.uri === awardUri,
   )
   for (const r of matching) {
-    await deleteResponse(ownDid, r.rkey)
+    await deleteResponse(ownDid, r.rkey, opts)
   }
   return matching.length
 }

--- a/src/lib/atproto/badges.ts
+++ b/src/lib/atproto/badges.ts
@@ -439,6 +439,55 @@ async function createEndorsementDefinition(ownDid: string): Promise<StrongRef> {
 }
 
 /**
+ * Find or create a GROUP's `endorsement` badge definition.
+ *
+ * The group-acting analogue of `ensureEndorsementDefinition`: when the
+ * viewer acts as a group, the award must reference a definition owned
+ * by the GROUP's repo, not the operator's. Reads the group's existing
+ * definitions through the same federated `listDefinitions` path (the
+ * XRPC proxy reads any repo by DID), resolves the canonical
+ * endorsement def, and returns its strong ref unchanged if found.
+ * Otherwise creates one via the group BFF route
+ * `/api/groups/<groupDid>/endorsement-definition`, which proxies the
+ * createRecord through the operator's OAuth session to the group's
+ * service auth.
+ *
+ * Unlike the personal path there's no Web-Lock / inflight dedupe here:
+ * group definition creation goes through one operator at a time and
+ * the read-then-create is cheap; duplicates self-heal on the next read
+ * via `resolveCanonicalEndorsementDef` (oldest wins), same as personal.
+ */
+export async function ensureGroupEndorsementDefinition(
+  groupDid: string,
+): Promise<StrongRef> {
+  const existing = await listDefinitions(groupDid)
+  const matched = resolveCanonicalEndorsementDef(existing)
+  if (matched) {
+    return { uri: matched.canonical.uri, cid: matched.canonical.cid }
+  }
+  const res = await authFetch(
+    `/api/groups/${encodeURIComponent(groupDid)}/endorsement-definition`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    },
+  )
+  const data = (await res.json().catch(() => ({}))) as {
+    uri?: string
+    cid?: string
+    error?: string
+  }
+  if (!res.ok || !data.uri || !data.cid) {
+    throw new Error(
+      data.error ||
+        `Failed to create group endorsement definition: ${res.status}`,
+    )
+  }
+  return { uri: data.uri, cid: data.cid }
+}
+
+/**
  * List badge awards from any user's PDS. Returns the raw records;
  * callers narrow to endorsement awards by resolving each record's
  * `badge` strongRef and filtering on the definition's `badgeType`.
@@ -580,12 +629,49 @@ async function writeBadgeAward(
  * answer lands in `app.certified.badge.award.note`). Empty / blank
  * notes are dropped before the write so the field is omitted entirely
  * for endorsements without a reason.
+ *
+ * Routing:
+ *   - Default: writes against the issuer's DEFAULT endorsement def on
+ *     `ownDid`'s personal PDS via the XRPC proxy (unchanged).
+ *   - With `opts.targetDid` (acting-as-group): the award is issued BY
+ *     the group. Ensures the GROUP's endorsement def, then writes the
+ *     award through the group BFF route `/api/groups/<targetDid>/endorse`,
+ *     which proxies via the operator's OAuth session to the group's
+ *     service auth. Mirrors `createFollow`'s group path.
  */
 export async function createEndorsementAward(
   ownDid: string,
   subjectDid: string,
   note?: string,
+  opts?: { targetDid?: string },
 ): Promise<{ uri: string; cid: string }> {
+  const targetDid = opts?.targetDid
+  if (targetDid && targetDid !== ownDid) {
+    const badge = await ensureGroupEndorsementDefinition(targetDid)
+    const res = await authFetch(
+      `/api/groups/${encodeURIComponent(targetDid)}/endorse`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ subject: subjectDid, badge, note }),
+      },
+    )
+    const data = (await res.json().catch(() => ({}))) as {
+      uri?: string
+      cid?: string
+      error?: string
+    }
+    if (!res.ok || !data.uri || !data.cid) {
+      throw new Error(
+        data.error ||
+          `Failed to create group endorsement award: ${res.status}`,
+      )
+    }
+    // Bust the endorsement-closure cache — same rationale as the
+    // personal path below.
+    invalidateEndorsementClosure()
+    return { uri: data.uri, cid: data.cid }
+  }
   const badge = await ensureEndorsementDefinition(ownDid)
   const result = await writeBadgeAward(ownDid, subjectDid, badge, "endorsement award", note)
   // Bust the endorsement-closure cache (certified-app #84). Cheap
@@ -603,11 +689,43 @@ export async function createEndorsementAward(
  * is best-effort (errors logged in dev, swallowed in prod) — the
  * read path drops unresolved list items silently, so a partial
  * failure delays cleanup but doesn't corrupt anything.
+ *
+ * Routing:
+ *   - Default: deletes the award on `ownDid`'s personal PDS via the
+ *     XRPC proxy (unchanged).
+ *   - With `opts.targetDid` (acting-as-group): the award lives on the
+ *     GROUP's repo, so the delete goes through the group BFF route
+ *     `/api/groups/<targetDid>/endorse`. Endorsement lists are
+ *     personal, so the group path skips `purgeAwardFromLists` (the
+ *     group has no lists referencing this award) but still busts both
+ *     caches for parity with the personal path.
  */
 export async function deleteEndorsementAward(
   ownDid: string,
   rkey: string,
+  opts?: { targetDid?: string },
 ): Promise<void> {
+  const targetDid = opts?.targetDid
+  if (targetDid && targetDid !== ownDid) {
+    const res = await authFetch(
+      `/api/groups/${encodeURIComponent(targetDid)}/endorse`,
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rkey }),
+      },
+    )
+    if (!res.ok) {
+      const data = (await res.json().catch(() => ({}))) as { error?: string }
+      throw new Error(
+        data.error ||
+          `Failed to delete group endorsement award: ${res.status}`,
+      )
+    }
+    invalidateEndorsementClosure()
+    invalidateEndorsementLists()
+    return
+  }
   const awardUri = `at://${ownDid}/${BADGE_AWARD_COLLECTION}/${rkey}`
   await purgeAwardFromLists(ownDid, awardUri)
   const res = await authFetch("/api/xrpc/com/atproto/repo/deleteRecord", {

--- a/src/lib/atproto/follow.ts
+++ b/src/lib/atproto/follow.ts
@@ -101,11 +101,37 @@ export async function createFollow(
   return { uri: data.uri, cid: data.cid }
 }
 
-/** Delete a follow record by rkey on the viewer's own PDS. */
+/**
+ * Delete a follow record by rkey.
+ *
+ * Routing (mirrors `createFollow`):
+ *   - Default: deletes on `ownDid`'s personal PDS via the XRPC proxy.
+ *   - With `targetDid` (acting-as-group): the follow lives on the
+ *     group's repo, so the delete goes through the group BFF route's
+ *     DELETE handler at `/api/groups/<targetDid>/follow`.
+ */
 export async function deleteFollow(
   ownDid: string,
   rkey: string,
+  opts?: { targetDid?: string },
 ): Promise<void> {
+  const targetDid = opts?.targetDid ?? ownDid
+  if (targetDid !== ownDid) {
+    const res = await authFetch(
+      `/api/groups/${encodeURIComponent(targetDid)}/follow`,
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rkey }),
+      },
+    )
+    if (!res.ok) {
+      throw new Error(
+        await extractError(res, "Failed to delete follow on group"),
+      )
+    }
+    return
+  }
   const res = await authFetch("/api/xrpc/com/atproto/repo/deleteRecord", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/src/lib/groups/org-context.tsx
+++ b/src/lib/groups/org-context.tsx
@@ -31,7 +31,7 @@ const OrgContext = createContext<OrgContextValue | undefined>(undefined)
 
 function loadPersistedOrg(): Group | null {
   try {
-    const raw = localStorage.getItem(ACTIVE_ORG_KEY)
+    const raw = window.sessionStorage.getItem(ACTIVE_ORG_KEY)
     if (!raw) return null
     return JSON.parse(raw) as Group
   } catch {
@@ -42,12 +42,12 @@ function loadPersistedOrg(): Group | null {
 function persistOrg(org: Group | null) {
   try {
     if (org) {
-      localStorage.setItem(ACTIVE_ORG_KEY, JSON.stringify(org))
+      window.sessionStorage.setItem(ACTIVE_ORG_KEY, JSON.stringify(org))
     } else {
-      localStorage.removeItem(ACTIVE_ORG_KEY)
+      window.sessionStorage.removeItem(ACTIVE_ORG_KEY)
     }
   } catch {
-    // ignore — localStorage may be unavailable
+    // ignore — sessionStorage may be unavailable
   }
 }
 
@@ -74,7 +74,7 @@ export function OrgProvider({ children }: { children: React.ReactNode }) {
   const fetchOrgs = useCallback(
     async (signal?: AbortSignal) => {
       // Don't clear state while auth is still loading — the persisted org
-      // from localStorage should survive until auth resolves
+      // from sessionStorage should survive until auth resolves
       if (authLoading) return
       if (!isAuthenticated || !did) {
         setGroups([])


### PR DESCRIPTION
## What

Implements the **"act-as, framed as delegation"** model from the switcher decision doc (`docs/switcher-mockups/pattern-gallery.html`). A person who owns or admins a group can operate that group as a **first-class atproto actor**: no separate login, no credential sharing, and no sticky mode that hides who is acting. The group is a real account; you act *for* it as a delegate, and your own DID stays the accountable operator.

Organizations can now **endorse**, **follow**, and **accept/reject endorsements they receive** as themselves.

## Why this shape

`docs/switcher-mockups/` walks through the full reasoning: seven-pattern design space, three built candidates, and the deciding insight that an atproto org is a full account (not a GitHub-style namespace), so act-as is the honest model. Safety is handled by three conditions, all implemented: a persistent indicator, a per-action confirm on the high-stakes endorse, and session-scoped persistence.

## Changes

**Backend — group BFF routes**
- `POST`/`DELETE /api/groups/[did]/endorse` — group `badge.award`.
- `POST /api/groups/[did]/endorsement-definition` — mint the group's endorsement definition.
- `POST`/`DELETE /api/groups/[did]/response` — group `badge.response` (accept/reject/reset).
- `DELETE` added to `/api/groups/[did]/follow` (group unfollow).
- All mirror the existing route pattern; the group service authorizes owner/admin and rejects members.

**Lib (`src/lib/atproto`)**
- `createEndorsementAward` / `deleteEndorsementAward` / `deleteFollow` / `createResponse` / `deleteResponse` / `deleteAllResponsesForAward` gain an optional `{ targetDid }` and route through the group BFF when delegating. `ensureGroupEndorsementDefinition` resolves/creates the group's definition. **Personal paths unchanged.**

**Frontend**
- `ActingAsBar`: persistent delegation banner — "Operating **\<Group\>** as @\<you\> (\<role\>)" with inline **Switch to personal**.
- Acting-as persistence moved to `sessionStorage` (session-scoped).
- Profile **Follow / Endorse / unfollow** and the Endorsements tab's **give + revoke-given + accept/reject-received** act AS the group when delegating; the endorse modal names endorser, operator, and subject. `useOwnResponseStates` reads the group's response state. The owner-side gates are unified under `canManage = owner || acting-as-this-group`.

## How it was built

Four disjoint-file tracks in parallel (routes / lib / bar+session / profile actions), then follow-up passes for the Endorsements-tab give surface and the respond-as-group flow, integrated and verified together.

## Out of scope (follow-ups)
- The personal `/endorsements` page + endorsement **lists** stay personal (an org's endorsements live on its own profile).
- The `/notifications` surface's response controls stay personal (group notifications are a separate feature).
- `personal-only.ts` nav-gating unchanged.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` — 0 new warnings (all changed files clean)
- [x] `vitest` 519/519 pass
- [x] `next build` succeeds; all new group routes register (`endorse`, `endorsement-definition`, `response`, follow `DELETE`)
- [ ] Manual (needs a live session + a group you admin): switch to a group → bar shows "Operating … as @you (role)"; endorse a profile → award lands on the **group** repo and the modal names all three parties; follow/unfollow as the group; on the group's profile Endorsements → Received, accept/reject lands a `badge.response` on the **group** repo; reload (same tab) stays delegated, new tab is personal
- [ ] Manual: personal session behaves exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
