### PR TITLE
fix(welcome): full-bleed footer

### DIFF
--- a/src/app/styles/landing.css
+++ b/src/app/styles/landing.css
@@ -1512,10 +1512,11 @@
 }
 
 /* /welcome footer wrapper — the app shell skips SiteFooter on this
-   route, so the landing layout renders it directly. Padding matches
-   the landing sections' horizontal inset so the footer row aligns
-   with the section content above it. */
+   route, so the landing layout renders it directly. Full-bleed (no
+   horizontal padding or max-width cap) so the off-white band and the
+   footer's border-top span the full viewport width; SiteFooter applies
+   its own 32px content inset. */
 .welcome-footer {
-  padding: 0 32px;
+  padding: 0;
   background: var(--color-off-white);
 }

--- a/src/app/welcome/layout.tsx
+++ b/src/app/welcome/layout.tsx
@@ -10,9 +10,8 @@ import SiteFooter from "@/components/layout/site-footer";
  * the global `.app-shell__content` reading column.
  *
  * Renders the global SiteFooter directly (the app-shell short-circuit
- * skips it on /welcome). Wrapped in `.landing-section__inner` so the
- * footer row aligns with the landing sections above it instead of
- * stretching to the viewport edges.
+ * skips it on /welcome), full-bleed so the footer bar (border-top +
+ * off-white band) spans the full viewport width like every other page.
  *
  * NOTE: this branch ships the local `useProfileNavbar` hook for
  * the transparent variant instead of main's `useNavbarVariant`;
@@ -28,9 +27,7 @@ export default function WelcomeLayout({
     <>
       {children}
       <div className="welcome-footer">
-        <div className="landing-section__inner">
-          <SiteFooter />
-        </div>
+        <SiteFooter />
       </div>
     </>
   );


### PR DESCRIPTION
## What
The footer on the **/welcome** page now spans the full viewport width.

## Why it wasn't
`welcome/layout.tsx` wrapped `SiteFooter` in `.landing-section__inner` (max-width 1536px, centered), and `.welcome-footer` added 32px of horizontal padding — so the footer's off-white band and `border-top` stopped short of the viewport edges on wide screens. (`SiteFooter` is designed to be full-width on every other page, where it renders as a sibling of the app-shell grid.)

## Change
- `welcome/layout.tsx`: drop the `.landing-section__inner` cap; render `SiteFooter` directly inside `.welcome-footer`.
- `landing.css`: `.welcome-footer` padding `0 32px` → `0` (full-bleed). `SiteFooter` keeps its own 32px content inset, so the bar reaches the edges while the content stays padded.

## Verification
- [x] `tsc --noEmit` clean
- [ ] Visual: footer band + top border now reach both viewport edges on /welcome (Vercel preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
