### PR TITLE
feat(lists): accept a bare DID when adding accounts to a list

### DIFF
--- a/src/components/profile/profile-lists.tsx
+++ b/src/components/profile/profile-lists.tsx
@@ -899,14 +899,15 @@ function PasteUrisModal({
     // Accept commas, newlines, and whitespace as separators so users
     // can paste a list of URIs from any reasonable source without
     // hand-formatting it. Dedupe within the input.
-    // Accept bare actor URIs (`at://did:plc:…`) in the accounts list:
-    // the profile record is conventionally `app.certified.actor.profile/self`,
-    // so any URI that ends at the DID gets normalized to the full
-    // record path before validation. For certs / projects the rkey
-    // is record-specific so we leave those URIs untouched.
+    // Accounts list: accept a bare DID (`did:plc:…`) or an actor URI
+    // (`at://did:plc:…`), with or without a trailing slash, and expand it
+    // to the conventional profile record path
+    // (`at://<did>/app.certified.actor.profile/self`) before validation —
+    // the profile record's rkey is always `self`. For certs / projects the
+    // rkey is record-specific, so those URIs are left untouched.
     const normalize = (uri: string): string => {
       if (type !== LIST_ACCOUNTS_TYPE) return uri
-      const m = uri.match(/^at:\/\/(did:[a-z0-9]+:[a-z0-9-]+)\/?$/)
+      const m = uri.match(/^(?:at:\/\/)?(did:[a-z]+:[A-Za-z0-9._:-]+)\/?$/)
       return m ? `at://${m[1]}/${ITEM_NSID[LIST_ACCOUNTS_TYPE]}/self` : uri
     }
 
@@ -1030,8 +1031,9 @@ function PasteUrisModal({
           will be added.
           {type === LIST_ACCOUNTS_TYPE ? (
             <>
-              {" "}For accounts a bare{" "}
-              <code className="profile-lists__paste-nsid">at://did:plc:…</code>{" "}
+              {" "}For accounts a bare DID{" "}
+              <code className="profile-lists__paste-nsid">did:plc:…</code>{" "}
+              (with or without <code className="profile-lists__paste-nsid">at://</code>)
               is also accepted — we&rsquo;ll expand it to the profile record.
             </>
           ) : null}
@@ -1042,7 +1044,11 @@ function PasteUrisModal({
           value={raw}
           onChange={(e) => setRaw(e.target.value)}
           rows={6}
-          placeholder="at://did:plc:…/…/abc123, at://did:plc:…/…/def456, …"
+          placeholder={
+            type === LIST_ACCOUNTS_TYPE
+              ? "did:plc:…, did:plc:…, …"
+              : "at://did:plc:…/…/abc123, at://did:plc:…/…/def456, …"
+          }
           disabled={running}
         />
         {rows.length > 0 ? (


### PR DESCRIPTION
## What

When adding **accounts** to a list, you can now paste a **bare DID** (e.g. `did:plc:5t5ulig2agi37nqgaoizw6ip`) — no `at://` prefix needed. It expands to the conventional account item `at://<did>/app.certified.actor.profile/self`.

Before, the typed-list paste flow rejected a bare DID with *"Not an at:// URI"*; it only accepted `at://did:plc:…`.

## Changes
- `profile-lists.tsx` paste normalizer: accept `did:…` with or without an `at://` prefix (and an optional trailing slash) for the accounts list. Full record URIs and cert/project lists are untouched.
- Help text + textarea placeholder updated to show the bare-DID form for accounts lists.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (changed file)
- [x] `vitest` 519/519 pass
- [x] `next build` compiles
- [x] Normalizer verified: `did:plc:…`, `at://did:plc:…`, `at://did:plc:…/` all expand; full profile URIs and non-DID tokens pass through unchanged
- [ ] Manual: on an accounts list, paste a bare DID → row resolves to the profile item and gets added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
