### PR TITLE
refactor(naming): rename cert → activity (display text + URL values)

### DIFF
--- a/src/app/activity/[did]/[rkey]/edit/page.tsx
+++ b/src/app/activity/[did]/[rkey]/edit/page.tsx
@@ -165,7 +165,7 @@ function parseAtUri(uri: string): { did: string; collection: string; rkey: strin
 }
 
 export default function ActivityEditPage() {
-  usePageTitle("Edit cert")
+  usePageTitle("Edit activity")
   const router = useRouter()
   const params = useParams()
   const did = useMemo(() => {
@@ -466,7 +466,7 @@ export default function ActivityEditPage() {
             <EmptyState
               icon={PenLine}
               title="Sign in to edit"
-              description="You need to be signed in to edit a cert."
+              description="You need to be signed in to edit an activity."
             />
           </div>
         </div>
@@ -481,8 +481,8 @@ export default function ActivityEditPage() {
           <div className="dashboard__main">
             <EmptyState
               icon={PenLine}
-              title="Cert not found"
-              description={activityError || "Couldn't load this cert to edit."}
+              title="Activity not found"
+              description={activityError || "Couldn't load this activity to edit."}
             />
           </div>
         </div>
@@ -497,8 +497,8 @@ export default function ActivityEditPage() {
           <div className="dashboard__main">
             <EmptyState
               icon={PenLine}
-              title="You can't edit this cert"
-              description="Only the cert's creator (or the active group it's published under) can make changes."
+              title="You can't edit this activity"
+              description="Only the activity's creator (or the active group it's published under) can make changes."
             />
           </div>
         </div>
@@ -760,7 +760,7 @@ export default function ActivityEditPage() {
           "Someone else saved while you were editing — please refresh and try again.",
         )
       } else {
-        setError(err instanceof Error ? err.message : "Failed to save cert")
+        setError(err instanceof Error ? err.message : "Failed to save activity")
       }
       setIsSubmitting(false)
     }
@@ -784,7 +784,7 @@ export default function ActivityEditPage() {
       }}
     >
       <EditBanner
-        label="Editing cert"
+        label="Editing activity"
         error={error}
         isSaving={isSubmitting}
         canSave={canSubmit}
@@ -794,7 +794,7 @@ export default function ActivityEditPage() {
         }}
       />
       <article className="page-layout cert-detail--wide create-cert">
-        <aside className="cert-detail__aside" aria-label="Cert metadata">
+        <aside className="cert-detail__aside" aria-label="Activity metadata">
           <div className="cert-detail__image cert-detail__image--editing">
             {displayImageUrl ? (
               /* eslint-disable-next-line @next/next/no-img-element */
@@ -965,7 +965,7 @@ export default function ActivityEditPage() {
                 type="text"
                 className="cert-detail__title-input"
                 aria-label="Title"
-                placeholder="Title for your cert"
+                placeholder="Title for your activity"
                 value={title}
                 maxLength={TITLE_MAX}
                 onChange={(e) => setTitle(e.target.value)}
@@ -1019,8 +1019,8 @@ export default function ActivityEditPage() {
             <LeafletEditor
               value={description}
               onChange={setDescription}
-              placeholder="Full description of this cert."
-              ariaLabel="Cert description"
+              placeholder="Full description of this activity."
+              ariaLabel="Activity description"
               did={did ?? ""}
               onImageUpload={(file) =>
                 uploadBlob(

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -130,7 +130,7 @@ interface RightsOption {
 }
 
 export default function CreatePage() {
-  usePageTitle("New cert")
+  usePageTitle("New activity")
   const { isAuthenticated, isLoading, did } = useAuth()
   const { activeOrg } = useOrg()
   const router = useRouter()
@@ -612,7 +612,7 @@ export default function CreatePage() {
   return (
     <form onSubmit={handleSubmit}>
       <article className="page-layout cert-detail--wide create-cert">
-        <aside className="cert-detail__aside" aria-label="Cert metadata">
+        <aside className="cert-detail__aside" aria-label="Activity metadata">
           {/* Image slot — `--editing` carries the dashed outline that
               signals "click here to set an image", matching the
               inline-edit mode of the detail page. When a blob is
@@ -803,7 +803,7 @@ export default function CreatePage() {
                 type="text"
                 className="cert-detail__title-input"
                 aria-label="Title"
-                placeholder="Title for your cert"
+                placeholder="Title for your activity"
                 value={title}
                 maxLength={TITLE_MAX}
                 onChange={(e) => setTitle(e.target.value)}
@@ -856,8 +856,8 @@ export default function CreatePage() {
             <LeafletEditor
               value={description}
               onChange={setDescription}
-              placeholder="Full description of this cert. Headings, lists, links, images, and video embeds are all supported via the toolbar."
-              ariaLabel="Cert description"
+              placeholder="Full description of this activity. Headings, lists, links, images, and video embeds are all supported via the toolbar."
+              ariaLabel="Activity description"
               did={did ?? ""}
               onImageUpload={(file) =>
                 uploadBlob(
@@ -1124,7 +1124,7 @@ export default function CreatePage() {
               loading={isSubmitting}
               disabled={!canSubmit}
             >
-              {isSubmitting ? "Publishing…" : "Publish cert"}
+              {isSubmitting ? "Publishing…" : "Publish activity"}
             </Button>
           </div>
         </div>

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -5,7 +5,7 @@ import Explore from "@/components/explore-page/explore"
 export const metadata: Metadata = {
   title: "Explore — Certified",
   description:
-    "Browse users, projects, and certs across the Certified network.",
+    "Browse users, projects, and activities across the Certified network.",
 }
 
 /**

--- a/src/app/profile/[handle]/page.tsx
+++ b/src/app/profile/[handle]/page.tsx
@@ -55,7 +55,7 @@ type TabKey =
 // own-profile only.
 const TABS: { key: TabKey; label: string }[] = [
   { key: "overview", label: "Overview" },
-  { key: "certs", label: "Certs" },
+  { key: "certs", label: "Activities" },
   { key: "projects", label: "Projects" },
   { key: "groups", label: "Groups" },
   { key: "endorsements", label: "Endorsements" },

--- a/src/app/profile/[handle]/page.tsx
+++ b/src/app/profile/[handle]/page.tsx
@@ -40,7 +40,7 @@ import { trackRecentlyViewed } from "@/lib/utils/recently-viewed"
 type TabKey =
   | "overview"
   | "about"
-  | "certs"
+  | "activities"
   | "projects"
   | "groups"
   | "endorsements"
@@ -55,7 +55,7 @@ type TabKey =
 // own-profile only.
 const TABS: { key: TabKey; label: string }[] = [
   { key: "overview", label: "Overview" },
-  { key: "certs", label: "Activities" },
+  { key: "activities", label: "Activities" },
   { key: "projects", label: "Projects" },
   { key: "groups", label: "Groups" },
   { key: "endorsements", label: "Endorsements" },
@@ -322,7 +322,10 @@ export default function UserProfilePage() {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const tabFromUrl = useMemo<TabKey>(() => {
-    const v = searchParams?.get("tab")
+    const raw = searchParams?.get("tab")
+    // Migration shim — the legacy ?tab=certs slug resolves to activities
+    // so old links / bookmarks keep working.
+    const v = raw === "certs" ? "activities" : raw
     return v && TABS.some((t) => t.key === v) ? (v as TabKey) : "overview"
   }, [searchParams])
   const [activeTab, setActiveTab] = useState<TabKey>(tabFromUrl)
@@ -482,11 +485,11 @@ export default function UserProfilePage() {
                 ) : null}
               </div>
             ) : null}
-            {activeTab === "certs" && (
+            {activeTab === "activities" && (
               <div
                 role="tabpanel"
-                id="tabpanel-certs"
-                aria-labelledby="tab-certs"
+                id="tabpanel-activities"
+                aria-labelledby="tab-activities"
               >
                 <ProfileCerts did={did} viewerIsOwner={isViewerThisEntity} />
               </div>

--- a/src/app/project/[did]/[rkey]/edit/page.tsx
+++ b/src/app/project/[did]/[rkey]/edit/page.tsx
@@ -190,7 +190,7 @@ export default function ProjectEditPage() {
         title:
           typeof r.record!.value.title === "string" && r.record!.value.title.trim()
             ? r.record!.value.title.trim()
-            : r.record!.uri.split("/").pop() ?? "(untitled cert)",
+            : r.record!.uri.split("/").pop() ?? "(untitled activity)",
       }))
     setItems(hydrated)
     itemsSeededRef.current = true
@@ -711,7 +711,7 @@ export default function ProjectEditPage() {
 
           <section className="cert-detail__section">
             <div className="cert-detail__section-header">
-              <h2 className="cert-detail__section-title">Certs</h2>
+              <h2 className="cert-detail__section-title">Activities</h2>
               {items.length > 0 ? (
                 <span className="cert-detail__section-count">
                   {items.length}
@@ -742,19 +742,19 @@ export default function ProjectEditPage() {
             ) : null}
 
             {ownCertsLoading ? (
-              <p className="cert-detail__empty-line">Loading your certs…</p>
+              <p className="cert-detail__empty-line">Loading your activities…</p>
             ) : ownCerts.length === 0 ? (
               <p className="cert-detail__empty-line">
-                You don&rsquo;t have any certs yet.{" "}
+                You don&rsquo;t have any activities yet.{" "}
                 <Link href="/create" className="create-project__inline-link">
-                  Create your first cert
+                  Create your first activity
                 </Link>
                 .
               </p>
             ) : (
               <>
                 <p className="create-project__quick-pick-label">
-                  Add your certs:
+                  Add your activities:
                 </p>
                 <ul className="create-project__quick-pick-list">
                   {ownCerts.map((c) => {

--- a/src/app/project/new/page.tsx
+++ b/src/app/project/new/page.tsx
@@ -449,7 +449,7 @@ export default function CreateProjectPage() {
 
           <section className="cert-detail__section">
             <div className="cert-detail__section-header">
-              <h2 className="cert-detail__section-title">Certs</h2>
+              <h2 className="cert-detail__section-title">Activities</h2>
               {items.length > 0 ? (
                 <span className="cert-detail__section-count">
                   {items.length}
@@ -487,19 +487,19 @@ export default function CreateProjectPage() {
                 items[] without typing anything. Hidden when the
                 user has no certs OR the active group has none. */}
             {ownCertsLoading ? (
-              <p className="cert-detail__empty-line">Loading your certs…</p>
+              <p className="cert-detail__empty-line">Loading your activities…</p>
             ) : ownCerts.length === 0 ? (
               <p className="cert-detail__empty-line">
-                You don&rsquo;t have any certs yet.{" "}
+                You don&rsquo;t have any activities yet.{" "}
                 <Link href="/create" className="create-project__inline-link">
-                  Create your first cert
+                  Create your first activity
                 </Link>
                 .
               </p>
             ) : (
               <>
                 <p className="create-project__quick-pick-label">
-                  Add your certs:
+                  Add your activities:
                 </p>
                 <ul className="create-project__quick-pick-list">
                   {ownCerts.map((c) => {

--- a/src/components/create/location-picker-dialog.tsx
+++ b/src/components/create/location-picker-dialog.tsx
@@ -531,7 +531,7 @@ export default function LocationPickerDialog({
             ) : myLocations.length === 0 ? (
               <p className="create-cert__loc-hint">
                 You haven&apos;t published any locations yet. Add one
-                via the New tab and it will appear here on the next cert.
+                via the New tab and it will appear here on the next activity.
               </p>
             ) : (
               <>

--- a/src/components/explore-page/explore-project-card.tsx
+++ b/src/components/explore-page/explore-project-card.tsx
@@ -70,7 +70,7 @@ export default function ExploreProjectCard({
         ) : null}
         <div className="explore-project-card__meta">
           <span className="explore-project-card__count">
-            {itemCount} cert{itemCount === 1 ? "" : "s"}
+            {itemCount} {itemCount === 1 ? "activity" : "activities"}
           </span>
           {createdLabel ? (
             <span className="explore-project-card__when">{createdLabel}</span>

--- a/src/components/explore-page/explore-types.ts
+++ b/src/components/explore-page/explore-types.ts
@@ -39,10 +39,10 @@ const PROJECT_FILTERS: FilterOption[] = [
 const CERT_FILTERS: FilterOption[] = [
   ...FEATURED_FILTERS,
   { key: "recent", label: "Recently viewed" },
-  { key: "by-me", label: "My certs", requiresAuth: true },
+  { key: "by-me", label: "My activities", requiresAuth: true },
   { key: "by-follows", label: "Accounts I follow", requiresAuth: true },
   { key: "by-endorsed", label: "Endorsed accounts", requiresAuth: true },
-  { key: "all", label: "All certs" },
+  { key: "all", label: "All activities" },
 ]
 
 export function filtersForKind(kind: ExploreKind): FilterOption[] {

--- a/src/components/explore-page/explore-types.ts
+++ b/src/components/explore-page/explore-types.ts
@@ -1,4 +1,4 @@
-export type ExploreKind = "accounts" | "projects" | "certs"
+export type ExploreKind = "accounts" | "projects" | "activities"
 
 export type SortOrder = "newest" | "oldest" | "alphabetical"
 
@@ -75,7 +75,7 @@ export const SUB_OPTIONS: Record<
     { key: "organizations", label: "Organizations" },
   ],
   projects: [],
-  certs: [
+  activities: [
     { key: "all", label: "All" },
     { key: "created", label: "Created", requiresAuth: true },
     { key: "contributed", label: "Contributed", requiresAuth: true },

--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -644,7 +644,7 @@ export default function Explore() {
               <div
                 className="explore__view-toggle"
                 role="group"
-                aria-label={`${kind === "certs" ? "Cert" : kind === "projects" ? "Project" : "Account"} view`}
+                aria-label={`${kind === "certs" ? "Activity" : kind === "projects" ? "Project" : "Account"} view`}
               >
                 <button
                   type="button"
@@ -737,7 +737,7 @@ export default function Explore() {
                 >
                   {kind === "certs" ? (
                     <>
-                      <p className="popover__section-heading">Cert quality</p>
+                      <p className="popover__section-heading">Activity quality</p>
                       {HYPERLABEL_DISPLAY_ORDER.map((tier) => (
                         <label
                           key={tier}
@@ -1019,7 +1019,7 @@ function SubPrefixDropdown({
 function searchPlaceholder(kind: ExploreKind): string {
   if (kind === "accounts") return "Search accounts by name…"
   if (kind === "projects") return "Search projects…"
-  return "Search certs…"
+  return "Search activities…"
 }
 
 function Popover({
@@ -1230,7 +1230,7 @@ function ResultsArea({
 
 function EmptyResults({ kind }: { kind: ExploreKind }) {
   const label =
-    kind === "accounts" ? "accounts" : kind === "projects" ? "projects" : "certs"
+    kind === "accounts" ? "accounts" : kind === "projects" ? "projects" : "activities"
   return (
     <EmptyState
       icon={kind === "accounts" ? Users : kind === "projects" ? FolderGit2 : CertIcon}

--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -104,11 +104,13 @@ const DEFAULT_ORG_TIER_SLUGS: readonly OrgTierSlug[] = ORG_TIER_SLUGS.filter(
 )
 
 function parseKind(v: string | null): ExploreKind {
-  if (v === "accounts" || v === "projects" || v === "certs") return v
-  // Migration shim — old URLs with ?kind=users or ?kind=profiles still
-  // resolve to accounts so external links keep working.
+  if (v === "accounts" || v === "projects" || v === "activities") return v
+  // Migration shim — old URLs with ?kind=users or ?kind=profiles resolve
+  // to accounts, and the legacy ?kind=certs resolves to activities, so
+  // external links keep working.
   if (v === "users" || v === "profiles") return "accounts"
-  return "certs"
+  if (v === "certs") return "activities"
+  return "activities"
 }
 
 function parseSort(v: string | null): SortOrder {
@@ -487,16 +489,16 @@ export default function Explore() {
     noEndorsementRings: showsDegreeControl && degrees.size === 0,
     // Cert-quality filter — only meaningful for the certs kind, but
     // passing it for other kinds is a no-op at the load-page level.
-    excludeCertLabels: kind === "certs" ? excludeCertLabels : undefined,
-    includeCertLabels: kind === "certs" ? includeCertLabels : undefined,
+    excludeCertLabels: kind === "activities" ? excludeCertLabels : undefined,
+    includeCertLabels: kind === "activities" ? includeCertLabels : undefined,
     // Org-quality filter — used on accounts (filters the actor list)
     // and certs (filters certs whose author org carries the tier).
     excludeOrgLabels:
-      kind === "accounts" || kind === "certs" || kind === "projects"
+      kind === "accounts" || kind === "activities" || kind === "projects"
         ? excludeOrgLabels
         : undefined,
     includeOrgLabels:
-      kind === "accounts" || kind === "certs" || kind === "projects"
+      kind === "accounts" || kind === "activities" || kind === "projects"
         ? includeOrgLabels
         : undefined,
   })
@@ -644,7 +646,7 @@ export default function Explore() {
               <div
                 className="explore__view-toggle"
                 role="group"
-                aria-label={`${kind === "certs" ? "Activity" : kind === "projects" ? "Project" : "Account"} view`}
+                aria-label={`${kind === "activities" ? "Activity" : kind === "projects" ? "Project" : "Account"} view`}
               >
                 <button
                   type="button"
@@ -707,7 +709,7 @@ export default function Explore() {
                   Account quality only — projects' record-tier
                   filtering is keyed off the author's org label, not
                   the project itself. */}
-              {kind === "certs" || kind === "accounts" || kind === "projects" ? (
+              {kind === "activities" || kind === "accounts" || kind === "projects" ? (
                 <Popover
                   open={qualityOpen}
                   onClose={() => setQualityOpen(false)}
@@ -715,7 +717,7 @@ export default function Explore() {
                     <button
                       type="button"
                       className={`explore__chrome-btn explore__chrome-btn--icon${
-                        (kind === "certs" && !qualityIsDefault) ||
+                        (kind === "activities" && !qualityIsDefault) ||
                         !orgQualityIsDefault
                           ? " explore__chrome-btn--active"
                           : ""
@@ -724,7 +726,7 @@ export default function Explore() {
                       aria-expanded={qualityOpen}
                       aria-haspopup="menu"
                       aria-label={`Filter by quality${
-                        (kind === "certs" && !qualityIsDefault) ||
+                        (kind === "activities" && !qualityIsDefault) ||
                         !orgQualityIsDefault
                           ? " (filtered)"
                           : ""
@@ -735,7 +737,7 @@ export default function Explore() {
                     </button>
                   }
                 >
-                  {kind === "certs" ? (
+                  {kind === "activities" ? (
                     <>
                       <p className="popover__section-heading">Activity quality</p>
                       {HYPERLABEL_DISPLAY_ORDER.map((tier) => (
@@ -799,7 +801,7 @@ export default function Explore() {
                     className="popover__reset-btn"
                     onClick={onResetQuality}
                     disabled={
-                      (kind !== "certs" || qualityIsDefault) &&
+                      (kind !== "activities" || qualityIsDefault) &&
                       orgQualityIsDefault
                     }
                   >

--- a/src/components/explore-page/project-list-row.tsx
+++ b/src/components/explore-page/project-list-row.tsx
@@ -50,7 +50,7 @@ export default function ProjectListRow({
       : null
 
   const itemCount = countItems(value.items)
-  const countLabel = `${itemCount} cert${itemCount === 1 ? "" : "s"}`
+  const countLabel = `${itemCount} ${itemCount === 1 ? "activity" : "activities"}`
   // `value.location` comes in two shapes on the wire:
   //   - inline string (legacy / direct text), e.g. "Bern, CH"
   //   - strongRef { uri, cid } pointing at an `app.certified.location`

--- a/src/components/feed/activity-card.tsx
+++ b/src/components/feed/activity-card.tsx
@@ -57,7 +57,7 @@ function ActivityCard({ record, did, label }: ActivityCardProps) {
           <img
             className="feed-card__image"
             src={imageUrl}
-            alt={value.title || "Cert image"}
+            alt={value.title || "Activity image"}
             loading="lazy"
             onError={() => setImageFailed(true)}
           />

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -631,7 +631,7 @@ export default function ActivityDetail({
         )
       } else {
         console.error("Failed to save cert:", err)
-        setSaveError(err instanceof Error ? err.message : "Failed to save cert")
+        setSaveError(err instanceof Error ? err.message : "Failed to save activity")
       }
     } finally {
       setIsSaving(false)
@@ -705,8 +705,8 @@ export default function ActivityDetail({
             className="cert-detail__title-input"
             value={drafts.title}
             maxLength={256}
-            placeholder="Cert title"
-            aria-label="Cert title"
+            placeholder="Activity title"
+            aria-label="Activity title"
             onChange={(e) =>
               setDrafts((d) => ({ ...d, title: e.target.value }))
             }
@@ -719,8 +719,8 @@ export default function ActivityDetail({
             <Link
               href={`/activity/${encodeURIComponent(did)}/${encodeURIComponent(rkey ?? "")}/edit`}
               className="cert-detail__edit-btn"
-              aria-label="Edit cert"
-              title="Edit cert"
+              aria-label="Edit activity"
+              title="Edit activity"
             >
               <Pencil size={14} strokeWidth={1.75} aria-hidden />
               Edit
@@ -728,8 +728,8 @@ export default function ActivityDetail({
             <button
               type="button"
               className="cert-detail__delete-btn"
-              aria-label="Delete cert"
-              title="Delete cert"
+              aria-label="Delete activity"
+              title="Delete activity"
               onClick={() => {
                 setDeleteError(null)
                 setDeleteOpen(true)
@@ -823,7 +823,7 @@ export default function ActivityDetail({
           the left rail. */}
       {editing ? (
         <EditBanner
-          label="Editing cert"
+          label="Editing activity"
           error={saveError}
           isSaving={isSaving}
           onCancel={handleCancelEdit}
@@ -832,7 +832,7 @@ export default function ActivityDetail({
       ) : null}
 
       <article className="page-layout cert-detail--wide">
-      <aside className="cert-detail__aside" aria-label="Cert details">
+      <aside className="cert-detail__aside" aria-label="Activity details">
         <div
           className={
             editing
@@ -1098,8 +1098,8 @@ export default function ActivityDetail({
                 onChange={(next) =>
                   setDrafts((d) => ({ ...d, description: next }))
                 }
-                placeholder="Full description of this cert."
-                ariaLabel="Cert description"
+                placeholder="Full description of this activity."
+                ariaLabel="Activity description"
                 did={did}
                 onImageUpload={(file) =>
                   uploadBlob(
@@ -1168,9 +1168,9 @@ export default function ActivityDetail({
     </article>
     {deleteOpen ? (
       <DeleteRecordDialog
-        title="Delete this cert"
+        title="Delete this activity"
         recordName={effectiveValue.title || ""}
-        recordTypeLabel="cert"
+        recordTypeLabel="activity"
         isDeleting={isDeleting}
         errorMessage={deleteError}
         onCancel={() => {

--- a/src/components/feed/cert-locations-map.tsx
+++ b/src/components/feed/cert-locations-map.tsx
@@ -270,7 +270,7 @@ export default function CertLocationsMap({ locations }: CertLocationsMapProps) {
 
       {expanded ? (
         <AppDialog
-          ariaLabel="Larger map of cert locations"
+          ariaLabel="Larger map of activity locations"
           className="cert-detail__map-modal"
           maxWidth={1100}
           onClose={() => setExpanded(false)}

--- a/src/components/home/home-feed.tsx
+++ b/src/components/home/home-feed.tsx
@@ -342,14 +342,14 @@ function QualityFilter({
         onClick={() => setOpen((v) => !v)}
         aria-haspopup="true"
         aria-expanded={open}
-        aria-label="Filter feed by cert quality"
-        title="Filter by cert quality"
+        aria-label="Filter feed by activity quality"
+        title="Filter by activity quality"
       >
         <FilterIcon size={14} strokeWidth={1.75} aria-hidden />
       </button>
       {open ? (
-        <div className="home-feed__filter-pop" role="dialog" aria-label="Cert quality filters">
-          <p className="home-feed__filter-title">Certs quality</p>
+        <div className="home-feed__filter-pop" role="dialog" aria-label="Activity quality filters">
+          <p className="home-feed__filter-title">Activities quality</p>
           <ul className="home-feed__filter-list">
             {HYPERLABEL_DISPLAY_ORDER.map((tier) => (
               <li key={tier}>
@@ -707,11 +707,11 @@ function EndorsedAccountLink({ did }: { did: string }) {
 function EventSentence({ event }: { event: HomeFeedEvent }) {
   switch (event.kind) {
     case "cert.create":
-      return <>created a cert</>
+      return <>created an activity</>
     case "collection.create":
       return <CollectionSentence record={event.record} />
     case "project.created_with_cert":
-      return <>created a project with a cert</>
+      return <>created a project with an activity</>
     case "endorsement.award":
     case "legacy.endorsement":
       return <EndorsementSentence subjectDid={event.subjectDid} />
@@ -776,7 +776,7 @@ function CertTargetName({ did, rkey }: { did: string; rkey: string }) {
     typeof activity?.value.title === "string" && activity.value.title.length > 0
       ? activity.value.title
       : null
-  return <>{title ?? "a cert"}</>
+  return <>{title ?? "an activity"}</>
 }
 
 /**
@@ -840,11 +840,11 @@ function ProjectTargetName({ did, rkey }: { did: string; rkey: string }) {
 function UnhydratedSentence({ rawKind }: { rawKind: string }) {
   switch (rawKind) {
     case "cert.create":
-      return <>created a cert</>
+      return <>created an activity</>
     case "collection.create":
       return <>created a project</>
     case "project.created_with_cert":
-      return <>created a project with a cert</>
+      return <>created a project with an activity</>
     case "evaluation.create":
       return <>added an evaluation</>
     case "measurement.create":
@@ -892,7 +892,7 @@ function CollectionSentence({ record }: { record: CollectionRecord }) {
     case "list:projects":
       return <>created a list of projects</>
     case "list:certs":
-      return <>created a list of certs</>
+      return <>created a list of activities</>
     case "list:accounts":
       return <>created a list of accounts</>
     case "portfolio":
@@ -945,7 +945,7 @@ export function CertPreview({
   const title =
     typeof record.value.title === "string" && record.value.title.length > 0
       ? record.value.title
-      : "Untitled cert"
+      : "Untitled activity"
   const description =
     typeof record.value.shortDescription === "string" &&
     record.value.shortDescription.length > 0
@@ -1026,7 +1026,14 @@ function CollectionPreview({
         )
       : null
   const itemCount = Array.isArray(v.items) ? v.items.length : 0
-  const itemNoun = collectionType === "list:endorsements" ? "endorsement" : "cert"
+  const itemNoun =
+    collectionType === "list:endorsements"
+      ? itemCount === 1
+        ? "endorsement"
+        : "endorsements"
+      : itemCount === 1
+        ? "activity"
+        : "activities"
 
   return (
     <PreviewCard
@@ -1035,9 +1042,7 @@ function CollectionPreview({
       imageUrl={imageUrl}
       description={description}
       meta={[
-        itemCount > 0
-          ? `${itemCount} ${itemNoun}${itemCount === 1 ? "" : "s"}`
-          : null,
+        itemCount > 0 ? `${itemCount} ${itemNoun}` : null,
       ].filter((s): s is string => !!s)}
     />
   )

--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -158,7 +158,7 @@ function HomeSidebar({ activeDid }: { activeDid: string }) {
         items={previewCerts}
         total={certs.length}
         renderItem={(c) => <CertRow key={c.uri} record={c} fallbackDid={activeDid} />}
-        moreHref={`${profileBase}?tab=certs`}
+        moreHref={`${profileBase}?tab=activities`}
         emptyLabel="No activities yet."
       />
     </>

--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -152,14 +152,14 @@ function HomeSidebar({ activeDid }: { activeDid: string }) {
         emptyLabel="No projects yet."
       />
       <SidebarSection
-        title="My certs"
+        title="My activities"
         icon={CertIcon}
         isLoading={certsLoading && previewCerts.length === 0}
         items={previewCerts}
         total={certs.length}
         renderItem={(c) => <CertRow key={c.uri} record={c} fallbackDid={activeDid} />}
         moreHref={`${profileBase}?tab=certs`}
-        emptyLabel="No certs yet."
+        emptyLabel="No activities yet."
       />
     </>
   )
@@ -319,7 +319,7 @@ function CertRow({
           )}
         </span>
         <span className="home-row__label">
-          {record.value.title || "Untitled cert"}
+          {record.value.title || "Untitled activity"}
         </span>
       </Link>
     </li>

--- a/src/components/landing/sections/network-stats.tsx
+++ b/src/components/landing/sections/network-stats.tsx
@@ -37,7 +37,7 @@ export default function NetworkStats() {
       value: counts.organizations,
     },
     { key: "projects", label: "Projects", value: counts.projects },
-    { key: "achievements", label: "Certs", value: counts.achievements },
+    { key: "achievements", label: "Activities", value: counts.achievements },
     {
       key: "endorsements",
       label: "Endorsements",

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -56,7 +56,7 @@ interface ProfileTab {
 
 const PROFILE_TABS: ProfileTab[] = [
   { key: "overview", label: "Overview" },
-  { key: "certs", label: "Certs" },
+  { key: "certs", label: "Activities" },
   { key: "projects", label: "Projects" },
   { key: "groups", label: "Groups", groupsOnly: true },
   { key: "endorsements", label: "Endorsements" },
@@ -83,7 +83,7 @@ type DetailTab = { key: string; label: string; subRoute?: string };
  *  tabs replaces ?kind= on /explore and clears the kind-specific
  *  state to match the on-page behavior. */
 const EXPLORE_TABS: { key: string; label: string }[] = [
-  { key: "certs", label: "Certs" },
+  { key: "certs", label: "Activities" },
   { key: "projects", label: "Projects" },
   { key: "accounts", label: "Accounts" },
 ];
@@ -101,7 +101,7 @@ const CERT_DETAIL_TABS: DetailTab[] = [
 const PROJECT_DETAIL_TABS: DetailTab[] = [
   { key: "overview", label: "Overview" },
   { key: "description", label: "Description" },
-  { key: "certs", label: "Certs" },
+  { key: "certs", label: "Activities" },
   { key: "updates", label: "Updates" },
 ];
 
@@ -589,7 +589,7 @@ export default function DesktopTopBar() {
             <nav
               className="desktop-top-bar__tabs"
               role="tablist"
-              aria-label={isOnCertDetail ? "Cert sections" : "Project sections"}
+              aria-label={isOnCertDetail ? "Activity sections" : "Project sections"}
             >
               {(isOnCertDetail
                 ? CERT_DETAIL_TABS
@@ -664,7 +664,7 @@ export default function DesktopTopBar() {
                 onClick={() => setCreateOpen(false)}
               >
                 <FileBadge size={16} strokeWidth={1.75} aria-hidden />
-                <span>New cert</span>
+                <span>New activity</span>
               </Link>
               <Link
                 href="/project/new"

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -56,7 +56,7 @@ interface ProfileTab {
 
 const PROFILE_TABS: ProfileTab[] = [
   { key: "overview", label: "Overview" },
-  { key: "certs", label: "Activities" },
+  { key: "activities", label: "Activities" },
   { key: "projects", label: "Projects" },
   { key: "groups", label: "Groups", groupsOnly: true },
   { key: "endorsements", label: "Endorsements" },
@@ -83,7 +83,7 @@ type DetailTab = { key: string; label: string; subRoute?: string };
  *  tabs replaces ?kind= on /explore and clears the kind-specific
  *  state to match the on-page behavior. */
 const EXPLORE_TABS: { key: string; label: string }[] = [
-  { key: "certs", label: "Activities" },
+  { key: "activities", label: "Activities" },
   { key: "projects", label: "Projects" },
   { key: "accounts", label: "Accounts" },
 ];
@@ -101,7 +101,7 @@ const CERT_DETAIL_TABS: DetailTab[] = [
 const PROJECT_DETAIL_TABS: DetailTab[] = [
   { key: "overview", label: "Overview" },
   { key: "description", label: "Description" },
-  { key: "certs", label: "Activities" },
+  { key: "activities", label: "Activities" },
   { key: "updates", label: "Updates" },
 ];
 
@@ -215,7 +215,9 @@ export default function DesktopTopBar() {
     [isOnOwnProfile, profileAboutAvailable, profileGroupsAvailable],
   );
   const activeTab = useMemo(() => {
-    const v = searchParams?.get("tab");
+    const raw = searchParams?.get("tab");
+    // Legacy ?tab=certs -> activities so old links highlight correctly.
+    const v = raw === "certs" ? "activities" : raw;
     if (v && visibleProfileTabs.some((t) => t.key === v)) return v;
     return "overview";
   }, [searchParams, visibleProfileTabs]);
@@ -517,11 +519,13 @@ export default function DesktopTopBar() {
               // <Explore> uses (users / profiles legacy → accounts).
               const raw = searchParams?.get("kind") ?? null;
               const currentKind =
-                raw === "accounts" || raw === "projects" || raw === "certs"
+                raw === "accounts" || raw === "projects" || raw === "activities"
                   ? raw
                   : raw === "users" || raw === "profiles"
                   ? "accounts"
-                  : "certs";
+                  : raw === "certs"
+                  ? "activities"
+                  : "activities";
               const isActive = currentKind === t.key;
               const params = new URLSearchParams();
               // Reset other state (filter/sub/q/sort/view/attrs) when

--- a/src/components/lists/add-to-list-menu.tsx
+++ b/src/components/lists/add-to-list-menu.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/lib/atproto/typed-lists"
 
 const TYPE_LABEL: Record<TypedListType, string> = {
-  "list:certs": "cert",
+  "list:certs": "activity",
   "list:projects": "project",
   "list:accounts": "account",
 }

--- a/src/components/profile/profile-certs.tsx
+++ b/src/components/profile/profile-certs.tsx
@@ -107,7 +107,7 @@ export default function ProfileCerts({ did, viewerIsOwner }: ProfileCertsProps) 
       <EmptyState
         icon={Inbox}
         title="No contributions yet"
-        description="Certs on other users' repos that list this user as a contributor will appear here."
+        description="Activities on other users' repos that list this user as a contributor will appear here."
       />
     ) : undefined
 
@@ -117,7 +117,7 @@ export default function ProfileCerts({ did, viewerIsOwner }: ProfileCertsProps) 
         <nav
           className="profile-certs__subtabs"
           role="tablist"
-          aria-label="Certs sections"
+          aria-label="Activities sections"
         >
           <button
             type="button"
@@ -158,7 +158,7 @@ export default function ProfileCerts({ did, viewerIsOwner }: ProfileCertsProps) 
             <Link href="/create">
               <Button variant="primary" size="sm">
                 <Plus size={14} strokeWidth={1.75} aria-hidden />
-                New cert
+                New activity
               </Button>
             </Link>
           ) : null}
@@ -173,8 +173,8 @@ export default function ProfileCerts({ did, viewerIsOwner }: ProfileCertsProps) 
               type="search"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search certs"
-              aria-label="Search certs"
+              placeholder="Search activities"
+              aria-label="Search activities"
               className="profile-certs__search-input"
             />
           </label>
@@ -187,7 +187,7 @@ export default function ProfileCerts({ did, viewerIsOwner }: ProfileCertsProps) 
               onClick={() => setSortOpen((v) => !v)}
               aria-haspopup="menu"
               aria-expanded={sortOpen}
-              aria-label="Sort certs"
+              aria-label="Sort activities"
               title="Sort"
             >
               <ArrowUpDown size={16} strokeWidth={1.75} aria-hidden />

--- a/src/components/profile/profile-lists.tsx
+++ b/src/components/profile/profile-lists.tsx
@@ -43,7 +43,7 @@ import { parseAtUri } from "@/lib/atproto/activity-uri"
 import { getInitials } from "@/lib/utils/initials"
 
 const SECTIONS: { type: TypedListType; title: string; emptyHint: string }[] = [
-  { type: LIST_CERTS_TYPE, title: "Certs", emptyHint: "No cert lists yet." },
+  { type: LIST_CERTS_TYPE, title: "Activities", emptyHint: "No activity lists yet." },
   { type: LIST_PROJECTS_TYPE, title: "Projects", emptyHint: "No project lists yet." },
   { type: LIST_ACCOUNTS_TYPE, title: "Accounts", emptyHint: "No account lists yet." },
 ]
@@ -583,7 +583,7 @@ function CertItemRow({
   const title =
     typeof activity?.value.title === "string" && activity.value.title.length > 0
       ? activity.value.title
-      : "Untitled cert"
+      : "Untitled activity"
   const imageUrl =
     activity?.value.image && parsed
       ? resolveActivityImageUrl(activity.value.image, parsed.did)
@@ -847,7 +847,7 @@ function CreateListModal({
 }
 
 const LABELS: Record<TypedListType, string> = {
-  "list:certs": "certs",
+  "list:certs": "activities",
   "list:projects": "projects",
   "list:accounts": "accounts",
 }
@@ -1315,7 +1315,7 @@ function AddItemsModal({
 }
 
 const SEARCH_PLACEHOLDERS: Record<TypedListType, string> = {
-  "list:certs": "Search certs by title",
+  "list:certs": "Search activities by title",
   "list:projects": "Search projects by title",
   "list:accounts": "Search accounts by handle or name",
 }
@@ -1382,7 +1382,7 @@ async function searchCerts(query: string, signal: AbortSignal): Promise<SearchRe
       title:
         typeof rec.value.title === "string" && rec.value.title.length > 0
           ? rec.value.title
-          : "Untitled cert",
+          : "Untitled activity",
       subtitle: null,
       imageUrl,
     })

--- a/src/components/profile/profile-overview.tsx
+++ b/src/components/profile/profile-overview.tsx
@@ -333,7 +333,7 @@ export default function ProfileOverview({
 
       <section className="profile-overview__stats" aria-label="Profile stats">
         <Link
-          href={`${basePath}?tab=certs`}
+          href={`${basePath}?tab=activities`}
           scroll={false}
           className="profile-overview__stat"
         >
@@ -402,7 +402,7 @@ export default function ProfileOverview({
           {createdActivities.length + contributedActivities.length >
           ACTIVITY_PREVIEW ? (
             <Link
-              href={`${basePath}?tab=certs`}
+              href={`${basePath}?tab=activities`}
               scroll={false}
               className="profile-overview__see-all"
             >

--- a/src/components/profile/profile-overview.tsx
+++ b/src/components/profile/profile-overview.tsx
@@ -337,7 +337,7 @@ export default function ProfileOverview({
           scroll={false}
           className="profile-overview__stat"
         >
-          <span className="profile-overview__stat-label">Certs</span>
+          <span className="profile-overview__stat-label">Activities</span>
           <span className="profile-overview__stat-split">
             <span className="profile-overview__stat-value">
               {activitiesLoading
@@ -397,7 +397,7 @@ export default function ProfileOverview({
             id="profile-overview-activities-heading"
             className="profile-overview__section-title"
           >
-            Recent certs
+            Recent activities
           </h2>
           {createdActivities.length + contributedActivities.length >
           ACTIVITY_PREVIEW ? (
@@ -414,7 +414,7 @@ export default function ProfileOverview({
         {activitiesLoading && previewActivities.length === 0 ? (
           <div className="profile-overview__loading"><LoadingSpinner size="sm" /></div>
         ) : previewActivities.length === 0 ? (
-          <p className="profile-overview__empty">No certs yet.</p>
+          <p className="profile-overview__empty">No activities yet.</p>
         ) : (
           <ul className="profile-overview__activity-list">
             {previewActivities.map((a) => {
@@ -425,7 +425,7 @@ export default function ProfileOverview({
                     <ActivityThumb value={a.value} did={did} />
                     <span className="profile-overview__activity-text">
                       <span className="profile-overview__activity-title">
-                        {a.value.title || "Untitled cert"}
+                        {a.value.title || "Untitled activity"}
                       </span>
                       {a.value.shortDescription ? (
                         <span className="profile-overview__activity-desc">

--- a/src/components/profile/profile-projects.tsx
+++ b/src/components/profile/profile-projects.tsx
@@ -83,7 +83,7 @@ export default function ProfileProjects({ did, viewerIsOwner }: ProfileProjectsP
           title="No projects yet"
           description={
             viewerIsOwner
-              ? "Create your first project to group related certs together."
+              ? "Create your first project to group related activities together."
               : "When this profile creates a project collection, it'll appear here."
           }
         />
@@ -204,7 +204,7 @@ function ProjectBox({ project }: ProjectBoxProps) {
 
       <div className="profile-projects__box-certs">
         <div className="profile-projects__box-certs-head">
-          <h3 className="profile-projects__box-certs-title">Certs</h3>
+          <h3 className="profile-projects__box-certs-title">Activities</h3>
           <span className="profile-projects__box-certs-count">
             {totalCerts}
           </span>
@@ -216,7 +216,7 @@ function ProjectBox({ project }: ProjectBoxProps) {
           </div>
         ) : previews.length === 0 ? (
           <p className="profile-projects__section-empty">
-            <CertIcon size={14} strokeWidth={1.5} aria-hidden /> No certs in this
+            <CertIcon size={14} strokeWidth={1.5} aria-hidden /> No activities in this
             project yet.
           </p>
         ) : (
@@ -230,7 +230,7 @@ function ProjectBox({ project }: ProjectBoxProps) {
             </ul>
             {detailHref && hiddenCount > 0 ? (
               <Link href={detailHref} className="profile-projects__box-see-all">
-                See all {totalCerts} certs
+                See all {totalCerts} activities
                 <ArrowRight size={14} strokeWidth={1.75} aria-hidden />
               </Link>
             ) : null}
@@ -251,7 +251,7 @@ function CertRow({ resolution }: CertRowProps) {
   const parsed = parseAtUri(record.uri)
   const rkey = parsed?.rkey ?? ""
   const href = activityDetailHref(did, rkey)
-  const title = asString(record.value.title) || "Untitled cert"
+  const title = asString(record.value.title) || "Untitled activity"
   const imageUrl = record.value.image
     ? resolveActivityImageUrl(record.value.image, did)
     : null

--- a/src/components/project/project-detail.tsx
+++ b/src/components/project/project-detail.tsx
@@ -1131,11 +1131,11 @@ export default function ProjectDetail({
           {certCount > 0 && certsHref ? (
             <section
               className="project-detail__certs project-detail__certs--preview"
-              aria-label="Certs preview"
+              aria-label="Activities preview"
             >
               <div className="project-detail__certs-header">
                 <h2 className="project-detail__certs-title">
-                  Certs in this project
+                  Activities in this project
                 </h2>
                 <span className="project-detail__certs-count">
                   {certCount}
@@ -1233,7 +1233,7 @@ export default function ProjectDetail({
         {activeTab === "certs" ? (
         <section className="project-detail__certs">
           <div className="project-detail__certs-header">
-            <h2 className="project-detail__certs-title">Certs in this project</h2>
+            <h2 className="project-detail__certs-title">Activities in this project</h2>
             <span className="project-detail__certs-count">{certCount}</span>
             {editing && !addingCert ? (
               <button
@@ -1242,7 +1242,7 @@ export default function ProjectDetail({
                 onClick={() => setAddingCert(true)}
               >
                 <Plus size={14} strokeWidth={1.75} aria-hidden />
-                Add cert
+                Add activity
               </button>
             ) : null}
           </div>
@@ -1253,7 +1253,7 @@ export default function ProjectDetail({
                 onSelect={handleAddCert}
                 prioritizeAuthorDid={sessionDid ?? undefined}
                 excludeUris={draftItemUris}
-                placeholder="Search for a cert to add…"
+                placeholder="Search for an activity to add…"
                 autoFocus
                 clearOnSelect
               />
@@ -1274,8 +1274,8 @@ export default function ProjectDetail({
               ) : resolvedActivities.length === 0 ? (
                 <EmptyState
                   icon={Inbox}
-                  title="No certs in this project yet"
-                  description="Click “Add cert” above to search for and add certs."
+                  title="No activities in this project yet"
+                  description="Click “Add activity” above to search for and add activities."
                 />
               ) : (
                 resolvedActivities.map((rec) => (
@@ -1291,7 +1291,7 @@ export default function ProjectDetail({
                       <button
                         type="button"
                         className="project-detail__cert-menu-btn"
-                        aria-label="Cert actions"
+                        aria-label="Activity actions"
                         aria-haspopup="menu"
                         aria-expanded={openMenuUri === rec.uri}
                         onClick={(e) => {
@@ -1345,8 +1345,8 @@ export default function ProjectDetail({
               emptyState={
                 <EmptyState
                   icon={Inbox}
-                  title="No certs in this project yet"
-                  description="When certs are added to this project, they'll appear here."
+                  title="No activities in this project yet"
+                  description="When activities are added to this project, they'll appear here."
                 />
               }
             />

--- a/src/components/project/project-detail.tsx
+++ b/src/components/project/project-detail.tsx
@@ -265,11 +265,13 @@ export default function ProjectDetail({
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const tabParam = searchParams?.get("tab") ?? "overview"
-  const activeTab: "overview" | "description" | "certs" | "updates" =
-    tabParam === "description" ||
-    tabParam === "certs" ||
-    tabParam === "updates"
-      ? tabParam
+  // Legacy ?tab=certs resolves to activities so old links keep working.
+  const normalizedTab = tabParam === "certs" ? "activities" : tabParam
+  const activeTab: "overview" | "description" | "activities" | "updates" =
+    normalizedTab === "description" ||
+    normalizedTab === "activities" ||
+    normalizedTab === "updates"
+      ? normalizedTab
       : "overview"
 
   /** Build a URL pointing at another subtab on this page —
@@ -277,7 +279,7 @@ export default function ProjectDetail({
    *  (rare today; future-proof). Returns null when pathname isn't
    *  resolved yet so callers can skip rendering the link. */
   const buildTabHref = useCallback(
-    (tab: "overview" | "description" | "certs" | "updates"): string | null => {
+    (tab: "overview" | "description" | "activities" | "updates"): string | null => {
       if (!pathname) return null
       const params = new URLSearchParams(searchParams?.toString() ?? "")
       if (tab === "overview") params.delete("tab")
@@ -289,7 +291,7 @@ export default function ProjectDetail({
   )
 
   const descriptionHref = buildTabHref("description")
-  const certsHref = buildTabHref("certs")
+  const certsHref = buildTabHref("activities")
   const updatesHref = buildTabHref("updates")
 
   // Image resolution order:
@@ -1230,7 +1232,7 @@ export default function ProjectDetail({
           )
         ) : null}
 
-        {activeTab === "certs" ? (
+        {activeTab === "activities" ? (
         <section className="project-detail__certs">
           <div className="project-detail__certs-header">
             <h2 className="project-detail__certs-title">Activities in this project</h2>

--- a/src/components/search/cert-search.tsx
+++ b/src/components/search/cert-search.tsx
@@ -62,7 +62,7 @@ export default function CertSearch({
   onSelect,
   prioritizeAuthorDid,
   excludeUris,
-  placeholder = "Search certs",
+  placeholder = "Search activities",
   className = "",
   autoFocus = false,
   clearOnSelect = false,
@@ -287,7 +287,7 @@ export default function CertSearch({
   if (isSearching) liveStatus = "Searching"
   else if (results.length > 0)
     liveStatus = `${results.length} result${results.length === 1 ? "" : "s"}`
-  else if (query.trim()) liveStatus = "No certs found"
+  else if (query.trim()) liveStatus = "No activities found"
 
   // Partition for the rendered listbox — own certs first if any.
   // We render a divider between groups (only when both groups have
@@ -357,7 +357,7 @@ export default function CertSearch({
           )}
           {!isSearching && results.length === 0 && query.trim() && (
             <li className="cert-search__empty">
-              No certs found for &ldquo;{query.trim()}&rdquo;.
+              No activities found for &ldquo;{query.trim()}&rdquo;.
             </li>
           )}
 
@@ -369,7 +369,7 @@ export default function CertSearch({
               role="presentation"
               aria-hidden="true"
             >
-              Your certs
+              Your activities
             </li>
           ) : null}
 
@@ -415,7 +415,7 @@ function CertSearchRow({
     ? resolveActivityImageUrl(record.value.image, did)
     : null
   const authorHandle = info?.handle ?? null
-  const title = record.value.title || "Untitled cert"
+  const title = record.value.title || "Untitled activity"
 
   return (
     <>
@@ -425,7 +425,7 @@ function CertSearchRow({
           role="presentation"
           aria-hidden="true"
         >
-          Other certs
+          Other activities
         </li>
       ) : null}
       <li

--- a/src/components/search/global-search.tsx
+++ b/src/components/search/global-search.tsx
@@ -414,7 +414,7 @@ export default function GlobalSearch({
               role="presentation"
               aria-hidden="true"
             >
-              Certs
+              Activities
             </li>
           ) : null}
           {certs.map((row, i) => {
@@ -512,7 +512,7 @@ function CertRowItem({
   const imageUrl = record.value.image
     ? resolveActivityImageUrl(record.value.image, did)
     : null
-  const title = record.value.title || "Untitled cert"
+  const title = record.value.title || "Untitled activity"
   const handle = info?.handle ?? null
 
   return (

--- a/src/components/workspace/workspace-pane.tsx
+++ b/src/components/workspace/workspace-pane.tsx
@@ -126,7 +126,7 @@ function truncateDid(did: string): string {
 
 function hrefForLexicon(did: string, lex: WorkspaceLexicon): string {
   const base = `/profile/${encodeURIComponent(did)}`
-  if (lex === "certs") return `${base}?tab=certs`
+  if (lex === "certs") return `${base}?tab=activities`
   if (lex === "projects") return `${base}?tab=projects`
   if (lex === "lists") return `${base}?tab=lists`
   if (lex === "endorsementsReceived") return `${base}?tab=endorsements`

--- a/src/hooks/use-cert-projects.ts
+++ b/src/hooks/use-cert-projects.ts
@@ -113,7 +113,7 @@ export function useCertProjects(did: string | null, rkey: string | null) {
         setError(
           err instanceof Error
             ? err.message
-            : "Failed to load projects containing this cert",
+            : "Failed to load projects containing this activity",
         )
         setProjects([])
       })

--- a/src/hooks/use-explore.ts
+++ b/src/hooks/use-explore.ts
@@ -511,13 +511,13 @@ async function loadPage(args: LoadArgs): Promise<LoadedPage> {
   // all options reads as "nothing matches", which is the natural
   // affordance for re-adding a selection.
   if (
-    (args.kind === "certs" || args.kind === "projects") &&
+    (args.kind === "activities" || args.kind === "projects") &&
     isExplicitlyEmpty(args.includeCertLabels)
   ) {
     return EMPTY_PAGE
   }
   if (
-    (args.kind === "accounts" || args.kind === "certs") &&
+    (args.kind === "accounts" || args.kind === "activities") &&
     isExplicitlyEmpty(args.includeOrgLabels)
   ) {
     return EMPTY_PAGE
@@ -528,7 +528,7 @@ async function loadPage(args: LoadArgs): Promise<LoadedPage> {
     args.noEndorsementRings &&
     (
       (args.kind === "accounts" && args.filter === "endorsed") ||
-      ((args.kind === "certs" || args.kind === "projects") &&
+      ((args.kind === "activities" || args.kind === "projects") &&
         args.filter === "by-endorsed")
     )
   ) {

--- a/src/hooks/use-own-certs.ts
+++ b/src/hooks/use-own-certs.ts
@@ -61,7 +61,7 @@ export function useOwnCerts(did: string | null): {
           title:
             typeof rec.value?.title === "string" && rec.value.title.trim()
               ? rec.value.title.trim()
-              : rec.uri.split("/").pop() ?? "(untitled cert)",
+              : rec.uri.split("/").pop() ?? "(untitled activity)",
           createdAt:
             typeof rec.value?.createdAt === "string"
               ? rec.value.createdAt

--- a/src/hooks/use-project-items.ts
+++ b/src/hooks/use-project-items.ts
@@ -113,8 +113,8 @@ export function useProjectItems(items: unknown): {
             if (!res.ok) {
               throw new Error(
                 res.status === 404
-                  ? "Cert not found"
-                  : `Failed to load cert (${res.status})`,
+                  ? "Activity not found"
+                  : `Failed to load activity (${res.status})`,
               )
             }
             const data = (await res.json()) as {
@@ -135,7 +135,7 @@ export function useProjectItems(items: unknown): {
             next[idx] = {
               ...next[idx],
               error:
-                err instanceof Error ? err.message : "Failed to load cert",
+                err instanceof Error ? err.message : "Failed to load activity",
             }
           }
         }),

--- a/src/lib/atproto/cert.ts
+++ b/src/lib/atproto/cert.ts
@@ -44,6 +44,6 @@ export async function putCertRecord(
       method: "PUT",
       body: { rkey, record: body, ...(swap ? { swapRecord: swap } : {}) },
     },
-    errorFallback: "Failed to save cert",
+    errorFallback: "Failed to save activity",
   })
 }

--- a/src/lib/atproto/workspace.ts
+++ b/src/lib/atproto/workspace.ts
@@ -359,7 +359,7 @@ export type WorkspaceLexicon =
   | "followers"
 
 export const WORKSPACE_LEXICON_LABEL: Record<WorkspaceLexicon, string> = {
-  certs: "Certs",
+  certs: "Activities",
   projects: "Projects",
   lists: "Lists",
   endorsementsReceived: "Endorsements",


### PR DESCRIPTION
Renames the product noun **cert / certs / certificate → activity / activities** to match the underlying record type (`org.hypercerts.claim.activity`). Scope (per your choice): **user-facing display text + URL/query values**. Code identifiers, CSS classes, and filenames are unchanged.

## What's renamed
**Display text** (commit 1): page titles, section headings, tab labels, empty states, aria-labels, placeholders, toast/error copy, and metadata — across `src/app`, components, and hooks.

**URL/query values** (commit 2): the user-visible `?tab` / `?kind` value `certs` → `activities` on three surfaces, each with **legacy-alias parsing** so old links still resolve:
- explore `?kind=certs` → `?kind=activities`
- profile `?tab=certs` → `?tab=activities`
- project detail `?tab=certs` → `?tab=activities`

plus the links that build those URLs.

## What's deliberately preserved
- **Brand:** "Certified", certified.app, certs.social, Certified Group Service / CGS.
- **Lexicon / record types:** `app.certified.*`, `org.hypercerts.*` ($type, NSIDs, collections), `list:certs`, `cert.create`.
- **Internal values & code:** `WorkspaceLexicon "certs"`, `FeaturedKind` / `MA_EARTH_COLLECTIONS.certs` (static lookups), the recently-viewed localStorage kind, and all identifiers, CSS classes (`cert-detail__*`), and filenames (`cert-search.tsx`, `use-own-certs.ts`, …).

## How it was done
A constrained parallel workflow renamed display text across disjoint directories, then an adversarial verifier diffed the result (zero brand/lexicon/identifier regressions). I then did the URL-value pass by hand for cross-file contract consistency, leaning on tsc (the `ExploreKind`/`TabKey` literal changes flag every stale comparison) and adding the legacy aliases.

## Verification
- [x] `tsc --noEmit` clean (catches any missed kind/tab comparison)
- [x] `eslint` 0 new errors
- [x] `vitest` 519/519 pass
- [x] `next build` compiles
- [x] Brand/lexicon safety: no `Certified` / `app.certified.*` / `org.hypercerts.*` string modified (verified against the diff)
- [ ] Manual spot-check: profile "Activities" tab, explore Activities view, "New activity" / edit flows, and that legacy `?tab=certs` / `?kind=certs` links still land correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
