### PR TITLE
chore(cert): remove the Record tab from the cert overview

### DIFF
--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -899,43 +899,6 @@
   font-feature-settings: 'tnum' 1;
 }
 
-/* ---------- Record tab (schema field/value table) ---------- */
-
-.cert-detail__record-table {
-  width: 100%;
-  border-collapse: collapse;
-  table-layout: fixed;
-}
-
-.cert-detail__record-row {
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-.cert-detail__record-row:last-child {
-  border-bottom: none;
-}
-
-.cert-detail__record-field {
-  width: 38%;
-  text-align: left;
-  vertical-align: top;
-  padding: 10px 16px 10px 0;
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--fg-muted);
-  word-break: break-word;
-}
-
-.cert-detail__record-value {
-  vertical-align: top;
-  padding: 10px 0;
-  font-size: 0.875rem;
-  color: var(--fg-primary);
-  line-height: 1.5;
-  word-break: break-word;
-}
-
 /* ---------- Contributors list ----------
 
    Single-column stack — lives inside the sidebar so it never gets the

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -214,12 +214,10 @@ export default function ActivityDetail({
     | "overview"
     | "description"
     | "contributors"
-    | "updates"
-    | "record" =
+    | "updates" =
     tabParam === "description" ||
     tabParam === "contributors" ||
-    tabParam === "updates" ||
-    tabParam === "record"
+    tabParam === "updates"
       ? tabParam
       : "overview"
 
@@ -1165,63 +1163,6 @@ export default function ActivityDetail({
               variant="full"
             />
           ) : null
-        ) : activeTab === "record" ? (
-          <section className="cert-detail__section cert-detail__record">
-            <div className="cert-detail__section-header">
-              <h2 className="cert-detail__section-title">Record</h2>
-            </div>
-            {/* Field/value table mirroring the
-                org.hypercerts.claim.activity schema. Scalars render
-                their stored value; complex fields (description,
-                image, contributors, locations) render a factual
-                summary. Absent optional fields read "Not set" so the
-                full schema is always visible. */}
-            <table className="cert-detail__record-table">
-              <tbody>
-                {(
-                  [
-                    [
-                      "$type",
-                      effectiveValue.$type ?? "org.hypercerts.claim.activity",
-                    ],
-                    ["title", effectiveValue.title || null],
-                    ["shortDescription", effectiveValue.shortDescription || null],
-                    ["createdAt", effectiveValue.createdAt || null],
-                    ["startDate", effectiveValue.startDate || null],
-                    ["endDate", effectiveValue.endDate || null],
-                    ["workScope", workScopeLabel || null],
-                    [
-                      "description",
-                      showFullDescription ? "Rich text document" : null,
-                    ],
-                    ["image", effectiveImageUrl ? "Image attached" : null],
-                    [
-                      "contributors",
-                      contributorCount > 0 ? String(contributorCount) : null,
-                    ],
-                    [
-                      "locations",
-                      locations.length > 0 ? String(locations.length) : null,
-                    ],
-                    ["rights", value.rights?.uri ?? null],
-                  ] as Array<[string, string | null]>
-                ).map(([field, val]) => (
-                  <tr key={field} className="cert-detail__record-row">
-                    <th scope="row" className="cert-detail__record-field">
-                      {field}
-                    </th>
-                    <td className="cert-detail__record-value">
-                      {val ? (
-                        val
-                      ) : (
-                        <span className="cert-detail__meta-aux">Not set</span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </section>
         ) : null}
       </div>
     </article>

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -93,7 +93,6 @@ const CERT_DETAIL_TABS: DetailTab[] = [
   { key: "description", label: "Description" },
   { key: "contributors", label: "Contributors" },
   { key: "updates", label: "Updates" },
-  { key: "record", label: "Record" },
 ];
 
 /** Project detail page subtabs. Same `?tab=` URL contract as the


### PR DESCRIPTION
## What
Removes the **Record** tab (the raw `org.hypercerts.claim.activity` field/value table) from the cert detail / overview page.

## Changes
- `desktop-top-bar.tsx`: drop `{ key: "record", label: "Record" }` from `CERT_DETAIL_TABS` (the single source for the tab strip, desktop + mobile).
- `activity-detail.tsx`: remove `"record"` from the `activeTab` union and the `?tab=` parsing (a stale `?tab=record` URL now falls back to **Overview**), and delete the record panel branch.
- `cert-detail.css`: remove the now-orphaned `.cert-detail__record*` rules.

## Verification
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files (no new warnings)
- [x] `vitest` 519/519 pass
- [x] `next build` compiles
- [x] No `?tab=record` links anywhere; `CERT_DETAIL_TABS` confirmed the only tab definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)
