### PR TITLE
fix(resolve-did): batch author/contributor resolution to stop 429s

### DIFF
--- a/docs/resolve-did-batch/plan.md
+++ b/docs/resolve-did-batch/plan.md
@@ -1,0 +1,72 @@
+# Fix: author/contributor 429s on explore + activity detail
+
+## Symptom
+On `/explore` and the activity (cert) detail page, author bylines and the
+contributor list sometimes fail to load; the console shows
+`Failed to load resource: the server responded with a status of 429`.
+
+## Root cause
+`/api/resolve-did` is rate-limited to **60 requests/min per IP** (and per
+session DID). The byline + contributor components each resolve **one DID per
+row** on mount, with no HTTP-level batching:
+
+- `ActivityAuthor` (`activity-author.tsx`) → `useAuthorInfo(did)` → one
+  `GET /api/resolve-did?did=` per cert row.
+- `ActivityContributor` → `useContributorInfo(identity)` → one request per
+  contributor.
+- `useAuthorNamesMap` → `Promise.all(dids.map(fetchName))` — fans out one
+  request per DID at once.
+
+A page with 30+ distinct authors plus a detail page's contributors blows the
+60/min window. Two amplifiers:
+
+1. **No denormalized fallback.** Unlike account rows (which prefer
+   `actor.displayName` and only fall back to a lookup), the raw `ActivityRecord`
+   carries only the author DID, so the byline always resolves over the network.
+2. **No negative caching.** On error, `useAuthorInfo` / `useContributorInfo`
+   do `cache.delete(did)` and rethrow. The failed row settles to a skeleton/error
+   and never recovers on that view; remounts (virtualized lists, tab switches,
+   StrictMode) re-fire against the still-limited endpoint.
+
+## Fix
+Collapse N requests into one, the same way the home feed already avoids N
+lookups (it denormalizes author profiles inline).
+
+1. **Batch endpoint** `POST /api/resolve-dids` — accepts `{ identities: string[] }`
+   (DID or handle, capped at 50), resolves each with bounded server-side
+   concurrency, returns `{ results: { [input]: payload | null } }`. Reuses the
+   exact per-DID resolution from the GET route (extracted to `resolve-core.ts`),
+   so certs/bsky precedence and the indexer fast-path are unchanged. One
+   rate-limit hit per batch instead of per DID.
+2. **Client coalescer** `src/lib/atproto/resolve-did-batch.ts` — DataLoader-style.
+   `loadResolvedProfile(identity)` returns a cached/in-flight promise or queues
+   the identity; a short timer flushes the queue as chunked POSTs (<=50).
+   Resilient failure: on 429/batch error it resolves to a DID fallback and
+   negative-caches with a TTL so the row degrades gracefully and self-heals on a
+   later view instead of looping.
+3. **Rewire the three hooks** (`use-author-info`, `use-contributor-info`,
+   `use-author-names-map`) onto the coalescer. Public APIs unchanged.
+
+## Files (disjoint)
+- NEW `src/app/api/resolve-did/resolve-core.ts` — shared resolution (moved from route).
+- EDIT `src/app/api/resolve-did/route.ts` — thin GET wrapper over resolve-core.
+- NEW `src/app/api/resolve-dids/route.ts` — batch POST.
+- NEW `src/lib/atproto/resolve-did-batch.ts` — client coalescer.
+- EDIT `src/hooks/use-author-info.ts`, `use-contributor-info.ts`, `use-author-names-map.ts`.
+- NEW tests: coalescer (mock fetch), batch route (mirror resolve-did rate-limit suite).
+
+## Out of scope
+- Denormalizing the author profile into the explore/feed indexer query (a bigger
+  indexer-side change; the batch endpoint solves the 429 without it).
+- Changing the 60/min limit (batching makes raising it unnecessary).
+
+## Acceptance
+- tsc clean; eslint no new; vitest green (existing 519 + new); `next build` compiles.
+- Existing `resolve-did/__tests__` (rate-limit, fastpath, fallback-precedence)
+  still pass unchanged (GET behaviour byte-identical).
+- A render pass needing K authors issues `ceil(K/50)` requests, not K.
+- A 429 leaves bylines showing a usable fallback, not a stuck skeleton.
+
+## Rollback
+Revert the branch. The batch endpoint is additive; the GET route is unchanged
+behaviourally; reverting the hooks restores the per-DID path.

--- a/docs/resolve-did-batch/review-round-1.md
+++ b/docs/resolve-did-batch/review-round-1.md
@@ -1,0 +1,55 @@
+# Implementation review — round 1 (decisions)
+
+Two reviewers (client-coalescer correctness; server route regression/abuse).
+GET extraction confirmed byte-for-byte faithful; brand/lexicon strings moved
+verbatim. Decisions below.
+
+## Accepted
+
+1. **Identity-weighted rate limit on the batch route** (server should-fix).
+   A 50-identity batch fans out up to ~150 upstream fetches; a flat
+   60-*request*/min budget let one IP drive ~9k upstream fetches/min. Fix:
+   charge the limiter `cost = identities.length` against a **600-identity/min**
+   budget (per IP and per session-DID). 600 supports ~12 full explore pages/min
+   of *distinct* authors (the coalescer dedups repeats to cost 0), while
+   bounding upstream to ~1800 fetches/min/IP. Implemented via a backward-compatible
+   `cost` param on `checkHttpRateLimit` (default 1 → existing routes unchanged;
+   `incrby` only when cost > 1; TTL gate generalised `count === 1` → `count === cost`).
+   Side benefit: the old route's shared `"anon"` DID bucket meant *all* signed-out
+   users shared one 60/min budget — itself a contributor to the reported 429s.
+   The batch path gives anonymous users 10x more headroom than the GET path they
+   replace.
+
+2. **Honor the 429 cooldown across flushes** (client #3). A flush already armed
+   in the 16ms window before a concurrent chunk got 429'd ignored the new
+   cooldown. `flush` now defers (re-arms) when `Date.now() < cooldownUntil`
+   instead of relying only on `scheduleFlush`.
+
+3. **Track and clear negative-eviction timers** (client #2). Per-identity 30s
+   `setTimeout`s were untracked and leaked (and bled across fake-timer tests).
+   Now held in a `Map`, replaced on reschedule, and cleared by the reset helper.
+
+4. **New tests**: cooldown-defers-next-flush; a load arriving during an in-flight
+   flush (re-entrancy); reset clears eviction timers. Batch-route mocks updated
+   for `incrby` + the weighted 429.
+
+## Declined (with rationale)
+
+- **`useAuthorNamesMap` self-heal on a transient miss** (client #1). Making the
+  names map re-query a null result requires it to stay in the effect's `missing`
+  set, which re-fires `fetchName` → `setTick` on every render → a re-render loop.
+  The original (and current) behaviour caches the DID fallback so `missing`
+  empties and the effect early-returns. This is pre-existing, not a regression,
+  and the synchronous-map sort/search design depends on it. The coalescer still
+  batches and negative-caches the underlying request, so there is no storm. Left
+  as-is intentionally.
+
+- **Remove dead `error` plumbing in `useAuthorInfo`** (client #4, nit). The
+  `.catch`/`error` state is now unreachable because `loadResolvedProfile` never
+  rejects, but it's harmless defensive code and `error` is part of the hook's
+  public return type (consumers may destructure it). Not worth the churn.
+
+- **Concurrent chunk flushing** (client #5, nit). Sequential `await` per chunk is
+  intentional: it keeps the >50-identity case gentle on the very limiter we're
+  trying not to trip. Latency cost only applies to pages with >50 distinct
+  authors, which are rare.

--- a/src/app/api/resolve-did/resolve-core.ts
+++ b/src/app/api/resolve-did/resolve-core.ts
@@ -1,0 +1,470 @@
+import { resolveHandle, resolveHandleToDid, resolvePdsUrl } from "@/lib/atproto/did"
+import { isValidDid } from "@/lib/utils/did"
+import {
+  buildAvatarUrlFromCid,
+  buildBannerUrlFromCid,
+} from "@/lib/atproto/profile"
+
+/**
+ * Shared DID/handle -> profile resolution, used by both the single-DID
+ * `GET /api/resolve-did` route and the batched `POST /api/resolve-dids`
+ * route. The batch route exists so author bylines / contributor lists
+ * resolve a whole page of identities in one request instead of one
+ * request per row (which blows the route's 60/min rate limit — see
+ * docs/resolve-did-batch/plan.md).
+ *
+ * The resolution logic here is byte-for-byte the original GET-handler
+ * body; only the rate-limiting and HTTP cache-control wrappers stay in
+ * the route files. Both routes therefore share identical certs/bsky
+ * precedence and the optional indexer fast-path.
+ */
+
+const CERTS_PROFILE_COLLECTION = "app.certified.actor.profile"
+const CERTS_PROFILE_RKEY = "self"
+
+/**
+ * Optional indexer fast-path (default OFF). When enabled, identity
+ * (handle + the bsky profile block) is read from the magic-indexer's
+ * `actorProfile(did)` query instead of fanning out to `resolveHandle` +
+ * `app.bsky.actor.getProfile` for DIDs the indexer has already
+ * backfilled. The certs lookup is unchanged and always runs in parallel.
+ * Fully backward-compatible: with the flag off this is byte-identical to
+ * the legacy three-upstream fan-out, and even with the flag on every
+ * indexer miss falls back to the legacy path per-field, so resolution
+ * never regresses against an un-deployed / un-indexed upstream. See
+ * magic-indexer #151 / #153 / #154.
+ */
+const USE_INDEXER = process.env.RESOLVE_DID_USE_INDEXER === "true"
+
+/**
+ * Upstream indexer GraphQL endpoint. Mirrors the resolution in
+ * `/api/indexer` (INDEXER_URL → NEXT_PUBLIC_INDEXER_URL → the railway
+ * prod fallback) so the server-side `actorProfile` query targets the
+ * same instance as the proxied client ops.
+ */
+const UPSTREAM_INDEXER_URL =
+  process.env.INDEXER_URL ||
+  process.env.NEXT_PUBLIC_INDEXER_URL ||
+  "https://magic-indexer-prod.up.railway.app/graphql"
+
+const RESOLVE_ACTOR_PROFILE_QUERY = `query ResolveActorProfile($did:String!){ actorProfile(did:$did){ did handle displayName description avatarCid bannerCid } }`
+
+type IndexerActorProfile = {
+  did?: string | null
+  handle?: string | null
+  displayName?: string | null
+  description?: string | null
+  avatarCid?: string | null
+  bannerCid?: string | null
+}
+
+/**
+ * Server-side `actorProfile(did)` lookup against the magic-indexer.
+ * POSTs the fixed GraphQL query with an 8s timeout, attaching the
+ * rate-limit bypass header only when `INDEXER_RATELIMIT_BYPASS_KEY` is
+ * set. Returns the `actorProfile` object or null on any error, non-OK
+ * status, GraphQL error, or empty payload — every failure mode collapses
+ * to null so the caller cleanly falls back to the legacy path.
+ */
+async function fetchIndexerActorProfile(
+  did: string
+): Promise<IndexerActorProfile | null> {
+  try {
+    const bypassKey = process.env.INDEXER_RATELIMIT_BYPASS_KEY
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    }
+    if (bypassKey) headers["X-RateLimit-Bypass"] = bypassKey
+
+    const res = await fetch(UPSTREAM_INDEXER_URL, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        operationName: "ResolveActorProfile",
+        query: RESOLVE_ACTOR_PROFILE_QUERY,
+        variables: { did },
+      }),
+      signal: AbortSignal.timeout(8_000),
+    })
+    if (!res.ok) return null
+    const data = (await res.json()) as {
+      data?: { actorProfile?: IndexerActorProfile | null }
+      errors?: unknown
+    }
+    if (data.errors) return null
+    return data.data?.actorProfile ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Bluesky's public appView — serves `app.bsky.actor.getProfile`
+ *  unauthenticated. */
+const BSKY_APPVIEW = "https://public.api.bsky.app"
+
+type BlobLike = {
+  ref?: { $link: string } | string
+}
+
+function extractBlobLink(ref: BlobLike["ref"]): string | null {
+  if (!ref) return null
+  if (typeof ref === "string") return ref
+  if (typeof ref === "object" && "$link" in ref) return ref.$link
+  return null
+}
+
+type CertsProfileValue = {
+  displayName?: string
+  description?: string
+  pronouns?: string
+  website?: string
+  createdAt?: string
+  avatar?: { $type?: string; uri?: string; image?: BlobLike } | undefined
+  banner?: { $type?: string; uri?: string; image?: BlobLike } | undefined
+}
+
+/**
+ * Resolve a Certs profile field (avatar or banner) into a URL.
+ *
+ * - `org.hypercerts.defs#uri` → return `uri` verbatim.
+ * - blob variant → a relative URL through our XRPC proxy so federated
+ *   DIDs get their blob streamed from their home PDS (see the
+ *   `com.atproto.sync.getBlob` branch in /api/xrpc).
+ * - anything else (missing, malformed) → null.
+ */
+function resolveCertsField(
+  field: CertsProfileValue["avatar"] | CertsProfileValue["banner"],
+  did: string
+): string | null {
+  if (!field) return null
+  if (field.$type === "org.hypercerts.defs#uri" && field.uri) {
+    return field.uri
+  }
+  const link = extractBlobLink(field.image?.ref)
+  if (link) {
+    return `/api/xrpc/com/atproto/sync/getBlob?did=${encodeURIComponent(
+      did
+    )}&cid=${encodeURIComponent(link)}`
+  }
+  return null
+}
+
+/**
+ * Fetch the Certified profile record for a DID and return the
+ * pre-resolved avatar + banner URLs alongside the text fields. Returns
+ * null if the record is missing or unreachable. Errors are swallowed —
+ * callers fall back to the Bluesky profile.
+ *
+ * We resolve the DID to its actual PDS first so that Certs profiles
+ * for users on any PDS in the network work, not just our own. The
+ * request uses the public unauthenticated XRPC directly against the
+ * target PDS.
+ */
+async function getCertsProfile(did: string): Promise<{
+  displayName?: string
+  description?: string
+  pronouns?: string
+  website?: string
+  avatarUrl: string | null
+  bannerUrl: string | null
+  createdAt?: string
+} | null> {
+  try {
+    const targetPds = await resolvePdsUrl(did)
+    if (!targetPds) return null
+
+    const params = new URLSearchParams({
+      repo: did,
+      collection: CERTS_PROFILE_COLLECTION,
+      rkey: CERTS_PROFILE_RKEY,
+    })
+    const res = await fetch(
+      `${targetPds}/xrpc/com.atproto.repo.getRecord?${params.toString()}`,
+      { signal: AbortSignal.timeout(8_000) }
+    )
+    if (!res.ok) return null
+    const data = (await res.json()) as { value?: CertsProfileValue }
+    const value = data.value
+    if (!value) return null
+    return {
+      displayName: value.displayName,
+      description: value.description,
+      pronouns: value.pronouns,
+      website: value.website,
+      avatarUrl: resolveCertsField(value.avatar, did),
+      bannerUrl: resolveCertsField(value.banner, did),
+      createdAt: value.createdAt,
+    }
+  } catch {
+    return null
+  }
+}
+
+/** Fetch a user's Bluesky profile view from the public appView. Works
+ *  without authentication, so signed-out visitors to the profile page
+ *  still get full author info + avatar + banner.
+ *
+ *  Named `fetchBskyAppViewProfile` (not `getBlueskyProfile`) to avoid
+ *  shadowing the exported `getBlueskyProfile` in `lib/atproto/profile.ts`,
+ *  which reads `app.bsky.actor.profile` from the user's OWN PDS — a
+ *  different operation with the same name. */
+async function fetchBskyAppViewProfile(did: string): Promise<{
+  displayName?: string
+  description?: string
+  avatar?: string
+  banner?: string
+} | null> {
+  try {
+    const res = await fetch(
+      `${BSKY_APPVIEW}/xrpc/app.bsky.actor.getProfile?actor=${encodeURIComponent(did)}`,
+      { signal: AbortSignal.timeout(8_000) }
+    )
+    if (!res.ok) return null
+    const data = (await res.json()) as {
+      displayName?: string
+      description?: string
+      avatar?: string
+      banner?: string
+    }
+    return data
+  } catch {
+    return null
+  }
+}
+
+/** The bsky identity block fed into the downstream per-field merge —
+ *  the same shape whether it originated from the indexer's
+ *  `actorProfile` or the appView's `app.bsky.actor.getProfile`. */
+type BskyIdentity = {
+  displayName?: string
+  description?: string
+  avatar?: string
+  banner?: string
+}
+
+/**
+ * Resolve the `{ handle, bsky }` identity for a DID — the part of the
+ * lookup the indexer fast-path can replace. Two modes:
+ *
+ *   - Legacy (flag OFF, or the indexer query failed entirely): the
+ *     original `resolveHandle(did)` + `fetchBskyAppViewProfile(did)`
+ *     fan-out, run in parallel.
+ *   - Indexer (flag ON + a non-null `actorProfile`): handle comes from
+ *     `actorProfile.handle ?? resolveHandle(did)`; the bsky block is
+ *     built from the indexer's denormalised fields when the indexer
+ *     HAS a bsky profile for this DID (signalled by a displayName or
+ *     avatarCid), otherwise it falls back to `fetchBskyAppViewProfile`
+ *     for an un-backfilled / un-observed DID.
+ *
+ * The certs lookup is intentionally NOT handled here — it always runs
+ * in parallel in the caller and its precedence (certs → bsky) is
+ * unchanged.
+ */
+async function resolveIdentity(did: string): Promise<{
+  handle: string | null
+  bsky: BskyIdentity | null
+}> {
+  // Legacy fan-out, also the universal fallback when the flag is off.
+  const legacy = async (): Promise<{
+    handle: string | null
+    bsky: BskyIdentity | null
+  }> => {
+    const [handleResult, bskyResult] = await Promise.allSettled([
+      resolveHandle(did),
+      fetchBskyAppViewProfile(did),
+    ])
+    return {
+      handle: handleResult.status === "fulfilled" ? handleResult.value : null,
+      bsky: bskyResult.status === "fulfilled" ? bskyResult.value : null,
+    }
+  }
+
+  if (!USE_INDEXER) return legacy()
+
+  const actor = await fetchIndexerActorProfile(did)
+  // Indexer query failed / returned nothing → full legacy fallback so
+  // the route never regresses against an un-deployed indexer schema.
+  if (!actor) return legacy()
+
+  // handle: prefer the indexer's denormalised handle, else resolve it.
+  const handle =
+    actor.handle ??
+    (await resolveHandle(did).catch(() => null))
+
+  // The indexer HAS a bsky profile for this DID when it carries a
+  // displayName or an avatarCid — build the bsky block from its
+  // denormalised fields. Otherwise the DID is un-backfilled / not
+  // observed, so fall back to the appView for the bsky block only.
+  const indexerHasBsky = !!(actor.displayName || actor.avatarCid)
+  if (indexerHasBsky) {
+    const indexerAvatar = buildAvatarUrlFromCid(did, actor.avatarCid)
+    const indexerBanner = buildBannerUrlFromCid(did, actor.bannerCid)
+
+    // PER-FIELD fallback: a displayName-set-but-avatarCid-null indexer row
+    // used to render a sticky blank avatar (the read-side amplifier of the
+    // data-loss bug) because `indexerHasBsky` skipped the appView wholesale.
+    // When the indexer is missing a needed image field, lazily hit the
+    // appView ONCE and fill ONLY the gaps — the indexer stays authoritative
+    // for whatever it does carry, and the fast path stays fast (no appView
+    // fetch) whenever the avatar+banner CIDs are present.
+    let appView: BskyIdentity | null = null
+    if (!actor.avatarCid || !actor.bannerCid) {
+      appView = await fetchBskyAppViewProfile(did)
+    }
+
+    return {
+      handle,
+      bsky: {
+        displayName: actor.displayName ?? appView?.displayName ?? undefined,
+        description: actor.description ?? appView?.description ?? undefined,
+        avatar: indexerAvatar ?? appView?.avatar ?? undefined,
+        banner: indexerBanner ?? appView?.banner ?? undefined,
+      },
+    }
+  }
+
+  const bsky = await fetchBskyAppViewProfile(did)
+  return { handle, bsky }
+}
+
+/** The resolved-profile payload returned by both routes. */
+export interface ResolvedProfilePayload {
+  did: string
+  handle: string
+  displayName?: string
+  description?: string
+  pronouns?: string
+  website?: string
+  // null is a meaningful wire value here: a Certs profile with a
+  // deliberately-cleared avatar/banner resolves to null (not undefined),
+  // which the all-or-nothing precedence below relies on.
+  avatar?: string | null
+  banner?: string | null
+  createdAt?: string
+  hasCertifiedProfile: boolean
+  hasBlueskyProfile: boolean
+  blueskyProfile: {
+    displayName?: string
+    description?: string
+    avatar?: string
+    banner?: string
+  } | null
+}
+
+/**
+ * Resolve a free-form identity (a DID, or a handle that gets resolved to
+ * a DID via the public appView) to a DID. Returns null when the input is
+ * neither a valid DID nor a resolvable handle.
+ */
+export async function resolveInputToDid(
+  didParam: string,
+  handleParam: string
+): Promise<string | null> {
+  let did = didParam || ""
+  const handle = handleParam || ""
+
+  // If a handle was provided (and no valid DID), resolve it to a DID via
+  // Bluesky's public appView. Lets callers pass an identity that was
+  // typed as a handle, not a DID (e.g. contributor rows).
+  if (!isValidDid(did) && handle) {
+    const resolved = await resolveHandleToDid(handle.trim())
+    if (resolved) did = resolved
+  }
+
+  return isValidDid(did) ? did : null
+}
+
+/**
+ * Resolve a single (already-validated) DID into the full profile
+ * payload. This is the exact merge the GET route used to inline: the
+ * certs lookup and the identity (handle + bsky) resolution run in
+ * parallel, then the certs profile takes all-or-nothing precedence over
+ * the bsky fallback.
+ */
+export async function buildProfilePayload(
+  did: string
+): Promise<ResolvedProfilePayload> {
+  // Run the certs lookup and the identity (handle + bsky) resolution in
+  // parallel. `resolveIdentity` is the adaptive layer (indexer fast-path
+  // or legacy fan-out). Certs ALWAYS comes from its own PDS lookup and
+  // its precedence over bsky below is unchanged. Each branch is allowed
+  // to fail independently — we combine whatever succeeds.
+  const [identityResult, certsResult] = await Promise.allSettled([
+    resolveIdentity(did),
+    getCertsProfile(did),
+  ])
+
+  const identity =
+    identityResult.status === "fulfilled"
+      ? identityResult.value
+      : { handle: null, bsky: null }
+  const handle = identity.handle
+  const bsky = identity.bsky
+  const certs = certsResult.status === "fulfilled" ? certsResult.value : null
+
+  // ALL-OR-NOTHING fallback rule (maintainer product decision): the
+  // Bluesky profile is only a wholesale fallback. We use the Bluesky
+  // fields ONLY when the user has no Certified profile, or a completely
+  // empty one. The moment a Certified profile carries ANY meaningful
+  // content, we treat it as authoritative and use ITS fields exclusively
+  // — a blank field in a partly-filled certs profile is assumed to be
+  // INTENTIONALLY blank, so we must NOT backfill it from Bluesky
+  // per-field (e.g. someone who set a display name but deliberately
+  // cleared their avatar should get no avatar, not their old bsky one).
+  //
+  // `certsHasContent` is the single gate: a certs record exists AND at
+  // least one displayed profile field is non-empty. A stub record that
+  // only carries {$type, createdAt} therefore counts as empty, so the
+  // bsky fallback still applies to it.
+  const certsHasContent = !!(
+    certs &&
+    (certs.displayName ||
+      certs.description ||
+      certs.avatarUrl ||
+      certs.bannerUrl ||
+      certs.pronouns ||
+      certs.website)
+  )
+  const displayName = certsHasContent ? certs?.displayName : bsky?.displayName
+  const description = certsHasContent ? certs?.description : bsky?.description
+  const pronouns = certs?.pronouns
+  const website = certs?.website
+  const avatar = certsHasContent ? certs?.avatarUrl : bsky?.avatar
+  const banner = certsHasContent ? certs?.bannerUrl : bsky?.banner
+  const createdAt = certs?.createdAt
+  // True when the user has a non-empty app.certified.actor.profile (the
+  // same `certsHasContent` gate above). Surfaced to the client so the
+  // profile sidebar / header can render the "Bluesky profile" tag only
+  // when the user has NOT authored a Certified profile. Issue #74.
+  const hasCertifiedProfile = certsHasContent
+  // True when an app.bsky.actor.profile is reachable + populated. Used by
+  // the first-signin onboarding gate so the import modal only opens for
+  // users who actually have bsky content worth importing.
+  const hasBlueskyProfile = !!(bsky?.displayName || bsky?.avatar)
+  // The raw bsky-derived seed values, surfaced separately from the
+  // merged fields above so the onboarding form can populate its inputs
+  // from bsky even when the merged values already resolve to certified.
+  const blueskyProfile = bsky
+    ? {
+        displayName: bsky.displayName,
+        description: bsky.description,
+        avatar: bsky.avatar,
+        banner: bsky.banner,
+      }
+    : null
+
+  return {
+    did,
+    handle: handle || did,
+    displayName,
+    description,
+    pronouns,
+    website,
+    avatar,
+    banner,
+    createdAt,
+    hasCertifiedProfile,
+    hasBlueskyProfile,
+    blueskyProfile,
+  }
+}

--- a/src/app/api/resolve-did/route.ts
+++ b/src/app/api/resolve-did/route.ts
@@ -1,330 +1,19 @@
 import { NextRequest, NextResponse } from "next/server"
-import { resolveHandle, resolveHandleToDid, resolvePdsUrl } from "@/lib/atproto/did"
-import { isValidDid } from "@/lib/utils/did"
 import { extractRouteError } from "@/lib/utils/api"
 import { getSessionDid } from "@/lib/auth/session"
 import { enforceRateLimitMulti, makeLimiter } from "@/lib/auth/rate-limit"
 import { clientIp } from "@/lib/utils/ip"
-import {
-  buildAvatarUrlFromCid,
-  buildBannerUrlFromCid,
-} from "@/lib/atproto/profile"
-
-const CERTS_PROFILE_COLLECTION = "app.certified.actor.profile"
-const CERTS_PROFILE_RKEY = "self"
-
-/**
- * Optional indexer fast-path (default OFF). When enabled, the route
- * reads identity (handle + the bsky profile block) from the magic-
- * indexer's `actorProfile(did)` query instead of fanning out to
- * `resolveHandle` + `app.bsky.actor.getProfile` for DIDs the indexer
- * has already backfilled. The certs lookup is unchanged and always runs
- * in parallel. Fully backward-compatible: with the flag off the route is
- * byte-identical to the legacy three-upstream fan-out, and even with the
- * flag on every indexer miss falls back to the legacy path per-field, so
- * resolve-did never regresses against an un-deployed / un-indexed
- * upstream. See magic-indexer #151 / #153 / #154.
- */
-const USE_INDEXER = process.env.RESOLVE_DID_USE_INDEXER === "true"
-
-/**
- * Upstream indexer GraphQL endpoint. Mirrors the resolution in
- * `/api/indexer` (INDEXER_URL → NEXT_PUBLIC_INDEXER_URL → the railway
- * prod fallback) so the server-side `actorProfile` query targets the
- * same instance as the proxied client ops.
- */
-const UPSTREAM_INDEXER_URL =
-  process.env.INDEXER_URL ||
-  process.env.NEXT_PUBLIC_INDEXER_URL ||
-  "https://magic-indexer-prod.up.railway.app/graphql"
-
-const RESOLVE_ACTOR_PROFILE_QUERY = `query ResolveActorProfile($did:String!){ actorProfile(did:$did){ did handle displayName description avatarCid bannerCid } }`
-
-type IndexerActorProfile = {
-  did?: string | null
-  handle?: string | null
-  displayName?: string | null
-  description?: string | null
-  avatarCid?: string | null
-  bannerCid?: string | null
-}
-
-/**
- * Server-side `actorProfile(did)` lookup against the magic-indexer.
- * POSTs the fixed GraphQL query with an 8s timeout, attaching the
- * rate-limit bypass header only when `INDEXER_RATELIMIT_BYPASS_KEY` is
- * set. Returns the `actorProfile` object or null on any error, non-OK
- * status, GraphQL error, or empty payload — every failure mode collapses
- * to null so the caller cleanly falls back to the legacy path.
- */
-async function fetchIndexerActorProfile(
-  did: string
-): Promise<IndexerActorProfile | null> {
-  try {
-    const bypassKey = process.env.INDEXER_RATELIMIT_BYPASS_KEY
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-    }
-    if (bypassKey) headers["X-RateLimit-Bypass"] = bypassKey
-
-    const res = await fetch(UPSTREAM_INDEXER_URL, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        operationName: "ResolveActorProfile",
-        query: RESOLVE_ACTOR_PROFILE_QUERY,
-        variables: { did },
-      }),
-      signal: AbortSignal.timeout(8_000),
-    })
-    if (!res.ok) return null
-    const data = (await res.json()) as {
-      data?: { actorProfile?: IndexerActorProfile | null }
-      errors?: unknown
-    }
-    if (data.errors) return null
-    return data.data?.actorProfile ?? null
-  } catch {
-    return null
-  }
-}
+import { buildProfilePayload, resolveInputToDid } from "./resolve-core"
 
 // 60/min. Mirrors search-actors (judgment-002): this route is
 // unauthenticated and issues up to 3 outbound fetches per request, so
 // rate-limit on DID **and** IP simultaneously — a session-DID rotation
 // would otherwise bypass the limit, and we don't want to flood the
-// upstream PDS / appView we proxy.
+// upstream PDS / appView we proxy. Callers that need many identities at
+// once should use the batched `POST /api/resolve-dids` instead of
+// firing one GET per identity.
 const LIMITER_DID = makeLimiter("resolve-did-did", 60, 60)
 const LIMITER_IP = makeLimiter("resolve-did-ip", 60, 60)
-
-/** Bluesky's public appView — serves `app.bsky.actor.getProfile`
- *  unauthenticated. */
-const BSKY_APPVIEW = "https://public.api.bsky.app"
-
-type BlobLike = {
-  ref?: { $link: string } | string
-}
-
-function extractBlobLink(ref: BlobLike["ref"]): string | null {
-  if (!ref) return null
-  if (typeof ref === "string") return ref
-  if (typeof ref === "object" && "$link" in ref) return ref.$link
-  return null
-}
-
-type CertsProfileValue = {
-  displayName?: string
-  description?: string
-  pronouns?: string
-  website?: string
-  createdAt?: string
-  avatar?: { $type?: string; uri?: string; image?: BlobLike } | undefined
-  banner?: { $type?: string; uri?: string; image?: BlobLike } | undefined
-}
-
-/**
- * Resolve a Certs profile field (avatar or banner) into a URL.
- *
- * - `org.hypercerts.defs#uri` → return `uri` verbatim.
- * - blob variant → a relative URL through our XRPC proxy so federated
- *   DIDs get their blob streamed from their home PDS (see the
- *   `com.atproto.sync.getBlob` branch in /api/xrpc).
- * - anything else (missing, malformed) → null.
- */
-function resolveCertsField(
-  field: CertsProfileValue["avatar"] | CertsProfileValue["banner"],
-  did: string
-): string | null {
-  if (!field) return null
-  if (field.$type === "org.hypercerts.defs#uri" && field.uri) {
-    return field.uri
-  }
-  const link = extractBlobLink(field.image?.ref)
-  if (link) {
-    return `/api/xrpc/com/atproto/sync/getBlob?did=${encodeURIComponent(
-      did
-    )}&cid=${encodeURIComponent(link)}`
-  }
-  return null
-}
-
-/**
- * Fetch the Certified profile record for a DID and return the
- * pre-resolved avatar + banner URLs alongside the text fields. Returns
- * null if the record is missing or unreachable. Errors are swallowed —
- * callers fall back to the Bluesky profile.
- *
- * We resolve the DID to its actual PDS first so that Certs profiles
- * for users on any PDS in the network work, not just our own. The
- * request uses the public unauthenticated XRPC directly against the
- * target PDS.
- */
-async function getCertsProfile(did: string): Promise<{
-  displayName?: string
-  description?: string
-  pronouns?: string
-  website?: string
-  avatarUrl: string | null
-  bannerUrl: string | null
-  createdAt?: string
-} | null> {
-  try {
-    const targetPds = await resolvePdsUrl(did)
-    if (!targetPds) return null
-
-    const params = new URLSearchParams({
-      repo: did,
-      collection: CERTS_PROFILE_COLLECTION,
-      rkey: CERTS_PROFILE_RKEY,
-    })
-    const res = await fetch(
-      `${targetPds}/xrpc/com.atproto.repo.getRecord?${params.toString()}`,
-      { signal: AbortSignal.timeout(8_000) }
-    )
-    if (!res.ok) return null
-    const data = (await res.json()) as { value?: CertsProfileValue }
-    const value = data.value
-    if (!value) return null
-    return {
-      displayName: value.displayName,
-      description: value.description,
-      pronouns: value.pronouns,
-      website: value.website,
-      avatarUrl: resolveCertsField(value.avatar, did),
-      bannerUrl: resolveCertsField(value.banner, did),
-      createdAt: value.createdAt,
-    }
-  } catch {
-    return null
-  }
-}
-
-/** Fetch a user's Bluesky profile view from the public appView. Works
- *  without authentication, so signed-out visitors to the profile page
- *  still get full author info + avatar + banner.
- *
- *  Named `fetchBskyAppViewProfile` (not `getBlueskyProfile`) to avoid
- *  shadowing the exported `getBlueskyProfile` in `lib/atproto/profile.ts`,
- *  which reads `app.bsky.actor.profile` from the user's OWN PDS — a
- *  different operation with the same name. */
-async function fetchBskyAppViewProfile(did: string): Promise<{
-  displayName?: string
-  description?: string
-  avatar?: string
-  banner?: string
-} | null> {
-  try {
-    const res = await fetch(
-      `${BSKY_APPVIEW}/xrpc/app.bsky.actor.getProfile?actor=${encodeURIComponent(did)}`,
-      { signal: AbortSignal.timeout(8_000) }
-    )
-    if (!res.ok) return null
-    const data = (await res.json()) as {
-      displayName?: string
-      description?: string
-      avatar?: string
-      banner?: string
-    }
-    return data
-  } catch {
-    return null
-  }
-}
-
-/** The bsky identity block fed into the downstream per-field merge —
- *  the same shape whether it originated from the indexer's
- *  `actorProfile` or the appView's `app.bsky.actor.getProfile`. */
-type BskyIdentity = {
-  displayName?: string
-  description?: string
-  avatar?: string
-  banner?: string
-}
-
-/**
- * Resolve the `{ handle, bsky }` identity for a DID — the part of the
- * lookup the indexer fast-path can replace. Two modes:
- *
- *   - Legacy (flag OFF, or the indexer query failed entirely): the
- *     original `resolveHandle(did)` + `fetchBskyAppViewProfile(did)`
- *     fan-out, run in parallel.
- *   - Indexer (flag ON + a non-null `actorProfile`): handle comes from
- *     `actorProfile.handle ?? resolveHandle(did)`; the bsky block is
- *     built from the indexer's denormalised fields when the indexer
- *     HAS a bsky profile for this DID (signalled by a displayName or
- *     avatarCid), otherwise it falls back to `fetchBskyAppViewProfile`
- *     for an un-backfilled / un-observed DID.
- *
- * The certs lookup is intentionally NOT handled here — it always runs
- * in parallel in the GET handler and its precedence (certs → bsky) is
- * unchanged.
- */
-async function resolveIdentity(did: string): Promise<{
-  handle: string | null
-  bsky: BskyIdentity | null
-}> {
-  // Legacy fan-out, also the universal fallback when the flag is off.
-  const legacy = async (): Promise<{
-    handle: string | null
-    bsky: BskyIdentity | null
-  }> => {
-    const [handleResult, bskyResult] = await Promise.allSettled([
-      resolveHandle(did),
-      fetchBskyAppViewProfile(did),
-    ])
-    return {
-      handle: handleResult.status === "fulfilled" ? handleResult.value : null,
-      bsky: bskyResult.status === "fulfilled" ? bskyResult.value : null,
-    }
-  }
-
-  if (!USE_INDEXER) return legacy()
-
-  const actor = await fetchIndexerActorProfile(did)
-  // Indexer query failed / returned nothing → full legacy fallback so
-  // the route never regresses against an un-deployed indexer schema.
-  if (!actor) return legacy()
-
-  // handle: prefer the indexer's denormalised handle, else resolve it.
-  const handle =
-    actor.handle ??
-    (await resolveHandle(did).catch(() => null))
-
-  // The indexer HAS a bsky profile for this DID when it carries a
-  // displayName or an avatarCid — build the bsky block from its
-  // denormalised fields. Otherwise the DID is un-backfilled / not
-  // observed, so fall back to the appView for the bsky block only.
-  const indexerHasBsky = !!(actor.displayName || actor.avatarCid)
-  if (indexerHasBsky) {
-    const indexerAvatar = buildAvatarUrlFromCid(did, actor.avatarCid)
-    const indexerBanner = buildBannerUrlFromCid(did, actor.bannerCid)
-
-    // PER-FIELD fallback: a displayName-set-but-avatarCid-null indexer row
-    // used to render a sticky blank avatar (the read-side amplifier of the
-    // data-loss bug) because `indexerHasBsky` skipped the appView wholesale.
-    // When the indexer is missing a needed image field, lazily hit the
-    // appView ONCE and fill ONLY the gaps — the indexer stays authoritative
-    // for whatever it does carry, and the fast path stays fast (no appView
-    // fetch) whenever the avatar+banner CIDs are present.
-    let appView: BskyIdentity | null = null
-    if (!actor.avatarCid || !actor.bannerCid) {
-      appView = await fetchBskyAppViewProfile(did)
-    }
-
-    return {
-      handle,
-      bsky: {
-        displayName: actor.displayName ?? appView?.displayName ?? undefined,
-        description: actor.description ?? appView?.description ?? undefined,
-        avatar: indexerAvatar ?? appView?.avatar ?? undefined,
-        banner: indexerBanner ?? appView?.banner ?? undefined,
-      },
-    }
-  }
-
-  const bsky = await fetchBskyAppViewProfile(did)
-  return { handle, bsky }
-}
 
 /**
  * GET /api/resolve-did?did=<did>
@@ -349,6 +38,10 @@ async function resolveIdentity(did: string): Promise<{
  * - Certs: direct public XRPC against the target DID's PDS
  * - Bluesky: public appView at public.api.bsky.app
  * so this route works for signed-out visitors too.
+ *
+ * The resolution itself lives in `resolve-core.ts` and is shared with
+ * the batch route; this handler only owns rate-limiting, input parsing,
+ * and the per-DID HTTP cache-control.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -363,136 +56,33 @@ export async function GET(request: NextRequest) {
     ])
     if (rateDenied) return rateDenied
 
-    let did = request.nextUrl.searchParams.get("did") || ""
-    const handleParam = request.nextUrl.searchParams.get("handle") || ""
-
-    // If a handle was provided (and no valid DID), resolve it to a DID
-    // via Bluesky's public appView. Lets the endpoint serve contributor
-    // rows where the identity was typed as a handle, not a DID.
-    if (!isValidDid(did) && handleParam) {
-      const resolved = await resolveHandleToDid(handleParam.trim())
-      if (resolved) {
-        did = resolved
-      }
-    }
-
-    if (!isValidDid(did)) {
+    const did = await resolveInputToDid(
+      request.nextUrl.searchParams.get("did") || "",
+      request.nextUrl.searchParams.get("handle") || ""
+    )
+    if (!did) {
       return NextResponse.json({ error: "Invalid DID" }, { status: 400 })
     }
 
-    // Run the certs lookup and the identity (handle + bsky) resolution
-    // in parallel. `resolveIdentity` is the adaptive layer: with the
-    // indexer flag off it's the original `resolveHandle` +
-    // `fetchBskyAppViewProfile` fan-out; with the flag on it reads
-    // identity from the indexer's `actorProfile(did)` with per-field
-    // fallback. Certs ALWAYS comes from its own PDS lookup and its
-    // precedence over bsky below is unchanged. Each branch is allowed
-    // to fail independently — we combine whatever succeeds.
-    const [identityResult, certsResult] = await Promise.allSettled([
-      resolveIdentity(did),
-      getCertsProfile(did),
-    ])
+    const payload = await buildProfilePayload(did)
 
-    const identity =
-      identityResult.status === "fulfilled"
-        ? identityResult.value
-        : { handle: null, bsky: null }
-    const handle = identity.handle
-    const bsky = identity.bsky
-    const certs =
-      certsResult.status === "fulfilled" ? certsResult.value : null
-
-    // ALL-OR-NOTHING fallback rule (maintainer product decision):
-    // the Bluesky profile is only a wholesale fallback. We use the
-    // Bluesky fields ONLY when the user has no Certified profile, or
-    // a completely empty one. The moment a Certified profile carries
-    // ANY meaningful content, we treat it as authoritative and use
-    // ITS fields exclusively — a blank field in a partly-filled certs
-    // profile is assumed to be INTENTIONALLY blank, so we must NOT
-    // backfill it from Bluesky per-field (e.g. someone who set a
-    // display name but deliberately cleared their avatar should get
-    // no avatar, not their old bsky one).
-    //
-    // `certsHasContent` is the single gate: a certs record exists AND
-    // at least one displayed profile field is non-empty. A stub record
-    // that only carries {$type, createdAt} therefore counts as empty,
-    // so the bsky fallback still applies to it.
-    const certsHasContent = !!(
-      certs &&
-      (certs.displayName ||
-        certs.description ||
-        certs.avatarUrl ||
-        certs.bannerUrl ||
-        certs.pronouns ||
-        certs.website)
-    )
-    const displayName = certsHasContent
-      ? certs?.displayName
-      : bsky?.displayName
-    const description = certsHasContent
-      ? certs?.description
-      : bsky?.description
-    const pronouns = certs?.pronouns
-    const website = certs?.website
-    const avatar = certsHasContent ? certs?.avatarUrl : bsky?.avatar
-    const banner = certsHasContent ? certs?.bannerUrl : bsky?.banner
-    const createdAt = certs?.createdAt
-    // True when the user has a non-empty app.certified.actor.profile
-    // (the same `certsHasContent` gate above). Surfaced to the client
-    // so the profile sidebar / header can render the "Bluesky profile"
-    // tag only when the user has NOT authored a Certified profile
-    // (i.e. the fields we're showing all originate from
-    // app.bsky.actor.profile). Issue #74.
-    const hasCertifiedProfile = certsHasContent
-    // True when an app.bsky.actor.profile is reachable + populated.
-    // Used by the first-signin onboarding gate so the import modal
-    // only opens for users who actually have bsky content worth
-    // importing (skips first-time-on-atproto users).
-    const hasBlueskyProfile = !!(bsky?.displayName || bsky?.avatar)
-    // The raw bsky-derived seed values, surfaced separately from
-    // the merged fields above so the onboarding form can populate
-    // its inputs from bsky even when the merged values already
-    // resolve to certified (e.g. partial onboarding states).
-    const blueskyProfile = bsky
-      ? {
-          displayName: bsky.displayName,
-          description: bsky.description,
-          avatar: bsky.avatar,
-          banner: bsky.banner,
-        }
-      : null
-
-    // Own DID: short 10s cache so repeat navigations (clicking your
-    // own profile from the nav) feel instant without a network hit,
-    // while edits still propagate within seconds. The edit-profile
-    // save handlers also call this endpoint with `cache: "reload"`
-    // right after putRecord to evict the entry explicitly — that
-    // path is what guarantees the freshly-saved values show on the
-    // very next page load. Foreign lookups (feed bylines, handle
-    // search, etc.) keep the longer cache. `sessionDid` was resolved
-    // once at the top for the rate limiter; reuse it here.
+    // Own DID: short 10s cache so repeat navigations (clicking your own
+    // profile from the nav) feel instant without a network hit, while
+    // edits still propagate within seconds. The edit-profile save
+    // handlers also call this endpoint with `cache: "reload"` right
+    // after putRecord to evict the entry explicitly — that path is what
+    // guarantees the freshly-saved values show on the very next page
+    // load. Foreign lookups (feed bylines, handle search, etc.) keep the
+    // longer cache. `sessionDid` was resolved once at the top for the
+    // rate limiter; reuse it here.
     const cacheControl =
       sessionDid && sessionDid === did
         ? "private, max-age=10"
         : "public, max-age=60, stale-while-revalidate=300"
 
-    return NextResponse.json(
-      {
-        did,
-        handle: handle || did,
-        displayName,
-        description,
-        pronouns,
-        website,
-        avatar,
-        banner,
-        createdAt,
-        hasCertifiedProfile,
-        hasBlueskyProfile,
-        blueskyProfile,
-      },
-      { headers: { "Cache-Control": cacheControl } }
-    )
+    return NextResponse.json(payload, {
+      headers: { "Cache-Control": cacheControl },
+    })
   } catch (err: unknown) {
     const { status, message } = extractRouteError(err)
     return NextResponse.json({ error: message }, { status })

--- a/src/app/api/resolve-dids/__tests__/route.test.ts
+++ b/src/app/api/resolve-dids/__tests__/route.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { NextRequest } from "next/server"
+
+/**
+ * Tests for the batched POST /api/resolve-dids route — the sibling of
+ * GET /api/resolve-did that resolves a whole page of author / contributor
+ * identities in one request (so a busy explore page doesn't fire one GET
+ * per row and trip the 60/min limit).
+ *
+ * Approach mirrors the resolve-did rate-limit suite: let the REAL limiter
+ * run with a stubbed Redis backend (incr -> 1 allows), stub the atproto /
+ * session deps, and mock global fetch so an allowed request resolves each
+ * identity through the shared core without touching the network. The
+ * certs lookup is short-circuited (resolvePdsUrl -> null), so each
+ * identity resolves to its handle via the legacy fan-out.
+ */
+
+const incr = vi.fn()
+const expire = vi.fn().mockResolvedValue(1)
+
+vi.mock("@/lib/auth/stores", () => ({
+  getRedis: () => ({ incr, expire }),
+}))
+
+vi.mock("@/lib/auth/session", () => ({
+  getSessionDid: vi.fn(async () => null),
+}))
+
+vi.mock("@/lib/atproto/did", () => ({
+  resolveHandle: vi.fn(async (did: string) => `${did.slice(-4)}.test`),
+  resolveHandleToDid: vi.fn(async (handle: string) =>
+    handle === "known.test" ? "did:plc:cccccccccccccccccccccccc" : null,
+  ),
+  resolvePdsUrl: vi.fn(async () => null),
+}))
+
+const DID_A = "did:plc:aaaaaaaaaaaaaaaaaaaaaaaa"
+const DID_B = "did:plc:bbbbbbbbbbbbbbbbbbbbbbbb"
+const DID_FROM_HANDLE = "did:plc:cccccccccccccccccccccccc"
+
+const mockFetch = vi.fn()
+const originalFetch = globalThis.fetch
+
+beforeEach(() => {
+  incr.mockReset().mockResolvedValue(1)
+  expire.mockReset().mockResolvedValue(1)
+  globalThis.fetch = mockFetch as unknown as typeof fetch
+  // appView getProfile returns a minimal bsky profile; everything else
+  // 404s. Fresh Response per call (bodies are single-use streams).
+  mockFetch.mockReset()
+  mockFetch.mockImplementation((url: string) => {
+    if (typeof url === "string" && url.includes("getProfile")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ displayName: "Someone" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+    }
+    return Promise.resolve(new Response("", { status: 404 }))
+  })
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.unstubAllEnvs()
+})
+
+async function postResolve(body: unknown): Promise<Response> {
+  vi.resetModules()
+  const { POST } = await import("../route")
+  const req = new NextRequest("http://localhost/api/resolve-dids", {
+    method: "POST",
+    headers: { "x-real-ip": "203.0.113.7", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  return POST(req)
+}
+
+describe("POST /api/resolve-dids", () => {
+  it("resolves a batch keyed by the exact input identity", async () => {
+    const res = await postResolve({ identities: [DID_A, DID_B] })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(Object.keys(body.results).sort()).toEqual([DID_A, DID_B].sort())
+    expect(body.results[DID_A].did).toBe(DID_A)
+    expect(body.results[DID_A].handle).toBe(`${DID_A.slice(-4)}.test`)
+  })
+
+  it("resolves a handle identity to its DID", async () => {
+    const res = await postResolve({ identities: ["known.test"] })
+    const body = await res.json()
+    expect(body.results["known.test"]).not.toBeNull()
+    expect(body.results["known.test"].did).toBe(DID_FROM_HANDLE)
+  })
+
+  it("returns null for an unresolvable identity without failing the batch", async () => {
+    const res = await postResolve({ identities: [DID_A, "not a handle"] })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.results[DID_A]).not.toBeNull()
+    expect(body.results["not a handle"]).toBeNull()
+  })
+
+  it("dedupes and ignores non-string entries", async () => {
+    const res = await postResolve({ identities: [DID_A, DID_A, 42, "", "  "] })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(Object.keys(body.results)).toEqual([DID_A])
+  })
+
+  it("rejects a non-array body with 400", async () => {
+    const res = await postResolve({ identities: "nope" })
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects more than the per-request cap with 400", async () => {
+    const many = Array.from(
+      { length: 51 },
+      (_, i) => `did:plc:${i.toString().padStart(24, "0")}`,
+    )
+    const res = await postResolve({ identities: many })
+    expect(res.status).toBe(400)
+  })
+
+  it("returns an empty result set for an empty list (no upstream calls)", async () => {
+    const res = await postResolve({ identities: [] })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.results).toEqual({})
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("returns 429 when the limiter denies, before any upstream work", async () => {
+    incr.mockResolvedValue(61)
+    const res = await postResolve({ identities: [DID_A] })
+    expect(res.status).toBe(429)
+    expect(res.headers.get("Retry-After")).toBeTruthy()
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/resolve-dids/__tests__/route.test.ts
+++ b/src/app/api/resolve-dids/__tests__/route.test.ts
@@ -15,11 +15,14 @@ import { NextRequest } from "next/server"
  * identity resolves to its handle via the legacy fan-out.
  */
 
+// The batch route charges the limiter by identity count, so it uses
+// `incrby` (cost > 1). `incr` is kept for the single-identity cost-1 path.
 const incr = vi.fn()
+const incrby = vi.fn()
 const expire = vi.fn().mockResolvedValue(1)
 
 vi.mock("@/lib/auth/stores", () => ({
-  getRedis: () => ({ incr, expire }),
+  getRedis: () => ({ incr, incrby, expire }),
 }))
 
 vi.mock("@/lib/auth/session", () => ({
@@ -42,7 +45,10 @@ const mockFetch = vi.fn()
 const originalFetch = globalThis.fetch
 
 beforeEach(() => {
+  // Default: fresh bucket — return the amount added so the count stays
+  // well under the 600/min budget and the request is allowed.
   incr.mockReset().mockResolvedValue(1)
+  incrby.mockReset().mockImplementation(async (_key: string, by: number) => by)
   expire.mockReset().mockResolvedValue(1)
   globalThis.fetch = mockFetch as unknown as typeof fetch
   // appView getProfile returns a minimal bsky profile; everything else
@@ -132,10 +138,19 @@ describe("POST /api/resolve-dids", () => {
   })
 
   it("returns 429 when the limiter denies, before any upstream work", async () => {
-    incr.mockResolvedValue(61)
+    // Over the 600-identity/min budget on both the cost-1 (incr) and
+    // weighted (incrby) paths.
+    incr.mockResolvedValue(601)
+    incrby.mockResolvedValue(601)
     const res = await postResolve({ identities: [DID_A] })
     expect(res.status).toBe(429)
     expect(res.headers.get("Retry-After")).toBeTruthy()
     expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("charges the limiter by identity count (incrby = batch size)", async () => {
+    await postResolve({ identities: [DID_A, DID_B] })
+    // Two distinct identities -> cost 2 on each bucket (DID + IP).
+    expect(incrby).toHaveBeenCalledWith(expect.any(String), 2)
   })
 })

--- a/src/app/api/resolve-dids/route.ts
+++ b/src/app/api/resolve-dids/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from "next/server"
+import { extractRouteError } from "@/lib/utils/api"
+import { getSessionDid } from "@/lib/auth/session"
+import { enforceRateLimitMulti, makeLimiter } from "@/lib/auth/rate-limit"
+import { clientIp } from "@/lib/utils/ip"
+import {
+  buildProfilePayload,
+  resolveInputToDid,
+  type ResolvedProfilePayload,
+} from "../resolve-did/resolve-core"
+
+/**
+ * POST /api/resolve-dids
+ * Body: { identities: string[] }  (each a DID or a handle)
+ *
+ * Batched sibling of `GET /api/resolve-did`. Author bylines and
+ * contributor lists need to resolve a whole page of identities at once;
+ * doing that one GET per row blows the GET route's 60/min rate limit and
+ * leaves avatars stuck (see docs/resolve-did-batch/plan.md). This route
+ * resolves up to `MAX_IDENTITIES` identities in a single request — one
+ * rate-limit hit for the whole page — reusing the exact same per-DID
+ * resolution as the GET route, so certs/bsky precedence and the indexer
+ * fast-path are identical.
+ *
+ * Response: { results: { [input: string]: ResolvedProfilePayload | null } }
+ * keyed by the EXACT input string the client sent, so the client can map
+ * each queued identity back to its result. A null value means the
+ * identity didn't resolve (invalid / unknown); the client renders its
+ * own fallback.
+ */
+
+// One batch == one rate-limit hit. The same 60/min budget as the GET
+// route now covers 60 *pages* per minute instead of 60 rows, which is
+// what removes the 429s. DID **and** IP, mirroring the GET route.
+const LIMITER_DID = makeLimiter("resolve-dids-did", 60, 60)
+const LIMITER_IP = makeLimiter("resolve-dids-ip", 60, 60)
+
+/** Hard cap per request. The client chunks larger sets into multiple
+ *  POSTs; this bounds the upstream fan-out a single request can trigger. */
+const MAX_IDENTITIES = 50
+
+/** Server-side fan-out concurrency. Each identity issues up to ~3
+ *  upstream fetches (handle, bsky appView, certs PDS getRecord); cap how
+ *  many run at once so a 50-identity batch stays polite to the upstream
+ *  PDS / appView instead of opening 150 sockets at once. */
+const RESOLVE_CONCURRENCY = 8
+
+/** Resolve `items` through `worker` with at most `limit` in flight,
+ *  preserving input order in the returned array. */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let next = 0
+  async function run(): Promise<void> {
+    while (next < items.length) {
+      const i = next++
+      results[i] = await worker(items[i])
+    }
+  }
+  const runners = Array.from(
+    { length: Math.min(limit, items.length) },
+    () => run()
+  )
+  await Promise.all(runners)
+  return results
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    // Rate-limit first — same posture as the GET route. fail-OPEN on a
+    // limiter backend error (handled inside enforceRateLimitMulti).
+    const sessionDid = await getSessionDid()
+    const rateDenied = await enforceRateLimitMulti([
+      { limit: LIMITER_DID, identifier: sessionDid ?? "anon" },
+      { limit: LIMITER_IP, identifier: clientIp(request) },
+    ])
+    if (rateDenied) return rateDenied
+
+    const body = (await request.json().catch(() => null)) as {
+      identities?: unknown
+    } | null
+    const raw = body?.identities
+    if (!Array.isArray(raw)) {
+      return NextResponse.json(
+        { error: "Expected { identities: string[] }" },
+        { status: 400 }
+      )
+    }
+
+    // Normalise: strings only, trimmed, de-duplicated, blanks dropped.
+    // Dedup keeps the upstream fan-out tight when a page repeats an
+    // author and keeps us under MAX_IDENTITIES on real-world pages.
+    const identities = Array.from(
+      new Set(
+        raw
+          .filter((v): v is string => typeof v === "string")
+          .map((v) => v.trim())
+          .filter(Boolean)
+      )
+    )
+
+    if (identities.length > MAX_IDENTITIES) {
+      return NextResponse.json(
+        { error: `Too many identities (max ${MAX_IDENTITIES})` },
+        { status: 400 }
+      )
+    }
+
+    const results: Record<string, ResolvedProfilePayload | null> = {}
+    if (identities.length === 0) {
+      return NextResponse.json({ results })
+    }
+
+    const resolved = await mapWithConcurrency(
+      identities,
+      RESOLVE_CONCURRENCY,
+      async (identity): Promise<ResolvedProfilePayload | null> => {
+        try {
+          const did = await resolveInputToDid(identity, identity)
+          if (!did) return null
+          return await buildProfilePayload(did)
+        } catch {
+          // One identity failing must not fail the whole batch — the
+          // client renders a fallback for nulls.
+          return null
+        }
+      }
+    )
+    identities.forEach((identity, i) => {
+      results[identity] = resolved[i]
+    })
+
+    // No HTTP cache (POST). The client coalescer owns caching; freshness
+    // for a viewer's own profile is handled by the GET route's
+    // cache-busting edit path, unchanged.
+    return NextResponse.json({ results })
+  } catch (err: unknown) {
+    const { status, message } = extractRouteError(err)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/src/app/api/resolve-dids/route.ts
+++ b/src/app/api/resolve-dids/route.ts
@@ -29,11 +29,18 @@ import {
  * own fallback.
  */
 
-// One batch == one rate-limit hit. The same 60/min budget as the GET
-// route now covers 60 *pages* per minute instead of 60 rows, which is
-// what removes the 429s. DID **and** IP, mirroring the GET route.
-const LIMITER_DID = makeLimiter("resolve-dids-did", 60, 60)
-const LIMITER_IP = makeLimiter("resolve-dids-ip", 60, 60)
+// Budget is counted in IDENTITIES, not requests: each request charges
+// `identities.length` against the window (see the `cost` arg below). A
+// 50-identity page costs 50; a 1-identity lookup costs 1. 600/min is
+// ~12 full explore pages of *distinct* authors per minute (the client
+// coalescer dedups repeats to cost 0), and bounds upstream fan-out to
+// ~600x3 fetches/min/IP — far tighter than a flat 60-*request* budget,
+// which would let one IP drive ~9k upstream fetches/min through the
+// 50x fan-out. DID **and** IP, mirroring the GET route. Replacing the
+// per-row GET calls also lifts anonymous users off the GET route's
+// shared "anon" 60/min bucket, which itself contributed to the 429s.
+const LIMITER_DID = makeLimiter("resolve-dids-did", 600, 60)
+const LIMITER_IP = makeLimiter("resolve-dids-ip", 600, 60)
 
 /** Hard cap per request. The client chunks larger sets into multiple
  *  POSTs; this bounds the upstream fan-out a single request can trigger. */
@@ -70,14 +77,10 @@ async function mapWithConcurrency<T, R>(
 
 export async function POST(request: NextRequest) {
   try {
-    // Rate-limit first — same posture as the GET route. fail-OPEN on a
-    // limiter backend error (handled inside enforceRateLimitMulti).
+    // Parse + normalise BEFORE rate-limiting so the limiter can charge by
+    // identity count. Body parsing is cheap and does no upstream work, so
+    // the "deny before any upstream fetch" property still holds.
     const sessionDid = await getSessionDid()
-    const rateDenied = await enforceRateLimitMulti([
-      { limit: LIMITER_DID, identifier: sessionDid ?? "anon" },
-      { limit: LIMITER_IP, identifier: clientIp(request) },
-    ])
-    if (rateDenied) return rateDenied
 
     const body = (await request.json().catch(() => null)) as {
       identities?: unknown
@@ -113,6 +116,16 @@ export async function POST(request: NextRequest) {
     if (identities.length === 0) {
       return NextResponse.json({ results })
     }
+
+    // Charge the window by identity count (one unit per upstream
+    // resolution this request will trigger). fail-OPEN on a limiter
+    // backend error (handled inside enforceRateLimitMulti).
+    const cost = identities.length
+    const rateDenied = await enforceRateLimitMulti([
+      { limit: LIMITER_DID, identifier: sessionDid ?? "anon", cost },
+      { limit: LIMITER_IP, identifier: clientIp(request), cost },
+    ])
+    if (rateDenied) return rateDenied
 
     const resolved = await mapWithConcurrency(
       identities,

--- a/src/hooks/use-author-info.ts
+++ b/src/hooks/use-author-info.ts
@@ -1,13 +1,12 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { authFetch } from "@/lib/auth/fetch"
-import { createBoundedCache } from "@/lib/utils/bounded-cache"
+import { loadResolvedProfile } from "@/lib/atproto/resolve-did-batch"
 
 /**
  * Compact profile info for rendering an activity card's author byline.
- * Handles are resolved via /api/resolve-did which also returns the
- * Bluesky display name and avatar URL in one round-trip.
+ * Handles are resolved via the batched resolve-did coalescer, which also
+ * returns the Bluesky display name and avatar URL in one round-trip.
  */
 export interface AuthorInfo {
   did: string
@@ -16,41 +15,20 @@ export interface AuthorInfo {
   avatarUrl: string | null
 }
 
-// Module-level cache so the same author rendered in multiple feed cards
-// only fires one network request. Shared across all `useAuthorInfo`
-// callers for the lifetime of the JS module.
-const cache = createBoundedCache<string, Promise<AuthorInfo>>()
-
+/**
+ * Resolve one author DID through the shared coalescer
+ * (`loadResolvedProfile`), which batches all authors needed in a render
+ * pass into a single request and dedupes/caches across every byline.
+ * Never rejects: an unresolvable DID (or a transient 429) degrades to a
+ * DID-only byline rather than a stuck skeleton or a retry storm.
+ */
 function fetchAuthor(did: string): Promise<AuthorInfo> {
-  const existing = cache.get(did)
-  if (existing) return existing
-
-  const p: Promise<AuthorInfo> = authFetch(
-    `/api/resolve-did?did=${encodeURIComponent(did)}`
-  )
-    .then((res) => {
-      if (!res.ok) throw new Error("Failed to resolve DID")
-      return res.json() as Promise<{
-        did: string
-        handle: string
-        displayName?: string
-        avatar?: string
-      }>
-    })
-    .then((data) => ({
-      did,
-      handle: data.handle || did,
-      displayName: data.displayName ?? null,
-      avatarUrl: data.avatar ?? null,
-    }))
-    .catch((err) => {
-      // Invalidate the cache entry on error so a later render can retry
-      cache.delete(did)
-      throw err
-    })
-
-  cache.set(did, p)
-  return p
+  return loadResolvedProfile(did).then((data) => ({
+    did,
+    handle: data?.handle || did,
+    displayName: data?.displayName ?? null,
+    avatarUrl: data?.avatar ?? null,
+  }))
 }
 
 export function useAuthorInfo(did: string | null): {

--- a/src/hooks/use-author-names-map.ts
+++ b/src/hooks/use-author-names-map.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useMemo, useState } from "react"
-import { authFetch } from "@/lib/auth/fetch"
+import { loadResolvedProfile } from "@/lib/atproto/resolve-did-batch"
 
 /**
  * Resolve a batch of DIDs to display-name-or-handle strings via the
@@ -25,24 +25,15 @@ const namePromises = new Map<string, Promise<string>>()
 function fetchName(did: string): Promise<string> {
   const cached = namePromises.get(did)
   if (cached) return cached
-  const p = authFetch(`/api/resolve-did?did=${encodeURIComponent(did)}`)
-    .then((res) => {
-      if (!res.ok) throw new Error("resolve failed")
-      return res.json() as Promise<{
-        handle?: string
-        displayName?: string
-      }>
-    })
-    .then((data) => {
-      const name = (data.displayName || data.handle || did).toLowerCase()
-      nameCache.set(did, name)
-      return name
-    })
-    .catch(() => {
-      // On failure cache the DID itself so we don't retry forever.
-      nameCache.set(did, did.toLowerCase())
-      return did.toLowerCase()
-    })
+  // Resolve through the shared coalescer so the whole tab's DIDs batch
+  // into one request instead of one per row. `loadResolvedProfile` never
+  // rejects — a miss / transient 429 resolves to null, which we fall
+  // back to the DID for (same behaviour as the old catch branch).
+  const p = loadResolvedProfile(did).then((data) => {
+    const name = (data?.displayName || data?.handle || did).toLowerCase()
+    nameCache.set(did, name)
+    return name
+  })
   namePromises.set(did, p)
   return p
 }

--- a/src/hooks/use-contributor-info.ts
+++ b/src/hooks/use-contributor-info.ts
@@ -1,9 +1,8 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { authFetch } from "@/lib/auth/fetch"
 import { isDid } from "@/lib/utils/did"
-import { createBoundedCache } from "@/lib/utils/bounded-cache"
+import { loadResolvedProfile } from "@/lib/atproto/resolve-did-batch"
 import type { AuthorInfo } from "./use-author-info"
 
 /**
@@ -12,11 +11,6 @@ import type { AuthorInfo } from "./use-author-info"
  * string that may be a DID, a handle, or plain text.
  */
 export type ContributorInfo = AuthorInfo
-
-// Module-level cache keyed by the raw contributor identity string.
-// Keeps the same contributor appearing in multiple activities from
-// triggering duplicate network requests.
-const cache = createBoundedCache<string, Promise<ContributorInfo | null>>()
 
 /**
  * Heuristic: does this look like an atproto handle? We can't be
@@ -40,47 +34,23 @@ export function isAtprotoIdentity(value: string | undefined | null): boolean {
 }
 
 /**
- * Resolve a contributor identity to profile info via `/api/resolve-did`,
- * which supports both `did=` and `handle=` query params and handles
- * Certs / Bluesky profile fallback internally.
+ * Resolve a contributor identity (DID or handle) to profile info through
+ * the shared resolve-did coalescer, which batches every contributor on
+ * an activity into one request, handles both DID and handle inputs, and
+ * applies the Certs / Bluesky profile fallback server-side. Returns null
+ * for an unresolvable identity (or a transient 429) — the caller renders
+ * a plain-text fallback. Never rejects.
  */
 function fetchContributor(identity: string): Promise<ContributorInfo | null> {
-  const existing = cache.get(identity)
-  if (existing) return existing
-
-  const query = isDid(identity)
-    ? `did=${encodeURIComponent(identity)}`
-    : `handle=${encodeURIComponent(identity)}`
-
-  const p: Promise<ContributorInfo | null> = authFetch(
-    `/api/resolve-did?${query}`
-  )
-    .then((res) => {
-      if (!res.ok) return null
-      return res.json() as Promise<{
-        did: string
-        handle: string
-        displayName?: string
-        avatar?: string
-      }>
-    })
-    .then((data) => {
-      if (!data) return null
-      return {
-        did: data.did,
-        handle: data.handle || data.did,
-        displayName: data.displayName ?? null,
-        avatarUrl: data.avatar ?? null,
-      }
-    })
-    .catch((err) => {
-      // Invalidate on error so a later render can retry
-      cache.delete(identity)
-      throw err
-    })
-
-  cache.set(identity, p)
-  return p
+  return loadResolvedProfile(identity).then((data) => {
+    if (!data) return null
+    return {
+      did: data.did,
+      handle: data.handle || data.did,
+      displayName: data.displayName ?? null,
+      avatarUrl: data.avatar ?? null,
+    }
+  })
 }
 
 /**

--- a/src/lib/atproto/__tests__/resolve-did-batch.test.ts
+++ b/src/lib/atproto/__tests__/resolve-did-batch.test.ts
@@ -126,6 +126,64 @@ describe("resolve-did batch coalescer", () => {
     expect(bodyOf(1).identities).toHaveLength(10)
   })
 
+  it("defers the next batch until the 429 cooldown lapses", async () => {
+    authFetch.mockResolvedValueOnce(jsonResponse({ error: "x" }, 429))
+    const first = loadResolvedProfile("did:plc:a")
+    await vi.advanceTimersByTimeAsync(20)
+    expect(await first).toBeNull()
+    expect(authFetch).toHaveBeenCalledTimes(1)
+
+    // A fresh identity queued during the cooldown must NOT be sent yet.
+    authFetch.mockResolvedValue(
+      jsonResponse({
+        results: { "did:plc:b": { did: "did:plc:b", handle: "b.test" } },
+      }),
+    )
+    const second = loadResolvedProfile("did:plc:b")
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(authFetch).toHaveBeenCalledTimes(1)
+
+    // Once the 5s cooldown elapses it goes out.
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(await second).toMatchObject({ handle: "b.test" })
+    expect(authFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it("sends loads that arrive mid-flush in their own later batch", async () => {
+    // Hold the first request open so a second load lands while flush #1
+    // is in flight.
+    let releaseFirst!: (r: Response) => void
+    const firstResponse = new Promise<Response>((res) => {
+      releaseFirst = res
+    })
+    authFetch.mockReturnValueOnce(firstResponse)
+
+    const pA = loadResolvedProfile("did:plc:a")
+    await vi.advanceTimersByTimeAsync(20)
+    expect(authFetch).toHaveBeenCalledTimes(1)
+
+    // Arrives while flush #1 awaits its response — must not be lost.
+    const pB = loadResolvedProfile("did:plc:b")
+
+    authFetch.mockResolvedValue(
+      jsonResponse({
+        results: { "did:plc:b": { did: "did:plc:b", handle: "b.test" } },
+      }),
+    )
+    releaseFirst(
+      jsonResponse({
+        results: { "did:plc:a": { did: "did:plc:a", handle: "a.test" } },
+      }),
+    )
+    expect(await pA).toMatchObject({ handle: "a.test" })
+
+    await vi.advanceTimersByTimeAsync(20)
+    expect(await pB).toMatchObject({ handle: "b.test" })
+    expect(authFetch).toHaveBeenCalledTimes(2)
+    // B went out on its own request, not bundled into A's.
+    expect(bodyOf(1).identities).toEqual(["did:plc:b"])
+  })
+
   it("resolves blank identities to null without a request", async () => {
     const p = loadResolvedProfile("   ")
     expect(await p).toBeNull()

--- a/src/lib/atproto/__tests__/resolve-did-batch.test.ts
+++ b/src/lib/atproto/__tests__/resolve-did-batch.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+/**
+ * Tests for the client-side resolve-did coalescer. The point of this
+ * module is to collapse one-request-per-row into one batched POST, and to
+ * degrade gracefully (never throw, self-heal) on a 429 — the behaviours
+ * that fix the explore/contributor 429s. We mock `authFetch` and drive the
+ * batch window / TTLs with fake timers.
+ */
+
+const authFetch = vi.fn()
+vi.mock("@/lib/auth/fetch", () => ({
+  authFetch: (...args: unknown[]) => authFetch(...args),
+}))
+
+import {
+  loadResolvedProfile,
+  __resetResolveDidBatchForTests,
+} from "../resolve-did-batch"
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+function bodyOf(callIndex: number): { identities: string[] } {
+  return JSON.parse(authFetch.mock.calls[callIndex][1].body)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  authFetch.mockReset()
+  __resetResolveDidBatchForTests()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("resolve-did batch coalescer", () => {
+  it("batches loads in the same window into one request", async () => {
+    authFetch.mockResolvedValue(
+      jsonResponse({
+        results: {
+          "did:plc:a": { did: "did:plc:a", handle: "a.test", displayName: "Alice" },
+          "did:plc:b": { did: "did:plc:b", handle: "b.test" },
+        },
+      }),
+    )
+
+    const p1 = loadResolvedProfile("did:plc:a")
+    const p2 = loadResolvedProfile("did:plc:b")
+    await vi.advanceTimersByTimeAsync(20)
+    const [a, b] = await Promise.all([p1, p2])
+
+    expect(authFetch).toHaveBeenCalledTimes(1)
+    expect(authFetch.mock.calls[0][0]).toBe("/api/resolve-dids")
+    expect(bodyOf(0).identities).toEqual(["did:plc:a", "did:plc:b"])
+    expect(a?.displayName).toBe("Alice")
+    expect(b?.handle).toBe("b.test")
+  })
+
+  it("dedupes identical identities to a single queue entry and promise", async () => {
+    authFetch.mockResolvedValue(
+      jsonResponse({
+        results: { "did:plc:a": { did: "did:plc:a", handle: "a.test" } },
+      }),
+    )
+
+    const p1 = loadResolvedProfile("did:plc:a")
+    const p2 = loadResolvedProfile("did:plc:a")
+    expect(p1).toBe(p2)
+
+    await vi.advanceTimersByTimeAsync(20)
+    await p1
+    expect(authFetch).toHaveBeenCalledTimes(1)
+    expect(bodyOf(0).identities).toEqual(["did:plc:a"])
+  })
+
+  it("degrades to null on a 429 instead of throwing", async () => {
+    authFetch.mockResolvedValue(jsonResponse({ error: "rate limited" }, 429))
+    const p = loadResolvedProfile("did:plc:a")
+    await vi.advanceTimersByTimeAsync(20)
+    await expect(p).resolves.toBeNull()
+  })
+
+  it("caches a negative result, then re-queries after the TTL", async () => {
+    // First attempt is rate-limited.
+    authFetch.mockResolvedValueOnce(jsonResponse({ error: "x" }, 429))
+    const first = loadResolvedProfile("did:plc:a")
+    await vi.advanceTimersByTimeAsync(20)
+    expect(await first).toBeNull()
+
+    // Within the TTL the negative entry is reused — no new request.
+    authFetch.mockResolvedValue(
+      jsonResponse({
+        results: { "did:plc:a": { did: "did:plc:a", handle: "a.test" } },
+      }),
+    )
+    const cached = loadResolvedProfile("did:plc:a")
+    expect(await cached).toBeNull()
+    expect(authFetch).toHaveBeenCalledTimes(1)
+
+    // Past the negative TTL the entry is evicted and a fresh load resolves.
+    await vi.advanceTimersByTimeAsync(31_000)
+    const retry = loadResolvedProfile("did:plc:a")
+    await vi.advanceTimersByTimeAsync(20)
+    expect(await retry).toMatchObject({ handle: "a.test" })
+    expect(authFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it("chunks a set larger than the max batch into multiple requests", async () => {
+    authFetch.mockResolvedValue(jsonResponse({ results: {} }))
+    const ids = Array.from(
+      { length: 60 },
+      (_, i) => `did:plc:${i.toString().padStart(24, "0")}`,
+    )
+    const ps = ids.map((id) => loadResolvedProfile(id))
+    await vi.advanceTimersByTimeAsync(20)
+    await Promise.all(ps)
+
+    expect(authFetch).toHaveBeenCalledTimes(2)
+    expect(bodyOf(0).identities).toHaveLength(50)
+    expect(bodyOf(1).identities).toHaveLength(10)
+  })
+
+  it("resolves blank identities to null without a request", async () => {
+    const p = loadResolvedProfile("   ")
+    expect(await p).toBeNull()
+    await vi.advanceTimersByTimeAsync(20)
+    expect(authFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/atproto/resolve-did-batch.ts
+++ b/src/lib/atproto/resolve-did-batch.ts
@@ -1,0 +1,169 @@
+"use client"
+
+import { authFetch } from "@/lib/auth/fetch"
+import { createBoundedCache } from "@/lib/utils/bounded-cache"
+
+/**
+ * Client-side request coalescer for DID/handle -> profile resolution.
+ *
+ * The byline + contributor components each need to resolve one identity
+ * per row. Firing one `GET /api/resolve-did` per row blows that route's
+ * 60/min rate limit on a busy explore page or a contributor-heavy
+ * activity, which is what produced the intermittent 429s and stuck
+ * avatars (see docs/resolve-did-batch/plan.md).
+ *
+ * This is a DataLoader-style batcher: individual `loadResolvedProfile`
+ * calls within the same render pass are collected and flushed as a
+ * single `POST /api/resolve-dids`. A page of K authors costs ceil(K/50)
+ * requests instead of K.
+ *
+ * Resilience: a failed or rate-limited identity resolves to `null`
+ * (callers render a fallback) rather than throwing — so a transient 429
+ * degrades a byline to its DID instead of looping retries against an
+ * already-limited endpoint. Negative results are cached only briefly so
+ * the next view re-attempts them.
+ */
+
+/** The subset of the resolve payload the byline / name hooks consume.
+ *  The wire payload carries more fields; this is intentionally narrow. */
+export interface ResolvedDidResult {
+  did: string
+  handle: string
+  displayName?: string
+  description?: string
+  avatar?: string | null
+  banner?: string | null
+}
+
+/** Collect a single render pass's worth of loads before flushing. */
+const BATCH_WINDOW_MS = 16
+/** Mirror the server's per-request cap; larger sets chunk into N POSTs. */
+const MAX_BATCH = 50
+/** Re-allow a failed identity after this long so views self-heal. */
+const NEGATIVE_TTL_MS = 30_000
+/** Pause flushing for this long after a 429, then resume. */
+const COOLDOWN_MS = 5_000
+
+interface QueueEntry {
+  identity: string
+  resolve: (value: ResolvedDidResult | null) => void
+}
+
+// identity -> settled-or-in-flight promise. A resolved value of `null`
+// means "looked up, not resolvable (yet)". Bounded so a long session
+// browsing many profiles can't grow the map without limit.
+const cache = createBoundedCache<string, Promise<ResolvedDidResult | null>>(
+  1000
+)
+
+let queue: QueueEntry[] = []
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+let cooldownUntil = 0
+
+/**
+ * Resolve a DID or handle to its profile, batched. Returns the same
+ * promise for in-flight / cached identities (dedup), and never rejects —
+ * a failure resolves to `null` so callers degrade gracefully.
+ */
+export function loadResolvedProfile(
+  identity: string
+): Promise<ResolvedDidResult | null> {
+  const key = identity.trim()
+  if (!key) return Promise.resolve(null)
+
+  const existing = cache.get(key)
+  if (existing) return existing
+
+  const promise = new Promise<ResolvedDidResult | null>((resolve) => {
+    queue.push({ identity: key, resolve })
+  })
+  cache.set(key, promise)
+  scheduleFlush()
+  return promise
+}
+
+function scheduleFlush(): void {
+  if (flushTimer) return
+  // Honour any active 429 cooldown by pushing the flush out to its end.
+  const delay = Math.max(BATCH_WINDOW_MS, cooldownUntil - Date.now())
+  flushTimer = setTimeout(() => {
+    flushTimer = null
+    void flush()
+  }, delay)
+}
+
+async function flush(): Promise<void> {
+  if (queue.length === 0) return
+  // Drain everything queued so far; new loads during the awaits below
+  // accumulate in a fresh queue and schedule their own flush.
+  const drained = queue
+  queue = []
+  for (let i = 0; i < drained.length; i += MAX_BATCH) {
+    await sendChunk(drained.slice(i, i + MAX_BATCH))
+  }
+}
+
+async function sendChunk(chunk: QueueEntry[]): Promise<void> {
+  const identities = chunk.map((e) => e.identity)
+  try {
+    const res = await authFetch("/api/resolve-dids", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ identities }),
+    })
+
+    if (res.status === 429) {
+      // Rate-limited: back off so we stop hammering, and degrade this
+      // chunk to fallbacks. The negative TTL lets a later render retry
+      // once the cooldown has lapsed.
+      cooldownUntil = Date.now() + COOLDOWN_MS
+      failChunk(chunk)
+      return
+    }
+    if (!res.ok) {
+      failChunk(chunk)
+      return
+    }
+
+    const data = (await res.json()) as {
+      results?: Record<string, ResolvedDidResult | null>
+    }
+    const results = data.results ?? {}
+    for (const entry of chunk) {
+      const result = results[entry.identity] ?? null
+      entry.resolve(result)
+      // Positive results stay cached for the session; negatives expire so
+      // an identity that wasn't resolvable yet gets another chance.
+      if (result === null) scheduleNegativeEviction(entry.identity)
+    }
+  } catch {
+    failChunk(chunk)
+  }
+}
+
+function failChunk(chunk: QueueEntry[]): void {
+  for (const entry of chunk) {
+    entry.resolve(null)
+    scheduleNegativeEviction(entry.identity)
+  }
+}
+
+function scheduleNegativeEviction(identity: string): void {
+  const cached = cache.get(identity)
+  setTimeout(() => {
+    // Only evict if this exact negative promise is still cached — never
+    // clobber a newer successful re-resolution of the same identity.
+    if (cache.get(identity) === cached) cache.delete(identity)
+  }, NEGATIVE_TTL_MS)
+}
+
+/** Test-only: reset all module state between cases. */
+export function __resetResolveDidBatchForTests(): void {
+  cache.clear()
+  queue = []
+  if (flushTimer) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
+  cooldownUntil = 0
+}

--- a/src/lib/atproto/resolve-did-batch.ts
+++ b/src/lib/atproto/resolve-did-batch.ts
@@ -59,6 +59,9 @@ const cache = createBoundedCache<string, Promise<ResolvedDidResult | null>>(
 let queue: QueueEntry[] = []
 let flushTimer: ReturnType<typeof setTimeout> | null = null
 let cooldownUntil = 0
+// Per-identity TTL timers for negative-cache eviction, tracked so they
+// can be replaced on reschedule and cleared on reset (no timer leak).
+const evictionTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
 /**
  * Resolve a DID or handle to its profile, batched. Returns the same
@@ -94,6 +97,14 @@ function scheduleFlush(): void {
 
 async function flush(): Promise<void> {
   if (queue.length === 0) return
+  // A 429 on a concurrent chunk can set a cooldown after this flush was
+  // already armed (within the normal 16ms window). Respect it: re-arm for
+  // the cooldown's remainder and leave the queue intact so nothing is
+  // lost or sent early.
+  if (Date.now() < cooldownUntil) {
+    scheduleFlush()
+    return
+  }
   // Drain everything queued so far; new loads during the awaits below
   // accumulate in a fresh queue and schedule their own flush.
   const drained = queue
@@ -150,11 +161,16 @@ function failChunk(chunk: QueueEntry[]): void {
 
 function scheduleNegativeEviction(identity: string): void {
   const cached = cache.get(identity)
-  setTimeout(() => {
+  // Replace any pending timer for this identity so retries don't stack.
+  const existing = evictionTimers.get(identity)
+  if (existing) clearTimeout(existing)
+  const timer = setTimeout(() => {
+    evictionTimers.delete(identity)
     // Only evict if this exact negative promise is still cached — never
     // clobber a newer successful re-resolution of the same identity.
     if (cache.get(identity) === cached) cache.delete(identity)
   }, NEGATIVE_TTL_MS)
+  evictionTimers.set(identity, timer)
 }
 
 /** Test-only: reset all module state between cases. */
@@ -165,5 +181,7 @@ export function __resetResolveDidBatchForTests(): void {
     clearTimeout(flushTimer)
     flushTimer = null
   }
+  for (const timer of evictionTimers.values()) clearTimeout(timer)
+  evictionTimers.clear()
   cooldownUntil = 0
 }

--- a/src/lib/auth/rate-limit.ts
+++ b/src/lib/auth/rate-limit.ts
@@ -169,14 +169,24 @@ export function makeLimiter(
 export async function checkHttpRateLimit(
   limit: HttpRateLimit,
   identifier: string,
+  cost = 1,
 ): Promise<HttpRateLimitResult> {
   const redis = getRedis()
   const nowSec = Math.floor(Date.now() / 1000)
   const bucket = Math.floor(nowSec / limit.windowSec)
   const key = `rl:${limit.name}:${identifier}:${bucket}`
 
-  const count = await redis.incr(key)
-  if (count === 1) {
+  // `cost` lets a single request consume more than one unit of budget —
+  // used by batch routes that fan out to several upstream fetches per
+  // request, so the budget bounds total upstream load rather than request
+  // count. cost===1 keeps the exact INCR-by-one path every existing
+  // caller relies on (and the test mocks that only stub `incr`).
+  const count =
+    cost === 1 ? await redis.incr(key) : await redis.incrby(key, cost)
+  // The bucket-creating call is the one whose post-increment count equals
+  // its own cost (the prior value was 0). Generalises the old `count === 1`
+  // so the TTL is still set exactly once per window.
+  if (count === cost) {
     // Set TTL once on first hit; +60s buffer so the bucket outlives
     // the wall-clock window slightly. Don't await — fire and forget
     // since the count is what we care about.
@@ -196,10 +206,10 @@ export async function checkHttpRateLimit(
  * #70 H5: cheap to spin up a new did:plc). Both buckets INCR even
  * on denial so a burst attacker stays on the same trajectory. */
 export async function checkHttpRateLimitMulti(
-  pairs: { limit: HttpRateLimit; identifier: string }[],
+  pairs: { limit: HttpRateLimit; identifier: string; cost?: number }[],
 ): Promise<HttpRateLimitResult> {
   const results = await Promise.all(
-    pairs.map((p) => checkHttpRateLimit(p.limit, p.identifier)),
+    pairs.map((p) => checkHttpRateLimit(p.limit, p.identifier, p.cost ?? 1)),
   )
   // Deny if any pair tripped. resetAt = the earliest reset across
   // the denied buckets (so Retry-After reflects when SOMETHING
@@ -273,7 +283,7 @@ export async function enforceRateLimit(
 }
 
 export async function enforceRateLimitMulti(
-  pairs: { limit: HttpRateLimit; identifier: string }[],
+  pairs: { limit: HttpRateLimit; identifier: string; cost?: number }[],
   message?: string,
 ): Promise<NextResponse | null> {
   try {


### PR DESCRIPTION
## Symptom
On `/explore` and the activity (cert) detail page, author bylines and the contributor list sometimes fail to load; the console shows `Failed to load resource: the server responded with a status of 429`.

## Root cause
`/api/resolve-did` is rate-limited to **60 requests/min per IP** (and per session DID). The byline + contributor components each resolve **one DID per row** on mount, with no HTTP-level batching, so a page with many distinct authors plus a contributor-heavy activity blows the window. Two amplifiers:

1. **No denormalized fallback.** Unlike account rows (which prefer the indexer's inline `displayName` and only fall back to a lookup), the raw `ActivityRecord` carries only the author DID, so the byline always resolves over the network. The home feed already avoids this by denormalizing inline.
2. **No recovery.** On error the hooks did `cache.delete(did)` and rethrew, so a 429'd avatar settled to a stuck skeleton and never recovered on that view.
3. **Shared `"anon"` bucket.** Signed-out users all share one `"anon"` DID bucket at 60/min — a global cap that compounds the bursts.

## Fix
Collapse N requests into one, mirroring the home feed's inline denormalization.

- **`POST /api/resolve-dids`** — resolves up to 50 identities (DID or handle) in one request with bounded server concurrency (8). The per-DID resolution was extracted verbatim into `resolve-core.ts` and is shared with the GET route, so certs/bsky precedence and the indexer fast-path are unchanged (GET stays byte-for-byte; its 16 tests pass untouched).
- **Client coalescer** (`resolve-did-batch.ts`) — DataLoader-style. Loads in a render pass batch into one POST; dedup + bounded cache. On a 429 it degrades to a DID fallback and negative-caches with a TTL (no throw, no retry storm, self-heals on a later view). Honors a 429 cooldown across flushes.
- **Rewire** `useAuthorInfo` / `useContributorInfo` / `useAuthorNamesMap` onto the coalescer. Public APIs unchanged.
- **Identity-weighted rate limit** on the batch route: charges `identities.length` against a 600-identity/min budget (per IP + DID), so the budget bounds *upstream fan-out* rather than request count. Backward-compatible `cost` param on the shared limiter (cost-1 path unchanged for every existing route). This also gives anonymous users 10x more headroom than the GET path they replace.

A page needing K authors now issues `ceil(K/50)` requests, not K.

## Preserved
- Brand / lexicon: `app.certified.*`, `org.hypercerts.*`, "Certified" strings moved verbatim (net zero change, verified against the diff).
- GET `/api/resolve-did` behavior, including own-DID cache-control and the edit-time cache bust.

## Review
Two-reviewer implementation pass; decisions logged in `docs/resolve-did-batch/review-round-1.md` (accepted: weighted limit, cooldown-across-flushes, timer-leak fix; declined with rationale: names-map self-heal, dead error plumbing, concurrent chunking).

## Verification
- [x] `tsc --noEmit` clean
- [x] `eslint` no new errors/warnings on changed files
- [x] `vitest` 536/536 (519 existing + 17 new); existing resolve-did + all rate-limit route suites green
- [x] `next build` compiles; `/api/resolve-dids` registered
- [ ] Manual: load `/explore` and a contributor-heavy activity, confirm bylines/contributors populate without 429s, and that a forced 429 degrades to DID fallbacks rather than stuck skeletons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
