### PR TITLE
Component library: cost-no-object completion (Combobox/SegmentedControl, Popover portal, Input variants, verification harness)

### DIFF
--- a/docs/component-library/decisions.html
+++ b/docs/component-library/decisions.html
@@ -1,0 +1,703 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Certified — Component Library PR #129 Decision Brief</title>
+<style>
+  /* ======================================================================
+     PALETTE — near-monochrome, faithful to src/app/styles/tokens.css.
+     Light by default; data-theme="dark" on <html> flips it.
+     ====================================================================== */
+  :root {
+    color-scheme: light;
+    --bg-canvas: #f9f9f9;
+    --bg-sunken: #eeeeee;
+    --bg-raised: #f3f3f3;
+    --bg-elevated: #ffffff;
+    --fg-primary: #111111;
+    --fg-secondary: #4c4546;
+    --fg-muted: #6b6263;
+    --border-subtle: rgba(0, 0, 0, 0.06);
+    --border-default: rgba(0, 0, 0, 0.09);
+    --border-medium: rgba(0, 0, 0, 0.12);
+    --border-hover: rgba(0, 0, 0, 0.18);
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+    --accent: #111111;
+    --accent-soft: rgba(17, 17, 17, 0.05);
+    --rec-border: #111111;
+    --rec-bg: rgba(17, 17, 17, 0.035);
+    --rec-badge-bg: #111111;
+    --rec-badge-fg: #ffffff;
+    --pro: #1f7a4d;
+    --pro-bg: rgba(46, 204, 113, 0.08);
+    --con: #9a3b3b;
+    --con-bg: rgba(186, 26, 26, 0.06);
+    --code-bg: rgba(0, 0, 0, 0.05);
+    --selection-bg: #111111;
+    --selection-fg: #ffffff;
+  }
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --bg-canvas: #18181b;
+    --bg-sunken: #111114;
+    --bg-raised: #26262b;
+    --bg-elevated: #2d2d33;
+    --fg-primary: #f5f5f7;
+    --fg-secondary: #c7c7cc;
+    --fg-muted: #8e8e93;
+    --border-subtle: rgba(255, 255, 255, 0.06);
+    --border-default: rgba(255, 255, 255, 0.10);
+    --border-medium: rgba(255, 255, 255, 0.14);
+    --border-hover: rgba(255, 255, 255, 0.22);
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
+    --accent: #f5f5f7;
+    --accent-soft: rgba(255, 255, 255, 0.06);
+    --rec-border: #f5f5f7;
+    --rec-bg: rgba(255, 255, 255, 0.05);
+    --rec-badge-bg: #f5f5f7;
+    --rec-badge-fg: #0b0b0d;
+    --pro: #6ee7a7;
+    --pro-bg: rgba(110, 231, 167, 0.10);
+    --con: #f87171;
+    --con-bg: rgba(248, 113, 113, 0.10);
+    --code-bg: rgba(255, 255, 255, 0.07);
+    --selection-bg: #f5f5f7;
+    --selection-fg: #0b0b0d;
+  }
+
+  * { box-sizing: border-box; }
+  ::selection { background: var(--selection-bg); color: var(--selection-fg); }
+
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--bg-canvas);
+    color: var(--fg-primary);
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    transition: background 0.2s ease, color 0.2s ease;
+  }
+
+  .wrap {
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 56px 28px 120px;
+  }
+
+  /* ---- Headings: serif ---- */
+  h1, h2, h3, h4 {
+    font-family: Georgia, "Times New Roman", "Iowan Old Style", serif;
+    font-weight: 600;
+    color: var(--fg-primary);
+    letter-spacing: -0.01em;
+    line-height: 1.25;
+  }
+  h1 { font-size: 2.05rem; margin: 0 0 0.35em; }
+  h2 { font-size: 1.4rem; margin: 0; }
+  h3 { font-size: 1.12rem; margin: 0; }
+  p { margin: 0 0 1em; color: var(--fg-secondary); }
+  a { color: var(--fg-primary); }
+
+  code, .mono {
+    font-family: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, Consolas, monospace;
+    font-size: 0.85em;
+    background: var(--code-bg);
+    padding: 0.08em 0.36em;
+    border-radius: 2px;
+  }
+
+  /* ---- Top bar ---- */
+  .topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 40px;
+    padding-bottom: 18px;
+    border-bottom: 1px solid var(--border-default);
+  }
+  .eyebrow {
+    font-family: "Inter", sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.13em;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--fg-muted);
+    margin: 0 0 10px;
+  }
+  .theme-toggle {
+    flex: none;
+    appearance: none;
+    border: 1px solid var(--border-medium);
+    background: var(--bg-elevated);
+    color: var(--fg-secondary);
+    font-family: "Inter", sans-serif;
+    font-size: 0.78rem;
+    font-weight: 500;
+    padding: 7px 13px;
+    border-radius: 2px;
+    cursor: pointer;
+    transition: border-color 0.15s ease, color 0.15s ease;
+    white-space: nowrap;
+  }
+  .theme-toggle:hover { border-color: var(--border-hover); color: var(--fg-primary); }
+
+  .intro { max-width: 760px; }
+  .intro p { color: var(--fg-secondary); }
+  .gate-line {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 4px 0 8px;
+  }
+  .pill {
+    font-family: "Inter", sans-serif;
+    font-size: 0.74rem;
+    font-weight: 500;
+    padding: 3px 9px;
+    border-radius: 999px;
+    border: 1px solid var(--border-default);
+    background: var(--bg-raised);
+    color: var(--fg-secondary);
+    white-space: nowrap;
+  }
+  .pill--ok { color: var(--pro); border-color: color-mix(in srgb, var(--pro) 40%, transparent); background: var(--pro-bg); }
+
+  /* ---- Summary table ---- */
+  .summary {
+    margin: 36px 0 56px;
+  }
+  .summary h2 { margin-bottom: 14px; }
+  table.sumtable {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+    border: 1px solid var(--border-default);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  table.sumtable th, table.sumtable td {
+    text-align: left;
+    padding: 11px 14px;
+    border-bottom: 1px solid var(--border-subtle);
+    vertical-align: top;
+  }
+  table.sumtable thead th {
+    font-family: "Inter", sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: var(--fg-muted);
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--border-default);
+  }
+  table.sumtable tbody tr:last-child td { border-bottom: none; }
+  table.sumtable tbody tr:hover { background: var(--accent-soft); }
+  table.sumtable td.idcell { white-space: nowrap; color: var(--fg-muted); font-family: "Inter", sans-serif; font-size: 0.82rem; }
+  table.sumtable td.deccell { color: var(--fg-primary); }
+  table.sumtable a { text-decoration: none; border-bottom: 1px solid var(--border-medium); }
+  table.sumtable a:hover { border-bottom-color: var(--fg-primary); }
+  .rec-tag {
+    display: inline-block;
+    font-family: "Inter", sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--fg-primary);
+  }
+  .effort-chip {
+    display: inline-block;
+    font-family: "Inter", sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    padding: 1px 7px;
+    border-radius: 999px;
+    border: 1px solid var(--border-medium);
+    color: var(--fg-muted);
+    background: var(--bg-raised);
+    margin-left: 6px;
+  }
+
+  /* ---- Decision cards ---- */
+  .card {
+    border: 1px solid var(--border-default);
+    border-radius: 2px;
+    background: var(--bg-elevated);
+    padding: 30px 30px 26px;
+    margin: 0 0 30px;
+    box-shadow: var(--shadow-sm);
+    scroll-margin-top: 20px;
+  }
+  .card-head {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 6px;
+  }
+  .card-id {
+    font-family: "Inter", sans-serif;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--fg-muted);
+    padding-top: 4px;
+    flex: none;
+  }
+  .card h2 { line-height: 1.3; }
+  .question {
+    font-family: "Inter", sans-serif;
+    font-size: 0.98rem;
+    font-style: italic;
+    color: var(--fg-secondary);
+    margin: 12px 0 18px;
+    padding-left: 14px;
+    border-left: 2px solid var(--border-medium);
+  }
+  .bg {
+    font-size: 0.9rem;
+    color: var(--fg-secondary);
+    margin-bottom: 22px;
+  }
+  .bg p { font-size: 0.9rem; margin-bottom: 0.7em; }
+
+  .section-label {
+    font-family: "Inter", sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: var(--fg-muted);
+    margin: 24px 0 12px;
+  }
+
+  /* ---- Options grid ---- */
+  .options {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+  }
+  .opt {
+    border: 1px solid var(--border-default);
+    border-radius: 2px;
+    background: var(--bg-canvas);
+    padding: 18px 18px 16px;
+    display: flex;
+    flex-direction: column;
+  }
+  .opt--rec {
+    border: 2px solid var(--rec-border);
+    background: var(--rec-bg);
+  }
+  .opt-toprow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 4px;
+  }
+  .opt h4 {
+    font-family: "Inter", sans-serif;
+    font-size: 0.96rem;
+    font-weight: 600;
+    margin: 0;
+  }
+  .rec-badge {
+    flex: none;
+    font-family: "Inter", sans-serif;
+    font-size: 0.64rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: var(--rec-badge-bg);
+    color: var(--rec-badge-fg);
+    padding: 3px 8px;
+    border-radius: 999px;
+  }
+  .opt-entails {
+    font-size: 0.86rem;
+    color: var(--fg-secondary);
+    margin: 6px 0 12px;
+  }
+  .opt ul {
+    list-style: none;
+    margin: 0 0 10px;
+    padding: 0;
+  }
+  .opt li {
+    font-size: 0.84rem;
+    line-height: 1.5;
+    padding: 3px 0 3px 18px;
+    position: relative;
+    color: var(--fg-secondary);
+  }
+  .pros-label, .cons-label {
+    font-family: "Inter", sans-serif;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 8px 0 3px;
+  }
+  .pros-label { color: var(--pro); }
+  .cons-label { color: var(--con); }
+  .opt li.pro::before { content: "+"; position: absolute; left: 2px; color: var(--pro); font-weight: 700; }
+  .opt li.con::before { content: "\2212"; position: absolute; left: 2px; color: var(--con); font-weight: 700; }
+
+  .opt-meta {
+    margin-top: auto;
+    padding-top: 12px;
+    border-top: 1px solid var(--border-subtle);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .opt-meta div {
+    font-size: 0.8rem;
+    color: var(--fg-secondary);
+  }
+  .opt-meta .mk {
+    font-family: "Inter", sans-serif;
+    font-size: 0.66rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-muted);
+    margin-right: 6px;
+  }
+
+  /* ---- Rationale ---- */
+  .rationale {
+    margin-top: 24px;
+    padding: 16px 18px;
+    background: var(--bg-raised);
+    border: 1px solid var(--border-subtle);
+    border-radius: 2px;
+  }
+  .rationale .section-label { margin-top: 0; }
+  .rationale p { font-size: 0.9rem; margin-bottom: 0; color: var(--fg-secondary); }
+  .rationale .rec-name {
+    font-weight: 600;
+    color: var(--fg-primary);
+    font-style: normal;
+  }
+
+  /* ---- Evidence ---- */
+  details.evidence {
+    margin-top: 16px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 2px;
+    background: var(--bg-canvas);
+  }
+  details.evidence > summary {
+    cursor: pointer;
+    list-style: none;
+    padding: 11px 16px;
+    font-family: "Inter", sans-serif;
+    font-size: 0.74rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-muted);
+    user-select: none;
+  }
+  details.evidence > summary::-webkit-details-marker { display: none; }
+  details.evidence > summary::before {
+    content: "\25B8";
+    display: inline-block;
+    margin-right: 8px;
+    transition: transform 0.15s ease;
+  }
+  details.evidence[open] > summary::before { transform: rotate(90deg); }
+  details.evidence > summary:hover { color: var(--fg-primary); }
+  details.evidence ul {
+    margin: 0;
+    padding: 0 18px 14px 36px;
+    list-style: disc;
+  }
+  details.evidence li {
+    font-size: 0.82rem;
+    line-height: 1.55;
+    color: var(--fg-secondary);
+    margin-bottom: 7px;
+  }
+  details.evidence code { word-break: break-word; }
+
+  .backtop {
+    display: inline-block;
+    margin-top: 14px;
+    font-family: "Inter", sans-serif;
+    font-size: 0.74rem;
+    color: var(--fg-muted);
+    text-decoration: none;
+  }
+  .backtop:hover { color: var(--fg-primary); }
+
+  footer.foot {
+    margin-top: 50px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border-default);
+    font-size: 0.82rem;
+    color: var(--fg-muted);
+  }
+
+  @media (max-width: 640px) {
+    .wrap { padding: 36px 18px 80px; }
+    .card { padding: 22px 18px 20px; }
+    h1 { font-size: 1.7rem; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="topbar">
+    <div>
+      <p class="eyebrow">Certified · Component Library</p>
+      <h1>PR&nbsp;#129 — Open Decision Brief</h1>
+    </div>
+    <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark theme">Dark mode</button>
+  </div>
+
+  <div class="intro">
+    <p>
+      PR&nbsp;#129 consolidates the app onto a single canonical <code>src/components/ui/*</code> family,
+      migrating consumers across three rounds and removing more lines than it adds. The gate is
+      <strong>green</strong> and the PR is Draft, mergeable, and clean.
+    </p>
+    <div class="gate-line">
+      <span class="pill pill--ok">tsc&nbsp;0&nbsp;errors</span>
+      <span class="pill pill--ok">eslint&nbsp;0&nbsp;err&nbsp;/&nbsp;66&nbsp;warn</span>
+      <span class="pill pill--ok">536&nbsp;tests</span>
+      <span class="pill pill--ok">next&nbsp;build&nbsp;OK</span>
+      <span class="pill">CI&nbsp;all-pass</span>
+      <span class="pill">MERGEABLE&nbsp;/&nbsp;CLEAN</span>
+    </div>
+    <p>
+      What remains are seven judgment calls about how far to push the consolidation and how to land
+      the PR. Each was researched against the codebase; for each there is a recommended option, a
+      rationale, and the supporting evidence. Nothing here is auto-decided — these are choices for you.
+    </p>
+  </div>
+
+  <!-- ============================= SUMMARY ============================= -->
+  <section class="summary" id="summary">
+    <h2>Summary — recommendations at a glance</h2>
+    <table class="sumtable">
+      <thead>
+        <tr>
+          <th style="width:62px;">ID</th>
+          <th>Decision</th>
+          <th style="width:230px;">Recommended</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="idcell">d1</td>
+          <td class="deccell"><a href="#d1-combobox">Build a real Combobox primitive &amp; migrate the 5 search/typeahead fields?</a></td>
+          <td><span class="rec-tag">Keep as-is</span><span class="effort-chip">vs L</span></td>
+        </tr>
+        <tr>
+          <td class="idcell">d2</td>
+          <td class="deccell"><a href="#d2-toggle">SegmentedControl / ToggleGroup primitive vs. bespoke toggle controls?</a></td>
+          <td><span class="rec-tag">Keep bespoke</span><span class="effort-chip">vs L</span></td>
+        </tr>
+        <tr>
+          <td class="idcell">d3</td>
+          <td class="deccell"><a href="#d3-topbar-tabs">Desktop top-bar tab strips: bespoke chrome vs. Tabs href primitive?</a></td>
+          <td><span class="rec-tag">Keep bespoke (status quo)</span><span class="effort-chip">vs M</span></td>
+        </tr>
+        <tr>
+          <td class="idcell">d4</td>
+          <td class="deccell"><a href="#d4-corenav">Core-nav switcher menus: enhance Popover (portal+collision) vs. §9 sanction?</a></td>
+          <td><span class="rec-tag">Leave (respect §9)</span><span class="effort-chip">vs M-L</span></td>
+        </tr>
+        <tr>
+          <td class="idcell">d5</td>
+          <td class="deccell"><a href="#d5-verify">Closing the auth-gated visual-verification gap?</a></td>
+          <td><span class="rec-tag">(c) Accept gate-only + human glance</span></td>
+        </tr>
+        <tr>
+          <td class="idcell">d6</td>
+          <td class="deccell"><a href="#d6-gallery">Keep or remove the dev-only <code>/dev/gallery</code> route before merge?</a></td>
+          <td><span class="rec-tag">Keep (gated)</span></td>
+        </tr>
+        <tr>
+          <td class="idcell">d7</td>
+          <td class="deccell"><a href="#d7-merge">Next step for PR&nbsp;#129?</a></td>
+          <td><span class="rec-tag">(a) Logged-in pass, then user merges</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- ============================= DECISIONS ============================= -->
+  <!-- Cards injected by the renderer below -->
+  <div id="cards"></div>
+
+  <footer class="foot">
+    Generated for the component-library consolidation (PR&nbsp;#129). All seven decisions are
+    judgment calls for the user; recommendations are advisory. The model never merges — the PR is
+    held Draft + gate-green until you pull the trigger.
+  </footer>
+
+</div>
+
+<script id="data" type="application/json">
+[{"id":"d1-combobox","title":"Build a real Combobox primitive and migrate the remaining search/typeahead fields?","question":"Should we build a shared Combobox primitive (on top of Input) and migrate the five search/typeahead fields onto it, or keep them as-is now that Input chrome is partially adopted?","background":"There are five typeahead/search inputs in the app, all implementing the same combobox state machine independently (1,995 LOC total): src/components/search/global-search.tsx (557), cert-search.tsx (469), people-search.tsx (382), groups/handle-search.tsx (283), create/contributor-identity-field.tsx (304). Each re-implements: 250ms debounce, a requestSeq ref to drop stale responses, outside-click-to-close, ArrowUp/Down/Home/End/Enter/Escape keyboard nav with wrap-around, a highlight index + scrollIntoView('nearest'), and the full WAI-ARIA combobox a11y wiring (role=combobox + aria-autocomplete=list + aria-expanded + aria-controls + aria-activedescendant on the input; role=listbox + role=option + aria-selected on the rows; an sr-only aria-live status region in 3 of them). The component-library consolidation already shipped the *input chrome* enablers (Input.trailingButton interactive slot, leadingIcon, combobox ARIA passthrough), but stopped at the input — the dropdown/list/keyboard state machine was never extracted. This is the remaining open question on PR #129.\n\nCurrent Input adoption is split: cert-search, people-search, and handle-search already render the field via <Input> (size + leadingIcon=SearchIcon + trailingButton=clear/X, or trailingIcon=spinner for handle-search). global-search and contributor-identity-field still render a fully bespoke raw <input>: global-search uses the .people-search__field/.people-search__input/.people-search__clear BEM chrome by hand (it predates the trailingButton slot and fans out to two sources, so it was left bespoke), and contributor-identity-field renders a .cert-detail__meta-input that must sit flush in a Role+Weight table row (no Input wrapper div, no label block) and carries commit-on-blur/Enter semantics specific to the contributor form.\n\nThe list/dropdown chrome is NOT shared today — each block owns its own BEM CSS (.people-search__dropdown/__item, .cert-search__dropdown/__item/__thumb/__group-header, .handle-search__dropdown/__item, .create-cert__contrib-id-dropdown/-option) in layout.css/pages.css. global-search reuses people-search's classes; the others are distinct. Row rendering genuinely diverges: people rows (Avatar + name + handle), cert rows (lazy thumbnail + title + per-row useAuthorInfo lookup + Your/Other group headers), handle rows (DID-resolution branch + a searchError state), contributor rows (name + handle, exclude-set filtering, inline meta styling). There are no dedicated unit tests for any of the five (only resolve-handle.test.ts is adjacent), so a refactor lands without a regression net for these specific components.","evidence":["All five implement the same combobox state machine: shared-logic grep (moveHighlight|onEscape|handleKeyDown|SEARCH_DEBOUNCE_MS|requestSeq) returns 14-15 matches each in global-search/cert-search/people-search; handle-search and contributor-identity-field have their own slimmer copies (no requestSeq, no Home/End, no live region)","Input adoption is split 3/2: cert-search.tsx, people-search.tsx, groups/handle-search.tsx import @/components/ui/input and render <Input ... leadingIcon/trailingButton>; global-search.tsx and create/contributor-identity-field.tsx import 0 and render a raw <input> (global uses .people-search__field chrome by hand; contributor uses .cert-detail__meta-input)","src/components/ui/input.tsx already ships the combobox enablers: trailingButton (interactive, pointer-events kept, not aria-hidden, lines 21-31/130-181), leadingIcon, and a full ...props passthrough so role=combobox/aria-activedescendant/aria-controls flow straight to the <input>","Shared ARIA contract across all five: input carries role=combobox + aria-autocomplete=list + aria-expanded + aria-controls + aria-activedescendant; rows carry role=option + aria-selected; listbox carries role=listbox; 3 of 5 (global/cert/people) add an sr-only aria-live=polite status region","Row payloads diverge hard: people-search=Actor(Avatar); cert-search/global-search=ActivityRecord with lazy <img> thumbnail + per-row useAuthorInfo(did) hook + 'Your/Other activities' group headers; handle-search has a looksLikeCompleteDid() resolution branch + searchError state; contributor-identity-field filters an excludeIdentities Set and commits on blur/Enter","List/dropdown chrome is per-block BEM, not shared: layout.css has distinct .people-search__dropdown (also reused by global-search), .cert-search__dropdown/__thumb/__group-header, .handle-search__dropdown; pages-side .create-cert__contrib-id-dropdown — ~56 CSS rule references across the four blocks","Usage sites (blast radius if migrated): GlobalSearch->desktop-top-bar; PeopleSearch->/search + endorse-people-modal; CertSearch->/project/new + project-detail; HandleSearch->org-settings + new-endorsement-panel; ContributorIdentityField->/create + activity edit. 9 call sites across 9 files","No dedicated tests for any of the five components (only src/lib/atproto/__tests__/resolve-handle.test.ts is adjacent); a state-machine extraction would land without a per-component regression net","No Combobox primitive exists and none was planned: grep for 'combobox' in AGENTS.md/DESIGN.md/docs returns only Input.trailingButton documentation; the consolidation deliberately enabled the input chrome but left the dropdown state machine un-extracted"],"options":[{"label":"Keep as-is","entails":"Ship PR #129 with the current split: three fields on <Input> chrome, two (global-search, contributor-identity-field) bespoke. Document the duplicated combobox state machine as a known follow-up but extract nothing now.","pros":["Zero risk to a green gate (tsc 0, eslint 0/66, 536 tests, build OK) on an already-large PR","The input *chrome* is already consolidated for 3/5 — the most visible divergence (field look, clear button, focus ring) is handled by the trailingButton enabler that shipped","Row rendering genuinely differs per surface (Avatar vs thumbnail+useAuthorInfo vs DID-resolution vs exclude-set), so the duplicated code is mostly the state machine, not the visible UI","No new abstraction to design, review, or get wrong; nothing to re-test without a regression net"],"cons":["~1,995 LOC keeps five near-identical copies of debounce + requestSeq + keyboard nav + outside-click + ARIA wiring; the next typeahead is copy #6","Subtle drift already exists (handle-search/contributor lack requestSeq stale-drop, Home/End, and the live region) — bugs fixed in one won't propagate","global-search and contributor-identity-field stay off the primitive, so 'reach for a primitive first' (CLAUDE.md rule 10 / AGENTS §12) has two standing exceptions in the search area"],"effort":"S — no code changes; one paragraph in docs/AGENTS noting the deferred extraction"},{"label":"Build Combobox + migrate","entails":"Add src/components/ui/combobox.tsx (or a useCombobox hook) on top of Input that owns the state machine — debounce hook is optional, but requestSeq stale-drop, isOpen, highlight+scrollIntoView, the full keyboard handler, outside-click, and all ARIA wiring (input attrs + listbox/option ids + aria-live) — with a render-prop/children API for rows so each surface keeps its own row markup and data fetch. Migrate all five (cert/people/handle first as they already use Input; then global-search's two-source fan-out and contributor's commit-on-blur inline variant).","pros":["Collapses five state-machine copies into one tested primitive; fixes propagate (e.g. add requestSeq/Home/End/live-region to handle-search + contributor for free)","Brings the last two holdouts (global-search, contributor-identity-field) onto the primitive, closing the two standing exceptions to CLAUDE.md rule 10","A documented Combobox slots cleanly next to Input/Select/Popover in the ui/ catalog; future typeaheads start from it instead of copy-pasting people-search","Net LOC likely drops materially (the ~5 keyboard handlers + debounce + outside-click + ARIA blocks converge)"],"cons":["The hard part is the row/data variance, not the state machine: cert/global need per-row useAuthorInfo + lazy thumbnails + group headers + dividers; global fans out to TWO sources with a merged flat index + Cmd/K; handle has a DID-resolution pre-branch + error row; contributor commits on blur/Enter, filters an exclude Set, and must render flush as .cert-detail__meta-input with no wrapper/label. A primitive flexible enough for all five risks becoming a config-soup abstraction","No dedicated tests exist for the five today, so migration lands without a regression net unless tests are written first — adds scope","Touches 9 call sites across 9 files plus 4 BEM CSS blocks; meaningfully enlarges an already-large PR #129 and its review surface","global-search and contributor's bespoke wrappers (.people-search__field, .cert-detail__meta-input flush row) mean a literal lift can visually regress — exactly the DESIGN §14.6 'primitive would regress bespoke chrome' trap"],"effort":"L — new ui/combobox.tsx (+ likely a useCombobox hook), migrate 5 components (1,995 LOC) + 9 call sites, reconcile 4 CSS blocks, and write the missing tests for a safe landing"}],"recommendation":"Keep as-is","rationale":"The duplication is real but it's almost entirely the invisible state machine — the *visible* part (field chrome) is already consolidated for 3/5 via the Input.trailingButton enabler that shipped, and the row rendering legitimately differs per surface (Avatar vs lazy-thumbnail+per-row useAuthorInfo vs DID-resolution vs exclude-set+commit-on-blur). A Combobox flexible enough to absorb global-search's two-source fan-out with a merged flat index plus Cmd/K, handle-search's DID-resolution pre-branch, and contributor's flush inline .cert-detail__meta-input variant tends toward a config-soup abstraction whose cost exceeds the duplication it removes. Critically, there are no tests for any of the five, so an L-sized migration across 9 call sites and 4 CSS blocks would land on PR #129 (already large, gate green) with no regression net — and the two holdouts' bespoke wrappers are precisely the DESIGN §14.6 'primitive would visually regress bespoke chrome' case the team already chose to respect elsewhere. Recommend shipping #129 as-is and recording Combobox as a standalone, test-first follow-up: if it's done, it should be its own PR where a useCombobox hook (shared state machine, per-surface row render-prop) can be designed and tested deliberately rather than bolted onto this one. If the user wants to reduce drift now at lower risk, the cheapest partial win is migrating only global-search and contributor-identity-field onto <Input> chrome (M, no new primitive) to close the two rule-10 exceptions — but that's a separate, smaller decision than building the primitive."},{"id":"d2-toggle","title":"SegmentedControl / ToggleGroup primitive vs. keeping bespoke toggle controls","question":"Should we build a SegmentedControl / ToggleGroup primitive (incl. a color-coded variant) and migrate the remaining toggle controls (response-buttons, response-menu quick-actions, explore view-toggle, explore degree-pills), or keep them bespoke?","background":"Three rounds of migration are done; gate is green (tsc 0, eslint 0 errors / 66 warnings, 536 tests, next build OK). Four toggle-shaped controls remain un-migrated, and they do NOT share one selection model: (1) explore view-toggle (explore.tsx:650-673) is single-select list/gallery, exactly one active; (2) explore degree-pills (explore.tsx:872-942) is MULTI-select — any subset of {1,2,3}, empty set allowed, each pill an independent aria-pressed toggle; (3) response-buttons Show/Hide / Accept/Reject (response-buttons.tsx:99-139) is THREE-state (accepted / rejected / neutral default) where both buttons can be unpressed; (4) response-menu quick-actions (response-menu.tsx:130-182) is the same three-state model but COLOR-CODED (green accept / amber reject) with click-active-to-reset. The existing RadioGroup primitive (radio.tsx) — labelled the 'SegmentedControl base' in analysis.md:72 and radio.tsx:38-43 — is single-select-only (role=radiogroup, aria-checked, roving tabindex), so it cleanly fits only #1. The home-feed group-toggle that 'already uses Button pressed' (home-feed.tsx:645-654) is a single on/off button, not a multi-segment group, so it is not a ToggleGroup precedent. The design audit already adjudicated the response toggle group (component-audit.md:68, row 6): 'Keep as specialized; semantically distinct.'","evidence":["/workspace/certified-app/src/components/badges/response-buttons.tsx:99-139 — three-state toggle (isAccepted/isRejected/default both-unpressed), writes AT-proto records via createResponse, carries isWriting/error/aria-busy + per-row aria-label; 140 lines total","/workspace/certified-app/src/components/badges/response-menu.tsx:130-182 — color-coded quick-actions (response-menu__quick-btn--accept green / --reject amber), click-active calls resetToDefault, three-state; 183 lines total","/workspace/certified-app/src/components/explore-page/explore.tsx:650-673 — view-toggle, single-select (one of list/gallery), 2 raw buttons in role=group; the ONLY clean RadioGroup fit","/workspace/certified-app/src/components/explore-page/explore.tsx:508-528,872-942 — EndorsementDegreeBar, multi-select subset of {1,2,3}; toggle logic next.has(key)?delete:add, empty set encoded as sentinel — cannot be a radiogroup","/workspace/certified-app/src/components/ui/radio.tsx:38-44,80-179 — RadioGroup is single-select only (role=radiogroup, aria-checked); documented as the SegmentedControl base but models neither multi-select nor three-state","/workspace/certified-app/docs/design-audit/component-audit.md:68 — row 6 verdict on the Response toggle group: 'Keep as specialized; semantically distinct'","/workspace/certified-app/AGENTS.md:439-456 — §12 primitive catalog does NOT list RadioGroup/SegmentedControl; app consumers of RadioGroup are only theme-toggle, onboarding step-graph, dev gallery","/workspace/certified-app/src/components/ui/theme-toggle.tsx:97-136 — existing 'segmented' look is built inline on RadioGroup + Tailwind, NOT via a shared SegmentedControl wrapper — the established pattern is compose-per-site, not a new primitive","/workspace/certified-app/src/components/home/home-feed.tsx:645-654 — group-toggle is a single <Button variant=ghost pressed=expanded>, a 1-button on/off, not a multi-segment ToggleGroup","/workspace/certified-app/src/app/styles/feed.css:1200-1397 and explore.css:397-438,889-930 — all four controls already use design tokens (--fg-primary, --color-success/--color-warning via color-mix, --bg-sunken); no token violations to fix, so migration buys no token-correctness win","No test files reference ResponseButtons/ResponseMenu/explore view-toggle/degree-pills directly (grep of *.test.tsx) — call sites endorsements/page.tsx:137, profile-endorsements.tsx:580, notification-row.tsx:127"],"options":[{"label":"Keep bespoke","entails":"Make no code change. Optionally add one documentation line to AGENTS §12 / DESIGN noting these four controls are sanctioned specialized toggles (like the leaflet toolbar exception), citing component-audit row 6. The single genuinely-radio control (explore view-toggle) stays a raw 2-button role=group.","pros":["Zero behavior risk to record-writing controls (createResponse / deleteAllResponsesForAward) and their isWriting/error/aria-busy + per-row aria-label state","Honors the prior written verdict (component-audit.md:68 'Keep as specialized; semantically distinct') and the leaflet precedent (AGENTS §11.8 / §12) for sanctioned toggle-state BEM","No new primitive surface to maintain, document in §12, or add gallery coverage for — matches the established 'compose per-site on RadioGroup' pattern that ThemeToggle already uses","The three hardest controls (degree multi-select, two three-state response toggles) don't fit a radiogroup base anyway, so a primitive would only abstract the one trivial 2-button view-toggle"],"cons":["Four aria-pressed / role=group implementations remain hand-rolled, each re-deriving its own focus-visible + token classes","Leaves a small documented-but-unenforced gap: a future dev could hand-roll a 5th toggle without noticing the sanctioned set"],"effort":"S — 0 code files; at most 1 doc line in AGENTS.md §12 and/or DESIGN.md"},{"label":"Build SegmentedControl + migrate","entails":"Add src/components/ui/segmented-control.tsx (a styled wrapper) plus a multi-select ToggleGroup variant and a color-coded variant, then migrate explore view-toggle (single-select), explore degree-pills (multi-select), response-buttons and response-menu quick-actions (three-state + color). Update AGENTS §12 catalog, DESIGN, and the dev gallery; add tests.","pros":["One vocabulary for every toggle; centralizes focus-visible ring, token classes, and aria wiring","Future toggles have an obvious primitive to reach for, reducing drift","explore view-toggle becomes a clean single-select RadioGroup consumer"],"cons":["No single base fits all four: RadioGroup is single-select, so degree-pills (multi-select, empty-set) and both response toggles (three-state, neutral default) need a NEW multi/tri-state abstraction — this is net-new component design, not a migration","Highest-risk targets are record-writing controls with bespoke loading/error/aria-busy and per-row aria-label semantics (component-audit explicitly says keep specialized); folding them in risks behavior regressions for little visual change","color-coded variant pulls semantic green/amber state styling into a generic primitive, widening its API surface for a 2-call-site need","Touches ~4 components + CSS + §12 docs + gallery + tests; contradicts the established ThemeToggle pattern of composing the segmented look per-site rather than via a shared wrapper","No token-correctness or a11y payoff: all four already use tokens and carry correct aria-pressed/role=group/aria-checked"],"effort":"L — new primitive (1-2 files) + 4 migrated components + 2 CSS files + AGENTS/DESIGN/gallery + tests"}],"recommendation":"Keep bespoke","rationale":"The four remaining controls do not share a selection model, so there is no single primitive to migrate them to: RadioGroup (the documented 'SegmentedControl base') is single-select and fits only the trivial explore view-toggle, while the degree-pills are multi-select with an allowed empty set and both response controls are three-state with a neutral default and color-coding. A SegmentedControl that covered all four would be net-new multi/tri-state component design, not consolidation. The two response controls are the highest-value-at-risk: they write AT-proto records and carry bespoke loading/error/aria-busy and per-row aria-label state, and the design audit already ruled them 'Keep as specialized; semantically distinct' (component-audit.md:68). All four controls already use design tokens and correct aria, so migration buys no token-correctness or a11y win — only risk. The established pattern (ThemeToggle) is to compose the segmented look per-site on RadioGroup, not to add a shared wrapper. Recommend keeping bespoke and, at most, adding one documentation line marking these as sanctioned specialized toggles alongside the leaflet exception. If the user wants a small, safe win, the only defensible single migration is the explore view-toggle to RadioGroup (single-select, no record writes) — but even that is optional polish, not consolidation."},{"id":"d3-topbar-tabs","title":"Desktop top-bar tab strips: bespoke chrome vs. Tabs href primitive","question":"Should the desktop top-bar tab strips (profile / explore / cert-detail / project-detail row-2) be migrated onto the canonical <Tabs>/<Tab href> primitive, or kept as bespoke navbar chrome?","background":"DesktopTopBar (src/components/layout/desktop-top-bar.tsx, 739 lines) renders a sticky two-row chrome. Row 2 is a full-height tab strip that appears in four flavors, all hand-rolled as Next <Link> elements with role=tab and a shared .desktop-top-bar__tab BEM class: (1) Explore kind tabs (Activities/Projects/Accounts, ?kind=), (2) Profile section tabs (Overview/Activities/Projects/Groups/Endorsements/Followers/Lists/About, ?tab=), (3) Cert-detail subtabs, (4) Project-detail subtabs (both ?tab= / sub-route, with a Back button sharing the row). The analysis (analysis.md line 35) flags this strip as one of the hand-rolled tab strips that omit aria-controls, roving tabIndex, and Arrow/Home/End nav — i.e. it fails the WAI-ARIA tabs keyboard contract. The Tab primitive recently gained href-link support (renders as a Next <Link> with full roving-tabindex + arrow/Home/End nav and onChange sync), which is exactly the enabler this strip would need. The strip was, however, intentionally left un-migrated as part of the sanctioned core-nav chrome carve-out, and the decision is now open: force it onto the primitive or keep it bespoke.","options":[{"label":"Keep bespoke top-bar chrome (status quo)","entails":"Leave all four row-2 tab strips on .desktop-top-bar__tab / .desktop-top-bar__tabs as-is. No code change. Optionally add a one-line cross-ref comment in desktop-top-bar.tsx pointing at the sanctioned-chrome carve-out (analysis.md §9, AGENTS §12) so future passes don't re-litigate it.","pros":["Zero visual-regression risk: the bespoke geometry (full-height 44px stretch tabs, 18px symmetric padding, bottom-pinned inset-18px ::after underline, 12px first-tab alignment to the hamburger icon above) does NOT match what the canonical underline Tab produces (px-1/py-3, border-b-2 on the element itself, gap-4 TabList with its own border-b). Reproducing it exactly via className overrides is fiddly and the whole point of consolidation is to NOT carry per-call-site overrides.","Consistent with the explicit out-of-scope decision already recorded: analysis.md §9 line 263 lists 'Core nav chrome' as 'genuinely unique chrome, sanctioned'; the top bar is app-shell chrome.","No churn on a 739-line, state-heavy component (portaled switcher + create menus, anchor recompute effects) that has nothing to gain functionally from the swap beyond the tab strip itself.","The strip is a URL-router nav (each tab is a route/query Link), not a controlled in-page tab panel — the primitive's TabPanel half is unused here, so adoption only buys the keyboard-nav contract, not the panel wiring."],"cons":["Leaves the documented a11y gap in place: no roving tabIndex (every tab is a Tab stop, not one), no Arrow/Home/End navigation, no aria-controls. This is the one concrete defect the analysis calls out for this strip.","Perpetuates a hand-rolled role=tablist/role=tab implementation that the library was built to replace — a reviewer scanning for 'why is this still bespoke' needs the cross-ref comment to not flag it.","Four near-duplicate map() blocks with copy-pasted role/aria-selected/className logic stay in the component."],"effort":"S — 0 files changed (or 1 if adding the cross-ref comment to desktop-top-bar.tsx).","risk":"none"},{"label":"Migrate row-2 strips to Tabs href with custom className","entails":"Replace the four hand-rolled Link strips with <Tabs value={active} onChange={noop} variant=\"underline\"> + <TabList> + <Tab href=... >, then re-skin via className passthrough to restore the full-height stretch, 18px padding, bottom-pinned inset underline, and the 12px first-tab alignment. The primitive's TabList/Tab already accept className; the active underline would have to be overridden from border-b-2-on-element back to the bespoke ::after geometry (or the bespoke look abandoned in favor of the canonical underline).","pros":["Picks up the WAI-ARIA keyboard contract for free: roving tabIndex (one Tab stop), Arrow/Home/End nav across tabs, aria-controls wiring — closing the exact gap analysis.md line 35 flags.","Collapses four copy-pasted role=tab map() blocks toward one primitive; removes ~16 lines of bespoke .desktop-top-bar__tab CSS in layout.css if the look is allowed to become the canonical underline.","Makes the only production URL-router tab strip use the new Tab href enabler (today the sole href consumer is the dev gallery at src/app/dev/gallery/page.tsx) — proves the enabler in real chrome."],"cons":["High visual-regression risk to ship pixel-identical: the canonical underline (px-1 / py-3 / border-b-2 on the element, gap-4 TabList border-b) is geometrically different from the bespoke strip (full-height 44px stretch, 18px symmetric padding, bottom-pinned ::after inset 18px, 12px first-tab gutter alignment to the hamburger). Matching it needs className overrides on TabList AND every Tab plus likely a bespoke ::after, which re-introduces the per-call-site override the consolidation is trying to eliminate — a net wash on 'drift'.","aria-controls/TabPanel mismatch: Tab auto-wires aria-controls to a panel id that does not exist here (the content lives on a separate routed page, not a sibling TabPanel) — pointing aria-controls at a non-existent element is arguably worse a11y than the current omission, and would need suppressing.","onChange is dead weight: navigation is the router's job, so onChange becomes a no-op (or a redundant local mirror of activeTab) — the controlled-value contract doesn't fit a pure nav strip cleanly.","Touches a 739-line state-heavy core-shell component across four code paths (explore/profile/cert/project) plus layout.css; the back-button-shares-the-row case and the 12px-first-tab-alignment edge case both need bespoke handling on top of the primitive.","Contradicts the recorded out-of-scope decision (analysis.md §9 line 263) without a new reason — the keyboard-nav gain is real but could be added to the bespoke strip directly with far less surface area."],"effort":"M — ~1 component file (desktop-top-bar.tsx, four call sites) + ~16 lines of layout.css; pixel-matching the active underline pushes toward M+ with className/::after overrides.","risk":"medium"}],"recommendation":"Keep bespoke top-bar chrome (status quo)","rationale":"The two looks are not interchangeable: the bespoke strip is a full-height 44px stretch tab with 18px symmetric padding and a bottom-pinned, inset-18px ::after underline (plus a 12px first-tab gutter that aligns the text to the hamburger icon in the row above), whereas the canonical <Tab> underline is px-1/py-3 with a border-b-2 drawn on the element itself inside a gap-4 TabList that carries its own border-b. Forcing the migration means re-skinning TabList and every Tab with className overrides and re-creating the bespoke ::after — exactly the per-call-site override churn the consolidation exists to remove — so the 'consolidation' would be a wash on drift while carrying real visual-regression risk. The fit is also semantically poor: this is a URL-router nav where each tab is a Link to a route, not a controlled tab/panel pair, so the primitive's onChange becomes a no-op and its auto-wired aria-controls would point at a TabPanel that doesn't exist (worse than today's omission). The strip is already explicitly sanctioned as core nav chrome (analysis.md §9 line 263; AGENTS §12), consistent with the other intentional carve-outs. The one genuine win — the WAI-ARIA roving-tabindex + Arrow/Home/End keyboard contract that the strip lacks — is worth doing, but it can be added directly to the bespoke Links with a few lines (a roving tabIndex + an onKeyDown handler) at a fraction of the surface area and zero visual risk, rather than by adopting a primitive whose geometry and panel model don't fit. Recommend: keep bespoke, add a cross-ref comment, and (separately, if desired) bolt the keyboard contract onto the existing strip."},{"id":"d4-corenav","title":"Core-nav account-switcher menus: enhance Popover (portal + collision) to migrate, or respect the §9 sanction","question":"Should we add portal + collision handling to the canonical Popover so the portaled core-nav account-switcher / create menus can be migrated onto it, or respect the analysis.md §9 / AGENTS §12 sanction and leave these as bespoke chrome?","background":"Three layout files render account-switcher (and one \"create\") menus that are intentionally portaled to document.body to escape an ancestor overflow clip, and were left un-migrated in the consolidation.\n\nConcrete current state:\n- desktop-left-rail.tsx: switcher menu is createPortal'd to document.body (render 341-385) because `.left-rail` has `overflow-y: auto` (layout.css:1003) — at the 86px icon-only width the menu must extend rightward past the rail into the center column, so an in-flow menu is clipped. Position is a computed `position: fixed` anchor (left + bottom) recomputed on open/resize/scroll via getBoundingClientRect (105-125). It carries its own click-outside (127-138), Esc-to-close-with-focus-return (142-155), and close-on-nav (158-160) effects — duplicating Popover built-ins.\n- desktop-top-bar.tsx: TWO portaled menus — the switcher (render 696-736, fixed top+right) and the \"create\" menu (render 651-694, fixed top+left, 3 Link items). Each has its own anchor effect, click-outside, and Esc effect (switcher 246-292; create 299-360).\n- navbar.tsx: the desktop switcher is INLINE (`.account-switcher__menu`, not portaled, 290-310) and mobile uses the canonical BottomSheet (316-338). navbar is a different shape and largely not a portal/collision problem.\n\nWhy left: the canonical Popover (popover.tsx) is explicitly in-flow — wrapper `<span className=\"inline-flex relative\">` (119), PopoverContent `absolute top-full` (261). analysis.md:36 names the gap: Popover \"no portal/collision handling.\" analysis.md:263 sanctions core-nav chrome as out-of-scope. The shared body (AccountSwitcherList) is already a single extracted component reused by all sites; only the positioning shell differs. Gate is green and these surfaces work today.","evidence":["src/components/ui/popover.tsx:119 — Popover wrapper is `<span className=\"inline-flex relative\">`; :261 — PopoverContent is `absolute top-full z-[var(--z-popover)]`. Structurally in-flow; no portal, no fixed positioning, no collision/flip logic.","src/components/ui/popover.tsx:46-48 — primitive's own doc: 'Intentionally minimal — no Floating UI / popper.' Adding portal+collision reverses a stated design choice.","src/app/styles/layout.css:993-1006 — `.left-rail { overflow-y: auto }` is the clip forcing the portal; the menu must extend rightward past the rail at the 86px icon-only width (comment desktop-left-rail.tsx:93-96).","desktop-left-rail.tsx:341-385 (portal render) + :105-125 (computed fixed anchor via getBoundingClientRect, recomputed on resize+scroll) + :127-160 (own click-outside / Esc / close-on-nav effects).","desktop-top-bar.tsx:696-736 (switcher portal, fixed top+right) and :651-694 (create-menu portal, fixed top+left, 3 Link items) — two separate portaled menus, each with its own anchor+dismiss machinery (:246-292, :299-360).","navbar.tsx:290-310 — desktop switcher is INLINE `.account-switcher__menu` (not portaled); :316-338 — mobile uses canonical BottomSheet. navbar is a different shape from the two portaled files.","src/components/layout/account-switcher-list.tsx — the menu BODY is already one shared extracted component consumed by all three layout files; only the positioning shell differs, so body-level drift is already contained.","docs/component-library/analysis.md:36 — records Popover 'no portal/collision handling' as a known gap; :263 — sanctions core-nav chrome as out-of-scope (cross-ref AGENTS §12).","tokens.css:173,176 — `--z-popover: 40` (in-flow popovers) vs `--z-portal-sheet: 60` (portaled surfaces). A portaled Popover needs a new/elevated z-tier; rail menu reuses --z-popover (layout.css:1261) but renders above the rail via portal stacking — a subtlety a generic primitive must encode.","src/components/ui/bottom-sheet.tsx:4,109-133 — a portal primitive pattern (createPortal to document.body, SSR-guarded) already exists and is reused by navbar's mobile switcher; the codebase's 'escape my container' answer is BottomSheet on mobile, bespoke fixed-portal on desktop."],"options":[{"label":"Leave (respect §9 sanction)","entails":"No code change. The three portaled core-nav menus (left-rail switcher, top-bar switcher, top-bar create) and navbar's inline+BottomSheet switcher stay bespoke. Optionally add a one-line cross-ref comment at each site pointing to analysis.md §9 / AGENTS §12 so future agents don't re-flag them. The shared AccountSwitcherList body already prevents body-level drift.","pros":["Zero risk to a green gate (tsc 0 / eslint 0 / 536 tests / build OK) on a Draft PR otherwise done.","Honors the explicit written sanction (analysis.md:263, AGENTS §12) — the consolidation's own decision log already reasoned this through.","Keeps Popover 'intentionally minimal' (popover.tsx:46-48) — no Floating-UI-class positioning engine smuggled into a primitive used by 10 in-flow call sites.","The hard part — the menu body — is already a single shared component; only ~3 positioning shells differ: low drift for high migration cost.","No new z-index tier or collision math to test across 3 anchor geometries (left+bottom, top+right, top+left) and dark mode."],"cons":["Three/four `role=menu` surfaces keep hand-rolled click-outside / Esc / focus-return effects that duplicate Popover built-ins — the exact duplication the library exists to kill.","Popover's roving-focus + focus-into-menu-on-open a11y wins (popover.tsx:209-253) are not inherited; these menus keep bespoke, weaker keyboard handling.","'Reach for a primitive first' (CLAUDE.md rule 10) is visibly unsatisfied here, which can read as inconsistency to reviewers."],"effort":"S — 0 lines, or a few comment lines across desktop-left-rail.tsx / desktop-top-bar.tsx / navbar.tsx."},{"label":"Enhance Popover + migrate","entails":"Add an opt-in portal/collision mode to popover.tsx: a `portal`/`strategy=\"fixed\"` prop that (a) renders PopoverContent via createPortal to document.body (SSR-guarded, like bottom-sheet.tsx), (b) computes a fixed anchor from the trigger's getBoundingClientRect with side/align + viewport collision flip, (c) recomputes on resize+scroll. Then migrate the 3 portaled menus (and ideally navbar's inline desktop switcher) onto it, deleting per-site anchor/click-outside/Esc effects (~50-85 lines each). Add a new z-tier or reuse --z-portal-sheet.","pros":["Removes ~3 sets of duplicated dismiss/anchor machinery (roughly 150-220 lines across the two files) and routes core-nav menus through one keyboard/ARIA implementation.","Closes the gap analysis.md:36 names ('no portal/collision handling'), making Popover genuinely the single menu primitive.","Brings roving focus + focus-on-open + Esc-with-focus-return to the switcher menus for free — a real a11y upgrade.","Satisfies CLAUDE.md rule 10 uniformly."],"cons":["High visual-regression surface: three distinct anchor geometries (rail menu opens UP and rightward past an overflow clip; top-bar switcher pins top+right; create pins top+left) plus dark mode and the 86px icon-only rail width — each must be browser-verified, not just gate-checked.","Reverses Popover's explicit 'intentionally minimal, no Floating UI' design (popover.tsx:46-48); a hand-rolled collision/flip engine is error-prone (off-by-scrollbar, RTL, resize jank).","Contradicts a written sanction (analysis.md:263 / AGENTS §12); per the user's own rule, overriding a recorded decision needs its rationale logged, and this reopens a closed scope item on an otherwise-finished Draft PR.","Touches a primitive consumed by 10 in-flow call sites; portal-mode plumbing risks regressing already-migrated explore/profile/project/lists menus if the prop surface leaks.","navbar is a genuinely different shape (inline desktop + BottomSheet mobile); folding it in is extra work for little dedup, and leaving it out means 'unify' is only partially met.","Scope creep against the PR's stated done-state."],"effort":"M-L — popover.tsx (portal/collision engine, ~80-150 new lines + new prop surface), desktop-left-rail.tsx, desktop-top-bar.tsx (×2 menus), optionally navbar.tsx; new z-token; gallery/test additions; full browser re-verification across 3 geometries + dark mode + 800/1100/1300 breakpoints."}],"recommendation":"Leave (respect §9 sanction)","rationale":"The sanction is well-founded, not incidental. These menus are portaled for a real structural reason — `.left-rail { overflow-y: auto }` (layout.css:1003) clips an in-flow menu, and the rail menu must open upward and rightward past that clip at the 86px width — which the canonical Popover, by explicit design (`inline-flex relative` + `absolute top-full`, plus its own 'no Floating UI' note at popover.tsx:46-48), cannot do without growing a fixed-position collision engine. The dedup prize is smaller than it looks: the menu BODY is already a single shared component (account-switcher-list.tsx) reused everywhere, so the only thing not unified is ~3 positioning shells with three different anchor geometries. Migrating means adding hand-rolled collision/flip math to a primitive used by 10 in-flow call sites and re-verifying bespoke chrome in a browser across three geometries, dark mode, and three breakpoints — exactly the visual-regression risk DESIGN §14.6 and analysis.md §9 sanctioned away — on a Draft PR whose gate is green and whose scope is closed. Cost/benefit favors leaving it: high regression risk and primitive bloat for modest, body-already-deduped savings. At most, add a one-line cross-ref comment at each portaled menu pointing to analysis.md §9 so the next agent doesn't re-flag it. The cleaner long-term home for 'escape my container' is the existing BottomSheet-style portal pattern, not a collision engine bolted onto the in-flow menu primitive — but that is a separate deliberate decision, not consolidation cleanup."},{"id":"d5-verify","title":"Closing the auth-gated visual-verification gap","question":"How should we close the visual-verification gap for the auth-gated surfaces (profile/[handle], home feed, groups/[groupDid], settings, workspace) that the unauthenticated screenshot harness can't reach: (a) human logged-in pass, (b) build mock-data/auth fixtures and extend a gallery harness to render composed surfaces, or (c) accept gate-only verification?","background":"PR #129 migrated the app to src/components/ui/* over 3 rounds; the gate is green (tsc 0, eslint 0 errors/66 warnings, 536 tests, next build OK). Visual verification of the primitives is covered by /dev/gallery (src/app/dev/gallery/page.tsx, 767 lines) which renders every UI primitive with its NEW enabler states, plus an existing Playwright screenshot harness (scripts/audit-screenshots.mjs, 117 lines) that crawls 22 routes x 2 viewports x 2 themes. The open gap: the composed authenticated surfaces can't be screenshotted because they hard-gate on isAuthenticated and redirect/spinner when signed out — so the migrated chrome inside profile, home feed, groups detail, settings, and workspace is only verified at the primitive level and via unit tests, never as a composed pixel render.","evidence":["scripts/audit-screenshots.mjs already exists (117 lines): a Playwright harness that pre-warms then screenshots 22 SURFACES x {desktop 1440, mobile 390} x {light,dark}. Its list already INCLUDES the gated routes (03-home, 07-profile-index, 08-settings, 20-endorsements, 21-workspace) but they capture the signed-out gate/redirect/spinner, not the composed authenticated UI.","Hard-gated client pages (redirect or spinner when signed out): src/app/page.tsx, profile/page.tsx, profile/[handle]/page.tsx, create/page.tsx, notifications/page.tsx, settings/edit-profile/page.tsx, project/new/page.tsx, activity/[did]/[rkey]/edit, project/[did]/[rkey]/edit. Component-level gates: components/home/home.tsx (router.replace('/welcome') when !isAuthenticated, returns LoadingSpinner until auth+activeDid resolve), project/project-detail.tsx, feed/activity-detail.tsx.","Workspace (src/app/workspace/page.tsx -> components/workspace/workspace.tsx) is NOT auth-gated and does not fetch network data — it is already fully screenshottable today by the existing harness; it does not actually belong in the gap.","Data layer is deep and network-bound. profile/[handle]/page.tsx alone fans out to ~25+ data hooks (useUserProfile, useUserActivities, useFollowers, useFollowing, useEndorsementLists, useReceivedEndorsements, useGivenEndorsements, useProjectItems, useTypedLists, useOrgMarker, useCgsMemberships, ...). Across src/hooks, ~50 hooks fetch: authFetch has 39 importers; @atproto/api Agent is referenced ~93 times; calls hit /api/xrpc/* (ATProto proxy), /api/indexer, and external hosts public.api.bsky.app + plc.directory.","No mock infrastructure exists: msw is NOT installed (node_modules/msw absent); the only file matching mock/fixture/seed is src/app/api/auth/callback-handler/__tests__/seed-anti-clobber.test.ts (an API route test, not UI fixtures). There are no shared fixture/factory files.","Existing tests mock data per-test with vi.mock at the hook boundary, not via a reusable harness. src/app/__tests__/endorsements-received-rejected.test.tsx mocks 9 separate modules (useAuth, useOrg, navbar, next/navigation, 4 endorsement hooks) just to render ONE tab of the endorsements page. There is no AuthProvider/OrgProvider test wrapper that supplies a logged-in fixture identity.","Auth is real OAuth/ATProto: lib/auth/auth-context.tsx boots from GET /api/auth/session, which calls getOAuthClient().restore(did) against a live PDS. There is no test/dev bypass to fake a session. Booting dev needs NEXT_PUBLIC_PDS_URL, PUBLIC_URL, COOKIE_SECRET, UPSTASH_REDIS_*, INDEXER_URL, INDEXER_DID (.env.local.example); .env.local has 5 vars set.","The gallery (src/app/dev/gallery/page.tsx) renders primitives only with literal props (no data hooks, no providers beyond useToast). Extending it to render composed surfaces would require either importing the real surface components (which call the gating hooks and fetch) or building parallel mock-data props for each composed component."],"options":[{"label":"(a) Human logged-in visual pass","entails":"USER (or a reviewer) logs into a running dev/preview build with a real ATProto identity and manually walks profile/[handle], /home feed, groups/[groupDid], settings, and the deep-link tabs, eyeballing the migrated chrome in light + dark. Optionally capture a few manual screenshots for the PR. Zero code changes.","pros":["Zero engineering cost and zero new dependencies / test surface to maintain.","Exercises the REAL data + REAL auth path — catches integration regressions a mock harness would mask (e.g. a hook returning a shape the migrated component renders wrong).","Covers all 5 surfaces and arbitrary tab/empty/loading states a human notices in passing.","Matches how the 3 migration rounds were presumably already spot-checked; nothing new to learn."],"cons":["Not repeatable or CI-enforceable — no artifact, no regression guard for the NEXT change.","Requires a working logged-in environment with seeded data (an identity that actually has groups, endorsements, projects) to see populated states; an empty account shows mostly empty states.","Relies on the USER's time and on them noticing subtle token/spacing regressions by eye.","No light/dark or mobile/desktop matrix unless the human deliberately toggles each."],"effort":"S — 0 files changed; ~20-40 min of manual walkthrough against a dev/preview build.","risk":"Low technical risk; moderate coverage risk (human miss). No risk to the codebase."},{"label":"(b) Mock-data/auth fixtures + composed-surface harness","entails":"Add a dev-only fixture seam: a fake-session bypass in dev (env-flagged stub for /api/auth/session + the XRPC/indexer fetches, most cleanly via installing msw or a dev fetch-shim) plus fixture data (a seeded identity with groups/projects/certs/endorsements). Then either (i) extend /dev/gallery into composed-surface routes that mount the real profile/home/groups/settings components against the fixtures, or (ii) add Playwright auth-state injection to scripts/audit-screenshots.mjs. New dependency (msw) + new fixture files + harness wiring.","pros":["Repeatable and CI-friendly — produces stable screenshots for every surface x viewport x theme, a real regression guard going forward.","Deterministic populated states (groups, endorsements, projects) without depending on a live account's contents.","Builds reusable test infrastructure (fixtures + provider harness) that future component work and the per-hook vi.mock tests could share, reducing the 9-mocks-per-test boilerplate.","Plugs straight into the EXISTING scripts/audit-screenshots.mjs harness (option b-ii), so the screenshot plumbing is already written."],"cons":["High build cost: ~50 hooks fetch across two seams (authFetch/@atproto/api Agent + raw fetch), hitting /api/xrpc, /api/indexer, and external bsky/plc — every response shape a composed surface needs must be hand-authored as a fixture. Profile alone needs ~25 hook responses.","No existing mock infra to extend: msw is not installed and zero fixture/factory files exist — this is greenfield, and fixtures drift out of sync with real API shapes (a mock harness can render 'green' while the real surface is broken).","A dev-only auth/fetch bypass is security-sensitive (must be env-gated so it can never ship to prod, mirroring the gallery's NODE_ENV !== production guard) and adds permanent maintenance surface.","Out of scope for a component-library consolidation PR — this is net-new testing infrastructure and per the workflow rules likely warrants its own plan/PR rather than bolting onto #129.","Effort is genuinely L and easy to under-estimate; the 'just extend the gallery' framing hides that composed surfaces pull real data hooks, not literal props like the current gallery."],"effort":"L — install msw (or write a dev fetch-shim) + dev fake-session bypass in /api/auth/session and auth-context; author fixtures for ~25-50 hook responses across 5 surfaces; wire either new /dev composed routes or Playwright storage-state into scripts/audit-screenshots.mjs. Touches auth-context, the session route, scripts/, and many new fixture files. Realistically multi-day, its own PR.","risk":"Medium-to-high: dev-only auth bypass is security-sensitive; fixtures can mask real breakage (false-green); large new maintenance surface; scope creep on #129."},{"label":"(c) Accept gate-only verification for #129","entails":"Ship #129 with the verification already in hand — primitive-level gallery coverage (/dev/gallery), the 536-test suite (which includes composed-component tests like person-card, project-item-row, profile-edit-form, activity-card via targeted vi.mock), green tsc/eslint/build, and the existing unauthenticated screenshot sweep. Document the auth-gated composed-surface pixel render as an explicit, known out-of-scope gap in the PR body, optionally pairing it with a quick (a)-style human glance before merge. Defer any harness to a separate follow-up.","pros":["Unblocks #129 immediately — the gate is already green and the migration is purely a primitive-swap, which is exactly what the gallery + unit tests are designed to verify.","Honest scoping: a component-library consolidation PR verifies primitives and component contracts; full composed-surface visual regression is a distinct concern that deserves its own decision, not a rider on this PR.","No security-sensitive dev auth bypass introduced under deadline pressure.","Lowest cost; reversible — option (b) can still be built later as its own planned PR if composed-surface regressions actually start slipping through.","Consistent with the project's existing verification posture (per-hook vi.mock tests + primitive gallery), so it adds no new convention to maintain."],"cons":["Leaves a real residual gap: the migrated chrome inside profile/home/groups/settings is never seen as a composed pixel render before merge — a token/spacing/layout regression that only manifests in composition could slip past tsc/eslint/unit tests.","No CI regression guard for those surfaces going forward.","'Accept the gap' is only defensible because the change is a mechanical primitive swap; it would be weaker for a layout-level redesign.","If the USER wants pixel-level confidence on those 5 surfaces specifically, this option does not provide it without also doing (a)."],"effort":"S — 0 code files; update the PR body to state the out-of-scope gap. Optionally pair with a ~20-min (a) human glance.","risk":"Low: relies on the change being a primitive swap (high test + primitive-gallery coverage already). Residual risk is composed-layout regressions going unseen until later."}],"recommendation":"(c) Accept gate-only verification for #129","rationale":"For PR #129 specifically, recommend (c), ideally paired with a short (a)-style human glance before merge — and explicitly NOT (b) inside this PR. Three load-bearing facts drive this: (1) #129 is a mechanical primitive-swap consolidation, which is precisely the change class that the existing /dev/gallery primitive renders, the 536-test suite (including composed-component tests like person-card, project-item-row, profile-edit-form), and green tsc/eslint/build already verify well; the marginal value of pixel-rendering the 5 composed surfaces is real but modest. (2) Option (b) is genuinely L and greenfield, not a quick gallery extension: msw is not installed, zero fixture files exist, and the surfaces fan out to ~50 data hooks across two fetch seams (authFetch + @atproto/api Agent) hitting /api/xrpc, /api/indexer, and external bsky/plc — profile alone needs ~25 hand-authored responses. Bolting that onto a consolidation PR is scope creep and introduces a security-sensitive dev auth/fetch bypass under deadline pressure; per the user's workflow rules it warrants its own plan -> review -> PR. (3) The cheapest high-value mitigation is the human glance in (a): it exercises the real auth+data path (which a fixture harness would mask) and covers all 5 surfaces in ~20-40 min with zero new maintenance surface. Note one scoping correction: workspace is not actually auth-gated and fetches no network data, so it is already screenshottable by the existing harness and does not belong in the gap. If composed-surface regressions later start slipping through, build (b) deliberately as a follow-up — preferably the b-ii variant that injects a Playwright storage-state into the already-written scripts/audit-screenshots.mjs, rather than reinventing the screenshot plumbing."},{"id":"d6-gallery","title":"Keep or remove the dev-only /dev/gallery route before merge","question":"Should the dev-only component gallery at src/app/dev/gallery/page.tsx (gated to non-production with notFound()) ship in PR #129, or be removed before merge?","background":"/dev/gallery is a single 766-line \"use client\" page that live-renders every src/components/ui/* primitive with its variants/states, including the new enablers (Badge tone=neutral/count-bare, Button pressed, segmented Tabs + href link tabs, Input trailingButton/combobox, EmptyState inline/compact, Skeleton animate=false, Popover). It carries data-testid hooks on interactive demos, suggesting it doubles as a visual/screenshot crawl target. The gate is a runtime guard: `if (process.env.NODE_ENV === \"production\") notFound();` at the top of the component (page.tsx:82). It is the only file under src/app/dev/. The open question is whether to keep it (gated) or delete it before the staging->main PR merges.","evidence":["/workspace/certified-app/src/app/dev/gallery/page.tsx:82 — gate is `if (process.env.NODE_ENV === \"production\") notFound();` (client component, runs at render/prerender time)","Gate VERIFIED effective in a real production build: .next/server/app/dev/gallery.meta reports `\"status\": 404`; the prerendered .next/server/app/dev/gallery.html contains 0 occurrences of 'Component gallery'/'Core interactive' (the body never renders in prod)","Compiled .next/server/app/dev/gallery/page.js contains no 'production' string — the NODE_ENV branch is dead-code-eliminated at prod build, confirming the build ran with NODE_ENV=production and the guard fires deterministically","Residual prod surface DOES exist: route still listed in .next/app-path-routes-manifest.json, routes-manifest.json (`dev/gallery(?:/)?$`), and prerender-manifest.json; a ~28K prerendered 404 stub (gallery.html/.rsc) plus page.js (~4K) and page_client-reference-manifest.js (~46K) are emitted. /dev/gallery is a reachable URL in prod that returns a normal 404 — it does NOT leak the gallery UI, but it is not zero-surface","No inbound references anywhere: grep across src, tests, and docs found no import/link/navigation to /dev/gallery (the only 'gallery' hits are unrelated — an image gallery in /workspace/certified-app/src/components/explore-page/explore.tsx and a CSS class in docs/component-library/index.html)","No middleware.ts and no robots/sitemap entry (checked next.config.ts), so the route is not separately excluded from crawling — it relies entirely on the in-component notFound() guard","Removal blast radius is minimal/mechanical: delete the one file (and the now-empty /workspace/certified-app/src/app/dev/ dir, which has no layout/page of its own). No other code, test, or doc depends on it","Gate uses NODE_ENV, not a deploy-env flag — on Vercel preview deployments NODE_ENV is 'production', so the gallery is ALSO 404 on the PR preview URL; it is only reachable via `npm run dev` locally"],"options":[{"label":"Keep (gated)","entails":"No change. Leave src/app/dev/gallery/page.tsx in place, relying on the verified NODE_ENV !== production notFound() guard.","pros":["Zero functional risk: gate is verified working in a real prod build (404, no UI leak)","Keeps a single living catalog of every ui/* primitive + the new enablers — valuable for future contributors and for the screenshot/visual-regression crawl the data-testid hooks imply","No work, no merge churn","Mechanical to remove later if ever desired"],"cons":["Ships a reachable (if 404) /dev/gallery URL and a ~28K 404 stub + client-reference manifest into the prod build — small but non-zero route surface","Relies entirely on one NODE_ENV line; a future refactor that strips/standalone-bundles client guards, or a switch to a deploy-env flag, could regress it silently","766-line client page is dead weight in the prod artifact (gated, but still compiled)","Not reachable on preview either, so it can't be reviewed on the PR URL — only locally"],"effort":"S — zero files touched","risk":"Low — verified 404 in prod build; only residual is an unused route entry + 404 stub"},{"label":"Remove","entails":"Delete src/app/dev/gallery/page.tsx + the now-empty src/app/dev/ dir before merge.","pros":["Eliminates the residual prod route surface, the 404 stub, and the client-reference manifest — nothing dev-only ships to prod","Removes reliance on the NODE_ENV guard as the sole defense (defense-by-deletion)","Smaller, cleaner prod artifact and route manifest","Mechanical: one file + one empty dir, no dependents, no test/doc breakage"],"cons":["Loses the single live catalog of all ui/* primitives and the new enablers — the screenshot/visual-verification target goes away","data-testid hooks suggest it may be wired into a visual/QA flow; deleting could orphan that workflow (none found in-repo, but confirm before deleting)","Would need to be re-created if a primitive gallery is wanted again","Minor: re-run the build/test gate after deletion to confirm green"],"effort":"S — 1 file + 1 empty dir","risk":"Low — no inbound references; confirm no external screenshot CI consumes the route first"}],"recommendation":"Keep (gated)","rationale":"The gate is verified to work in an actual production build: gallery.meta shows status 404 and the prerendered HTML contains none of the gallery body, with the NODE_ENV branch dead-code-eliminated. So the only thing shipping to prod is an unused route entry plus a ~28K 404 stub: real but trivial surface, and crucially with no UI/data leak. Against that tiny cost, the page is a single living catalog of every ui/* primitive including all the new enablers this PR adds, and its pervasive data-testid hooks indicate it is meant as a screenshot/visual-verification crawl target, exactly the artifact a component-library consolidation wants to retain. Removal is cheap and mechanical (one file + empty dir, no dependents), so it can be deleted at any time later with zero cost; there is no urgency to do it now and lose the catalog. One watch-item: the guard is a single NODE_ENV line and is the sole defense, so if the team prefers belt-and-suspenders, hardening it (e.g. a deploy-env flag or a build-time exclusion) is a better follow-up than deletion. Recommend keep, unless an external/CI screenshot job is confirmed NOT to consume it AND the team wants strictly zero dev surface in prod, in which case removal is the clean call and is equally low-risk."},{"id":"d7-merge","title":"Next step for PR #129 (component-library consolidation)","question":"PR #129 is Draft, gate-green, and not merged (per the never-auto-merge rule). What is the next step: (a) user does a logged-in visual pass then merges, (b) do more migration first, or (c) split the PR?","background":"PR #129 (head=staging -> base=feat/positioning-redesign) is the component-library consolidation: one canonical src/components/ui/ family plus the app migrated onto it over 3 rounds. It is Draft, MERGEABLE / mergeStateStatus=CLEAN, with all CI checks passing (CodeRabbit pass/skipped, Vercel deploy completed, Vercel preview comments pass). I re-ran the gate locally and confirmed it green: tsc --noEmit = 0 errors; eslint = 0 errors / 66 warnings (exactly the PR's claimed numbers, down from a 67-warning baseline); the dev gallery is guarded with `if (process.env.NODE_ENV === 'production') notFound()` so it cannot ship to prod. Per the user's certified-app rule the model never merges; the user merges. The PR is held open only because the never-auto-merge contract requires a human to pull the trigger, plus the PR body itself flags that a logged-in visual pass on auth-gated surfaces is still recommended. The headline size (98 files, +7231/-3241) overstates the code risk: by numstat, +3148 of the additions (43%) are pure docs/styleguide/gallery additions (analysis.md, the ~152KB index.html styleguide, the /dev/gallery route) with zero deletions and no runtime path in production; the real code change is the ui/ library (34 files, +2738/-409, new infrastructure) plus a net-negative app+styles migration (app 39 files +1011/-1390, styles 22 files +334/-1442) — i.e. consolidation that removes more lines than it adds.","evidence":["PR #129 JSON: isDraft=true, mergeable=MERGEABLE, mergeStateStatus=CLEAN, additions=7231, deletions=3241, changedFiles=98, baseRefName=feat/positioning-redesign, headRefName=staging, 21 commits","gh pr checks 129: CodeRabbit pass (review skipped), Vercel pass (deployment completed), Vercel Preview Comments pass","Local gate re-confirmed: `npx tsc --noEmit` exit 0 (0 errors); `npx eslint .` = 66 problems (0 errors, 66 warnings) — matches PR body's 0 err / 66 warn claim","Gallery prod guard: src/app/dev/gallery/page.tsx line 82 `if (process.env.NODE_ENV === 'production') notFound();` (comment line 78: 'Gated to non-production via notFound()')","PR diff numstat by area (origin/feat/positioning-redesign...staging): ui/ library 34 files +2738/-409; app migration 39 files +1011/-1390; styles 22 files +334/-1442; docs+gallery 3 files +3148/-0","Intentionally-left items are documented non-violations: analysis.md §9 (core-nav chrome navbar/bottom-nav/left-rail/account-switcher-list + home-feed quality/evaluator panels), §5.6 (map.tsx #5e5e5e, global-error, theme-color meta), AGENTS.md §12 (useClickOutsideClose panels), DESIGN §14.6 (per-call-site card/bespoke migration only when intentionally touched)","Residual un-migrated surface is small: grep finds exactly one useClickOutsideClose consumer (src/components/home/home-feed.tsx); map.tsx #5e5e5e at lines 157/160/162 with a keep-comment; core-nav chrome in src/components/layout/{navbar,bottom-nav,desktop-left-rail,desktop-top-bar}.tsx","Branch topology: staging is exactly 21 commits ahead of origin/feat/positioning-redesign and fully synced with origin/staging (0 ahead, 0 behind)","d1-d4 are sibling open-question decisions in this same research batch (no d1-d4 decision docs exist on disk); option (b) is therefore blocked on their resolution","PR body explicitly states auth-gated surfaces (profile/feed/groups/settings/workspace) were verified at component level via gallery + gate, and 'a logged-in human visual pass on those is still recommended'"],"options":[{"label":"(a) Logged-in visual pass, then user merges","entails":"Run a logged-in human (or authenticated Playwright) visual pass on the auth-gated surfaces the gate could not cover (profile, feed, groups, settings, workspace — light + dark), spot-fix anything that regresses, then mark the PR Ready and let the USER merge staging -> feat/positioning-redesign. The intentionally-left items (d1-d4) are handled as separate follow-ups against feat/positioning-redesign, not gated on this PR.","pros":["Matches the documented contract exactly: PR is Draft + CI green, the one open gap the PR self-identifies is the logged-in pass, and merging is the user's call.","Low residual risk: the only verification gap is auth-gated routes; everything else is gate-verified (tsc 0, eslint 0 err, 536 tests, next build OK) and browser-verified on reachable routes.","Migration is a net-deletion consolidation; landing it now removes duplicate UI vocabularies (the audit's 12 button / 8 card families) and unblocks the rest of the redesign on a clean base.","Does not block on d1-d4: those are deliberate, documented non-violations (1 home-feed useClickOutsideClose panel per AGENTS §12, map.tsx #5e5e5e per §5.6, sanctioned core-nav chrome per analysis §9), so deferring them costs nothing.","The longer the consolidation sits unmerged, the more feat/positioning-redesign drifts and the more re-migration churn accrues."],"cons":["Requires a human (or a logged-in Playwright session with real auth) to actually do the visual pass; the model cannot complete this step unattended.","If the visual pass finds regressions on auth-gated surfaces, there is a small fix loop before Ready.","Leaves the documented d1-d4 items un-migrated (by design) — a reviewer skimming might mistake them for omissions; mitigated by the PR body's explicit rationale section."],"effort":"S — verification + Ready flip; no further code unless the visual pass surfaces a regression. Touches no files by default.","risk":"Low — gate green, CI green, mergeable/clean, gallery prod-guarded; only the auth-gated visual confirmation is outstanding."},{"label":"(b) Do more migration first","entails":"Before flipping to Ready, migrate some of the intentionally-left items — which requires first resolving the sibling open questions d1-d4 (the home-feed quality/evaluator panel, map.tsx #5e5e5e, the sanctioned core-nav chrome, and the bespoke chrome that would visually regress) — then fold those changes into this PR.","pros":["Could land a more 'complete' consolidation in one PR if d1-d4 conclude that some currently-deferred items should in fact be migrated."],"cons":["Directly contradicts the documented decisions: these items are sanctioned non-violations (analysis §9, AGENTS §12, §5.6, DESIGN §14.6 'migrate per-call-site only when intentionally touched'), so 'more migration' is not obviously correct work.","Strictly blocked on d1-d4, which are unresolved sibling questions in this same batch — cannot start until the USER decides them.","Several deferred items are explicitly 'a primitive would visually regress' (profile-sidebar H1-size inputs, desktop-top-bar full-height tabs, color-coded response toggles) — migrating them risks making the UI worse, not better.","Grows an already-large PR and delays landing the net-positive consolidation, increasing drift against feat/positioning-redesign."],"effort":"M-L and indeterminate — scope is undefined until d1-d4 resolve; would touch core-nav layout files (navbar, bottom-nav, desktop-left-rail, desktop-top-bar), home-feed.tsx, map.tsx — the highest-risk chrome in the app.","risk":"Medium-High — editing sanctioned core-nav chrome and 'would-regress' surfaces is exactly the visual-regression class the deferrals were created to avoid."},{"label":"(c) Split the PR","entails":"Break #129 into smaller PRs — e.g. ui/ library + styleguide first, then app migration in one or more follow-ups against feat/positioning-redesign.","pros":["Smaller diffs are individually easier to review.","Isolating the ui/ library lets the primitive infra land independently of consumer changes."],"cons":["The headline size overstates the real change: 43% of additions are zero-risk docs/styleguide/gallery; the code is ui/ infra plus a net-negative migration — not the kind of sprawling change splitting is meant to tame.","Splitting is costly and error-prone: the migration commits depend on the new primitive APIs (Badge tone/shape, Tabs segmented/href, Popover selected, Input trailingButton, etc.), so a ui-only PR would ship dead/unused API surface and the app PR would have a hard dependency ordering.","Re-partitioning 21 well-scoped commits across multiple PRs is real work that re-opens an already gate-green, CI-green, mergeable state for no correctness gain.","The PR is already organized into reviewable per-track commits with a thorough body and linked analysis/styleguide; reviewers can read it commit-by-commit without a split.","Net effect is more total review surface (multiple PR bodies, multiple CI runs, cross-PR dependency tracking), not less."],"effort":"M — no new feature code, but commit re-authoring across branches, multiple PR bodies, and per-branch Vercel env scoping for each new feature branch.","risk":"Medium — mechanical churn on a currently-clean PR; risk of introducing a broken intermediate state where the ui-only PR ships unused APIs or the app PR fails to build against an un-merged base."}],"recommendation":"(a) Logged-in visual pass, then user merges","rationale":"The PR is already in the exact state the workflow contract aims for: Draft, gate-green (tsc 0, eslint 0 err / 66 warn, 536 tests, next build OK — all re-confirmed locally), CI all-pass, and MERGEABLE/CLEAN. The only gap the PR itself flags is a logged-in visual pass on auth-gated surfaces (profile, feed, groups, settings, workspace), which the gate and the unauthenticated browser pass could not cover. That is a small, bounded verification step — not more engineering. The headline +7231/-3241 looks heavy but decomposes into 43% pure docs/styleguide/gallery additions (zero deletions, prod-guarded via notFound) plus a net-deletion app+styles migration, so the real risk surface is far smaller than the number suggests; splitting (c) would add review and dependency-ordering overhead for no correctness benefit because the migration commits depend on the new primitive APIs. Option (b) is both contingent on the unresolved sibling questions d1-d4 and points at sanctioned non-violations (core-nav chrome, the home-feed panel, map.tsx #5e5e5e) and 'would-regress' surfaces that were deliberately deferred per analysis §9 / AGENTS §12 / §5.6 / DESIGN §14.6 — migrating them now risks making the UI worse and delays a net-positive consolidation while feat/positioning-redesign drifts. So: do the logged-in pass, fix only what regresses, flip to Ready, and let the user merge; keep d1-d4 as separate follow-ups."}]
+</script>
+
+<script>
+  // ---- Theme toggle (light/dark) ----
+  (function () {
+    var root = document.documentElement;
+    var btn = document.getElementById("themeToggle");
+    function sync() {
+      var dark = root.getAttribute("data-theme") === "dark";
+      btn.textContent = dark ? "Light mode" : "Dark mode";
+    }
+    btn.addEventListener("click", function () {
+      var dark = root.getAttribute("data-theme") === "dark";
+      root.setAttribute("data-theme", dark ? "light" : "dark");
+      sync();
+    });
+    sync();
+  })();
+
+  // ---- Render decision cards from embedded JSON ----
+  (function () {
+    var data;
+    try {
+      data = JSON.parse(document.getElementById("data").textContent);
+    } catch (e) {
+      document.getElementById("cards").textContent = "Failed to parse decision data.";
+      return;
+    }
+
+    function el(tag, cls, text) {
+      var n = document.createElement(tag);
+      if (cls) n.className = cls;
+      if (text != null) n.textContent = text;
+      return n;
+    }
+
+    function recName(d) {
+      // recommendation string may be a label or a leading-token; match against option labels.
+      var rec = d.recommendation || "";
+      for (var i = 0; i < d.options.length; i++) {
+        if (d.options[i].label === rec) return d.options[i].label;
+      }
+      // fall back to prefix match (e.g. "(c) Accept..." vs option label)
+      for (var j = 0; j < d.options.length; j++) {
+        if (rec.indexOf(d.options[j].label) === 0 || d.options[j].label.indexOf(rec) === 0) return d.options[j].label;
+      }
+      return rec;
+    }
+
+    var container = document.getElementById("cards");
+    var recLabelByCard = {};
+
+    data.forEach(function (d) {
+      var rec = recName(d);
+      recLabelByCard[d.id] = rec;
+
+      var card = el("section", "card");
+      card.id = d.id;
+
+      var head = el("div", "card-head");
+      head.appendChild(el("span", "card-id", d.id.split("-")[0].toUpperCase()));
+      head.appendChild(el("h2", null, d.title));
+      card.appendChild(head);
+
+      card.appendChild(el("p", "question", d.question));
+
+      // background — may contain multiple paragraphs separated by \n\n
+      var bg = el("div", "bg");
+      (d.background || "").split(/\n\n+/).forEach(function (para) {
+        if (para.trim()) bg.appendChild(el("p", null, para.trim()));
+      });
+      card.appendChild(bg);
+
+      // options
+      card.appendChild(el("div", "section-label", "Options"));
+      var grid = el("div", "options");
+      d.options.forEach(function (o) {
+        var isRec = o.label === rec;
+        var opt = el("div", "opt" + (isRec ? " opt--rec" : ""));
+
+        var top = el("div", "opt-toprow");
+        top.appendChild(el("h4", null, o.label));
+        if (isRec) top.appendChild(el("span", "rec-badge", "Recommended"));
+        opt.appendChild(top);
+
+        if (o.entails) opt.appendChild(el("p", "opt-entails", o.entails));
+
+        if (o.pros && o.pros.length) {
+          opt.appendChild(el("div", "pros-label", "Pros"));
+          var ulp = el("ul");
+          o.pros.forEach(function (p) { ulp.appendChild(el("li", "pro", p)); });
+          opt.appendChild(ulp);
+        }
+        if (o.cons && o.cons.length) {
+          opt.appendChild(el("div", "cons-label", "Cons"));
+          var ulc = el("ul");
+          o.cons.forEach(function (c) { ulc.appendChild(el("li", "con", c)); });
+          opt.appendChild(ulc);
+        }
+
+        var meta = el("div", "opt-meta");
+        if (o.effort) {
+          var ef = el("div");
+          ef.appendChild(el("span", "mk", "Effort"));
+          ef.appendChild(document.createTextNode(o.effort));
+          meta.appendChild(ef);
+        }
+        if (o.risk) {
+          var rk = el("div");
+          rk.appendChild(el("span", "mk", "Risk"));
+          rk.appendChild(document.createTextNode(o.risk));
+          meta.appendChild(rk);
+        }
+        if (meta.childNodes.length) opt.appendChild(meta);
+
+        grid.appendChild(opt);
+      });
+      card.appendChild(grid);
+
+      // rationale
+      var rat = el("div", "rationale");
+      rat.appendChild(el("div", "section-label", "Recommendation & rationale"));
+      var rp = el("p");
+      var strong = el("span", "rec-name", "Recommended: " + rec + ". ");
+      rp.appendChild(strong);
+      rp.appendChild(document.createTextNode(d.rationale || ""));
+      rat.appendChild(rp);
+      card.appendChild(rat);
+
+      // evidence (collapsible) — some decisions carry an explicit evidence array
+      if (d.evidence && d.evidence.length) {
+        var det = el("details", "evidence");
+        var sum = el("summary", null, "Evidence (" + d.evidence.length + ")");
+        det.appendChild(sum);
+        var ul = el("ul");
+        d.evidence.forEach(function (e) { ul.appendChild(el("li", null, e)); });
+        det.appendChild(ul);
+        card.appendChild(det);
+      }
+
+      var back = el("a", "backtop", "↑ Back to summary");
+      back.href = "#summary";
+      card.appendChild(back);
+
+      container.appendChild(card);
+    });
+  })();
+</script>
+</body>
+</html>

--- a/docs/component-library/index.html
+++ b/docs/component-library/index.html
@@ -1,94 +1,823 @@
 <!DOCTYPE html>
+<!--
+  GENERATED FILE — DO NOT EDIT BY HAND.
+  Produced from the live dev gallery at /dev/gallery by
+  scripts/generate-styleguide.mjs. To refresh: start the dev server, then run
+  `npm run styleguide:generate`. Editing this file directly will be lost on
+  the next regeneration and defeats the single-source-of-truth guarantee.
+  Generated: 2026-06-03T15:05:30.866Z
+-->
 <html lang="en" data-theme="light">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Certified — Component Library Styleguide</title>
+<title>Certified — Component Library Styleguide (generated)</title>
 <style>
 /* ==========================================================================
-   DESIGN TOKENS — faithful copy of src/app/styles/tokens.css
-   :root (light) + :root[data-theme="dark"] blocks, copied verbatim so every
-   example renders with production colors / spacing / radii / shadows and
-   flips correctly when the theme toggle sets data-theme="dark" on <html>.
+   GENERATED-STYLEGUIDE CHROME (not part of the captured design system).
+   Scoped under .sg-gen-* so it can't collide with snapshot classes.
    ========================================================================== */
-:root {
-  color-scheme: light dark;
+.sg-gen-banner {
+  position: sticky;
+  top: 0;
+  z-index: 2147483647;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 10px 16px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #f9f9f9;
+  background: #111111;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+}
+.sg-gen-banner__msg { max-width: 78ch; }
+.sg-gen-banner code {
+  background: rgba(255, 255, 255, 0.12);
+  padding: 1px 5px;
+  border-radius: 2px;
+}
+.sg-gen-banner__toggle {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font: inherit;
+  color: #111111;
+  background: #f9f9f9;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 6px 12px;
+}
+.sg-gen-banner__toggle:hover { background: #ffffff; }
+.sg-gen-banner__toggle:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
 
-  /* ===== Invariant primitives (do NOT override in dark theme) ===== */
-  --color-primary: #111111;
-  --color-white: #FFFFFF;
+/* ==========================================================================
+   CAPTURED CSS — inlined verbatim from every stylesheet the live /dev/gallery
+   page loads (Tailwind utilities, globals + token imports, next/font faces),
+   plus any inline <style> blocks. Do not hand-edit; regenerate instead.
+   ========================================================================== */
+/* ---- linked stylesheet: http://127.0.0.1:3000/_next/static/chunks/%5Broot-of-the-server%5D__09be3ul._.css ---- */
+/* [next]/internal/font/google/inter_ad991c7.module.css [app-client] (css) */
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/2c55a0e60120577a-s.0bjc5tiuqdqro.woff2") format("woff2");
+  unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/9c72aa0f40e4eef8-s.0m6w47a4e5dy9.woff2") format("woff2");
+  unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/ad66f9afd8947f86-s.11u06r12fd6v_.woff2") format("woff2");
+  unicode-range: U+1F??;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/5476f68d60460930-s.0wxq9webf.ew4.woff2") format("woff2");
+  unicode-range: U+370-377, U+37A-37F, U+384-38A, U+38C, U+38E-3A1, U+3A3-3FF;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/2bbe8d2671613f1f-s.067x_6k0k23tk.woff2") format("woff2");
+  unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/1bffadaabf893a1e-s.16ipb6fqu393i.woff2") format("woff2");
+  unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/83afe278b6a6bb3c-s.p.0q-301v4kxxnr.woff2") format("woff2");
+  unicode-range: U+??, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/2c55a0e60120577a-s.0bjc5tiuqdqro.woff2") format("woff2");
+  unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/9c72aa0f40e4eef8-s.0m6w47a4e5dy9.woff2") format("woff2");
+  unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/ad66f9afd8947f86-s.11u06r12fd6v_.woff2") format("woff2");
+  unicode-range: U+1F??;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/5476f68d60460930-s.0wxq9webf.ew4.woff2") format("woff2");
+  unicode-range: U+370-377, U+37A-37F, U+384-38A, U+38C, U+38E-3A1, U+3A3-3FF;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/2bbe8d2671613f1f-s.067x_6k0k23tk.woff2") format("woff2");
+  unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/1bffadaabf893a1e-s.16ipb6fqu393i.woff2") format("woff2");
+  unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/83afe278b6a6bb3c-s.p.0q-301v4kxxnr.woff2") format("woff2");
+  unicode-range: U+??, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/2c55a0e60120577a-s.0bjc5tiuqdqro.woff2") format("woff2");
+  unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/9c72aa0f40e4eef8-s.0m6w47a4e5dy9.woff2") format("woff2");
+  unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/ad66f9afd8947f86-s.11u06r12fd6v_.woff2") format("woff2");
+  unicode-range: U+1F??;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/5476f68d60460930-s.0wxq9webf.ew4.woff2") format("woff2");
+  unicode-range: U+370-377, U+37A-37F, U+384-38A, U+38C, U+38E-3A1, U+3A3-3FF;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/2bbe8d2671613f1f-s.067x_6k0k23tk.woff2") format("woff2");
+  unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/1bffadaabf893a1e-s.16ipb6fqu393i.woff2") format("woff2");
+  unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/83afe278b6a6bb3c-s.p.0q-301v4kxxnr.woff2") format("woff2");
+  unicode-range: U+??, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/2c55a0e60120577a-s.0bjc5tiuqdqro.woff2") format("woff2");
+  unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/9c72aa0f40e4eef8-s.0m6w47a4e5dy9.woff2") format("woff2");
+  unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/ad66f9afd8947f86-s.11u06r12fd6v_.woff2") format("woff2");
+  unicode-range: U+1F??;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/5476f68d60460930-s.0wxq9webf.ew4.woff2") format("woff2");
+  unicode-range: U+370-377, U+37A-37F, U+384-38A, U+38C, U+38E-3A1, U+3A3-3FF;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/2bbe8d2671613f1f-s.067x_6k0k23tk.woff2") format("woff2");
+  unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/1bffadaabf893a1e-s.16ipb6fqu393i.woff2") format("woff2");
+  unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/83afe278b6a6bb3c-s.p.0q-301v4kxxnr.woff2") format("woff2");
+  unicode-range: U+??, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/2c55a0e60120577a-s.0bjc5tiuqdqro.woff2") format("woff2");
+  unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/9c72aa0f40e4eef8-s.0m6w47a4e5dy9.woff2") format("woff2");
+  unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/ad66f9afd8947f86-s.11u06r12fd6v_.woff2") format("woff2");
+  unicode-range: U+1F??;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/5476f68d60460930-s.0wxq9webf.ew4.woff2") format("woff2");
+  unicode-range: U+370-377, U+37A-37F, U+384-38A, U+38C, U+38E-3A1, U+3A3-3FF;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/2bbe8d2671613f1f-s.067x_6k0k23tk.woff2") format("woff2");
+  unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/1bffadaabf893a1e-s.16ipb6fqu393i.woff2") format("woff2");
+  unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/83afe278b6a6bb3c-s.p.0q-301v4kxxnr.woff2") format("woff2");
+  unicode-range: U+??, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: Inter Fallback;
+  src: local(Arial);
+  ascent-override: 90.44%;
+  descent-override: 22.52%;
+  line-gap-override: 0.0%;
+  size-adjust: 107.12%;
+}
+
+.inter_ad991c7-module__LhgUwq__className {
+  font-family: Inter, Inter Fallback;
+  font-style: normal;
+}
+
+.inter_ad991c7-module__LhgUwq__variable {
+  --font-inter: "Inter", "Inter Fallback";
+}
+
+/* [next]/internal/font/google/noto_serif_401d723b.module.css [app-client] (css) */
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/f235270b8afd907b-s.0~jsdkr17n-8q.woff2") format("woff2");
+  unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/c14305b455766245-s.0qncrtrst02xg.woff2") format("woff2");
+  unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/c8fb9a90ee866113-s.102o-a7zijeb4.woff2") format("woff2");
+  unicode-range: U+1F??;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/c4a62e80926bd3eb-s.0ko54~va4hedv.woff2") format("woff2");
+  unicode-range: U+370-377, U+37A-37F, U+384-38A, U+38C, U+38E-3A1, U+3A3-3FF;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/f696e86c2120700b-s.0_g40rg5afsj9.woff2") format("woff2");
+  unicode-range: U+302-303, U+305, U+307-308, U+310, U+312, U+315, U+31A, U+326-327, U+32C, U+32F-330, U+332-333, U+338, U+33A, U+346, U+34D, U+391-3A1, U+3A3-3A9, U+3B1-3C9, U+3D1, U+3D5-3D6, U+3F0-3F1, U+3F4-3F5, U+2016-2017, U+2034-2038, U+203C, U+2040, U+2043, U+2047, U+2050, U+2057, U+205F, U+2070-2071, U+2074-208E, U+2090-209C, U+20D0-20DC, U+20E1, U+20E5-20EF, U+2100-2112, U+2114-2115, U+2117-2121, U+2123-214F, U+2190, U+2192, U+2194-21AE, U+21B0-21E5, U+21F1-21F2, U+21F4-2211, U+2213-2214, U+2216-22FF, U+2308-230B, U+2310, U+2319, U+231C-2321, U+2336-237A, U+237C, U+2395, U+239B-23B7, U+23D0, U+23DC-23E1, U+2474-2475, U+25AF, U+25B3, U+25B7, U+25BD, U+25C1, U+25CA, U+25CC, U+25FB, U+266D-266F, U+27C0-27FF, U+2900-2AFF, U+2B0E-2B11, U+2B30-2B4C, U+2BFE, U+3030, U+FF5B, U+FF5D, U+1D400-1D7FF, U+1EE??;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/00906005547b49fc-s.0fhmqdtqw92rm.woff2") format("woff2");
+  unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/c4270037a9fd2e09-s.174ah87jj.a_j.woff2") format("woff2");
+  unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/8e9d1a1dbcc3c9ea-s.p.04p-ex3i8ywzp.woff2") format("woff2");
+  unicode-range: U+??, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/f235270b8afd907b-s.0~jsdkr17n-8q.woff2") format("woff2");
+  unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/c14305b455766245-s.0qncrtrst02xg.woff2") format("woff2");
+  unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/c8fb9a90ee866113-s.102o-a7zijeb4.woff2") format("woff2");
+  unicode-range: U+1F??;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/c4a62e80926bd3eb-s.0ko54~va4hedv.woff2") format("woff2");
+  unicode-range: U+370-377, U+37A-37F, U+384-38A, U+38C, U+38E-3A1, U+3A3-3FF;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/f696e86c2120700b-s.0_g40rg5afsj9.woff2") format("woff2");
+  unicode-range: U+302-303, U+305, U+307-308, U+310, U+312, U+315, U+31A, U+326-327, U+32C, U+32F-330, U+332-333, U+338, U+33A, U+346, U+34D, U+391-3A1, U+3A3-3A9, U+3B1-3C9, U+3D1, U+3D5-3D6, U+3F0-3F1, U+3F4-3F5, U+2016-2017, U+2034-2038, U+203C, U+2040, U+2043, U+2047, U+2050, U+2057, U+205F, U+2070-2071, U+2074-208E, U+2090-209C, U+20D0-20DC, U+20E1, U+20E5-20EF, U+2100-2112, U+2114-2115, U+2117-2121, U+2123-214F, U+2190, U+2192, U+2194-21AE, U+21B0-21E5, U+21F1-21F2, U+21F4-2211, U+2213-2214, U+2216-22FF, U+2308-230B, U+2310, U+2319, U+231C-2321, U+2336-237A, U+237C, U+2395, U+239B-23B7, U+23D0, U+23DC-23E1, U+2474-2475, U+25AF, U+25B3, U+25B7, U+25BD, U+25C1, U+25CA, U+25CC, U+25FB, U+266D-266F, U+27C0-27FF, U+2900-2AFF, U+2B0E-2B11, U+2B30-2B4C, U+2BFE, U+3030, U+FF5B, U+FF5D, U+1D400-1D7FF, U+1EE??;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/00906005547b49fc-s.0fhmqdtqw92rm.woff2") format("woff2");
+  unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/c4270037a9fd2e09-s.174ah87jj.a_j.woff2") format("woff2");
+  unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: italic;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/8e9d1a1dbcc3c9ea-s.p.04p-ex3i8ywzp.woff2") format("woff2");
+  unicode-range: U+??, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/d829ba9c72f21fd6-s.0y.jwrte-75a4.woff2") format("woff2");
+  unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/cf1514ba67088a5f-s.15ww0itm2x.2r.woff2") format("woff2");
+  unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/142d1fb481f1ebcd-s.0bwgdetvyn-85.woff2") format("woff2");
+  unicode-range: U+1F??;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/41900da7e74536d5-s.15f~5j~qkim3f.woff2") format("woff2");
+  unicode-range: U+370-377, U+37A-37F, U+384-38A, U+38C, U+38E-3A1, U+3A3-3FF;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/aeacf25a943e1f19-s.10y4v8c15go72.woff2") format("woff2");
+  unicode-range: U+302-303, U+305, U+307-308, U+310, U+312, U+315, U+31A, U+326-327, U+32C, U+32F-330, U+332-333, U+338, U+33A, U+346, U+34D, U+391-3A1, U+3A3-3A9, U+3B1-3C9, U+3D1, U+3D5-3D6, U+3F0-3F1, U+3F4-3F5, U+2016-2017, U+2034-2038, U+203C, U+2040, U+2043, U+2047, U+2050, U+2057, U+205F, U+2070-2071, U+2074-208E, U+2090-209C, U+20D0-20DC, U+20E1, U+20E5-20EF, U+2100-2112, U+2114-2115, U+2117-2121, U+2123-214F, U+2190, U+2192, U+2194-21AE, U+21B0-21E5, U+21F1-21F2, U+21F4-2211, U+2213-2214, U+2216-22FF, U+2308-230B, U+2310, U+2319, U+231C-2321, U+2336-237A, U+237C, U+2395, U+239B-23B7, U+23D0, U+23DC-23E1, U+2474-2475, U+25AF, U+25B3, U+25B7, U+25BD, U+25C1, U+25CA, U+25CC, U+25FB, U+266D-266F, U+27C0-27FF, U+2900-2AFF, U+2B0E-2B11, U+2B30-2B4C, U+2BFE, U+3030, U+FF5B, U+FF5D, U+1D400-1D7FF, U+1EE??;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/5d3604dad620f8b2-s.0-q.mttzq3gn~.woff2") format("woff2");
+  unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/2b4499d915222007-s.0nbtxmb3x1sqz.woff2") format("woff2");
+  unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/b4e85636e2ca4056-s.p.0c3c6tp9xl371.woff2") format("woff2");
+  unicode-range: U+??, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/d829ba9c72f21fd6-s.0y.jwrte-75a4.woff2") format("woff2");
+  unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/cf1514ba67088a5f-s.15ww0itm2x.2r.woff2") format("woff2");
+  unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/142d1fb481f1ebcd-s.0bwgdetvyn-85.woff2") format("woff2");
+  unicode-range: U+1F??;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/41900da7e74536d5-s.15f~5j~qkim3f.woff2") format("woff2");
+  unicode-range: U+370-377, U+37A-37F, U+384-38A, U+38C, U+38E-3A1, U+3A3-3FF;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/aeacf25a943e1f19-s.10y4v8c15go72.woff2") format("woff2");
+  unicode-range: U+302-303, U+305, U+307-308, U+310, U+312, U+315, U+31A, U+326-327, U+32C, U+32F-330, U+332-333, U+338, U+33A, U+346, U+34D, U+391-3A1, U+3A3-3A9, U+3B1-3C9, U+3D1, U+3D5-3D6, U+3F0-3F1, U+3F4-3F5, U+2016-2017, U+2034-2038, U+203C, U+2040, U+2043, U+2047, U+2050, U+2057, U+205F, U+2070-2071, U+2074-208E, U+2090-209C, U+20D0-20DC, U+20E1, U+20E5-20EF, U+2100-2112, U+2114-2115, U+2117-2121, U+2123-214F, U+2190, U+2192, U+2194-21AE, U+21B0-21E5, U+21F1-21F2, U+21F4-2211, U+2213-2214, U+2216-22FF, U+2308-230B, U+2310, U+2319, U+231C-2321, U+2336-237A, U+237C, U+2395, U+239B-23B7, U+23D0, U+23DC-23E1, U+2474-2475, U+25AF, U+25B3, U+25B7, U+25BD, U+25C1, U+25CA, U+25CC, U+25FB, U+266D-266F, U+27C0-27FF, U+2900-2AFF, U+2B0E-2B11, U+2B30-2B4C, U+2BFE, U+3030, U+FF5B, U+FF5D, U+1D400-1D7FF, U+1EE??;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/5d3604dad620f8b2-s.0-q.mttzq3gn~.woff2") format("woff2");
+  unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/2b4499d915222007-s.0nbtxmb3x1sqz.woff2") format("woff2");
+  unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: Noto Serif;
+  font-style: normal;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url("http://127.0.0.1:3000/_next/static/media/b4e85636e2ca4056-s.p.0c3c6tp9xl371.woff2") format("woff2");
+  unicode-range: U+??, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: Noto Serif Fallback;
+  src: local(Times New Roman);
+  ascent-override: 90.29%;
+  descent-override: 24.75%;
+  line-gap-override: 0.0%;
+  size-adjust: 118.4%;
+}
+
+.noto_serif_401d723b-module__YicImG__className {
+  font-family: Noto Serif, Noto Serif Fallback;
+}
+
+.noto_serif_401d723b-module__YicImG__variable {
+  --font-headline: "Noto Serif", "Noto Serif Fallback";
+}
+
+/* [project]/src/app/styles/tokens.css [app-client] (css) */
+.skip-nav {
+  z-index: 9999;
+  background: var(--color-primary);
+  width: 1px;
+  height: 1px;
+  color: var(--color-white);
+  font-size: .875rem;
+  font-family: var(--font-inter);
+  border-radius: 0 0 var(--radius) 0;
+  padding: 8px 16px;
+  text-decoration: none;
+  position: absolute;
+  top: auto;
+  left: -9999px;
+  overflow: hidden;
+}
+
+.skip-nav:focus {
+  width: auto;
+  height: auto;
+  position: fixed;
+  top: 0;
+  left: 0;
+  overflow: visible;
+}
+
+:root {
+  --lightningcss-light: initial;
+  --lightningcss-dark: ;
+  color-scheme: light dark;
+  --color-primary: #111;
+  --color-white: #fff;
   --color-accent: #5e5e5e;
   --color-accent-hover: #454747;
-
-  /* Landing-page palette */
-  --color-navy: #111111;
+  --color-navy: #111;
   --color-off-white: #f9f9f9;
-  --color-gray-100: #eeeeee;
+  --color-gray-100: #eee;
   --color-light-gray: #e5e5e5;
   --color-mid-gray: #6b6263;
   --color-dark-gray: #4c4546;
   --color-surface: #f9f9f9;
   --color-surface-container-low: #f3f3f3;
   --color-surface-container-high: #e7e7e7;
-
-  /* ===== Semantic tokens (overridden in dark theme) ===== */
-
-  /* Surfaces (elevation ramp — lightest to darkest in light mode) */
   --bg-canvas: #f9f9f9;
-  --bg-sunken: #eeeeee;
+  --bg-sunken: #eee;
   --bg-raised: #f3f3f3;
-  --bg-elevated: #FFFFFF;
-
-  /* Foregrounds */
-  --fg-primary: #111111;
+  --bg-elevated: #fff;
+  --fg-primary: #111;
   --fg-secondary: #4c4546;
   --fg-muted: #6b6263;
-
-  /* Borders (transparent overlays — adapt naturally) */
-  --border-subtle: rgba(0, 0, 0, 0.04);
-  --border-light: rgba(0, 0, 0, 0.06);
-  --border-default: rgba(0, 0, 0, 0.08);
-  --border-medium: rgba(0, 0, 0, 0.1);
-  --border-hover: rgba(0, 0, 0, 0.15);
-  --border-hover-soft: rgba(0, 0, 0, 0.12);
-
-  /* Overlays */
-  --overlay-weak: rgba(0, 0, 0, 0.04);
-  --overlay-medium: rgba(0, 0, 0, 0.08);
-  --navy-overlay-30: rgba(0, 0, 0, 0.3);
-  --navy-overlay-70: rgba(0, 0, 0, 0.7);
-
-  /* Media letterbox */
-  --media-letterbox: #000000;
-
-  /* Navbar + sheets */
-  --navbar-bg: rgba(255, 255, 255, 0.8);
-  --navbar-border: rgba(0, 0, 0, 0.05);
-  --sheet-bg: rgba(255, 255, 255, 0.95);
-
-  /* Shadows */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-  --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.12);
-
-  /* Focus + selection */
+  --border-subtle: #0000000a;
+  --border-light: #0000000f;
+  --border-default: #00000014;
+  --border-medium: #0000001a;
+  --border-hover: #00000026;
+  --border-hover-soft: #0000001f;
+  --overlay-weak: #0000000a;
+  --overlay-medium: #00000014;
+  --navy-overlay-30: #0000004d;
+  --navy-overlay-70: #000000b3;
+  --media-letterbox: #000;
+  --navbar-bg: #fffc;
+  --navbar-border: #0000000d;
+  --sheet-bg: #fffffff2;
+  --shadow-sm: 0 1px 2px #0000000d;
+  --shadow-md: 0 4px 12px #00000014;
+  --shadow-lg: 0 12px 32px #0000001f;
   --focus-ring: var(--color-accent);
   --selection-bg: var(--color-primary);
   --selection-fg: var(--color-white);
-
-  /* Status colors */
-  --color-success: #2ECC71;
+  --color-success: #2ecc71;
   --color-success-text: #047857;
-  --color-success-bg: rgba(46, 204, 113, 0.1);
-  --color-warning: #F5A623;
+  --color-success-bg: #2ecc711a;
+  --color-warning: #f5a623;
   --color-warning-bg: #fef9e7;
   --color-warning-border: #f5d880;
   --color-warning-text: #7a6420;
   --color-error: #ba1a1a;
-  --color-error-bg: rgba(186, 26, 26, 0.08);
-  --color-error-border: rgba(186, 26, 26, 0.22);
-
-  /* Badges */
+  --color-error-bg: #ba1a1a14;
+  --color-error-border: #ba1a1a38;
   --badge-success-bg: #e8f5e9;
   --badge-success-fg: #1b7a3d;
   --badge-warning-bg: #fff3e0;
@@ -97,34 +826,20 @@
   --badge-neutral-fg: #6b6263;
   --badge-neutral-border: #e5e7eb;
   --badge-count-bg: #b91c1c;
-  --badge-count-fg: #ffffff;
-
-  /* Primary button (inverts in dark mode) */
+  --badge-count-fg: #fff;
   --btn-primary-bg: var(--color-primary);
   --btn-primary-fg: var(--color-white);
-
-  /* Transitions */
-  --transition-fast: 150ms ease-out;
-  --transition-base: 250ms ease-out;
-  --transition-slow: 400ms cubic-bezier(0.16, 1, 0.3, 1);
-
-  /* Radius */
+  --transition-fast: .15s ease-out;
+  --transition-base: .25s ease-out;
+  --transition-slow: .4s cubic-bezier(.16, 1, .3, 1);
   --radius: 2px;
-
-  /* Navbar */
   --navbar-height: 64px;
-
-  /* Desktop top bar */
   --top-bar-row1: 52px;
   --top-bar-row2: 44px;
   --top-bar-total: var(--top-bar-row1);
-
-  /* Breakpoints (informational) */
   --bp-gt-mobile: 800px;
   --bp-gt-narrow-desktop: 1100px;
   --bp-gt-desktop: 1300px;
-
-  /* Z-index map */
   --z-rail-sticky: 10;
   --z-rail: 30;
   --z-popover: 40;
@@ -135,77 +850,76 @@
   --z-skip-nav: 9999;
   --z-feedback: 10000;
   --z-feedback-above: 10001;
-
-  /* ===== Styleguide chrome (NOT app tokens) ===== */
-  --sg-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
-/* ========== Dark theme — overrides semantic tokens only ========== */
-:root[data-theme="dark"] {
-  color-scheme: dark;
+@media (prefers-color-scheme: dark) {
+  :root {
+    --lightningcss-light: ;
+    --lightningcss-dark: initial;
+  }
+}
 
+@media (min-width: 800px) {
+  :root {
+    --bottom-nav-height: 0px;
+  }
+}
+
+:root[data-theme="dark"] {
+  --lightningcss-light: ;
+  --lightningcss-dark: initial;
+  color-scheme: dark;
   --bg-canvas: #18181b;
   --bg-sunken: #111114;
   --bg-raised: #26262b;
   --bg-elevated: #2d2d33;
-
   --fg-primary: #f5f5f7;
   --fg-secondary: #c7c7cc;
   --fg-muted: #8e8e93;
-
   --color-accent: #a0a0a8;
   --color-accent-hover: #c7c7cc;
-
-  --border-subtle: rgba(255, 255, 255, 0.04);
-  --border-light: rgba(255, 255, 255, 0.06);
-  --border-default: rgba(255, 255, 255, 0.08);
-  --border-medium: rgba(255, 255, 255, 0.12);
-  --border-hover: rgba(255, 255, 255, 0.18);
-  --border-hover-soft: rgba(255, 255, 255, 0.14);
-
-  --overlay-weak: rgba(255, 255, 255, 0.04);
-  --overlay-medium: rgba(255, 255, 255, 0.08);
-  --navy-overlay-30: rgba(0, 0, 0, 0.5);
-  --navy-overlay-70: rgba(0, 0, 0, 0.8);
-
-  --navbar-bg: rgba(11, 11, 13, 0.8);
-  --navbar-border: rgba(255, 255, 255, 0.06);
-  --sheet-bg: rgba(20, 20, 23, 0.95);
-
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
-  --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.6);
-
+  --border-subtle: #ffffff0a;
+  --border-light: #ffffff0f;
+  --border-default: #ffffff14;
+  --border-medium: #ffffff1f;
+  --border-hover: #ffffff2e;
+  --border-hover-soft: #ffffff24;
+  --overlay-weak: #ffffff0a;
+  --overlay-medium: #ffffff14;
+  --navy-overlay-30: #00000080;
+  --navy-overlay-70: #000c;
+  --navbar-bg: #0b0b0dcc;
+  --navbar-border: #ffffff0f;
+  --sheet-bg: #141417f2;
+  --shadow-sm: 0 1px 2px #0006;
+  --shadow-md: 0 4px 12px #00000080;
+  --shadow-lg: 0 12px 32px #0009;
   --focus-ring: #8e8e93;
   --selection-bg: #f5f5f7;
   --selection-fg: #0b0b0d;
-
-  --color-warning-bg: rgba(245, 166, 35, 0.1);
-  --color-warning-border: rgba(245, 166, 35, 0.3);
+  --color-warning-bg: #f5a6231a;
+  --color-warning-border: #f5a6234d;
   --color-warning-text: #fbbf24;
   --color-success-text: #6ee7a7;
-  --color-success-bg: rgba(110, 231, 167, 0.12);
+  --color-success-bg: #6ee7a71f;
   --color-error: #f87171;
-  --color-error-bg: rgba(248, 113, 113, 0.12);
-  --color-error-border: rgba(248, 113, 113, 0.3);
-
-  --badge-success-bg: rgba(46, 204, 113, 0.15);
+  --color-error-bg: #f871711f;
+  --color-error-border: #f871714d;
+  --badge-success-bg: #2ecc7126;
   --badge-success-fg: #6ee7a7;
-  --badge-warning-bg: rgba(245, 166, 35, 0.15);
+  --badge-warning-bg: #f5a62326;
   --badge-warning-fg: #fbbf24;
-  --badge-neutral-bg: rgba(255, 255, 255, 0.06);
+  --badge-neutral-bg: #ffffff0f;
   --badge-neutral-fg: #8e8e93;
-  --badge-neutral-border: rgba(255, 255, 255, 0.1);
+  --badge-neutral-border: #ffffff1a;
   --badge-count-bg: #dc2626;
-  --badge-count-fg: #ffffff;
-
+  --badge-count-fg: #fff;
   --btn-primary-bg: #f5f5f7;
   --btn-primary-fg: #0b0b0d;
-
   --color-navy: #f5f5f7;
   --color-off-white: #18181b;
   --color-gray-100: #26262b;
-  --color-light-gray: rgba(255, 255, 255, 0.1);
+  --color-light-gray: #ffffff1a;
   --color-mid-gray: #8e8e93;
   --color-dark-gray: #c7c7cc;
   --color-surface: #18181b;
@@ -213,1899 +927,23885 @@
   --color-surface-container-high: #3a3a40;
 }
 
-/* Global focus ring (copied from tokens.css) */
-a:focus-visible,
-button:focus-visible,
-[role="button"]:focus-visible,
-[tabindex]:focus-visible {
+a:focus-visible, button:focus-visible, [role="button"]:focus-visible, [tabindex]:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
-    animation-duration: 0.01ms !important;
-    transition-duration: 0.01ms !important;
+  *, :before, :after {
+    transition-duration: .01ms !important;
+    animation-duration: .01ms !important;
   }
 }
 
-::selection { background: var(--selection-bg); color: var(--selection-fg); }
+html {
+  scrollbar-gutter: stable;
+}
 
-/* ==========================================================================
-   BASE TYPE SYSTEM
-   In production: Inter (--font-inter) for UI, Noto Serif (--font-headline)
-   for headlines. This standalone file has NO network access, so we use the
-   documented fallbacks: system-ui for body/UI, Georgia, serif for headlines
-   (matching tailwind.config.ts's `headline` stack tail). The visual rhythm
-   (sizes/weights/tracking) is reproduced exactly from the Tailwind fontSize
-   scale; only the glyph shapes differ from production.
-   ========================================================================== */
-* { box-sizing: border-box; }
-html { scrollbar-gutter: stable; }
 body {
-  margin: 0;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-family: var(--font-inter), system-ui, -apple-system, sans-serif;
   color: var(--fg-secondary);
   background: var(--bg-canvas);
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
 }
-.font-headline { font-family: Georgia, "Times New Roman", serif; }
 
-/* Tailwind-equivalent type-scale utilities (from tailwind.config.ts) */
-.text-display { font-size: 3rem;     line-height: 1.1; font-weight: 700; letter-spacing: -0.03em; }
-.text-h1      { font-size: 2.25rem;  line-height: 1.2; font-weight: 700; letter-spacing: -0.02em; }
-.text-h2      { font-size: 1.75rem;  line-height: 1.3; font-weight: 600; letter-spacing: -0.01em; }
-.text-h3      { font-size: 1.375rem; line-height: 1.4; font-weight: 600; }
-.text-h4      { font-size: 1.125rem; line-height: 1.4; font-weight: 600; }
-.text-body    { font-size: 1rem;     line-height: 1.6; font-weight: 400; }
-.text-body-sm { font-size: 0.875rem; line-height: 1.5; font-weight: 400; }
-.text-caption { font-size: 0.75rem;  line-height: 1.4; font-weight: 500; letter-spacing: 0.05em; }
-
-h1, h2, h3, h4 { color: var(--fg-primary); }
-
-/* ==========================================================================
-   STYLEGUIDE LAYOUT CHROME
-   ========================================================================== */
-.sg-topbar {
-  position: sticky; top: 0; z-index: 200;
-  display: flex; align-items: center; justify-content: space-between; gap: 16px;
-  padding: 12px 24px;
-  background: var(--navbar-bg);
-  backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--navbar-border);
+h1, h2, h3, h4, h5, h6 {
+  color: var(--fg-primary);
 }
-.sg-topbar__brand { display: flex; align-items: center; gap: 12px; }
-.sg-topbar__brand-name { font-weight: 600; letter-spacing: -0.01em; color: var(--fg-primary); }
-.sg-topbar__brand-sub { color: var(--fg-muted); font-size: 0.8125rem; }
-.sg-theme-toggle {
-  display: inline-flex; align-items: center; gap: 8px;
-  padding: 8px 16px;
-  font: inherit; font-size: 0.8125rem; font-weight: 500; letter-spacing: 0.04em;
-  color: var(--btn-primary-fg);
-  background: var(--btn-primary-bg);
-  border: none; border-radius: var(--radius);
+
+.feed-card__time, .dash-card__stat-value, .profile-hero__count-value {
+  font-feature-settings: "tnum" 1;
+}
+
+.app-card__label, .dash-card__title, .dash-card__preview-label, .navbar__app-link, .domain-modal__label, .domain-modal__dns-label, .domain-modal__verify-label, .username-card__form-label, .location-card__type {
+  font-feature-settings: "case" 1;
+}
+
+::selection {
+  background: var(--selection-bg);
+  color: var(--selection-fg);
+}
+
+/* [project]/src/app/styles/layout.css [app-client] (css) */
+.theme-toggle-cycle {
+  width: 36px;
+  height: 36px;
+  color: var(--fg-secondary);
   cursor: pointer;
-  transition: opacity var(--transition-fast);
+  transition: color var(--transition-fast);
+  background: none;
+  border: none;
+  outline: none;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
 }
-.sg-theme-toggle:hover { opacity: 0.9; }
 
-.sg-shell { max-width: 1080px; margin: 0 auto; padding: 0 24px 120px; }
+.theme-toggle-cycle:hover {
+  color: var(--fg-primary);
+}
 
-.sg-intro { padding: 56px 0 24px; border-bottom: 1px solid var(--border-default); }
-.sg-intro h1 { margin: 0 0 16px; }
-.sg-intro p { max-width: 720px; color: var(--fg-secondary); }
-.sg-principles { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 14px; margin-top: 28px; }
-.sg-principle {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
+.theme-toggle-cycle:focus {
+  outline: none;
+}
+
+.theme-toggle-cycle:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
   border-radius: var(--radius);
-  padding: 16px;
 }
-.sg-principle h4 { margin: 0 0 6px; font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.12em; color: var(--fg-muted); }
-.sg-principle p { margin: 0; font-size: 0.875rem; color: var(--fg-secondary); }
 
-/* Table of contents */
-.sg-toc { display: flex; flex-wrap: wrap; gap: 8px; padding: 24px 0; border-bottom: 1px solid var(--border-default); }
-.sg-toc a {
-  font-size: 0.8125rem; color: var(--fg-secondary); text-decoration: none;
-  padding: 4px 10px; border: 1px solid var(--border-default); border-radius: 999px;
-  transition: border-color var(--transition-fast), color var(--transition-fast);
+.theme-toggle-cycle__icon {
+  display: inline-flex;
 }
-.sg-toc a:hover { border-color: var(--border-hover); color: var(--fg-primary); }
 
-/* Category + component sections */
-.sg-category { padding-top: 48px; }
-.sg-category > h2 { font-size: 1.75rem; letter-spacing: -0.01em; margin: 0 0 4px; }
-.sg-category > .sg-category-desc { color: var(--fg-muted); font-size: 0.9375rem; margin: 0 0 8px; }
+html:not([data-theme="dark"]) .signin-mark__img--dark, html[data-theme="dark"] .signin-mark__img--light {
+  display: none;
+}
 
-.sg-component {
-  margin-top: 40px;
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius);
-  background: var(--bg-elevated);
+.loading-screen {
+  z-index: var(--z-popover);
+  background: var(--bg-canvas);
+  pointer-events: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  position: fixed;
+  inset: 0;
+}
+
+.loading-screen__inner > * {
+  pointer-events: auto;
+}
+
+.loading-screen__inner {
+  flex-direction: column;
+  align-items: center;
+  display: flex;
+}
+
+.loading-screen__logo {
+  width: 64px;
+  height: 64px;
+  color: var(--fg-primary);
+  animation: 2s cubic-bezier(.4, 0, .6, 1) infinite logoPulse;
+}
+
+@keyframes logoPulse {
+  0%, 100% {
+    opacity: .3;
+    transform: scale(.95);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-screen__logo {
+    opacity: 1;
+    animation: none;
+    transform: none;
+  }
+}
+
+.loading-screen__error {
+  color: var(--color-error);
+  font-size: .8125rem;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  margin-bottom: 16px;
+}
+
+.loading-screen__link {
+  color: var(--fg-muted);
+  font-size: .8125rem;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  transition: color var(--transition-fast);
+  text-decoration: none;
+}
+
+.loading-screen__link:hover {
+  color: var(--fg-primary);
+}
+
+.navbar {
+  z-index: var(--z-navbar);
+  height: var(--navbar-height);
+  transition: background var(--transition-fast), backdrop-filter var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-base);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+}
+
+.navbar--hidden {
+  transform: translateY(-100%);
+}
+
+.navbar--default {
+  background: var(--navbar-bg);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 1px 0 var(--navbar-border);
+}
+
+.navbar--profile-overlay {
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  box-shadow: none;
+  background: none;
+}
+
+.navbar__back-overlay {
+  background: var(--navy-overlay-30);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  width: 40px;
+  height: 40px;
+  color: var(--color-white);
+  cursor: pointer;
+  transition: background var(--transition-fast), transform var(--transition-fast);
+  border: none;
+  border-radius: 999px;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.navbar__back-overlay:hover {
+  background: var(--navy-overlay-70);
+}
+
+.navbar__back-overlay:active {
+  transform: scale(.95);
+}
+
+.navbar__back-overlay:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.navbar__inner {
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  max-width: 1536px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 0 16px;
+  display: grid;
+}
+
+.navbar__left {
+  justify-content: flex-start;
+  align-items: center;
+  display: flex;
+}
+
+.navbar__logo {
+  color: var(--fg-primary);
+  justify-self: center;
+  align-items: center;
+  text-decoration: none;
+  display: flex;
+}
+
+.navbar__title {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  letter-spacing: -.01em;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  justify-self: center;
+  max-width: 60vw;
+  font-size: .9375rem;
+  font-weight: 450;
   overflow: hidden;
 }
-.sg-component__head {
-  display: flex; align-items: baseline; justify-content: space-between; gap: 12px; flex-wrap: wrap;
-  padding: 20px 24px;
-  border-bottom: 1px solid var(--border-subtle);
-  background: var(--bg-raised);
+
+.navbar__title-part {
+  color: inherit;
+  border-radius: var(--radius);
+  transition: background var(--transition-fast);
+  margin: 0 -2px;
+  padding: 3px 6px;
+  text-decoration: none;
 }
-.sg-component__title { font-size: 1.25rem; font-weight: 600; color: var(--fg-primary); }
-.sg-component__file { font-family: var(--sg-mono); font-size: 0.75rem; color: var(--fg-muted); }
-.sg-component__body { padding: 24px; }
-.sg-usage {
-  margin: 0 0 20px;
-  font-size: 0.875rem; line-height: 1.6; color: var(--fg-secondary);
-  padding: 12px 16px;
-  background: var(--bg-canvas);
-  border-left: 2px solid var(--border-hover);
+
+.navbar__title-part:hover {
+  background: var(--overlay-weak);
+}
+
+.navbar__title-sep {
+  color: var(--fg-muted);
+  font-weight: 400;
+}
+
+.navbar__logo-img {
+  width: auto;
+  height: 28px;
+  display: block;
+}
+
+.navbar__chevron-desktop {
+  display: none;
+}
+
+@media (min-width: 800px) {
+  .navbar__inner {
+    padding: 0 32px;
+  }
+
+  .navbar__chevron-desktop {
+    display: block;
+  }
+}
+
+.navbar__beta-label {
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: var(--fg-secondary);
+  background: var(--bg-sunken);
+  border-radius: var(--radius);
+  margin-left: 10px;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.navbar__right {
+  justify-content: flex-end;
+  align-items: center;
+  gap: 16px;
+  display: flex;
+}
+
+.navbar__signin-btn {
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  padding: 4px 8px;
+  display: inline-flex;
+}
+
+.navbar__signin-btn:hover {
+  opacity: .85;
+}
+
+.navbar__signin-btn:active {
+  transform: scale(.97);
+}
+
+.navbar__signin-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.navbar__signin-img {
+  width: auto;
+  height: 26px;
+  display: block;
+}
+
+.navbar__app-links {
+  align-items: center;
+  gap: 32px;
+  display: flex;
+}
+
+.navbar__app-link {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  letter-spacing: .15em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  transition: color var(--transition-fast);
+  border-bottom: 1.5px solid #0000;
+  padding: 4px 0;
+  font-size: .75rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.navbar__app-link:hover {
+  color: var(--fg-primary);
+}
+
+.navbar__app-link--active {
+  color: var(--fg-primary);
+  border-bottom-color: var(--fg-primary);
+}
+
+.navbar__user {
+  align-items: center;
+  gap: 12px;
+  display: flex;
+}
+
+.navbar__hamburger {
+  width: 44px;
+  height: 44px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  background: none;
+  border: none;
+  outline: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.navbar__hamburger:hover {
+  color: var(--fg-primary);
+}
+
+.navbar__hamburger:focus {
+  outline: none;
+}
+
+.navbar__hamburger:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
   border-radius: var(--radius);
 }
-.sg-usage strong { color: var(--fg-primary); }
 
-.sg-block-label {
-  display: block;
-  font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.12em;
-  color: var(--fg-muted); margin: 24px 0 12px; font-weight: 600;
+.navbar__dropdown {
+  top: var(--navbar-height);
+  background: var(--sheet-bg);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border-light);
+  z-index: calc(var(--z-navbar) - 1);
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px 32px;
+  display: none;
+  position: absolute;
+  left: 0;
+  right: 0;
 }
-.sg-block-label:first-child { margin-top: 0; }
 
-.sg-demo {
-  display: flex; flex-wrap: wrap; align-items: center; gap: 16px;
+.navbar__dropdown--open {
+  display: flex;
+}
+
+.navbar__dropdown-link {
+  color: var(--fg-muted);
+  transition: color var(--transition-fast);
+  padding: 8px 0;
+  font-size: .875rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.navbar__dropdown-link:hover, .navbar__dropdown-link--active {
+  color: var(--fg-primary);
+}
+
+:root {
+  --bottom-nav-height: 56px;
+}
+
+.bottom-nav {
+  z-index: var(--z-bottom-nav);
+  height: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px));
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  background: var(--bg-elevated);
+  border-top: 1px solid var(--border-subtle);
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.bottom-nav__inner {
+  justify-content: space-around;
+  align-items: center;
+  max-width: 720px;
+  height: 100%;
+  margin: 0 auto;
+  display: flex;
+}
+
+.bottom-nav__item {
+  height: 100%;
+  min-height: 44px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  -webkit-tap-highlight-color: transparent;
+  background: none;
+  border: none;
+  flex-direction: column;
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  gap: 2px;
+  padding: 0;
+  display: flex;
+}
+
+.bottom-nav__item:hover {
+  color: var(--fg-primary);
+}
+
+.bottom-nav__item:active {
+  transition: transform var(--transition-fast);
+  transform: scale(.92);
+}
+
+.bottom-nav__item--active {
+  color: var(--fg-primary);
+}
+
+.bottom-nav__label {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: .625rem;
+  font-weight: 500;
+  line-height: 1;
+}
+
+@media (min-width: 800px) {
+  .bottom-nav {
+    display: none;
+  }
+}
+
+.mobile-sidebar__section--profile {
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  display: flex;
+}
+
+.mobile-sidebar__profile {
+  min-width: 0;
+  color: inherit;
+  border-radius: var(--radius);
+  flex: 1;
+  text-decoration: none;
+  display: block;
+}
+
+a.mobile-sidebar__profile:hover .mobile-sidebar__name {
+  text-decoration: underline;
+}
+
+.mobile-sidebar__theme {
+  flex-shrink: 0;
+  margin-top: -4px;
+  margin-right: -8px;
+}
+
+.mobile-sidebar__section {
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 20px 24px;
+}
+
+.mobile-sidebar__section:last-child {
+  border-bottom: none;
+}
+
+.mobile-sidebar__name {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  margin-top: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.mobile-sidebar__handle {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-muted);
+  margin-top: 2px;
+  font-size: .8125rem;
+}
+
+.mobile-sidebar__link {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  text-align: left;
+  background: none;
+  border: none;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 12px 0;
+  font-size: .9375rem;
+  font-weight: 400;
+  text-decoration: none;
+  display: flex;
+}
+
+.mobile-sidebar__link--active {
+  color: var(--fg-primary);
+  font-weight: 600;
+}
+
+.mobile-sidebar__section--legal {
+  padding: 16px 24px;
+  font-size: .75rem;
+}
+
+.mobile-sidebar__legal-link {
+  color: var(--fg-muted);
+  text-decoration: none;
+}
+
+.mobile-sidebar__legal-link:hover {
+  color: var(--fg-primary);
+}
+
+.mobile-sidebar__legal-sep {
+  color: var(--border-medium);
+}
+
+.app-page {
+  background: var(--bg-canvas);
+  min-height: 100vh;
+}
+
+.app-page__inner {
+  padding: 16px 0;
+}
+
+.app-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  transition: border-color var(--transition-fast);
   padding: 24px;
-  background:
-    repeating-conic-gradient(var(--overlay-weak) 0% 25%, transparent 0% 50%) 0 / 20px 20px,
-    var(--bg-canvas);
+}
+
+.app-card:hover {
+  border-color: var(--border-hover-soft);
+}
+
+.app-card__label {
+  letter-spacing: .08em;
+  color: var(--fg-muted);
+  margin-bottom: 8px;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.app-shell {
+  background: var(--bg-canvas);
+  min-height: 100vh;
+}
+
+.app-shell__grid {
+  max-width: 1300px;
+  min-height: 100vh;
+  margin: 0 auto;
+}
+
+@media (min-width: 800px) {
+  .navbar {
+    display: none;
+  }
+
+  :root {
+    --navbar-height: 0px;
+  }
+
+  .app-shell__grid {
+    grid-template-columns: minmax(0, 1280px);
+    justify-content: center;
+    display: grid;
+  }
+}
+
+.app-shell__center {
+  min-height: 100vh;
+}
+
+.app-shell__content {
+  max-width: 720px;
+  padding: calc(var(--navbar-height) + 16px) 32px calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px) + 24px);
+  box-sizing: border-box;
+  min-height: 100vh;
+  margin: 0 auto;
+}
+
+@media (min-width: 800px) {
+  .app-shell__content {
+    max-width: 600px;
+  }
+}
+
+.app-shell:is(:has(.home-page), :has(.explore-page)) .app-shell__grid {
+  max-width: none;
+}
+
+@media (min-width: 800px) {
+  .app-shell:is(:has(.home-page), :has(.explore-page)) .app-shell__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .app-shell:is(:has(.home-page), :has(.explore-page)) .app-shell__content {
+    max-width: none;
+    padding-top: var(--navbar-height);
+    flex-direction: column;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    display: flex;
+  }
+
+  :is(.home-page, .explore-page) {
+    flex: 1;
+  }
+
+  html:is(:has(.home-page), :has(.explore-page)) .site-footer {
+    margin-top: 0;
+  }
+
+  html:has(.desktop-top-bar__row--tabs) {
+    --top-bar-total: calc(var(--top-bar-row1) + var(--top-bar-row2));
+  }
+}
+
+.app-shell--fullbleed .app-shell__content {
+  max-width: none;
+  padding-top: 0;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+@media (min-width: 800px) {
+  .app-shell--fullbleed .app-shell__content {
+    max-width: 1280px;
+    margin: 0 auto;
+  }
+}
+
+.auth-guard-loading {
+  justify-content: center;
+  align-items: center;
+  min-height: 60vh;
+  display: flex;
+}
+
+.dashboard {
+  padding: 0;
+}
+
+.dashboard__topbar {
+  background: none;
+  justify-content: space-between;
+  align-items: center;
+  padding: 48px 0 24px;
+  display: flex;
+  position: relative;
+}
+
+.dashboard__topbar:before {
+  content: "";
+  opacity: .04;
+  pointer-events: none;
+  background: url("http://127.0.0.1:3000/assets/guilloche_02.svg") center / contain no-repeat;
+  width: 200px;
+  height: 200px;
+  position: absolute;
+  top: 50%;
+  right: -40px;
+  transform: translateY(-50%);
+}
+
+.dashboard__page-title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  letter-spacing: -.01em;
+  font-size: clamp(2rem, 3vw + 1rem, 2.5rem);
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.dashboard__topbar-right {
+  align-items: center;
+  gap: 12px;
+  display: flex;
+}
+
+.dashboard__action-row {
+  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 0;
+  display: flex;
+}
+
+.dashboard__body {
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+  display: flex;
+}
+
+.dashboard__main {
+  flex-direction: column;
+  display: flex;
+}
+
+.dashboard__aside {
+  flex-direction: column;
+  gap: 16px;
+  display: flex;
+}
+
+.profile-card {
+  align-items: flex-start;
+  gap: 20px;
+  display: flex;
+}
+
+.profile-card__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.profile-card__name {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  letter-spacing: -.01em;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.profile-card__handle {
+  color: var(--fg-muted);
+  margin-top: 2px;
+  font-size: .8125rem;
+}
+
+.profile-card__bio {
+  color: var(--fg-secondary);
+  margin-top: 8px;
+  font-size: .875rem;
+  line-height: 1.5;
+}
+
+.profile-card__did {
+  word-break: break-all;
+  margin-top: 16px;
+}
+
+.profile-card__banner {
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, var(--bg-sunken) 0%, var(--bg-raised) 100%);
+  width: 100%;
+  height: 180px;
+  margin: 0 0 16px;
+  overflow: hidden;
+}
+
+.profile-card__banner img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.personal-info__hint {
+  color: var(--fg-muted);
+  margin-top: 4px;
+  font-size: .6875rem;
+  line-height: 1.4;
+}
+
+.personal-info__field--link {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.personal-info__field--link:hover {
+  text-decoration: underline;
+}
+
+.personal-info__full-width {
+  grid-column: 1 / -1;
+}
+
+.profile-fallback-note {
+  background: var(--color-warning-bg);
+  border: 1px solid var(--color-warning-border);
+  border-radius: var(--radius);
+  margin-top: 16px;
+  padding: 12px 16px;
+}
+
+.profile-fallback-note p {
+  color: var(--color-warning-text);
+  margin: 0;
+  font-size: .8125rem;
+  line-height: 1.5;
+}
+
+.personal-info__grid {
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 16px;
+  display: grid;
+}
+
+.personal-info__label {
+  letter-spacing: .15em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin-bottom: 6px;
+  font-size: .625rem;
+  font-weight: 500;
+  display: block;
+}
+
+.personal-info__field {
+  color: var(--fg-primary);
+  background: none;
+  border: none;
+  border-radius: 0;
+  padding: 12px 0;
+  font-size: .875rem;
+}
+
+.personal-info__field--mono {
+  letter-spacing: .02em;
+  color: var(--fg-muted);
+  word-break: break-all;
+  background: none;
+  border: none;
+  padding: 12px 0;
+  font-family: monospace;
+  font-size: .75rem;
+}
+
+.mt-4 {
+  margin-top: 16px;
+}
+
+.left-rail {
+  top: var(--navbar-height);
+  height: calc(100vh - var(--navbar-height));
+  background: var(--bg-canvas);
+  border-right: 1px solid var(--border-subtle);
+  z-index: var(--z-rail);
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-default) transparent;
+  flex-direction: column;
+  padding: 16px 0 24px;
+  display: none;
+  position: sticky;
+  overflow-y: auto;
+}
+
+@media (min-width: 800px) {
+  .left-rail {
+    display: flex;
+  }
+}
+
+.left-rail__brand {
+  height: 48px;
+  color: var(--fg-primary);
+  border-radius: var(--radius);
+  transition: opacity var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  margin: 0 8px 8px;
+  text-decoration: none;
+  display: flex;
+}
+
+.left-rail__brand:hover {
+  opacity: .8;
+}
+
+.left-rail__brand-icon {
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+  display: flex;
+}
+
+.left-rail__brand-wordmark {
+  height: 48px;
+  color: var(--fg-primary);
+  align-items: center;
+  padding-left: 12px;
+  display: none;
+}
+
+.left-rail__brand-wordmark-img {
+  width: auto;
+  height: 24px;
+  display: block;
+}
+
+:root[data-theme="dark"] .left-rail__brand-wordmark-img {
+  filter: invert();
+}
+
+@media (min-width: 1300px) {
+  .left-rail__brand {
+    justify-content: flex-start;
+    width: 220px;
+    margin: 0 0 8px;
+  }
+
+  .left-rail__brand-icon {
+    display: none;
+  }
+
+  .left-rail__brand-wordmark {
+    display: flex;
+  }
+}
+
+.left-rail__list {
+  flex: 1;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.left-rail__item {
+  margin: 0;
+}
+
+.left-rail__link {
+  height: 48px;
+  color: var(--fg-muted);
+  font-family: var(--font-inter), system-ui, sans-serif;
+  letter-spacing: -.005em;
+  border-radius: var(--radius);
+  transition: background var(--transition-fast), color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin: 0 8px;
+  padding: 0;
+  font-size: .875rem;
+  font-weight: 400;
+  text-decoration: none;
+  display: flex;
+}
+
+.left-rail__link:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-secondary);
+}
+
+.left-rail__link--active {
+  color: var(--fg-primary);
+  font-weight: 600;
+}
+
+.left-rail__icon {
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  position: relative;
+}
+
+.left-rail__badge {
+  background: var(--badge-count-bg);
+  min-width: 18px;
+  height: 18px;
+  color: var(--badge-count-fg);
+  font-feature-settings: "tnum" 1;
+  border-radius: 999px;
+  justify-content: center;
+  align-items: center;
+  padding: 0 5px;
+  font-size: .6875rem;
+  font-weight: 600;
+  line-height: 1;
+  display: flex;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+.left-rail__label {
+  display: none;
+}
+
+@media (min-width: 1300px) {
+  .left-rail {
+    align-items: flex-end;
+  }
+
+  .left-rail__list, .left-rail__bottom {
+    width: 220px;
+  }
+
+  .left-rail__label {
+    display: inline;
+  }
+
+  .left-rail__link {
+    justify-content: flex-start;
+    margin: 0;
+    padding-right: 12px;
+  }
+}
+
+.left-rail__bottom {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+  margin-top: 16px;
+  padding: 0 8px;
+  display: flex;
+}
+
+.left-rail__switcher {
+  cursor: pointer;
+  color: var(--fg-secondary);
+  letter-spacing: -.005em;
+  border-radius: var(--radius);
+  transition: background var(--transition-fast);
+  text-align: left;
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 4px;
+  font-family: inherit;
+  font-size: .8125rem;
+  font-weight: 500;
+  display: flex;
+}
+
+.left-rail__switcher:hover {
+  background: var(--overlay-weak);
+}
+
+.left-rail__switcher-meta {
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  display: none;
+}
+
+.left-rail__switcher-name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+  overflow: hidden;
+}
+
+.left-rail__switcher-handle {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.left-rail__switcher .chevron-down, .left-rail__switcher svg {
+  display: none;
+}
+
+@media (min-width: 1300px) {
+  .left-rail__switcher {
+    justify-content: flex-start;
+  }
+
+  .left-rail__switcher-meta, .left-rail__switcher svg {
+    display: flex;
+  }
+
+  .left-rail__switcher svg {
+    display: block;
+  }
+}
+
+.left-rail__primary {
+  background: var(--btn-primary-bg);
+  width: 44px;
+  height: 44px;
+  color: var(--btn-primary-fg);
+  border-radius: var(--radius);
+  letter-spacing: .01em;
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+  border: none;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  margin: 0 auto;
+  font-family: inherit;
+  font-size: .875rem;
+  font-weight: 500;
+  display: flex;
+}
+
+.left-rail__primary:hover {
+  opacity: .9;
+}
+
+.left-rail__primary-label {
+  display: none;
+}
+
+@media (min-width: 1300px) {
+  .left-rail__primary {
+    width: 100%;
+    height: 44px;
+    padding: 0 16px;
+  }
+
+  .left-rail__primary-label {
+    display: inline;
+  }
+}
+
+.acting-as-bar {
+  background: var(--btn-primary-bg);
+  width: 100%;
+  color: var(--btn-primary-fg);
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  display: flex;
+}
+
+.acting-as-bar__text {
+  margin: 0;
+  font-size: .8125rem;
+  line-height: 1.4;
+}
+
+.acting-as-bar__text b {
+  font-weight: 600;
+}
+
+.acting-as-bar__switch {
+  height: 28px;
+  color: var(--btn-primary-fg);
+  border: 1px solid var(--btn-primary-fg);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+  background: none;
+  flex-shrink: 0;
+  align-items: center;
+  padding: 0 12px;
+  font-family: inherit;
+  font-size: .8125rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.acting-as-bar__switch:hover {
+  opacity: .8;
+}
+
+.left-rail__signin-card {
+  flex-direction: column;
+  gap: 8px;
+  display: flex;
+}
+
+.left-rail__signin-title, .left-rail__signin-body {
+  margin: 0;
+  display: none;
+}
+
+@media (min-width: 1300px) {
+  .left-rail__signin-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius);
+    padding: 12px;
+  }
+
+  .left-rail__signin-title, .left-rail__signin-body {
+    display: block;
+  }
+
+  .left-rail__signin-title {
+    color: var(--fg-primary);
+    font-size: .875rem;
+    font-weight: 600;
+  }
+
+  .left-rail__signin-body {
+    color: var(--fg-muted);
+    font-size: .75rem;
+    line-height: 1.4;
+  }
+}
+
+.right-rail {
+  top: var(--top-bar-total);
+  height: calc(100vh - var(--top-bar-total));
+  background: var(--bg-canvas);
+  border-left: 1px solid var(--border-subtle);
+  z-index: var(--z-rail);
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-default) transparent;
+  flex-direction: column;
+  gap: 24px;
+  padding: 16px 16px 24px;
+  display: none;
+  position: sticky;
+  overflow-y: auto;
+}
+
+@media (min-width: 1100px) {
+  .right-rail {
+    display: flex;
+  }
+}
+
+.right-rail__search {
+  z-index: var(--z-rail-sticky);
+  background: var(--bg-canvas);
+  padding-bottom: 8px;
+  position: sticky;
+  top: 0;
+}
+
+.right-rail__section {
+  flex-direction: column;
+  display: flex;
+}
+
+.right-rail__heading {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin: 0 0 12px;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.right-rail__empty {
+  color: var(--fg-muted);
+  border-top: 1px solid var(--border-subtle);
+  margin: 0;
+  padding: 12px 0;
+  font-size: .875rem;
+}
+
+.right-rail__footer {
+  color: var(--fg-muted);
+  border-top: 1px solid var(--border-subtle);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: auto;
+  padding-top: 16px;
+  font-size: .75rem;
+  font-weight: 500;
+  display: flex;
+}
+
+.right-rail__footer-link {
+  cursor: pointer;
+  color: var(--fg-muted);
+  font: inherit;
+  transition: color var(--transition-fast);
+  background: none;
+  border: none;
+  padding: 0;
+  text-decoration: none;
+}
+
+.right-rail__footer-link:hover {
+  color: var(--fg-secondary);
+}
+
+.right-rail__footer-sep {
+  color: var(--fg-muted);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.news__list {
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.news__item {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.news__item:last-child {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.news__article {
+  color: inherit;
+  padding: 12px 0;
+}
+
+.news__images {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  gap: 2px;
+  margin: 8px 0 6px;
+  display: grid;
+  overflow: hidden;
+}
+
+.news__images--n1 {
+  grid-template-columns: 1fr;
+}
+
+.news__images--n2 {
+  grid-template-columns: 1fr 1fr;
+}
+
+.news__images--n3 {
+  grid-template-rows: 1fr 1fr;
+  grid-template-columns: 1fr 1fr;
+}
+
+.news__images--n3 .news__image:first-child {
+  grid-row: span 2;
+}
+
+.news__images--n4 {
+  grid-template-rows: 1fr 1fr;
+  grid-template-columns: 1fr 1fr;
+}
+
+.news__image {
+  object-fit: cover;
+  aspect-ratio: 16 / 10;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.news__images--n1 .news__image {
+  aspect-ratio: auto;
+  max-height: 360px;
+}
+
+.news__text {
+  color: var(--fg-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  font-size: .875rem;
+  line-height: 1.45;
+}
+
+.news__rich-link {
+  color: var(--fg-primary);
+  text-decoration: underline;
+  -webkit-text-decoration-color: var(--border-medium);
+  text-decoration-color: var(--border-medium);
+  text-underline-offset: 2px;
+  transition: text-decoration-color var(--transition-fast);
+}
+
+.news__rich-link:hover {
+  -webkit-text-decoration-color: var(--fg-primary);
+  text-decoration-color: var(--fg-primary);
+}
+
+.news__rich-link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.news__time-link {
+  color: var(--fg-muted);
+  transition: color var(--transition-fast);
+  margin-top: 6px;
+  font-size: .75rem;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.news__time-link:hover {
+  color: var(--fg-secondary);
+}
+
+.news__time-link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.news__more {
+  width: 100%;
+  font: inherit;
+  color: var(--fg-muted);
+  cursor: pointer;
+  text-align: center;
+  transition: color var(--transition-fast);
+  background: none;
+  border: none;
+  margin-top: 12px;
+  padding: 8px 0;
+  font-size: .8125rem;
+  font-weight: 400;
+  display: block;
+}
+
+.news__more:hover:not(:disabled) {
+  color: var(--fg-primary);
+}
+
+.news__more:disabled {
+  cursor: default;
+  opacity: .6;
+}
+
+.news__more:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.people-search {
+  width: 100%;
+  position: relative;
+}
+
+.people-search__clear {
+  width: 36px;
+  height: 36px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  border-radius: 999px;
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  margin-left: 2px;
+  padding: 0;
+  display: inline-flex;
+}
+
+.people-search__clear:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.people-search__dropdown {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  z-index: var(--z-popover);
+  max-height: min(360px, 50svh);
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  overflow-y: auto;
+}
+
+.people-search__empty {
+  color: var(--fg-muted);
+  text-align: left;
+  padding: 14px 12px;
+  font-size: .8125rem;
+}
+
+.people-search__item {
+  border-radius: var(--radius);
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  transition: background var(--transition-fast);
+  -webkit-user-select: none;
+  user-select: none;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  display: flex;
+}
+
+.people-search__item:hover {
+  background: var(--overlay-weak);
+}
+
+.people-search__item--highlighted {
+  background: var(--overlay-weak);
+  box-shadow: inset 2px 0 0 var(--fg-primary);
+}
+
+.people-search__item-info {
+  flex-direction: column;
+  flex: auto;
+  min-width: 0;
+  display: flex;
+}
+
+.people-search__item-name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .8125rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.people-search__item-handle {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .6875rem;
+  overflow: hidden;
+}
+
+.cert-search {
+  width: 100%;
+  position: relative;
+}
+
+.cert-search__clear {
+  width: 32px;
+  height: 32px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  border-radius: 999px;
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  margin-left: 2px;
+  padding: 0;
+  display: inline-flex;
+}
+
+.cert-search__clear:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.cert-search__dropdown {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  z-index: var(--z-popover);
+  max-height: min(360px, 50svh);
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  overflow-y: auto;
+}
+
+.cert-search__empty {
+  color: var(--fg-muted);
+  text-align: left;
+  padding: 14px 12px;
+  font-size: .8125rem;
+}
+
+.cert-search__group-header {
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--fg-muted);
+  pointer-events: none;
+  -webkit-user-select: none;
+  user-select: none;
+  padding: 8px 10px 4px;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.cert-search__item {
+  border-radius: var(--radius);
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  transition: background var(--transition-fast);
+  -webkit-user-select: none;
+  user-select: none;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  display: flex;
+}
+
+.cert-search__item:hover {
+  background: var(--overlay-weak);
+}
+
+.cert-search__item--highlighted {
+  background: var(--overlay-weak);
+  box-shadow: inset 2px 0 0 var(--fg-primary);
+}
+
+.cert-search__thumb {
+  border-radius: var(--radius);
+  object-fit: cover;
+  background: var(--bg-sunken);
+  flex: none;
+  width: 36px;
+  height: 36px;
+}
+
+.cert-search__thumb--placeholder {
+  color: var(--fg-muted);
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.cert-search__item-info {
+  flex-direction: column;
+  flex: auto;
+  gap: 1px;
+  min-width: 0;
+  display: flex;
+}
+
+.cert-search__item-title {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .8125rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.cert-search__item-handle {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .6875rem;
+  overflow: hidden;
+}
+
+.sr-only {
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+}
+
+.desktop-top-bar {
+  display: none;
+}
+
+@media (min-width: 800px) {
+  .desktop-top-bar {
+    background: var(--navbar-bg);
+    box-shadow: 0 1px 0 var(--navbar-border);
+    flex-direction: column;
+    display: flex;
+  }
+
+  .desktop-top-bar--placeholder {
+    height: var(--top-bar-row1);
+  }
+}
+
+.desktop-top-bar__row {
+  align-items: center;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 12px;
+  display: flex;
+}
+
+.desktop-top-bar__row--chrome {
+  height: var(--top-bar-row1);
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.desktop-top-bar__row--chrome:last-child {
+  border-bottom: 1px solid var(--border-medium);
+}
+
+.desktop-top-bar__row--tabs {
+  height: var(--top-bar-row2);
+  border-bottom: 1px solid var(--border-medium);
+  gap: 20px;
+}
+
+.desktop-top-bar__left {
+  align-items: center;
+  gap: 0;
+  min-width: 0;
+  display: flex;
+}
+
+.desktop-top-bar__brand {
+  width: 36px;
+  height: 36px;
+  color: var(--fg-primary);
+  border-radius: var(--radius);
+  transition: opacity var(--transition-fast);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.desktop-top-bar__brand--wordmark {
+  width: auto;
+}
+
+.desktop-top-bar__wordmark {
+  width: auto;
+  height: 20px;
+  display: block;
+}
+
+.desktop-top-bar__brand:hover {
+  opacity: .85;
+}
+
+.desktop-top-bar__title {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  letter-spacing: -.01em;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  min-width: 0;
+  margin: 0 0 0 14px;
+  font-size: 1rem;
+  font-weight: 450;
+  overflow: hidden;
+}
+
+.desktop-top-bar__title-part {
+  color: inherit;
+  border-radius: var(--radius);
+  transition: background var(--transition-fast);
+  margin: 0 -2px;
+  padding: 4px 8px;
+  text-decoration: none;
+}
+
+.desktop-top-bar__title-part:hover {
+  background: var(--overlay-weak);
+}
+
+.desktop-top-bar__title-part:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.desktop-top-bar__title-sep {
+  color: var(--fg-muted);
+  font-weight: 400;
+}
+
+.desktop-top-bar__right {
+  flex-shrink: 0;
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.desktop-top-bar__search {
+  width: 260px;
+}
+
+@media (min-width: 1100px) {
+  .desktop-top-bar__search {
+    width: 300px;
+  }
+}
+
+.desktop-top-bar__icon-btn {
+  width: 40px;
+  height: 40px;
+  color: var(--fg-secondary);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.desktop-top-bar__icon-btn:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.desktop-top-bar__icon-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.desktop-top-bar__switcher-wrap {
+  align-items: center;
+  margin-left: 4px;
+  display: inline-flex;
+}
+
+.desktop-top-bar__switcher {
+  border-radius: var(--radius);
+  cursor: pointer;
+  color: var(--fg-secondary);
+  transition: background var(--transition-fast);
+  background: none;
+  border: none;
+  align-items: center;
+  gap: 8px;
+  max-width: 260px;
+  padding: 4px 10px 4px 4px;
+  display: inline-flex;
+}
+
+.desktop-top-bar__switcher:hover {
+  background: var(--overlay-weak);
+}
+
+.desktop-top-bar__switcher:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.desktop-top-bar__switcher-meta {
+  text-align: left;
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.15;
+  display: flex;
+}
+
+.desktop-top-bar__switcher-name {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .8125rem;
+  font-weight: 600;
+  overflow: hidden;
+}
+
+.desktop-top-bar__switcher-handle {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .6875rem;
+  overflow: hidden;
+}
+
+@media (max-width: 1099.98px) {
+  .desktop-top-bar__switcher-meta {
+    display: none;
+  }
+}
+
+.desktop-top-bar__signin-btn {
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  padding: 4px 8px;
+  display: inline-flex;
+}
+
+.desktop-top-bar__signin-btn:hover {
+  opacity: .85;
+}
+
+.desktop-top-bar__signin-btn:active {
+  transform: scale(.97);
+}
+
+.desktop-top-bar__signin-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.desktop-top-bar__signin-img {
+  width: auto;
+  height: 28px;
+  display: block;
+}
+
+.desktop-top-bar__back {
+  height: 100%;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  background: none;
+  border: none;
+  align-items: center;
+  gap: 6px;
+  padding: 0 4px;
+  font-size: .875rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.desktop-top-bar__back:hover {
+  color: var(--fg-primary);
+}
+
+.desktop-top-bar__back:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.desktop-top-bar__create-wrap {
+  display: inline-flex;
+}
+
+.desktop-top-bar__create-menu {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  z-index: var(--z-popover);
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px;
+  display: flex;
+}
+
+.desktop-top-bar__create-item {
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  transition: background var(--transition-fast);
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  font-size: .875rem;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.desktop-top-bar__create-item:hover, .desktop-top-bar__create-item:focus-visible {
+  background: var(--overlay-weak);
+  outline: none;
+}
+
+.desktop-top-bar__create-item > svg {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+@media (min-width: 800px) {
+  .profile-page__mobile-header {
+    display: none;
+  }
+}
+
+.page-layout {
+  gap: 24px;
+  padding: 24px 16px;
+  display: grid;
+}
+
+@media (min-width: 800px) {
+  .page-layout {
+    grid-template-columns: 296px minmax(0, 1fr);
+    align-items: start;
+    gap: 32px;
+    padding: 24px;
+  }
+}
+
+.page-layout__main {
+  flex-direction: column;
+  gap: 24px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-sidebar {
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  display: none;
+}
+
+@media (min-width: 800px) {
+  .profile-sidebar {
+    display: flex;
+  }
+}
+
+.profile-sidebar__avatar {
+  display: inline-flex;
+}
+
+.profile-sidebar__name-block {
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 4px;
+  display: flex;
+}
+
+.profile-sidebar__name {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  letter-spacing: -.01em;
+  color: var(--fg-primary);
+  margin: 0;
+  font-size: 1.625rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.profile-sidebar__handle {
+  color: var(--fg-muted);
+  word-break: break-word;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: 1.125rem;
+  line-height: 1.2;
+  display: inline-flex;
+}
+
+.profile-sidebar__did {
+  color: var(--fg-muted);
+  align-items: center;
+  gap: 6px;
+  margin: 4px 0 0;
+  font-size: .6875rem;
+  display: inline-flex;
+}
+
+.profile-sidebar__did-value {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  -webkit-user-select: all;
+  user-select: all;
+  min-width: 0;
+  font-family: monospace;
+  font-size: .6875rem;
+  overflow: hidden;
+}
+
+.profile-sidebar__copy-btn {
+  width: 22px;
+  height: 22px;
+  color: var(--fg-muted);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  margin-left: 2px;
+  padding: 0;
+  display: inline-flex;
+}
+
+.profile-sidebar__copy-btn:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.profile-sidebar__copy-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.profile-sidebar__pronouns {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.profile-sidebar__actions {
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  margin-top: 4px;
+  display: flex;
+}
+
+.profile-sidebar__action-primary {
+  height: 36px;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  font-family: inherit;
+  font-size: .8125rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.profile-sidebar__action-primary:hover {
+  background: var(--bg-sunken);
+  border-color: var(--border-hover);
+}
+
+.profile-sidebar__action-secondary {
+  width: 36px;
+  height: 36px;
+  color: var(--fg-secondary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  transition: background var(--transition-fast), color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.profile-sidebar__action-secondary:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.profile-sidebar__followers {
+  color: var(--fg-secondary);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 8px 0 12px;
+  font-size: .875rem;
+  display: flex;
+}
+
+.profile-sidebar__followers-count {
+  color: var(--fg-primary);
+  font-weight: 600;
+}
+
+.profile-sidebar__followers-link {
+  color: inherit;
+  transition: color var(--transition-fast);
+  text-decoration: none;
+}
+
+.profile-sidebar__followers-link:hover, .profile-sidebar__followers-link:focus-visible {
+  color: var(--fg-primary);
+  text-underline-offset: 2px;
+  text-decoration: underline;
+}
+
+.profile-sidebar__followers-sep {
+  color: var(--fg-muted);
+}
+
+.profile-sidebar__stats {
+  flex-direction: column;
+  gap: 6px;
+  display: flex;
+}
+
+.profile-sidebar__stats .profile-sidebar__followers {
+  margin: 0;
+}
+
+.profile-sidebar__endorsed-by .profile-sidebar__followers-count {
+  color: inherit;
+}
+
+.profile-sidebar__details {
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.profile-sidebar__details li {
+  color: var(--fg-secondary);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: .875rem;
+  display: flex;
+}
+
+.profile-sidebar__details-date {
+  margin-top: 10px;
+}
+
+.profile-sidebar__details li > svg {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+.profile-sidebar__detail-link {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  transition: color var(--transition-fast);
+  text-decoration: none;
+  overflow: hidden;
+}
+
+.profile-sidebar__detail-link:hover {
+  color: var(--fg-primary);
+  text-decoration: underline;
+}
+
+.profile-sidebar__bsky-row {
+  padding-left: 0 !important;
+}
+
+.profile-sidebar__bsky-tag {
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-default);
+  color: var(--fg-secondary);
+  letter-spacing: .02em;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  border-radius: 999px;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: .6875rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.profile-sidebar__bsky-tag:hover, .profile-sidebar__bsky-tag:focus-visible {
+  background: var(--overlay-medium);
+  color: var(--fg-primary);
+  text-decoration: none;
+}
+
+.profile-sidebar__section-head {
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  display: flex;
+}
+
+.profile-sidebar__section-title {
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.profile-sidebar__section-title--link {
+  transition: color var(--transition-fast);
+  text-decoration: none;
+}
+
+.profile-sidebar__section-title--link:hover {
+  color: var(--fg-primary);
+}
+
+.profile-sidebar__see-all {
+  color: var(--fg-secondary);
+  transition: color var(--transition-fast);
+  align-items: center;
+  gap: 4px;
+  font-size: .75rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.profile-sidebar__see-all:hover {
+  color: var(--fg-primary);
+}
+
+.profile-sidebar__loading {
+  padding: 12px 0;
+}
+
+.profile-sidebar__empty {
+  color: var(--fg-muted);
+  margin: 0;
+  padding: 8px 0;
+  font-size: .875rem;
+}
+
+.profile-sidebar__groups {
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 12px;
+  padding-top: 16px;
+}
+
+.profile-sidebar__groups-list {
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.profile-sidebar__group-row {
+  border-radius: var(--radius);
+  color: inherit;
+  transition: background var(--transition-fast);
+  align-items: center;
+  gap: 10px;
+  margin: 0 -8px;
+  padding: 6px 8px;
+  text-decoration: none;
+  display: flex;
+}
+
+.profile-sidebar__group-row:hover {
+  background: var(--overlay-weak);
+}
+
+.profile-sidebar__group-meta {
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.2;
+  display: flex;
+}
+
+.profile-sidebar__group-name {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .8125rem;
+  font-weight: 600;
+  overflow: hidden;
+}
+
+.profile-sidebar__group-handle {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .6875rem;
+  overflow: hidden;
+}
+
+.profile-overview {
+  flex-direction: column;
+  gap: 24px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-overview__banner {
+  display: none;
+}
+
+@media (min-width: 800px) {
+  .profile-overview__banner {
+    aspect-ratio: 3;
+    border-radius: var(--radius);
+    background: linear-gradient(135deg,
+      var(--bg-sunken) 0%,
+      var(--bg-raised) 100%);
+    width: 100%;
+    max-height: 220px;
+    display: block;
+    overflow: hidden;
+  }
+
+  .profile-overview__banner--empty {
+    aspect-ratio: 6;
+    max-height: 96px;
+  }
+}
+
+.profile-overview__banner-img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.profile-overview__stats {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  display: grid;
+}
+
+.profile-overview__stat {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  color: inherit;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  text-decoration: none;
+  display: flex;
+}
+
+.profile-overview__stat:hover {
+  border-color: var(--border-hover-soft);
+  background: var(--bg-sunken);
+}
+
+.profile-overview__stat-label {
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  font-size: .75rem;
+  font-weight: 600;
+}
+
+.profile-overview__stat-split {
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  display: flex;
+}
+
+.profile-overview__stat-split--solo {
+  justify-content: flex-start;
+}
+
+.profile-overview__stat-value {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  letter-spacing: -.01em;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.profile-overview__stat-sub {
+  color: var(--fg-muted);
+  letter-spacing: .01em;
+  font-size: .75rem;
+}
+
+.profile-overview__about {
+  flex-direction: column;
+  gap: 8px;
+  display: flex;
+}
+
+.profile-overview__about-body {
+  color: var(--fg-secondary);
+  white-space: pre-wrap;
+  margin: 0;
+  font-size: .9375rem;
+  line-height: 1.55;
+}
+
+.profile-overview__about-block {
+  display: block;
+}
+
+.profile-overview__about-main {
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  display: flex;
+}
+
+@media (min-width: 1100px) {
+  .profile-overview__about-block--with-map {
+    grid-template-columns: minmax(0, 1fr) 280px;
+    align-items: start;
+    gap: 24px;
+    display: grid;
+  }
+}
+
+.profile-overview__types {
+  flex-direction: column;
+  gap: 10px;
+  display: flex;
+}
+
+.profile-overview__type-tags {
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.profile-overview__type-tag {
+  color: var(--fg-secondary);
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  align-items: center;
+  padding: 3px 10px;
+  font-size: .75rem;
+  font-weight: 500;
+  line-height: 1.4;
+  display: inline-flex;
+}
+
+.profile-overview__location {
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-overview__location-map {
+  border-radius: var(--radius);
+  border: 1px solid var(--border-subtle);
+  width: 100%;
+  overflow: hidden;
+}
+
+.profile-overview__location-name {
+  color: var(--fg-secondary);
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: .8125rem;
+  display: inline-flex;
+}
+
+.profile-overview__location-name svg {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+.profile-overview__location-picker-row {
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.profile-overview__location-hint {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .75rem;
+}
+
+.profile-overview__location-clear {
+  color: var(--fg-secondary);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  font-size: .75rem;
+  display: inline-flex;
 }
-.sg-demo--col { flex-direction: column; align-items: stretch; }
-.sg-demo--stack > * { width: 100%; }
-.sg-demo__caption { width: 100%; font-size: 0.75rem; color: var(--fg-muted); font-family: var(--sg-mono); }
 
-/* API / props tables */
-table.sg-api {
-  width: 100%; border-collapse: collapse; margin: 16px 0 0; font-size: 0.8125rem;
+.profile-overview__location-clear:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
 }
-table.sg-api caption {
-  text-align: left; font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.12em;
-  color: var(--fg-muted); font-weight: 600; padding: 24px 0 8px;
-}
-table.sg-api th, table.sg-api td {
-  text-align: left; padding: 8px 12px; border-bottom: 1px solid var(--border-subtle); vertical-align: top;
-}
-table.sg-api th { color: var(--fg-muted); font-weight: 600; }
-table.sg-api td:first-child, table.sg-api code { font-family: var(--sg-mono); color: var(--fg-primary); }
-table.sg-api td { color: var(--fg-secondary); }
-code.tok { font-family: var(--sg-mono); font-size: 0.8em; background: var(--bg-sunken); padding: 1px 5px; border-radius: var(--radius); color: var(--fg-primary); }
 
-/* ==========================================================================
-   APP PRIMITIVE STYLES (reproduced from the real classNames / inline utils)
-   These mirror what each TSX primitive renders. Class names match the source.
-   ========================================================================== */
+.profile-overview__location-attribution {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .6875rem;
+}
 
-/* ---- Button (button.tsx) ---- */
-.btn {
+.profile-overview__location-attribution a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.profile-overview__location-combobox {
+  position: relative;
+}
+
+.profile-overview__location-suggestions {
+  z-index: var(--z-popover);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius);
-  font: inherit; font-size: 0.875rem; font-weight: 500; letter-spacing: 0.05em;
-  transition: all 150ms; cursor: pointer;
-  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  box-shadow: var(--shadow-md);
+  max-height: 320px;
+  margin: 4px 0 0;
+  padding: 4px;
+  list-style: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  overflow-y: auto;
+}
+
+.profile-overview__location-suggestion {
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  display: flex;
+}
+
+.profile-overview__location-suggestion:hover, .profile-overview__location-suggestion--active {
+  background: var(--overlay-weak);
+}
+
+.profile-overview__location-suggestion-primary {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .875rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.profile-overview__location-suggestion-secondary {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.profile-overview__section-head {
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  display: flex;
+}
+
+.profile-overview__section-title {
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.profile-overview__see-all {
+  color: var(--fg-secondary);
+  transition: color var(--transition-fast);
+  align-items: center;
+  gap: 4px;
+  font-size: .75rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.profile-overview__see-all:hover {
+  color: var(--fg-primary);
+}
+
+.profile-overview__loading {
+  padding: 12px 0;
+}
+
+.profile-certs {
+  flex-direction: column;
+  display: flex;
+}
+
+.profile-certs__toolbar {
+  border-bottom: 1px solid var(--border-subtle);
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+  display: flex;
+}
+
+.profile-certs__controls {
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  padding-bottom: 8px;
+  display: inline-flex;
+}
+
+.profile-certs__search {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  height: 36px;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  display: inline-flex;
+}
+
+.profile-certs__search:focus-within {
+  border-color: var(--fg-primary);
+}
+
+.profile-certs__search-icon {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+.profile-certs__search-input {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  background: none;
+  border: none;
+  outline: none;
+  width: 200px;
+  font-size: .875rem;
+}
+
+.profile-certs__search-input::placeholder {
+  color: var(--fg-muted);
+}
+
+.profile-certs__search-input::-webkit-search-cancel-button {
+  appearance: none;
+}
+
+.profile-certs__sort-wrap {
+  display: inline-flex;
+  position: relative;
+}
+
+.profile-certs__sort-btn {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  width: 36px;
+  height: 36px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.profile-certs__sort-btn:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.profile-certs__sort-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+@media (min-width: 800px) {
+  .profile-certs .feed {
+    grid-template-columns: repeat(3, minmax(0, calc(33.3333% - 16px)));
+    gap: 28px 24px;
+    display: grid;
+  }
+
+  .profile-certs .feed-card {
+    border-radius: var(--radius);
+    transition: background var(--transition-fast);
+    border-bottom: none;
+    flex-direction: column;
+    padding: 10px;
+    display: flex;
+  }
+
+  .profile-certs .feed-card:hover {
+    background: var(--overlay-weak);
+  }
+
+  .profile-certs .feed-card__body:hover .feed-card__title {
+    text-decoration: none;
+  }
+
+  .profile-certs .feed-card__body {
+    flex-direction: column;
+    flex: 1;
+    display: flex;
+  }
+
+  .profile-certs .feed-card__title {
+    white-space: normal;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    min-height: 2.925rem;
+    display: -webkit-box;
+    overflow: hidden;
+  }
+
+  .profile-certs .feed-card__desc {
+    -webkit-line-clamp: 2;
+    min-height: 2.8rem;
+  }
+
+  .profile-certs .feed-card__meta {
+    margin-top: auto;
+  }
+
+  .profile-certs .feed__sentinel, .profile-certs .feed > .empty-state {
+    grid-column: 1 / -1;
+  }
+}
+
+.profile-overview__empty {
+  color: var(--fg-muted);
+  margin: 0;
+  padding: 8px 0;
+  font-size: .875rem;
+}
+
+.profile-overview__digest {
+  flex-direction: column;
+  display: flex;
+}
+
+.profile-overview__activity-list, .profile-overview__endorse-list {
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.profile-overview__activity-item, .profile-overview__endorse-item {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.profile-overview__activity-item:last-child, .profile-overview__endorse-item:last-child {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.profile-overview__activity-link {
+  color: inherit;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 0;
+  text-decoration: none;
+  display: flex;
+}
+
+.profile-overview__activity-link:hover .profile-overview__activity-title {
+  text-decoration: underline;
+}
+
+.profile-overview__activity-thumb {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  overflow: hidden;
+}
+
+.profile-overview__activity-thumb-img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.profile-overview__activity-thumb--placeholder {
+  background: linear-gradient(135deg,
+      var(--bg-sunken) 0%,
+      var(--overlay-weak) 100%);
+  color: var(--fg-muted);
+}
+
+.profile-overview__activity-thumb--placeholder svg {
+  opacity: .6;
+}
+
+.profile-overview__activity-text {
+  flex-direction: column;
+  flex: 1;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-overview__activity-title {
+  color: var(--fg-primary);
+  font-size: .9375rem;
+  font-weight: 500;
+}
+
+.profile-overview__activity-desc {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: .8125rem;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.profile-overview__activity-meta {
+  color: var(--fg-muted);
+  margin-top: 4px;
+  font-size: .6875rem;
+}
+
+.profile-overview__endorse-link {
+  color: inherit;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  text-decoration: none;
+  display: grid;
+}
+
+.profile-overview__endorse-link:hover .profile-overview__endorse-name {
+  text-decoration: underline;
+}
+
+.profile-overview__endorse-meta {
+  flex-direction: column;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-overview__endorse-name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .9375rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.profile-overview__endorse-when {
+  color: var(--fg-muted);
+  font-size: .6875rem;
+}
+
+.profile-overview__endorse-note {
+  color: var(--fg-muted);
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+  font-size: .8125rem;
+  font-style: italic;
+  overflow: hidden;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border-medium);
+  color: var(--fg-muted);
+  margin-top: 48px;
+  padding: 16px 32px 24px;
+  font-size: .75rem;
+}
+
+.site-footer__row {
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  display: flex;
+}
+
+.site-footer__left {
+  align-items: center;
+  gap: 8px;
+  display: inline-flex;
+}
+
+.app-shell:has(.legal-page) .app-shell__content {
+  max-width: 880px;
+}
+
+.site-footer__brand {
+  color: var(--fg-muted);
+  opacity: .7;
+}
+
+.site-footer__wordmark {
+  opacity: .7;
+  width: auto;
+  height: 14px;
+  display: block;
+}
+
+:root[data-theme="dark"] .site-footer__wordmark {
+  filter: invert();
+}
+
+.site-footer__link--button {
+  font-family: inherit;
+  font-size: inherit;
+  cursor: pointer;
+  background: none;
+  border: 0;
+  padding: 0;
+}
+
+.site-footer__nav {
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 16px;
+  display: inline-flex;
+}
+
+.site-footer__link {
+  color: var(--fg-muted);
+  transition: color var(--transition-fast);
+  text-decoration: none;
+}
+
+.site-footer__link:hover {
+  color: var(--fg-primary);
+}
+
+.site-footer__link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* [project]/src/app/styles/components.css [app-client] (css) */
+.empty-state {
+  text-align: center;
+  flex-direction: column;
+  align-items: center;
+  padding: 48px 16px;
+  display: flex;
+}
+
+.empty-state__icon {
+  color: var(--fg-muted);
+  opacity: .5;
+  margin-bottom: 16px;
+}
+
+.empty-state__title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  margin-bottom: 8px;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.empty-state__desc {
+  color: var(--fg-muted);
+  max-width: 320px;
+  font-size: .875rem;
+  line-height: 1.6;
+}
+
+.empty-state__actions {
+  margin-top: 20px;
+}
+
+.more-link-row {
+  text-align: right;
+  margin: 0 0 16px;
+  font-size: .875rem;
+}
+
+.more-link {
+  color: var(--fg-primary);
+  text-underline-offset: 2px;
+  text-decoration: underline;
+}
+
+.more-link:hover {
+  text-decoration-thickness: 2px;
+}
+
+.more-link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius);
+}
+
+.press-scale {
+  transition: transform var(--transition-fast);
+}
+
+.press-scale:active {
+  transform: scale(.98);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .press-scale:active {
+    transform: none;
+  }
+}
+
+.signin-modal__backdrop {
+  z-index: 100;
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  background: #00000040;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  animation: .2s ease-out modalFadeIn;
+  display: flex;
+  position: fixed;
+  inset: 0;
+  overflow-y: auto;
+}
+
+[data-theme="dark"] .signin-modal__backdrop {
+  background: var(--navy-overlay-70);
+}
+
+.signin-modal__wrapper {
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+  max-width: 460px;
+  animation: .3s cubic-bezier(.16, 1, .3, 1) modalSlideUp;
+  display: flex;
+  position: relative;
+}
+
+.signin-modal {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  width: 100%;
+  box-shadow: var(--shadow-lg);
+  flex-direction: column;
+  align-items: stretch;
+  padding: 40px 40px 36px;
+  display: flex;
+}
+
+dialog.signin-modal {
+  max-height: calc(100vh - 40px);
+  margin: auto;
+  position: fixed;
+  inset: 0;
+  overflow: hidden auto;
+}
+
+dialog.signin-modal::backdrop {
+  background: #00000080;
+}
+
+[data-theme="dark"] dialog.signin-modal::backdrop {
+  background: var(--navy-overlay-70);
+}
+
+dialog.signin-modal.app-modal {
+  border-radius: var(--radius);
+  padding: 0;
+  position: relative;
+}
+
+dialog.signin-modal.app-modal .signin-modal__header {
+  padding: 20px 40px 12px 24px;
+}
+
+dialog.signin-modal.app-modal .signin-modal__close {
+  border-radius: var(--radius);
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+}
+
+dialog.signin-modal.app-modal .signin-modal__body {
+  padding: 0 20px 20px;
+}
+
+.delete-record-dialog__warning {
+  color: var(--fg-secondary);
+  margin: 0 0 16px;
+  font-size: .875rem;
+  line-height: 1.5;
+}
+
+.delete-record-dialog__warning strong {
+  color: var(--color-error, #b91c1c);
+}
+
+.delete-record-dialog__field {
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+  display: flex;
+}
+
+.delete-record-dialog__label {
+  letter-spacing: .04em;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  font-size: .75rem;
+  font-weight: 600;
+}
+
+.delete-record-dialog__target {
+  font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+  color: var(--fg-primary);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  word-break: break-all;
+  padding: 6px 10px;
+  font-size: .8125rem;
+  display: block;
+}
+
+.delete-record-dialog__input {
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-hover);
+  border-radius: var(--radius);
+  width: 100%;
+  min-width: 0;
+  padding: 8px 12px;
+  font-size: .9375rem;
+}
+
+.delete-record-dialog__input:focus {
+  border-color: var(--color-error, #b91c1c);
+  outline: none;
+  box-shadow: 0 0 0 2px #b91c1c26;
+}
+
+.delete-record-dialog__error {
+  color: var(--color-error, #b91c1c);
+  margin: 0 0 12px;
+  font-size: .8125rem;
+}
+
+.delete-record-dialog__actions {
+  justify-content: flex-end;
+  gap: 8px;
+  display: flex;
+}
+
+.signin-modal__brandmark-wrap {
+  color: var(--fg-primary);
+  justify-content: center;
+  margin-bottom: 32px;
+  display: flex;
+}
+
+.signin-modal__brandmark {
+  display: block;
+}
+
+.signin-modal__form {
+  flex-direction: column;
+  display: flex;
+}
+
+.signin-modal__heading {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  letter-spacing: -.01em;
+  margin-bottom: 12px;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.signin-modal__input {
+  border: 1.5px solid var(--border-default);
+  border-radius: var(--radius);
+  width: 100%;
+  height: 56px;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  outline: none;
+  padding: 0 20px;
+  font-size: 1rem;
+}
+
+.signin-modal__input::placeholder {
+  color: var(--fg-muted);
+}
+
+.signin-modal__input:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 3px var(--overlay-medium);
+}
+
+.signin-modal__input:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+
+.signin-modal__remember {
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+  align-items: center;
+  gap: 10px;
+  margin-top: 16px;
+  display: flex;
+}
+
+.signin-modal__remember-input {
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+  position: absolute;
+}
+
+.signin-modal__remember-box {
+  border-radius: var(--radius);
+  border: 1.5px solid var(--border-hover);
+  background: var(--bg-elevated);
+  color: #0000;
+  width: 18px;
+  height: 18px;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.signin-modal__remember-input:checked + .signin-modal__remember-box {
+  background: var(--fg-primary);
+  border-color: var(--fg-primary);
+  color: var(--bg-canvas);
+}
+
+.signin-modal__remember-input:focus-visible + .signin-modal__remember-box {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.signin-modal__remember-label {
+  color: var(--fg-secondary);
+  font-size: .875rem;
+  font-weight: 500;
+}
+
+.signin-modal__error {
+  color: var(--color-error);
+  margin-top: 12px;
+  margin-bottom: 0;
+  font-size: .8125rem;
+  line-height: 1.4;
+}
+
+.signin-modal__submit {
+  letter-spacing: -.01em;
+  width: 100%;
+  height: 56px;
+  color: var(--btn-primary-fg);
+  background: var(--btn-primary-bg);
+  cursor: pointer;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+  border: none;
+  border-radius: 999px;
+  margin-top: 24px;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.signin-modal__submit:hover:not(:disabled) {
+  opacity: .92;
+}
+
+.signin-modal__submit:active:not(:disabled) {
+  transform: scale(.99);
+}
+
+.signin-modal__submit:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.signin-modal__submit:disabled {
+  opacity: .4;
+  cursor: not-allowed;
+}
+
+.signin-modal__alt {
+  border: 1.5px solid var(--border-default);
+  letter-spacing: -.01em;
+  width: 100%;
+  height: 56px;
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  background: none;
+  border-radius: 999px;
+  margin-top: 12px;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.signin-modal__alt:hover {
+  border-color: var(--border-hover);
+  background: var(--overlay-weak);
+}
+
+.signin-modal__alt:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.signin-modal__powered {
+  background-color: var(--fg-primary);
+  width: 165px;
+  height: 18px;
+  margin: 24px auto 0;
+  display: block;
+  -webkit-mask-image: url("http://127.0.0.1:3000/assets/powered_by_certified_black.svg");
+  mask-image: url("http://127.0.0.1:3000/assets/powered_by_certified_black.svg");
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+}
+
+[data-theme="dark"] .signin-modal__powered {
+  background-color: var(--fg-secondary);
+}
+
+@keyframes modalFadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes modalSlideUp {
+  from {
+    opacity: 0;
+    transform: translateY(16px)scale(.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .signin-modal__backdrop, .signin-modal__wrapper {
+    animation: none;
+  }
+}
+
+@media (max-width: 520px) {
+  .signin-modal__backdrop {
+    padding: 16px;
+  }
+
+  .signin-modal {
+    border-radius: var(--radius);
+    padding: 32px 24px 28px;
+  }
+
+  .signin-modal__brandmark-wrap {
+    margin-bottom: 24px;
+  }
+
+  .signin-modal__heading {
+    font-size: 1rem;
+  }
+
+  .signin-modal__input, .signin-modal__submit, .signin-modal__alt {
+    height: 52px;
+  }
+}
+
+.feedback-modal__backdrop {
+  z-index: var(--z-feedback);
+  background: var(--navy-overlay-70);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  justify-content: flex-end;
+  align-items: flex-end;
+  padding: 20px;
+  animation: .2s ease-out modalFadeIn;
+  display: flex;
+  position: fixed;
+  inset: 0;
+}
+
+.feedback-modal {
+  background: var(--bg-elevated);
+  border-radius: var(--radius);
+  width: 420px;
+  max-width: 90vw;
+  max-height: calc(100vh - 40px);
+  box-shadow: 0 24px 64px var(--navy-overlay-30);
+  border: 1px solid var(--border-default);
+  animation: .3s cubic-bezier(.16, 1, .3, 1) modalSlideUp;
+  overflow-y: auto;
+}
+
+.feedback-modal--expanded {
+  width: 640px;
+}
+
+.feedback-modal--expanded .feedback-modal__textarea {
+  min-height: 400px;
+}
+
+.feedback-modal__header {
+  border-bottom: 1px solid var(--bg-sunken);
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  display: flex;
+}
+
+.feedback-modal__expand {
+  border-radius: var(--radius);
+  width: 44px;
+  height: 44px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  margin-right: 8px;
+  display: flex;
+}
+
+.feedback-modal__expand:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.feedback-modal__title {
+  color: var(--fg-primary);
+  font-size: .875rem;
+  font-weight: 600;
+}
+
+.feedback-modal__close {
+  border-radius: var(--radius);
+  width: 44px;
+  height: 44px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.feedback-modal__close:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.feedback-modal__body {
+  padding: 24px;
+}
+
+.feedback-modal__greeting {
+  color: var(--fg-primary);
+  margin: 0 0 12px;
+  font-size: .9375rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.feedback-modal__label {
+  color: var(--fg-secondary);
+  margin-bottom: 8px;
+  font-size: .8125rem;
+  line-height: 1.4;
+  display: block;
+}
+
+.feedback-modal__label--email {
+  margin-top: 16px;
+}
+
+.feedback-modal__textarea {
+  box-sizing: border-box;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius);
+  width: 100%;
+  min-height: 120px;
+  font-size: .875rem;
+  font-family: var(--font-inter);
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  resize: vertical;
+  transition: border-color var(--transition-fast);
+  padding: 12px;
+}
+
+.feedback-modal__textarea:focus {
+  border-color: var(--color-accent);
+  outline: none;
+}
+
+.feedback-modal__input {
+  box-sizing: border-box;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius);
+  width: 100%;
+  height: 44px;
+  font-size: .875rem;
+  font-family: var(--font-inter);
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  transition: border-color var(--transition-fast);
+  padding: 0 12px;
+}
+
+.feedback-modal__input:focus {
+  border-color: var(--color-accent);
+  outline: none;
+}
+
+.feedback-modal__error {
+  color: var(--color-error);
+  margin-top: 4px;
+  font-size: .75rem;
+}
+
+.feedback-modal__submit {
+  background: var(--btn-primary-bg);
+  width: 100%;
+  height: 44px;
+  color: var(--btn-primary-fg);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  border: none;
+  margin-top: 20px;
+  font-size: .875rem;
+  font-weight: 500;
+}
+
+.feedback-modal__submit:hover:not(:disabled) {
+  background: var(--color-accent);
+}
+
+.feedback-modal__submit:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.feedback-modal__success {
+  text-align: center;
+  padding: 20px 0;
+}
+
+.feedback-modal__success p {
+  color: var(--fg-primary);
+  margin-bottom: 16px;
+  font-size: .9375rem;
+  font-weight: 500;
+}
+
+.feedback-modal__done {
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-fg);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  border: none;
+  padding: 8px 24px;
+  font-size: .875rem;
+  font-weight: 500;
+}
+
+.feedback-modal__done:hover {
+  background: var(--color-accent);
+}
+
+.feedback-modal__success-actions {
+  justify-content: center;
+  gap: 10px;
+  display: flex;
+}
+
+.feedback-modal__more {
+  color: var(--fg-primary);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  background: none;
+  padding: 8px 24px;
+  font-size: .875rem;
+  font-weight: 500;
+}
+
+.feedback-modal__more:hover {
+  background: var(--bg-canvas);
+  border-color: var(--fg-muted);
+}
+
+.feedback-bottom-sheet__backdrop, .feedback-bottom-sheet {
+  display: none;
+}
+
+@media (max-width: 799px) {
+  .feedback-modal__backdrop--desktop {
+    display: none;
+  }
+
+  .feedback-bottom-sheet__backdrop {
+    z-index: var(--z-feedback);
+    display: block;
+  }
+
+  .feedback-bottom-sheet {
+    z-index: var(--z-feedback-above);
+    display: flex;
+  }
+
+  .feedback-bottom-sheet .feedback-modal__textarea {
+    resize: none;
+    min-height: 80px;
+    font-size: 16px;
+  }
+
+  .feedback-bottom-sheet.bottom-sheet--expanded .feedback-modal__textarea {
+    min-height: 120px;
+  }
+
+  .feedback-bottom-sheet .feedback-modal__input {
+    font-size: 16px;
+  }
+
+  .feedback-bottom-sheet .feedback-modal__body {
+    padding: 16px 20px;
+  }
+
+  .feedback-modal__expand {
+    display: none;
+  }
+}
+
+.dash-card {
+  border: none;
+  border-bottom: 1px solid var(--border-light);
+  background: none;
+  border-radius: 0;
+  padding: 32px 0;
+}
+
+.dash-card:last-child {
+  border-bottom: none;
+}
+
+.dash-card__title {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  letter-spacing: .15em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin-bottom: 12px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.dash-card__desc {
+  color: var(--fg-muted);
+  margin-bottom: 20px;
+  font-size: .8125rem;
+  line-height: 1.6;
+}
+
+.username-card {
+  flex-direction: column;
+  gap: 8px;
+  display: flex;
+}
+
+.username-card__header {
+  justify-content: space-between;
+  align-items: center;
+  display: flex;
+}
+
+.username-card__value {
+  color: var(--fg-primary);
+  font-size: .875rem;
+}
+
+.username-card__form {
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 4px;
+  display: flex;
+}
+
+.username-card__actions {
+  justify-content: flex-end;
+  gap: 8px;
+  display: flex;
+}
+
+.handle-edit__row {
+  align-items: flex-start;
+  gap: 0;
+  display: flex;
+}
+
+.handle-edit__row > div:first-child {
+  flex: 1;
+  min-width: 0;
+}
+
+.handle-edit__suffix {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  align-items: center;
+  height: 44px;
+  margin-top: 26px;
+  padding: 0 0 0 2px;
+  font-family: monospace;
+  font-size: .875rem;
+  display: flex;
+}
+
+.username-card__switch-btns {
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+  display: flex;
+}
+
+.username-card__domain-btn {
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius);
+  color: var(--color-accent);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+  background: none;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  padding: 8px 14px;
+  font-size: .8125rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.username-card__domain-btn:hover {
+  border-color: var(--color-accent);
+  background: #0000000a;
+}
+
+.username-card__domain-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.username-card__form-label {
+  letter-spacing: .06em;
+  color: var(--fg-muted);
+  margin-bottom: 2px;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.username-card__subdomain-row {
+  align-items: center;
+  display: flex;
+}
+
+.username-card__subdomain-input {
+  border: none;
+  border-bottom: 1px solid var(--border-medium);
+  min-width: 0;
+  height: 40px;
+  color: var(--fg-primary);
+  transition: border-color var(--transition-fast);
+  background: none;
+  border-radius: 0;
+  outline: none;
+  flex: 1;
+  padding: 0 0 8px;
+  font-size: .875rem;
+}
+
+.username-card__subdomain-input:focus {
+  border-bottom-color: var(--fg-primary);
+  box-shadow: none;
+}
+
+.username-card__subdomain-input::placeholder {
+  color: var(--fg-muted);
+}
+
+.username-card__subdomain-input:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+
+.username-card__subdomain-suffix {
+  border: none;
+  border-bottom: 1px solid var(--border-medium);
+  height: 40px;
+  color: var(--fg-muted);
+  white-space: nowrap;
+  -webkit-user-select: none;
+  user-select: none;
+  background: none;
+  border-radius: 0;
+  align-items: center;
+  padding: 0 0 8px 8px;
+  font-size: .75rem;
+  display: flex;
+}
+
+.username-card__subdomain-hint {
+  color: var(--fg-muted);
+  margin-top: 4px;
+  font-size: .6875rem;
+}
+
+.username-card__error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .75rem;
+}
+
+.password-section__header {
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  display: flex;
+}
+
+.password-section--form {
+  flex-direction: column;
+  display: flex;
+}
+
+.password-section__status {
+  color: var(--fg-primary);
+  font-size: .875rem;
+}
+
+.password-section__status--empty {
+  color: var(--fg-muted);
+  font-style: italic;
+}
+
+.password-section__status--success {
+  color: var(--color-success-text);
+  margin-top: 4px;
+}
+
+.password-section__masked {
+  letter-spacing: 3px;
+  color: var(--fg-primary);
+  margin-top: 4px;
+  font-size: 1.125rem;
+}
+
+.password-section__hint {
+  color: var(--fg-muted);
+  margin-top: 4px;
+  margin-bottom: 0;
+  font-size: .8125rem;
+}
+
+.password-section--form .password-section__hint {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.password-section__fields {
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+}
+
+.password-section__actions {
+  gap: 8px;
+  margin-top: 12px;
+  display: flex;
+}
+
+.email-section__header {
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  display: flex;
+}
+
+.email-section--form {
+  flex-direction: column;
+  display: flex;
+}
+
+.email-section__status--success {
+  color: var(--color-success-text);
+  margin-top: 4px;
+  font-size: .875rem;
+}
+
+.email-section__hint {
+  color: var(--fg-muted);
+  margin-top: 4px;
+  margin-bottom: 0;
+  font-size: .8125rem;
+}
+
+.email-section--form .email-section__hint {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.email-section__fields {
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+}
+
+.email-section__actions {
+  gap: 8px;
+  margin-top: 12px;
+  display: flex;
+}
+
+.email-section__error {
+  color: var(--color-error);
+  margin-top: 8px;
+  font-size: .8125rem;
+}
+
+.domain-modal__backdrop {
+  z-index: 100;
+  background: var(--navy-overlay-70);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  justify-content: center;
+  align-items: center;
+  animation: .2s ease-out modalFadeIn;
+  display: flex;
+  position: fixed;
+  inset: 0;
+}
+
+.domain-modal {
+  background: var(--bg-elevated);
+  border-radius: var(--radius);
+  width: 90vw;
+  max-width: 480px;
+  box-shadow: 0 24px 64px var(--navy-overlay-30);
+  border: 1px solid var(--border-default);
+  flex-direction: column;
+  animation: .3s cubic-bezier(.16, 1, .3, 1) modalSlideUp;
+  display: flex;
+  overflow: hidden;
+}
+
+.domain-modal__header {
+  border-bottom: 1px solid var(--border-medium);
+  flex-shrink: 0;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 24px;
+  display: flex;
+}
+
+.domain-modal__header-icon {
+  color: var(--color-accent);
+  flex-shrink: 0;
+}
+
+.domain-modal__title {
+  color: var(--fg-primary);
+  letter-spacing: .02em;
+  flex: 1;
+  font-size: .8125rem;
+  font-weight: 600;
+}
+
+.domain-modal__close {
+  width: 32px;
+  height: 32px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.domain-modal__close:hover {
+  background: var(--bg-canvas);
+  color: var(--fg-primary);
+}
+
+.domain-modal__steps {
+  border-bottom: 1px solid var(--border-medium);
+  background: var(--bg-canvas);
+  justify-content: center;
+  align-items: center;
+  gap: 0;
+  padding: 16px 24px;
+  display: flex;
+}
+
+.domain-modal__step {
+  opacity: .4;
+  transition: opacity var(--transition-fast);
+  align-items: center;
+  gap: 6px;
+  display: flex;
+}
+
+.domain-modal__step--active {
+  opacity: 1;
+}
+
+.domain-modal__step--done {
+  opacity: .65;
+}
+
+.domain-modal__step-num {
+  background: var(--btn-primary-bg);
+  width: 22px;
+  height: 22px;
+  color: var(--btn-primary-fg);
+  border-radius: 50%;
+  justify-content: center;
+  align-items: center;
+  font-size: .6875rem;
+  font-weight: 600;
+  display: flex;
+}
+
+.domain-modal__step--active .domain-modal__step-num {
+  background: var(--color-accent);
+}
+
+.domain-modal__step--done .domain-modal__step-num {
+  background: var(--btn-primary-bg);
+}
+
+.domain-modal__step-label {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  font-size: .6875rem;
+  font-weight: 500;
+}
+
+.domain-modal__step-line {
+  background: var(--border-default);
+  flex-shrink: 0;
+  width: 24px;
+  height: 1px;
+  margin: 0 6px;
+}
+
+.domain-modal__body {
+  padding: 24px;
+}
+
+.domain-modal__desc {
+  color: var(--fg-secondary);
+  margin-bottom: 20px;
+  font-size: .8125rem;
+  line-height: 1.6;
+}
+
+.domain-modal__desc strong {
+  color: var(--fg-primary);
+  font-weight: 600;
+}
+
+.domain-modal__label {
+  letter-spacing: .06em;
+  color: var(--fg-muted);
+  margin-bottom: 8px;
+  font-size: .6875rem;
+  font-weight: 600;
+  display: block;
+}
+
+.domain-modal__input {
+  border: 1.5px solid var(--border-medium);
+  border-radius: var(--radius);
+  width: 100%;
+  height: 44px;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  outline: none;
+  padding: 0 14px;
+  font-size: .875rem;
+}
+
+.domain-modal__input::placeholder {
+  color: var(--fg-muted);
+}
+
+.domain-modal__input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--overlay-medium);
+}
+
+.domain-modal__hint {
+  color: var(--fg-muted);
+  margin-top: 8px;
+  margin-bottom: 20px;
+  font-size: .75rem;
+  line-height: 1.5;
+}
+
+.domain-modal__dns-card {
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+
+.domain-modal__dns-row {
+  border-bottom: 1px solid var(--border-subtle);
+  align-items: flex-start;
+  gap: 12px;
+  padding: 10px 14px;
+  display: flex;
+}
+
+.domain-modal__dns-row--last {
+  border-bottom: none;
+}
+
+.domain-modal__dns-label {
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  flex-shrink: 0;
+  min-width: 44px;
+  padding-top: 2px;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.domain-modal__dns-val {
+  color: var(--fg-primary);
+  flex: 1;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: .8125rem;
+  display: flex;
+}
+
+.domain-modal__dns-val--mono {
+  word-break: break-all;
+  font-family: SF Mono, Fira Code, Fira Mono, Menlo, Consolas, monospace;
+  font-size: .75rem;
+}
+
+.domain-modal__dns-val-break {
+  word-break: break-all;
+}
+
+.domain-modal__copy-btn {
+  background: var(--bg-elevated);
+  border-radius: var(--radius);
+  width: 28px;
+  height: 28px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color var(--transition-fast), background var(--transition-fast);
+  border: none;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.domain-modal__copy-btn:hover {
+  color: var(--color-accent);
+  background: #0000000f;
+}
+
+.domain-modal__info-box {
+  background: var(--color-warning-bg);
+  border: 1px solid var(--color-warning-border);
+  border-radius: var(--radius);
+  gap: 10px;
+  margin-bottom: 20px;
+  padding: 12px 14px;
+  display: flex;
+}
+
+.domain-modal__info-box p {
+  color: var(--color-warning-text);
+  margin: 0;
+  font-size: .75rem;
+  line-height: 1.5;
+}
+
+.domain-modal__info-icon {
+  color: var(--color-warning-border);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.domain-modal__error {
+  border-radius: var(--radius);
+  background: #dc35450f;
+  border: 1px solid #dc354533;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 20px;
+  padding: 12px 14px;
+  display: flex;
+}
+
+.domain-modal__error p {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .75rem;
+  line-height: 1.5;
+}
+
+.domain-modal__error svg {
+  color: var(--color-error);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.domain-modal__verify-summary {
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 20px;
+  padding: 14px;
+  display: flex;
+}
+
+.domain-modal__verify-row {
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  display: flex;
+}
+
+.domain-modal__verify-label {
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.domain-modal__verify-value {
+  color: var(--fg-primary);
+  text-align: right;
+  font-size: .8125rem;
+  font-weight: 500;
+}
+
+.domain-modal__verify-value--mono {
+  word-break: break-all;
+  font-family: SF Mono, Fira Code, Fira Mono, Menlo, Consolas, monospace;
+  font-size: .75rem;
+}
+
+.domain-modal__success {
+  text-align: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 24px 0;
+  display: flex;
+}
+
+.domain-modal__success-icon {
+  color: var(--color-success-text);
+}
+
+.domain-modal__success-title {
+  color: var(--fg-primary);
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.domain-modal__success-desc {
+  color: var(--fg-secondary);
+  font-size: .8125rem;
+  line-height: 1.5;
+}
+
+.domain-modal__success-desc strong {
+  color: var(--fg-primary);
+  font-weight: 600;
+}
+
+.domain-modal__actions {
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+  display: flex;
+}
+
+.domain-modal__spinner {
+  animation: 1s linear infinite spin;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .domain-modal__backdrop, .domain-modal, .domain-modal__spinner {
+    animation: none;
+  }
+}
+
+@media (max-width: 799px) {
+  .domain-modal {
+    border-radius: 0;
+    width: 100%;
+    max-width: none;
+    max-height: 100vh;
+    overflow-y: auto;
+  }
+
+  .domain-modal__steps {
+    padding: 12px 16px;
+  }
+
+  .domain-modal__step-label {
+    display: none;
+  }
+
+  .domain-modal__step-line {
+    width: 32px;
+  }
+
+  .domain-modal__body {
+    padding: 20px 16px;
+  }
+
+  .domain-modal__actions {
+    flex-direction: column-reverse;
+  }
+
+  .domain-modal__btn {
+    width: 100%;
+    min-height: 44px;
+  }
+}
+
+.edit-profile {
+  flex-direction: column;
+  gap: 20px;
+  display: flex;
+}
+
+.edit-profile__loading {
+  justify-content: center;
+  align-items: center;
+  min-height: 50vh;
+  display: flex;
+}
+
+.edit-profile__media {
+  margin-top: 16px;
+  position: relative;
+}
+
+.edit-profile__avatar-slot {
+  background: var(--bg-elevated);
+  border-radius: 999px;
+  padding: 4px;
+  line-height: 0;
+  position: absolute;
+  bottom: -32px;
+  left: 16px;
+}
+
+.edit-profile__media + * {
+  margin-top: 48px;
+}
+
+.edit-profile__fields {
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 20px;
+  display: flex;
+}
+
+.edit-profile__error {
+  margin-top: 16px;
+}
+
+.edit-profile__actions {
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 4px 0 8px;
+  display: flex;
+}
+
+@media (max-width: 520px) {
+  .edit-profile__actions {
+    flex-direction: column-reverse;
+    gap: 10px;
+  }
+
+  .edit-profile__actions > * {
+    width: 100%;
+  }
+
+  .edit-profile__actions :is(button, a) {
+    justify-content: center;
+    width: 100%;
+    display: flex;
+  }
+}
+
+.dashboard__back-btn {
+  border-radius: var(--radius);
+  border: 1px solid var(--border-default);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  font-size: .8125rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.dashboard__back-btn:hover {
+  background: var(--bg-canvas);
+  border-color: var(--border-hover);
+}
+
+.settings__section, .settings__2fa {
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 16px;
+  padding-top: 16px;
+}
+
+.settings__loading {
+  color: var(--fg-muted);
+  font-size: .8125rem;
+}
+
+.settings__2fa-status {
+  margin-bottom: 12px;
+}
+
+.settings__2fa-badge {
+  border-radius: var(--radius);
+  align-items: center;
+  padding: 4px 12px;
+  font-size: .75rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.settings__2fa-badge--off {
+  background: var(--bg-canvas);
+  color: var(--fg-muted);
+}
+
+.settings__2fa-badge--on {
+  color: var(--color-success);
+  background: #2ecc711a;
+}
+
+.settings__note {
+  color: var(--fg-muted);
+  font-size: .8125rem;
+  line-height: 1.6;
+}
+
+.settings__error {
+  color: var(--color-error);
+  font-size: .8125rem;
+  line-height: 1.6;
+}
+
+.connected-apps__header {
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 4px;
+  display: flex;
+}
+
+.connected-apps__count {
+  color: var(--fg-muted);
+  background: var(--bg-sunken);
+  border-radius: var(--radius);
+  padding: 4px 10px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.connected-apps__list {
+  flex-direction: column;
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.connected-apps__item-wrap {
+  display: contents;
+}
+
+.connected-apps__item {
+  color: inherit;
+  border-radius: var(--radius);
+  transition: background var(--transition-fast);
+  align-items: center;
+  gap: 14px;
+  padding: 16px;
+  text-decoration: none;
+  display: flex;
+}
+
+.connected-apps__item + .connected-apps__item {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.connected-apps__item--link:hover {
+  background: var(--overlay-weak);
+}
+
+.connected-apps__item:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.connected-apps__icon {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  overflow: hidden;
+}
+
+.connected-apps__logo {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}
+
+.connected-apps__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.connected-apps__name {
+  color: var(--fg-primary);
+  margin: 0;
+  font-size: .9375rem;
+  font-weight: 600;
+}
+
+.connected-apps__desc {
+  color: var(--fg-muted);
+  margin: 2px 0 0;
+  font-size: .8125rem;
+  line-height: 1.5;
+}
+
+@media (max-width: 520px) {
+  .connected-apps__item {
+    gap: 10px;
+    padding: 12px;
+  }
+
+  .connected-apps__desc {
+    display: none;
+  }
+}
+
+@media (max-width: 799px) {
+  .app-shell__content {
+    max-width: 100%;
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .app-shell--fullbleed .app-shell__content {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .dashboard__topbar {
+    padding: 32px 0 16px;
+  }
+
+  .dashboard__topbar:before {
+    display: none;
+  }
+
+  .dashboard__page-title {
+    font-size: 1.75rem;
+  }
+
+  .dash-card {
+    padding: 24px 0;
+  }
+
+  .profile-card {
+    text-align: center;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .profile-card__info {
+    text-align: center;
+  }
+
+  .profile-card__name {
+    font-size: 1.375rem;
+  }
+
+  .personal-info__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .personal-info__field {
+    padding: 10px 0;
+    font-size: .8125rem;
+  }
+
+  .personal-info__field--mono {
+    font-size: .75rem;
+  }
+
+  .connected-apps__item {
+    gap: 10px;
+    padding: 12px 0;
+  }
+
+  .connected-apps__desc {
+    display: none;
+  }
+
+  .app-detail {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .app-detail__icon {
+    width: 48px;
+    height: 48px;
+  }
+
+  .app-detail__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .my-data__record {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .my-data__record-meta {
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .my-data__did-info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .edit-profile__actions {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .edit-profile__actions button {
+    width: 100%;
+  }
+
+  .dashboard__back-btn {
+    padding: 6px 12px;
+    font-size: .75rem;
+  }
+
+  .dash-card__desc {
+    margin-bottom: 12px;
+  }
+}
+
+.org-sync__list {
+  flex-direction: column;
+  display: flex;
+}
+
+.org-sync__item {
+  border-bottom: 1px solid var(--border-subtle);
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  display: flex;
+}
+
+.org-sync__item:last-child {
+  border-bottom: none;
+}
+
+.org-sync__item-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.org-sync__item-handle {
+  color: var(--fg-primary);
+  font-size: .8125rem;
+  font-weight: 600;
+}
+
+.org-sync__item-did {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 2px;
+  font-family: monospace;
+  font-size: .6875rem;
+  overflow: hidden;
+}
+
+.org-sync__badge {
+  letter-spacing: .04em;
+  border-radius: var(--radius);
+  white-space: nowrap;
+  flex-shrink: 0;
+  padding: 4px 10px;
+  font-size: .6875rem;
+  font-weight: 500;
+}
+
+.org-sync__badge--removed {
+  color: var(--color-error);
+  background: #ba1a1a14;
+}
+
+.org-sync__badge--changed {
+  color: var(--color-accent);
+  background: var(--bg-canvas);
+}
+
+.pagination {
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+  padding-top: 16px;
+  display: flex;
+}
+
+.pagination__info {
+  color: var(--fg-muted);
+  text-align: center;
+  min-width: 48px;
+  font-size: .75rem;
+}
+
+@media (max-width: 799px) {
+  .username-card__subdomain-input, .domain-modal__input {
+    font-size: 16px;
+  }
+}
+
+.image-edit-overlay {
+  z-index: 1;
+  align-items: center;
+  gap: 6px;
+  display: inline-flex;
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+}
+
+.image-edit-overlay__btn {
+  color: var(--color-white);
+  font-family: var(--font-inter), system-ui, sans-serif;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: background var(--transition-fast), transform var(--transition-fast);
+  background: #111111c7;
+  border: none;
+  border-radius: 999px;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: .75rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.image-edit-overlay__btn:hover {
+  background: #111111eb;
+}
+
+.image-edit-overlay__btn:disabled {
+  cursor: not-allowed;
+  opacity: .55;
+}
+
+.image-edit-overlay__btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.image-edit-overlay__btn--ghost {
+  color: var(--color-primary);
+  background: #ffffffeb;
+}
+
+.image-edit-overlay__btn--ghost:hover {
+  background: var(--color-white);
+}
+
+.image-edit-overlay__input {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+}
+
+.onboarding-modal {
+  width: 100%;
+}
+
+.onboarding-modal__header {
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 20px 24px 12px;
+}
+
+.onboarding-modal__title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  letter-spacing: -.02em;
+  color: var(--fg-primary);
+  margin: 0 0 14px;
+  font-size: 1.375rem;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.onboarding-modal__steps {
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.onboarding-modal__step {
+  background: var(--bg-sunken);
+  color: var(--fg-muted);
+  font: inherit;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  border: none;
+  border-radius: 999px;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: .75rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.onboarding-modal__step:hover:not(:disabled):not(.onboarding-modal__step--current) {
+  background: var(--bg-raised);
+}
+
+.onboarding-modal__step--current:hover {
+  background: var(--fg-primary);
+}
+
+.onboarding-modal__step:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.onboarding-modal__step:disabled {
+  cursor: default;
+  opacity: .7;
+}
+
+.onboarding-modal__step--current {
+  background: var(--fg-primary);
+  color: var(--bg-canvas);
+}
+
+.onboarding-modal__step--done {
+  background: var(--bg-raised);
+  color: var(--fg-secondary);
+}
+
+.onboarding-modal__step-index {
+  background: var(--overlay-medium);
+  border-radius: 999px;
+  justify-content: center;
+  align-items: center;
+  width: 18px;
+  height: 18px;
+  font-size: .6875rem;
+  font-weight: 700;
+  display: inline-flex;
+}
+
+.onboarding-modal__step--current .onboarding-modal__step-index {
+  color: var(--bg-canvas);
+}
+
+.onboarding-modal__body {
+  max-height: 60vh;
+  padding: 20px 24px;
+  overflow-y: auto;
+}
+
+.onboarding-modal__footer {
+  border-top: 1px solid var(--border-subtle);
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 24px;
+  display: flex;
+}
+
+.onboarding-step__lede {
+  color: var(--fg-secondary);
+  margin: 0 0 16px;
+  font-size: .9375rem;
+  line-height: 1.5;
+}
+
+.onboarding-step__footnote {
+  color: var(--fg-muted);
+  margin: 16px 0 0;
+  font-size: .75rem;
+  line-height: 1.45;
+}
+
+.onboarding-step__error {
+  color: var(--color-error);
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  border-radius: var(--radius);
+  margin: 12px 0 0;
+  padding: 10px 14px;
+  font-size: .8125rem;
+}
+
+.onboarding-step__success {
+  color: var(--color-success-text);
+  margin: 12px 0 0;
+  font-size: .875rem;
+}
+
+.onboarding-step__loading {
+  color: var(--fg-secondary);
+  align-items: center;
+  gap: 12px;
+  padding: 18px;
+  font-size: .875rem;
+  display: flex;
+}
+
+.onboarding-step__hero {
+  margin-bottom: 36px;
+  position: relative;
+}
+
+.onboarding-step__banner {
+  aspect-ratio: 3;
+  object-fit: cover;
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  width: 100%;
+  max-height: 220px;
+  display: block;
+}
+
+.onboarding-step__banner--empty {
+  aspect-ratio: 6;
+  background: linear-gradient(135deg,
+    var(--bg-raised) 0%,
+    var(--bg-sunken) 100%);
+  max-height: 96px;
+}
+
+.onboarding-step__avatar-slot {
+  border: 3px solid var(--bg-elevated);
+  background: var(--bg-sunken);
+  border-radius: 50%;
+  width: 64px;
+  height: 64px;
+  position: absolute;
+  bottom: -28px;
+  left: 20px;
+  overflow: hidden;
+}
+
+.onboarding-step__avatar {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.onboarding-step__avatar--empty {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-secondary);
+  justify-content: center;
+  align-items: center;
+  font-size: 1.5rem;
+  font-weight: 700;
+  display: flex;
+}
+
+.onboarding-step__media-actions {
+  gap: 8px;
+  margin-bottom: 20px;
+  display: flex;
+}
+
+.onboarding-step__file-btn {
+  color: var(--fg-secondary);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-subtle);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  border-radius: 999px;
+  align-items: center;
+  padding: 6px 12px;
+  font-size: .75rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.onboarding-step__file-btn:hover {
+  border-color: var(--border-hover);
+  background: var(--bg-sunken);
+}
+
+.onboarding-step__fields, .onboarding-step__row {
+  flex-direction: column;
+  gap: 16px;
+  display: flex;
+}
+
+.onboarding-step__row--split {
+  grid-template-columns: 2fr 1fr;
+  gap: 12px;
+  display: grid;
+}
+
+@media (max-width: 799px) {
+  .onboarding-step__row--split {
+    grid-template-columns: 1fr;
+  }
+}
+
+.onboarding-step__field {
+  flex-direction: column;
+  gap: 6px;
+  display: flex;
+}
+
+.onboarding-step__label {
+  color: var(--fg-secondary);
+  letter-spacing: .01em;
+  justify-content: space-between;
+  align-items: center;
+  font-size: .75rem;
+  font-weight: 500;
+  display: flex;
+}
+
+.onboarding-step__label-count {
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: .6875rem;
+}
+
+.onboarding-step__graph-stats {
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-bottom: 18px;
+  display: grid;
+}
+
+.onboarding-step__tile {
+  background: var(--bg-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px;
+  display: flex;
+}
+
+.onboarding-step__tile--highlight {
+  background: var(--bg-elevated);
+  border-color: var(--border-hover);
+}
+
+.onboarding-step__tile-value {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  font-variant-numeric: tabular-nums;
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.onboarding-step__tile-label {
+  color: var(--fg-muted);
+  font-size: .75rem;
+}
+
+.onboarding-step__segments {
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  margin: 0 0 4px;
+  padding: 0;
+  display: grid;
+  overflow: hidden;
+}
+
+.onboarding-step__segments--two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.onboarding-step__segment {
+  color: var(--fg-secondary);
+  cursor: pointer;
+  border-right: 1px solid var(--border-default);
+  transition: background var(--transition-fast), color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  padding: 8px 12px;
+  font-size: .8125rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.onboarding-step__segment:last-child {
+  border-right: none;
+}
+
+.onboarding-step__segment:hover {
+  background: var(--bg-raised);
+}
+
+.onboarding-step__segment input[type="radio"] {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+}
+
+.onboarding-step__segment--active {
+  background: var(--fg-primary);
+  color: var(--bg-canvas);
+}
+
+.onboarding-step__segment--active:hover {
+  background: var(--fg-primary);
+}
+
+.onboarding-step__heading {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  margin: 0 0 16px;
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.onboarding-step__checklist {
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.onboarding-step__check {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  display: flex;
+}
+
+.onboarding-step__check--done {
+  border-color: var(--color-success);
+  background: var(--color-success-bg);
+}
+
+.onboarding-step__check--error {
+  border-color: var(--color-error);
+}
+
+.onboarding-step__check-icon {
+  background: var(--bg-sunken);
+  width: 22px;
+  height: 22px;
+  color: var(--fg-secondary);
+  border-radius: 999px;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  font-size: .8125rem;
+  display: inline-flex;
+}
+
+.onboarding-step__check--done .onboarding-step__check-icon {
+  background: var(--color-success);
+  color: var(--color-white);
+}
+
+.onboarding-step__check--error .onboarding-step__check-icon {
+  background: var(--color-error);
+  color: var(--color-white);
+}
+
+.onboarding-step__check-label {
+  color: var(--fg-primary);
+  font-size: .875rem;
+}
+
+.onboarding-banner {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  text-align: left;
+  width: calc(100% - 48px);
+  font: inherit;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  align-items: center;
+  gap: 12px;
+  margin: 16px 24px 0;
+  padding: 12px 16px;
+  display: flex;
+}
+
+.onboarding-banner:hover {
+  border-color: var(--border-hover);
+  background: var(--bg-raised);
+}
+
+.onboarding-banner:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.onboarding-banner__icon {
+  color: var(--fg-primary);
+  flex-shrink: 0;
+}
+
+.onboarding-banner__title {
+  min-width: 0;
+  color: var(--fg-primary);
+  flex: 1;
+  font-size: .9375rem;
+  font-weight: 600;
+}
+
+.onboarding-banner__chevron {
+  color: var(--fg-muted);
+  transition: transform var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.onboarding-banner:hover .onboarding-banner__chevron {
+  color: var(--fg-primary);
+  transform: translateX(2px);
+}
+
+.onboarding-step__progress {
+  color: var(--fg-primary);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  margin: 14px 0 0;
+  padding: 10px 14px;
+  font-size: .875rem;
+}
+
+.onboarding-step__progress--done {
+  border-color: var(--color-success);
+  background: #2ecc710d;
+}
+
+.onboarding-step__progress strong {
+  font-variant-numeric: tabular-nums;
+}
+
+.onboarding-step__import-actions {
+  justify-content: flex-end;
+  margin-top: 16px;
+  display: flex;
+}
+
+.onboarding-step__picker {
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 14px;
+  display: flex;
+}
+
+.onboarding-step__picker-search {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  color: var(--fg-muted);
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  display: flex;
+}
+
+.onboarding-step__picker-search input {
+  font: inherit;
+  color: var(--fg-primary);
+  background: none;
+  border: none;
+  outline: none;
+  flex: 1;
+  font-size: .875rem;
+}
+
+.onboarding-step__picker-meta {
+  color: var(--fg-muted);
+  justify-content: space-between;
+  align-items: center;
+  font-size: .75rem;
+  display: flex;
+}
+
+.onboarding-step__picker-toggle {
+  color: var(--fg-primary);
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: .75rem;
+  font-weight: 500;
+  text-decoration: underline;
+}
+
+.onboarding-step__picker-toggle:disabled {
+  opacity: .5;
+  cursor: default;
+  text-decoration: none;
+}
+
+.onboarding-step__picker-list {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.onboarding-step__picker-row {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.onboarding-step__picker-row:last-child {
+  border-bottom: none;
+}
+
+.onboarding-step__picker-row label {
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  grid-template-columns: auto auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  display: grid;
+}
+
+.onboarding-step__picker-row label:hover {
+  background: var(--bg-raised);
+}
+
+.onboarding-step__picker-row-info {
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  display: flex;
+}
+
+.onboarding-step__picker-row-name {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .875rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.onboarding-step__picker-row-handle {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.onboarding-step__picker-avatar-skel {
+  background: var(--bg-sunken);
+  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+}
+
+.onboarding-step__picker-empty {
+  text-align: center;
+  color: var(--fg-muted);
+  padding: 24px 16px;
+  font-size: .875rem;
+}
+
+.onboarding-step__picker-pagination {
+  color: var(--fg-muted);
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  font-size: .75rem;
+  display: flex;
+}
+
+.onboarding-step__picker-pagination button {
+  border: 1px solid var(--border-subtle);
+  color: var(--fg-primary);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: border-color var(--transition-fast);
+  background: none;
+  padding: 4px 10px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.onboarding-step__picker-pagination button:hover:not(:disabled) {
+  border-color: var(--border-hover);
+}
+
+.onboarding-step__picker-pagination button:disabled {
+  opacity: .4;
+  cursor: default;
+}
+
+.onboarding-success {
+  text-align: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 40px 32px 32px;
+  display: flex;
+}
+
+.onboarding-success__avatar {
+  object-fit: cover;
+  background: var(--bg-sunken);
+  width: 96px;
+  height: 96px;
+  box-shadow: 0 0 0 3px var(--bg-elevated), 0 6px 18px #0000001a;
+  border-radius: 50%;
+  margin-bottom: 20px;
+}
+
+.onboarding-success__avatar--empty {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-secondary);
+  justify-content: center;
+  align-items: center;
+  font-size: 2.5rem;
+  font-weight: 700;
+  display: flex;
+}
+
+.onboarding-success__title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  letter-spacing: -.02em;
+  color: var(--fg-primary);
+  margin: 0 0 6px;
+  font-size: 1.625rem;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.onboarding-success__subtitle {
+  color: var(--fg-secondary);
+  margin: 0 0 28px;
+  font-size: .9375rem;
+  line-height: 1.5;
+}
+
+/* [project]/src/app/styles/feed.css [app-client] (css) */
+.search-page {
+  flex-direction: column;
+  align-items: center;
+  padding-top: 8px;
+  display: flex;
+}
+
+.search-page__hint {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-muted);
+  margin-top: 12px;
+  font-size: .8125rem;
+}
+
+.create-form {
+  flex-direction: column;
+  gap: 20px;
+  display: flex;
+}
+
+.create-form__field {
+  flex-direction: column;
+  gap: 6px;
+  display: flex;
+}
+
+.create-form__label {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: var(--fg-muted);
+  font-size: .75rem;
+  font-weight: 600;
+}
+
+.create-form__input, .create-form__textarea {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  transition: border-color var(--transition-fast);
+  outline: none;
+  padding: 12px 14px;
+  font-size: .9375rem;
+}
+
+.create-form__input:focus, .create-form__textarea:focus {
+  border-color: var(--fg-primary);
+}
+
+.create-form__textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.create-form__error {
+  color: var(--color-error);
+  font-size: .8125rem;
+}
+
+.create-form__actions {
+  align-self: flex-start;
+  align-items: center;
+  gap: 12px;
+  display: flex;
+}
+
+.create-form__submit, .create-form__cancel {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: opacity var(--transition-fast), background var(--transition-fast);
+  padding: 12px 24px;
+  font-size: .875rem;
+  font-weight: 600;
+}
+
+.create-form__submit {
+  color: var(--btn-primary-fg);
+  background: var(--btn-primary-bg);
   border: none;
 }
-.btn:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
-.btn--primary    { background: var(--btn-primary-bg); color: var(--btn-primary-fg); }
-.btn--primary:hover { opacity: 0.9; }
-.btn--secondary  { background: transparent; color: var(--fg-primary); border: 1px solid var(--border-default); }
-.btn--secondary:hover { border-color: var(--border-hover); }
-.btn--ghost      { background: transparent; color: var(--fg-muted); }
-.btn--ghost:hover { background: var(--overlay-weak); color: var(--fg-primary); }
-.btn--destructive { background: var(--color-error-bg); color: var(--color-error); border: 1px solid var(--color-error-border); }
-.btn--destructive:hover { opacity: 0.9; }
-.btn--sm   { padding: 6px 16px;  font-size: 0.75rem; }
-.btn--md   { padding: 10px 24px; font-size: 0.875rem; }
-.btn--lg   { padding: 12px 32px; font-size: 0.875rem; }
-.btn--icon { height: 40px; width: 40px; padding: 0; }
-.btn:disabled, .btn[aria-disabled="true"] { opacity: 0.5; cursor: not-allowed; }
-/* pressed (aria-pressed="true") — active visual on secondary/ghost only */
-.btn--secondary.btn--pressed { background: var(--overlay-medium); color: var(--fg-primary); border-color: var(--border-hover); }
-.btn--ghost.btn--pressed     { background: var(--overlay-medium); color: var(--fg-primary); }
-.spin { animation: sg-spin 1s linear infinite; }
-@media (prefers-reduced-motion: reduce) { .spin { animation: none; } }
-@keyframes sg-spin { to { transform: rotate(360deg); } }
 
-/* ---- Input / Textarea / Select (input.tsx, textarea.tsx, select.tsx) ---- */
-.ui-field {
-  width: 100%;
+.create-form__cancel {
+  color: var(--fg-secondary);
+  border: 1px solid var(--border-light);
+  background: none;
+}
+
+.create-form__submit:hover {
+  opacity: .9;
+}
+
+.create-form__cancel:hover {
+  background: var(--overlay-weak);
+}
+
+.create-form__submit:disabled, .create-form__cancel:disabled {
+  opacity: .4;
+  cursor: not-allowed;
+}
+
+.feed-tabs {
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-canvas);
+  display: flex;
+}
+
+.feed-tabs__tab {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+  text-align: center;
+  background: none;
+  border: none;
+  border-bottom: 2px solid #0000;
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  gap: 2px;
+  padding: 14px 0;
+  font-size: .875rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.feed-tabs__tab:hover {
+  color: var(--fg-primary);
+}
+
+.feed-tabs__tab--active {
+  color: var(--fg-primary);
+  border-bottom-color: var(--fg-primary);
+  font-weight: 600;
+}
+
+.feed-tabs__tab-wrapper {
+  flex: 1;
+  justify-content: center;
+  display: flex;
+  position: relative;
+}
+
+.feed-tabs__chevron {
+  transition: transform var(--transition-fast);
+  margin-left: 4px;
+}
+
+.feed-tabs__chevron--open {
+  transform: rotate(180deg);
+}
+
+.feed-filter {
   background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  z-index: var(--z-popover);
+  min-width: 180px;
+  padding: 8px 0;
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.feed-filter__item {
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  display: flex;
+}
+
+.feed-filter__item:hover {
+  background: var(--bg-canvas);
+}
+
+.feed-filter__checkbox {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--fg-primary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.feed-filter__label {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  font-size: .8125rem;
+}
+
+@media (min-width: 800px) {
+  .feed-tabs__tab {
+    padding: 16px 0;
+    font-size: .9375rem;
+  }
+}
+
+.feed-evaluator-panel {
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-default);
+  width: 100%;
+  padding: 10px 16px 8px;
+}
+
+.feed-evaluators {
+  background: var(--bg-canvas);
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 10px 16px 8px;
+}
+
+.feed-evaluators__list {
+  flex-direction: column;
+  gap: 6px;
+  display: flex;
+}
+
+.feed-evaluators__row {
+  cursor: pointer;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+  font-size: .8125rem;
+  line-height: 1.3;
+  display: flex;
+}
+
+.feed-evaluators__row--disabled {
+  opacity: .45;
+  pointer-events: none;
+}
+
+.feed-evaluators__checkbox {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--fg-primary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.feed-evaluators__avatar {
+  object-fit: cover;
+  border-radius: 50%;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+}
+
+.feed-evaluators__avatar--placeholder {
+  background: var(--bg-sunken);
+  display: inline-block;
+}
+
+.feed-evaluators__name {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.feed-evaluators__handle {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.feed-evaluators__separator {
+  background: var(--border-subtle);
+  height: 1px;
+  margin: 8px 0;
+}
+
+.feed-evaluators__show-all {
+  cursor: pointer;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+  display: flex;
+}
+
+.feed-evaluators__show-all-label {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  font-size: .8125rem;
+  font-weight: 500;
+}
+
+.feed-unfiltered-banner {
+  z-index: 20;
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-fg);
+  font-family: var(--font-inter), system-ui, sans-serif;
+  text-align: center;
+  border-bottom: 1px solid var(--border-default);
+  padding: 8px 16px;
+  font-size: .8125rem;
+  font-weight: 500;
+  position: sticky;
+  top: 0;
+}
+
+.feed {
+  flex-direction: column;
+  display: flex;
+}
+
+.feed-card {
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 20px 0;
+}
+
+.feed-card:last-child {
+  border-bottom: none;
+}
+
+.feed-card__body {
+  color: inherit;
+  text-decoration: none;
+  display: block;
+}
+
+.feed-card__body:hover .feed-card__title {
+  text-decoration: underline;
+  -webkit-text-decoration-color: var(--fg-muted);
+  text-decoration-color: var(--fg-muted);
+  text-underline-offset: 3px;
+}
+
+.feed-card__author {
+  color: inherit;
+  align-items: center;
+  gap: 10px;
+  max-width: 100%;
+  margin-bottom: 12px;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.feed-card__author:hover .feed-card__author-name {
+  text-decoration: underline;
+}
+
+.feed-card__author-meta {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  min-width: 0;
+  line-height: 1.2;
+  display: flex;
+  overflow: hidden;
+}
+
+.feed-card__author-name-line {
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 100%;
+  display: inline-flex;
+}
+
+.feed-card__author-name {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  font-size: .875rem;
+  font-weight: 600;
+  overflow: hidden;
+}
+
+.feed-card__author-handle {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  font-size: .8125rem;
+  overflow: hidden;
+}
+
+.feed-card__author--skeleton {
+  pointer-events: none;
+}
+
+.feed-card__image-wrap {
+  aspect-ratio: 1;
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  width: 100%;
+  margin-bottom: 12px;
+  overflow: hidden;
+}
+
+.feed-card__image {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.feed-card__image-wrap--placeholder {
+  background: linear-gradient(135deg,
+      var(--bg-sunken) 0%,
+      var(--overlay-weak) 100%);
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.feed-card__image-placeholder-icon {
+  color: var(--fg-muted);
+  opacity: .6;
+}
+
+.feed-card__title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-bottom: 6px;
+  font-size: 1.125rem;
+  font-weight: 700;
+  line-height: 1.3;
+  overflow: hidden;
+}
+
+.feed-card__desc {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-secondary);
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  margin-bottom: 12px;
+  font-size: .875rem;
+  line-height: 1.6;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.feed-card__meta {
+  color: var(--fg-muted);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-size: .75rem;
+  display: flex;
+}
+
+.feed-card__time {
+  color: var(--fg-muted);
+  font-size: .75rem;
+}
+
+.feed-card__meta-sep {
+  background: var(--fg-muted);
+  border-radius: 50%;
+  flex-shrink: 0;
+  width: 3px;
+  height: 3px;
+}
+
+.feed__load-more {
+  justify-content: center;
+  padding: 24px 0;
+  display: flex;
+}
+
+.feed__load-more-btn {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--color-accent);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  background: none;
+  padding: 10px 24px;
+  font-size: .8125rem;
+  font-weight: 500;
+}
+
+.feed__load-more-btn:hover {
+  border-color: var(--border-hover);
+  background: var(--bg-canvas);
+}
+
+.feed__load-more-btn:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.feed-skeleton {
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 20px 0;
+}
+
+.feed-skeleton__meta {
+  gap: 8px;
+  margin-top: 12px;
+  display: flex;
+}
+
+@media (min-width: 800px) {
+  .feed-card {
+    padding: 24px 0;
+  }
+
+  .feed-card__title {
+    font-size: 1.25rem;
+  }
+
+  .feed-card__image-wrap {
+    border-radius: var(--radius);
+    margin-bottom: 16px;
+  }
+
+  .feed-card__desc {
+    margin-bottom: 16px;
+  }
+
+  .feed-card__meta {
+    gap: 10px;
+  }
+
+  .feed-skeleton {
+    padding: 24px 0;
+  }
+}
+
+.activity-detail__contributor {
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.activity-detail__contributor-link {
+  color: inherit;
+  border-radius: var(--radius);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  margin: -2px -4px;
+  padding: 2px 4px;
+  text-decoration: none;
+  display: flex;
+}
+
+.activity-detail__contributor-link:hover .activity-detail__contributor-name, .activity-detail__contributor-link:focus-visible .activity-detail__contributor-name {
+  text-decoration: underline;
+}
+
+.activity-detail__contributor-link--static {
+  cursor: default;
+}
+
+.activity-detail__contributor-link--static:hover .activity-detail__contributor-name {
+  text-decoration: none;
+}
+
+.activity-detail__contributor-meta {
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.15;
+  display: flex;
+}
+
+.activity-detail__contributor-name {
+  font-weight: 600;
+}
+
+.activity-detail__contributor-handle {
+  color: var(--fg-muted);
+  word-break: break-all;
+  font-size: .8125rem;
+}
+
+.activity-detail__contributor-role, .activity-detail__contributor-weight {
+  color: var(--fg-muted);
+  font-size: .8125rem;
+}
+
+.location-list {
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.location-card {
+  background: var(--bg-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  display: flex;
+}
+
+.location-card--fallback {
+  background: none;
+  border-style: dashed;
+}
+
+.location-card__icon {
+  background: var(--overlay-weak);
+  width: 28px;
+  height: 28px;
+  color: var(--fg-muted);
+  border-radius: 999px;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  margin-top: 2px;
+  display: inline-flex;
+}
+
+.location-card__body {
+  flex-direction: column;
+  flex: 1;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.location-card__name {
+  color: var(--fg-primary);
+  word-break: break-word;
+  margin: 0;
+  font-size: .9375rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.location-card__desc {
+  color: var(--fg-secondary);
+  word-break: break-word;
+  margin: 2px 0 0;
+  font-size: .8125rem;
+  line-height: 1.45;
+}
+
+.location-card__detail {
+  color: var(--fg-muted);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0 0;
+  font-size: .8125rem;
+  display: flex;
+}
+
+.location-card__coords {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--fg-secondary);
+  font-size: .75rem;
+}
+
+.location-card__type {
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--fg-muted);
+  background: var(--overlay-weak);
+  border-radius: var(--radius);
+  padding: 2px 6px;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.location-card__fallback {
+  word-break: break-word;
+}
+
+.location-card__map-link {
+  color: var(--fg-primary);
+  text-underline-offset: 2px;
+  font-weight: 500;
+  text-decoration: underline;
+}
+
+.location-card__map-link:hover {
+  color: var(--fg-secondary);
+}
+
+.location-card__uri {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--fg-muted);
+  word-break: break-all;
+  margin: 2px 0 0;
+  font-size: .75rem;
+}
+
+.certs-map {
+  border-radius: var(--radius);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-subtle);
+  z-index: 0;
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.certs-map .leaflet-container {
+  background: var(--bg-raised);
+  font-family: var(--font-inter), system-ui, -apple-system, sans-serif;
+  font-size: .8125rem;
+}
+
+.certs-map .leaflet-control-attribution {
+  color: var(--fg-muted);
+  background: #fffc;
+  padding: 2px 6px;
+  font-size: .625rem;
+}
+
+.certs-map .leaflet-control-attribution a {
+  color: var(--fg-secondary);
+}
+
+[data-theme="dark"] .certs-map .leaflet-control-attribution {
+  color: var(--fg-muted);
+  background: #141417d9;
+}
+
+[data-theme="dark"] .certs-map .leaflet-control-attribution a {
+  color: var(--fg-secondary);
+}
+
+.certs-map .leaflet-bar {
+  border: 1px solid var(--border-default);
+  box-shadow: var(--shadow-md);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.certs-map .leaflet-bar a {
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  border-bottom: 1px solid var(--border-subtle);
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.certs-map .leaflet-bar a:hover {
+  background: var(--bg-raised);
+}
+
+.certs-map .leaflet-bar a:last-child {
+  border-bottom: none;
+}
+
+.certs-map .leaflet-bar a.leaflet-disabled {
+  color: var(--fg-muted);
+  cursor: not-allowed;
+}
+
+.certs-map .leaflet-popup-content-wrapper {
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
+}
+
+.certs-map .leaflet-popup-content {
+  margin: 10px 14px;
+  font-size: .8125rem;
+  line-height: 1.45;
+}
+
+.certs-map .leaflet-popup-tip {
+  background: var(--bg-elevated);
+}
+
+.certs-map .leaflet-popup-close-button {
+  color: var(--fg-muted) !important;
+}
+
+.map-skeleton {
+  border-radius: var(--radius);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-subtle);
+  width: 100%;
+  animation: 1.4s ease-in-out infinite map-skeleton-pulse;
+}
+
+@keyframes map-skeleton-pulse {
+  0%, 100% {
+    opacity: .4;
+  }
+
+  50% {
+    opacity: .7;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .map-skeleton {
+    opacity: .5;
+    animation: none;
+  }
+}
+
+.location-card__map {
+  margin-top: 8px;
+}
+
+.page-tabs-bar, .endorsements-tabs-bar {
+  border-bottom: 1px solid var(--border-default);
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+  display: flex;
+}
+
+.page-tabs {
+  align-self: flex-end;
+  gap: 4px;
+  display: flex;
+}
+
+.page-tabs__tab {
+  color: var(--fg-muted);
+  cursor: pointer;
+  background: none;
+  border: none;
+  border-bottom: 2px solid #0000;
+  margin-bottom: -1px;
+  padding: 10px 16px;
+  font-size: .875rem;
+  font-weight: 500;
+  transition: color .15s, border-color .15s;
+}
+
+.page-tabs__tab:hover {
+  color: var(--fg-primary);
+}
+
+.page-tabs__tab--active {
+  color: var(--fg-primary);
+  border-bottom-color: var(--fg-primary);
+}
+
+.page-tabs-bar__new, .endorsements-new-btn {
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  cursor: pointer;
+  background: none;
+  border: none;
+  flex-shrink: 0;
+  align-self: center;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  font-size: .8125rem;
+  font-weight: 500;
+  transition: background .15s, color .15s;
+  display: inline-flex;
+}
+
+.page-tabs-bar__new:hover:not(:disabled), .endorsements-new-btn:hover:not(:disabled) {
+  background: var(--overlay-weak);
+}
+
+.page-tabs-bar__new:disabled, .endorsements-new-btn:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.page-section-heading {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  letter-spacing: -.01em;
+  margin: 0 0 12px;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.endorsement-panel {
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 16px;
+  display: flex;
+}
+
+.endorsement-panel__heading {
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  display: flex;
+}
+
+.endorsement-panel__heading-text {
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.endorsement-panel__close {
+  cursor: pointer;
+  color: var(--fg-muted);
+  border-radius: var(--radius);
+  background: none;
+  border: none;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  padding: 4px;
+  display: inline-flex;
+}
+
+.endorsement-panel__close:hover:not(:disabled) {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.endorsement-panel__close:disabled {
+  opacity: .4;
+  cursor: not-allowed;
+}
+
+.endorsement-panel__title {
+  color: var(--fg-primary);
+  font-size: .9375rem;
+  font-weight: 600;
+}
+
+.endorsement-panel__hint {
+  color: var(--fg-muted);
+  font-size: .8125rem;
+}
+
+.endorsement-panel__pick-hint {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.endorsement-panel__actions {
+  justify-content: flex-end;
+  gap: 8px;
+  display: flex;
+}
+
+.endorsements-loading {
+  justify-content: center;
+  padding: 32px 0;
+  display: flex;
+}
+
+.endorsements-hint {
+  color: var(--fg-secondary);
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  font-size: .8125rem;
+  line-height: 1.55;
+}
+
+.endorsements-empty {
+  min-height: 240px;
+  color: var(--fg-muted);
+  text-align: center;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+  padding: 24px;
+  font-size: .875rem;
+  display: flex;
+}
+
+.endorsements-list {
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.endorsement-row {
+  border-bottom: 1px solid var(--border-default);
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  display: flex;
+}
+
+.endorsement-row:last-child {
+  border-bottom: none;
+}
+
+.endorsement-row__main {
+  color: inherit;
+  flex: 1;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  text-decoration: none;
+  display: flex;
+}
+
+.endorsement-row__main:hover .endorsement-row__name {
+  text-decoration: underline;
+}
+
+.endorsement-row__meta {
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.2;
+  display: flex;
+}
+
+.endorsement-row__name {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .9375rem;
+  font-weight: 600;
+  overflow: hidden;
+}
+
+.endorsement-row__handle {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .8125rem;
+  overflow: hidden;
+}
+
+.endorsement-row__date {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+  font-size: .75rem;
+}
+
+.endorsement-row__revoke {
+  color: var(--fg-muted);
+  border-radius: var(--radius);
+  cursor: pointer;
+  background: none;
+  border: 1px solid #0000;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  padding: 6px;
+  transition: background .15s, color .15s, border-color .15s;
+  display: inline-flex;
+}
+
+.endorsement-row__revoke:hover:not(:disabled) {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+  border-color: var(--border-default);
+}
+
+.endorsement-row__revoke:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.endorsement-row__note {
+  color: var(--fg-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin-top: 4px;
+  font-size: .8125rem;
+  line-height: 1.4;
+  display: block;
+}
+
+.response-buttons {
+  flex-shrink: 0;
+  align-items: center;
+  gap: 6px;
+  display: inline-flex;
+}
+
+.response-buttons__btn {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  border-radius: var(--radius);
+  border: 1px solid var(--border-default);
+  background: var(--bg-elevated);
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+  padding: 4px 10px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.response-buttons__btn:hover:not(:disabled) {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.response-buttons__btn--pressed {
+  background: var(--fg-primary);
+  color: var(--bg-elevated);
+  border-color: var(--fg-primary);
+}
+
+.response-buttons__btn--pressed:hover:not(:disabled) {
+  background: var(--fg-primary);
+  color: var(--bg-elevated);
+  opacity: .85;
+}
+
+.response-buttons__btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.response-buttons__btn:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.response-buttons__error {
+  color: var(--color-error);
+  margin-left: 6px;
+  font-size: .6875rem;
+}
+
+.response-menu {
+  flex-shrink: 0;
+  position: relative;
+}
+
+.endorsement-row:not(:has(.response-menu, .endorsement-row__revoke)) .endorsement-row__date {
+  margin-right: 40px;
+}
+
+.response-menu__trigger {
+  border-radius: var(--radius);
+  width: 28px;
+  height: 28px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.response-menu__trigger:hover:not(:disabled) {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.response-menu__trigger:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.response-menu__trigger:disabled {
+  opacity: .4;
+  cursor: not-allowed;
+}
+
+.response-menu__trigger--accepted {
+  color: var(--color-success);
+}
+
+.response-menu__trigger--rejected {
+  color: var(--color-warning);
+}
+
+.response-menu__trigger--accepted:hover:not(:disabled), .response-menu__trigger--rejected:hover:not(:disabled) {
+  background: var(--overlay-weak);
+}
+
+.response-menu__quick-actions {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+  display: inline-flex;
+}
+
+.response-menu__quick-btn {
+  border: 1px solid var(--border-default);
+  background: var(--bg-elevated);
+  border-radius: var(--radius);
+  width: 28px;
+  height: 28px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast), color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.response-menu__quick-btn--accept:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-success) 12%, transparent);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+.response-menu__quick-btn--reject:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  border-color: var(--color-warning);
+  color: var(--color-warning);
+}
+
+.response-menu__quick-btn--accept.response-menu__quick-btn--active {
+  background: var(--color-success);
+  border-color: var(--color-success);
+  color: var(--bg-canvas);
+}
+
+.response-menu__quick-btn--accept.response-menu__quick-btn--active:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-success) 85%, black);
+  border-color: color-mix(in srgb, var(--color-success) 85%, black);
+  color: var(--bg-canvas);
+}
+
+.response-menu__quick-btn--reject.response-menu__quick-btn--active {
+  background: var(--color-warning);
+  border-color: var(--color-warning);
+  color: var(--bg-canvas);
+}
+
+.response-menu__quick-btn--reject.response-menu__quick-btn--active:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-warning) 85%, black);
+  border-color: color-mix(in srgb, var(--color-warning) 85%, black);
+  color: var(--bg-canvas);
+}
+
+.response-menu__quick-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.response-menu__quick-btn:disabled {
+  opacity: .4;
+  cursor: not-allowed;
+}
+
+.response-menu__menu {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  min-width: 180px;
+  box-shadow: var(--shadow-md);
+  z-index: var(--z-popover);
+  flex-direction: column;
+  gap: 1px;
+  padding: 4px;
+  display: flex;
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+}
+
+.response-menu__item {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  background: none;
+  border: none;
+  border-radius: 2px;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  font-size: .8125rem;
+  font-weight: 400;
+  display: flex;
+}
+
+.response-menu__item:hover:not(:disabled) {
+  background: var(--overlay-weak);
+}
+
+.response-menu__item:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.response-menu__item:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.response-menu__indicator {
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: var(--fg-muted);
+  margin: 0;
+  padding: 6px 10px 4px;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.response-menu__error {
+  color: var(--color-error);
+  margin: 0;
+  padding: 4px 10px;
+  font-size: .6875rem;
+}
+
+.response-menu__toast {
+  white-space: nowrap;
+  background: var(--fg-primary);
+  color: var(--bg-elevated);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  z-index: var(--z-popover);
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  font-size: .75rem;
+  display: inline-flex;
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+}
+
+.response-menu__toast-undo {
+  border: 1px solid var(--bg-elevated);
+  color: var(--bg-elevated);
+  font: inherit;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border-radius: 2px;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  font-weight: 600;
+  display: inline-flex;
+}
+
+.response-menu__toast-undo:hover:not(:disabled) {
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+}
+
+.response-menu__toast-undo:focus-visible {
+  outline: 2px solid var(--bg-elevated);
+  outline-offset: 2px;
+}
+
+.response-menu__toast-undo:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 799px) {
+  .response-buttons__btn {
+    min-height: 44px;
+    padding: 8px 14px;
+    font-size: .8125rem;
+  }
+
+  .response-menu__trigger {
+    width: 44px;
+    height: 44px;
+  }
+
+  .response-menu__item {
+    min-height: 44px;
+    padding: 10px 12px;
+  }
+}
+
+.endorsement-preview {
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  display: flex;
+}
+
+.endorsement-preview__meta {
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.2;
+  display: flex;
+}
+
+.endorsement-preview__name {
+  color: var(--fg-primary);
+  font-size: .9375rem;
+  font-weight: 600;
+}
+
+.endorsement-preview__handle {
+  color: var(--fg-muted);
+  font-size: .8125rem;
+}
+
+.endorsement-multi-list {
+  flex-direction: column;
+  gap: 6px;
+  max-height: 280px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  overflow-y: auto;
+}
+
+.endorsement-multi-row {
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  display: flex;
+}
+
+.endorsement-multi-row__meta {
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  line-height: 1.2;
+  display: flex;
+}
+
+.endorsement-multi-row__name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .875rem;
+  font-weight: 600;
+  overflow: hidden;
+}
+
+.endorsement-multi-row__handle {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.endorsement-multi-row__error {
+  color: var(--color-error);
+  margin-top: 2px;
+  font-size: .75rem;
+}
+
+.endorsement-multi-row__status {
+  border-radius: 999px;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+}
+
+.endorsement-multi-row__status--writing {
+  border: 2px solid var(--border-default);
+  border-top-color: var(--fg-primary);
+  animation: .8s linear infinite endorsement-multi-spin;
+}
+
+.endorsement-multi-row__status--success {
+  background: var(--color-success);
+  color: var(--color-white);
+}
+
+.endorsement-multi-row__status--error {
+  background: var(--color-error);
+  color: var(--color-white);
+}
+
+@keyframes endorsement-multi-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.endorsement-multi-row__remove {
+  cursor: pointer;
+  color: var(--fg-muted);
+  border-radius: var(--radius);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  padding: 4px;
+  display: inline-flex;
+}
+
+.endorsement-multi-row__remove:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.endorsement-multi-summary {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .875rem;
+}
+
+.profile-endorsements {
+  flex-direction: column;
+  gap: 32px;
+  padding: 16px 0;
+  display: flex;
+}
+
+.profile-endorsements__section {
+  flex-direction: column;
+  gap: 8px;
+  display: flex;
+}
+
+.profile-endorsements__heading-row {
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 4px;
+  display: flex;
+}
+
+.profile-endorsements__heading {
+  color: var(--fg-primary);
+  align-items: baseline;
+  gap: 8px;
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  display: inline-flex;
+}
+
+.profile-endorsements__endorse-btn {
+  border-radius: var(--radius);
+  border: 1px solid var(--border-default);
+  color: var(--fg-primary);
+  cursor: pointer;
+  background: none;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: .8125rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background .15s, color .15s, border-color .15s;
+  display: inline-flex;
+}
+
+.profile-endorsements__endorse-btn:hover:not(:disabled) {
+  background: var(--overlay-weak);
+  border-color: var(--fg-primary);
+}
+
+.profile-endorsements__endorse-btn:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+
+.profile-endorsements__endorse-btn--active {
+  background: var(--overlay-weak);
+  border-color: var(--fg-primary);
+  color: var(--fg-primary);
+}
+
+.profile-endorsements__endorse-error {
+  color: var(--color-error);
+  margin-top: 4px;
+  font-size: .75rem;
+  display: block;
+}
+
+.profile-endorsements__count {
+  color: var(--fg-muted);
+  font-size: .875rem;
+  font-weight: 600;
+}
+
+.profile-endorsements__pagination {
+  color: var(--fg-muted);
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+  font-size: .8125rem;
+  display: flex;
+}
+
+.profile-endorsements__pagination-btn {
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  color: var(--fg-secondary);
+  cursor: pointer;
+  background: none;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  font-size: .8125rem;
+  display: inline-flex;
+}
+
+.profile-endorsements__pagination-btn:hover:not(:disabled) {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.profile-endorsements__pagination-btn:disabled {
+  opacity: .4;
+  cursor: not-allowed;
+}
+
+.profile-endorsements__pagination-status {
+  font-variant-numeric: tabular-nums;
+}
+
+.profile-endorsements__placeholder {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .875rem;
+}
+
+.profile-endorsements__loading {
+  justify-content: center;
+  padding: 24px 0;
+  display: flex;
+}
+
+.received-endorsement-card {
+  border-bottom: 1px solid var(--border-default);
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 0;
+  display: flex;
+}
+
+.received-endorsement-card:last-child {
+  border-bottom: none;
+}
+
+.received-endorsement-card__endorsers {
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-left: 60px;
+  display: flex;
+}
+
+.endorser-chip {
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-default);
+  color: inherit;
+  border-radius: 9999px;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px 4px 4px;
+  font-size: .8125rem;
+  line-height: 1.2;
+  text-decoration: none;
+  transition: background .15s;
+  display: inline-flex;
+}
+
+.endorser-chip:hover {
+  background: var(--overlay-medium);
+}
+
+.endorser-chip__name {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.endorser-chip__date {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  font-size: .75rem;
+}
+
+@media (max-width: 799px) {
+  .create-form__input, .create-form__textarea {
+    font-size: 16px;
+  }
+}
+
+.feed-card__author-row {
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  display: flex;
+}
+
+.feed-card__time--inline {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+  font-size: .75rem;
+}
+
+.feed-card__action {
+  color: var(--fg-muted);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  font-size: .875rem;
+  display: flex;
+}
+
+.feed-card__action svg {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+.feed-card__action-subject {
+  color: var(--fg-primary);
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.feed-card__action-subject:hover {
+  text-decoration: underline;
+}
+
+.feed-card__note {
+  background: var(--bg-sunken);
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 12px 0 0;
+  padding: 12px;
+  font-size: .875rem;
+}
+
+.feed-card__desc--unknown {
+  color: var(--fg-muted);
+  word-break: break-all;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: .75rem;
+}
+
+.feed__warning {
+  background: var(--bg-sunken);
+  border-left: 3px solid var(--fg-muted);
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  margin: 12px 0;
+  padding: 10px 14px;
+  font-size: .875rem;
+}
+
+.feed__sentinel {
+  width: 100%;
+  height: 1px;
+}
+
+.feed__hint {
+  background: var(--bg-sunken);
+  border-radius: var(--radius);
+  color: var(--fg-muted);
+  align-items: center;
+  gap: 8px;
+  margin: 24px 0;
+  padding: 14px 16px;
+  font-size: .875rem;
+  display: flex;
+}
+
+.feed__hint svg {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+.feed__hint p {
+  margin: 0;
+}
+
+/* [project]/src/app/styles/profile.css [app-client] (css) */
+.profile-hero {
+  width: 100%;
+  position: relative;
+}
+
+.profile-hero__banner {
+  background: linear-gradient(135deg,
+    var(--bg-sunken) 0%,
+    var(--bg-raised) 100%);
+  width: 100%;
+  height: 180px;
+  overflow: hidden;
+}
+
+.profile-hero__banner--empty {
+  height: 90px;
+}
+
+.profile-hero__banner-img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.profile-hero__body {
+  padding: 0 16px 16px;
+}
+
+.profile-hero__row {
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 12px;
+  margin-top: -48px;
+  display: flex;
+}
+
+.profile-hero__avatar-wrap {
+  background: var(--bg-elevated);
+  border-radius: 999px;
+  flex-shrink: 0;
+  padding: 4px;
+  line-height: 0;
+}
+
+.profile-hero__action {
+  flex-shrink: 0;
+  padding-bottom: 4px;
+}
+
+.profile-hero__action-group {
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.profile-hero__eyebrow {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin: 12px 0 0;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.profile-hero__name {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  letter-spacing: -.01em;
+  margin: 12px 0 2px;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.profile-hero__eyebrow + .profile-hero__name {
+  margin-top: 4px;
+}
+
+.profile-hero__handle {
+  color: var(--fg-muted);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: .875rem;
+  font-weight: 400;
+  display: flex;
+}
+
+.profile-hero__pds-tag {
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-default);
+  color: var(--fg-muted);
+  letter-spacing: .01em;
+  border-radius: 999px;
+  align-items: center;
+  padding: 1px 8px;
+  font-size: .6875rem;
+  font-weight: 500;
+  line-height: 1.4;
+  display: inline-flex;
+}
+
+.profile-hero__count {
+  align-items: baseline;
+  gap: 6px;
+  margin: 12px 0 0;
+  font-size: .875rem;
+  display: inline-flex;
+}
+
+.profile-hero__count-value {
+  color: var(--fg-primary);
+  font-weight: 600;
+}
+
+.profile-hero__count-label {
+  color: var(--fg-muted);
+}
+
+.profile-hero__bio {
+  color: var(--fg-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 12px 0 0;
+  font-size: .9375rem;
+  line-height: 1.55;
+}
+
+@media (min-width: 800px) {
+  .profile-hero__banner {
+    height: 200px;
+  }
+
+  .profile-hero__banner--empty {
+    height: 100px;
+  }
+
+  .profile-hero__body {
+    padding: 0 24px 24px;
+  }
+
+  .profile-hero__row {
+    margin-top: -56px;
+  }
+
+  .profile-hero__name {
+    font-size: 1.75rem;
+  }
+}
+
+.profile-tabs {
+  border-top: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--border-light);
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  gap: 0;
+  margin-top: 8px;
+  padding: 0 16px;
+  display: flex;
+  overflow: auto hidden;
+}
+
+.profile-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.profile-tabs__tab {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  white-space: nowrap;
+  background: none;
+  border: none;
+  flex: none;
+  padding: 14px 20px;
+  font-size: .875rem;
+  font-weight: 500;
+  position: relative;
+}
+
+.profile-tabs__tab:hover {
+  color: var(--fg-primary);
+}
+
+.profile-tabs__tab--active {
+  color: var(--fg-primary);
+  font-weight: 600;
+}
+
+.profile-tabs__tab--active:after {
+  content: "";
+  background: var(--fg-primary);
+  border-radius: var(--radius);
+  height: 2px;
+  position: absolute;
+  bottom: -1px;
+  left: 16px;
+  right: 16px;
+}
+
+.profile-tabs__tab:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+  border-radius: 2px;
+}
+
+.profile-panel {
+  padding: 16px;
+}
+
+@media (min-width: 800px) {
+  .profile-panel--reading {
+    max-width: 720px;
+    margin: 0 auto;
+  }
+}
+
+.profile-groups {
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.profile-groups__item {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.profile-groups__item:last-child {
+  border-bottom: none;
+}
+
+.profile-groups__link {
+  color: inherit;
+  transition: background var(--transition-fast);
+  align-items: center;
+  gap: 12px;
+  padding: 12px 4px;
+  text-decoration: none;
+  display: flex;
+}
+
+.profile-groups__link:hover {
+  background: var(--overlay-weak);
+}
+
+.profile-groups__meta {
+  flex-direction: column;
+  flex: auto;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-groups__name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .9375rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.profile-groups__handle {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .8125rem;
+  overflow: hidden;
+}
+
+.profile-groups__role {
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  flex-shrink: 0;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.profile-groups__loading {
+  justify-content: center;
+  padding: 24px 0;
+  display: flex;
+}
+
+.profile-projects {
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.profile-projects__item {
+  border-bottom: 1px solid var(--border-subtle);
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px 0;
+  display: flex;
+}
+
+.profile-projects__item:first-child {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.profile-projects__icon {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  width: 32px;
+  height: 32px;
+  color: var(--fg-secondary);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.profile-projects__body {
+  flex-direction: column;
+  flex: 1;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-projects__title {
+  color: var(--fg-primary);
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.profile-projects__desc {
+  color: var(--fg-secondary);
+  margin: 0;
+  font-size: .875rem;
+  line-height: 1.4;
+}
+
+.profile-projects__meta {
+  color: var(--fg-muted);
+  margin: 4px 0 0;
+  font-size: .75rem;
+}
+
+.profile-projects__loading {
+  justify-content: center;
+  padding: 24px 0;
+  display: flex;
+}
+
+/* [project]/src/app/styles/pages.css [app-client] (css) */
+.handle-search {
+  position: relative;
+}
+
+.handle-search__clear {
+  border-radius: var(--radius);
+  width: 20px;
+  height: 20px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color var(--transition-fast), background var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
+}
+
+.handle-search__clear:hover {
+  color: var(--fg-primary);
+  background: var(--overlay-weak);
+}
+
+.handle-search__clear:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.handle-search__error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.handle-search__dropdown {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  z-index: 60;
+  max-height: 280px;
+  margin-top: 4px;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  overflow-y: auto;
+}
+
+.handle-search__item {
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  transition: background var(--transition-fast);
+  background: none;
+  border: none;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  display: flex;
+}
+
+.handle-search__item:hover, .handle-search__item--focused {
+  background: var(--bg-canvas);
+}
+
+.handle-search__item-info {
+  flex-direction: column;
+  min-width: 0;
+  display: flex;
+}
+
+.handle-search__item-name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .8125rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.handle-search__item-handle {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .6875rem;
+  overflow: hidden;
+}
+
+.org-list__loading {
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+  display: flex;
+}
+
+.org-list__empty {
+  color: var(--fg-muted);
+  margin: 24px 0 0;
+  font-size: .875rem;
+}
+
+.org-list__header {
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+  display: flex;
+}
+
+.org-list__count {
+  color: var(--fg-muted);
+  background: var(--bg-canvas);
+  border-radius: var(--radius);
+  padding: 2px 8px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.org-list__items {
+  flex-direction: column;
+  display: flex;
+}
+
+.org-list__item {
+  border-bottom: 1px solid var(--border-subtle);
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 0;
+  display: flex;
+}
+
+.org-list__item:last-child {
+  border-bottom: none;
+}
+
+.org-list__item-main {
+  color: inherit;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  display: flex;
+}
+
+.org-list__item-main:hover .org-list__item-name {
+  color: var(--fg-secondary);
+}
+
+.org-list__item-avatar {
+  background: var(--bg-canvas);
+  width: 40px;
+  height: 40px;
+  color: var(--fg-muted);
+  border-radius: 50%;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.org-list__item-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.org-list__item-name {
+  color: var(--fg-primary);
+  transition: color var(--transition-fast);
+  font-size: .875rem;
+  font-weight: 600;
+}
+
+.org-list__item-handle {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 2px;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.org-list__item-actions {
+  gap: 8px;
+  padding-left: 52px;
+  display: flex;
+}
+
+.org-list__action-btn {
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+  background: none;
+  padding: 6px 12px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.org-list__action-btn:hover {
+  color: var(--fg-primary);
+  border-color: var(--fg-primary);
+}
+
+.org-list__action-btn:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.org-list__action-btn--primary {
+  color: var(--fg-primary);
+  border-color: var(--fg-primary);
+}
+
+.org-list__action-btn--danger {
+  color: var(--fg-muted);
+}
+
+.org-list__action-btn--danger:hover {
+  color: var(--color-error);
+  border-color: var(--color-error);
+}
+
+.org-list__divider {
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 4px;
+  padding: 16px 0 12px;
+}
+
+.org-list__divider-text {
+  color: var(--fg-muted);
+  white-space: normal;
+  font-size: .75rem;
+  line-height: 1.5;
+  display: block;
+}
+
+.org-create__fields {
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 8px;
+  display: flex;
+}
+
+.org-create__handle-hint {
+  color: var(--fg-muted);
+  margin-top: 4px;
+  font-size: .75rem;
+}
+
+.org-create__actions {
+  border-top: 1px solid var(--border-light);
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 8px;
+  padding-top: 24px;
+  display: flex;
+}
+
+.org-profile__loading {
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+  display: flex;
+}
+
+.org-manage__actions {
+  gap: 8px;
+  margin-top: 8px;
+  display: flex;
+}
+
+.org-members__loading {
+  justify-content: center;
+  align-items: center;
+  padding: 24px 0;
+  display: flex;
+}
+
+.org-members__list {
+  flex-direction: column;
+  display: flex;
+}
+
+.org-members__item {
+  border-bottom: 1px solid var(--border-subtle);
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  display: flex;
+}
+
+.org-members__item:last-child {
+  border-bottom: none;
+}
+
+.org-members__item-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.org-members__item-actions {
+  flex-shrink: 0;
+  align-items: center;
+  gap: 12px;
+  display: flex;
+}
+
+.org-members__item-handle {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .8125rem;
+  font-weight: 600;
+  overflow: hidden;
+}
+
+.org-members__item-did {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 2px;
+  font-family: monospace;
+  font-size: .6875rem;
+  overflow: hidden;
+}
+
+.org-members__add {
+  border-top: 1px solid var(--border-light);
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 24px;
+  padding-top: 24px;
+  display: flex;
+}
+
+.org-members__add-title {
+  letter-spacing: .15em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.org-members__add-submit {
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.org-members__add-submit-label {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+  font-size: .8125rem;
+}
+
+.org-members__selected {
+  color: var(--fg-primary);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: .8125rem;
+  display: flex;
+}
+
+.org-members__selected-label {
+  color: var(--fg-muted);
+  margin-right: 4px;
+}
+
+.org-members__selected-tag {
+  align-items: center;
+  gap: 2px;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.org-members__selected-remove {
+  width: 16px;
+  height: 16px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color var(--transition-fast), background var(--transition-fast);
+  background: none;
+  border: none;
+  border-radius: 50%;
+  justify-content: center;
+  align-items: center;
+  margin-left: 1px;
+  padding: 0;
+  font-size: .875rem;
+  line-height: 1;
+  display: inline-flex;
+}
+
+.org-members__selected-remove:hover {
+  color: var(--color-error);
+  background: var(--color-error-bg);
+}
+
+.org-audit__loading {
+  justify-content: center;
+  align-items: center;
+  padding: 24px 0;
+  display: flex;
+}
+
+.org-audit__list {
+  flex-direction: column;
+  display: flex;
+}
+
+.org-audit__item {
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 12px 0;
+}
+
+.org-audit__item:last-child {
+  border-bottom: none;
+}
+
+.org-audit__item-main {
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+  display: flex;
+}
+
+.org-audit__action {
+  color: var(--fg-primary);
+  font-size: .8125rem;
+  font-weight: 500;
+}
+
+.org-audit__collection {
+  color: var(--fg-muted);
+  background: var(--bg-canvas);
+  border-radius: var(--radius);
+  padding: 2px 6px;
+  font-family: monospace;
+  font-size: .6875rem;
+}
+
+.org-audit__item-meta {
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 6px;
+  padding: 0;
+  display: flex;
+}
+
+.org-audit__detail {
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 8px;
+  padding: 0;
+  display: flex;
+}
+
+.org-audit__detail-row {
+  gap: 8px;
+  font-family: monospace;
+  font-size: .6875rem;
+  line-height: 1.4;
+  display: flex;
+}
+
+.org-audit__detail-label {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+  min-width: 72px;
+}
+
+.org-audit__detail-value {
+  color: var(--fg-secondary);
+  word-break: break-all;
+  margin: 0;
+}
+
+.org-audit__result {
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  border-radius: var(--radius);
+  padding: 2px 6px;
+  font-size: .6875rem;
+  font-weight: 500;
+}
+
+.org-audit__result--permitted {
+  color: var(--color-success-text);
+  background: var(--color-success-bg);
+}
+
+.org-audit__result--denied {
+  color: var(--color-error);
+  background: var(--color-error-bg);
+}
+
+.account-switcher {
+  position: relative;
+}
+
+.account-switcher__trigger {
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: background var(--transition-fast);
+  background: none;
+  border: none;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  display: flex;
+}
+
+.account-switcher__trigger:hover {
+  background: var(--bg-canvas);
+}
+
+.account-switcher__section-label {
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  padding: 12px 16px 6px;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.account-switcher__item {
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  min-width: 0;
+  transition: background var(--transition-fast);
+  background: none;
+  border: none;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  display: flex;
+}
+
+.account-switcher__item > :first-child {
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+.account-switcher__item > :last-child {
+  flex: auto;
+  min-width: 0;
+}
+
+.account-switcher__item:hover, .account-switcher__item--active {
+  background: var(--bg-canvas);
+}
+
+.account-switcher__item-name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .8125rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.account-switcher__item-handle {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .6875rem;
+  overflow: hidden;
+}
+
+.account-switcher__divider {
+  background: var(--border-light);
+  height: 1px;
+  margin: 4px 0;
+}
+
+.account-switcher__user-row {
+  align-items: center;
+  display: flex;
+}
+
+.account-switcher__user-row .account-switcher__item {
+  background: none;
+  flex: 1;
+  min-width: 0;
+  padding-right: 0;
+}
+
+.account-switcher__user-row .account-switcher__item > div {
+  min-width: 0;
+}
+
+.account-switcher__user-row .account-switcher__item-name, .account-switcher__user-row .account-switcher__item-handle {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.account-switcher__user-row:has(.account-switcher__item--active) {
+  background: var(--bg-canvas);
+}
+
+.account-switcher__signout {
+  width: 40px;
+  height: 40px;
+  color: var(--fg-muted);
+  border-radius: var(--radius);
+  cursor: pointer;
+  background: none;
+  border: none;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  margin-right: 8px;
+  transition: color .15s, background .15s;
+  display: flex;
+}
+
+.account-switcher__signout:hover {
+  color: var(--color-error);
+  background: var(--color-error-bg);
+}
+
+.account-switcher__signout-row {
+  width: 100%;
+  color: var(--fg-secondary);
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--radius);
+  background: none;
+  border: none;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  font-family: inherit;
+  font-size: .875rem;
+  transition: color .15s, background .15s;
+  display: flex;
+}
+
+.account-switcher__signout-row:hover {
+  color: var(--color-error);
+  background: var(--color-error-bg);
+}
+
+.account-switcher__signout-row:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.bottom-sheet__backdrop, .bottom-sheet {
+  display: none;
+}
+
+@media (max-width: 799px) {
+  .bottom-sheet__backdrop {
+    background: var(--navy-overlay-30);
+    z-index: 70;
+    animation: .2s ease-out bottomSheetFadeIn;
+    display: block;
+    position: fixed;
+    inset: 0;
+  }
+
+  .bottom-sheet {
+    background: var(--bg-elevated);
+    border-radius: var(--radius) var(--radius) 0 0;
+    z-index: 71;
+    flex-direction: column;
+    max-height: 70vh;
+    transition: max-height .3s ease-out;
+    animation: .3s ease-out bottomSheetSlideUp;
+    display: flex;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    overflow: hidden;
+  }
+
+  .bottom-sheet--expanded {
+    max-height: 92vh;
+  }
+
+  .bottom-sheet__handle {
+    cursor: grab;
+    touch-action: none;
+    flex-shrink: 0;
+    justify-content: center;
+    padding: 14px 0 10px;
+    display: flex;
+  }
+
+  .bottom-sheet__handle:after {
+    content: "";
+    background: var(--border-default);
+    border-radius: var(--radius);
+    width: 36px;
+    height: 4px;
+  }
+
+  .bottom-sheet__content {
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: env(safe-area-inset-bottom, 16px);
+    overflow: hidden auto;
+  }
+
+  @keyframes bottomSheetSlideUp {
+    from {
+      transform: translateY(100%);
+    }
+
+    to {
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes bottomSheetFadeIn {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+
+  .org-list__item-actions {
+    padding-left: 0;
+  }
+
+  .org-members__item {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .org-members__item-info {
+    width: 100%;
+  }
+
+  .org-members__selected-remove {
+    justify-content: center;
+    align-items: center;
+    width: 28px;
+    min-width: 44px;
+    height: 28px;
+    min-height: 44px;
+    display: inline-flex;
+  }
+}
+
+.app-shell__content:has(.apps-store) {
+  max-width: 1080px;
+}
+
+.apps-store {
+  padding-top: 8px;
+}
+
+.apps-store__header {
+  margin-bottom: 24px;
+}
+
+.apps-store__eyebrow {
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin-bottom: 8px;
+  font-size: .6875rem;
+  font-weight: 600;
+  display: inline-block;
+}
+
+.apps-store__title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  letter-spacing: -.02em;
+  color: var(--fg-primary);
+  margin: 0 0 10px;
+  font-size: clamp(2rem, 3vw + .5rem, 2.75rem);
+  font-weight: 700;
+  line-height: 1.05;
+}
+
+.apps-store__intro {
+  color: var(--fg-secondary);
+  max-width: 56ch;
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.apps-store__grid {
+  grid-template-columns: 1fr;
+  gap: 16px;
+  margin: 32px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+}
+
+.apps-store__cell {
+  margin: 0;
+  display: flex;
+}
+
+.apps-store__tile {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  width: 100%;
+  color: inherit;
+  transition: box-shadow var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+  padding: 18px 20px 20px;
+  text-decoration: none;
+  display: block;
+}
+
+.apps-store__tile:hover {
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+}
+
+.apps-store__tile:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 4px;
+}
+
+.apps-store__row {
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  column-gap: 14px;
+  display: grid;
+}
+
+.apps-store__icon-wrap {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  width: 64px;
+  height: 64px;
+  box-shadow: inset 0 0 0 1px var(--border-subtle);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+  overflow: hidden;
+}
+
+.apps-store__icon {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.apps-store__meta {
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.apps-store__name {
+  color: var(--fg-primary);
+  letter-spacing: -.01em;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.apps-store__tag {
+  color: var(--fg-muted);
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: .8125rem;
+  line-height: 1.35;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.apps-store__desc {
+  border-top: 1px solid var(--border-subtle);
+  color: var(--fg-secondary);
+  margin-top: 14px;
+  padding-top: 14px;
+  font-size: .875rem;
+  line-height: 1.5;
+  display: block;
+}
+
+.apps-store__footnote {
+  color: var(--fg-muted);
+  text-align: center;
+  margin: 32px 0 0;
+  font-size: .8125rem;
+}
+
+@media (min-width: 700px) {
+  .apps-store__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 799px) {
+  .apps-store__tile {
+    padding: 14px 14px 16px;
+  }
+
+  .apps-store__icon-wrap {
+    width: 56px;
+    height: 56px;
+  }
+}
+
+/* [project]/src/app/styles/notifications.css [app-client] (css) */
+.notification-list {
+  flex-direction: column;
+  display: flex;
+}
+
+.notification-list__sentinel {
+  min-height: 1px;
+}
+
+.notification-row {
+  border-bottom: 1px solid var(--border-subtle);
+  color: inherit;
+  transition: background var(--transition-fast);
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 4px;
+  text-decoration: none;
+  display: flex;
+  position: relative;
+}
+
+.notification-row:last-child {
+  border-bottom: none;
+}
+
+a.notification-row:hover, .notification-row--unread {
+  background: var(--bg-raised);
+}
+
+.notification-row--unread:before {
+  content: "";
+  background: var(--fg-primary);
+  width: 2px;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+}
+
+a.notification-row--unread:hover {
+  background: var(--bg-canvas);
+}
+
+.notification-row__avatar {
+  flex-shrink: 0;
+}
+
+.notification-row__body {
+  flex-direction: column;
+  flex: 1;
+  gap: 4px;
+  min-width: 0;
+  display: flex;
+}
+
+.notification-row__text {
+  color: var(--fg-primary);
+  font-size: .875rem;
+  line-height: 1.4;
+}
+
+.notification-row__text strong {
+  font-weight: 600;
+}
+
+.notification-row__time {
+  color: var(--fg-muted);
+  font-size: .6875rem;
+}
+
+.notification-row--skeleton {
+  pointer-events: none;
+}
+
+.bottom-nav__icon-wrap {
+  justify-content: center;
+  align-items: center;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  position: relative;
+}
+
+.bottom-nav__badge {
+  background: var(--badge-count-bg);
+  min-width: 16px;
+  height: 16px;
+  color: var(--badge-count-fg);
+  font-size: .625rem;
+  font-weight: 600;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  text-align: center;
+  pointer-events: none;
+  border-radius: 999px;
+  justify-content: center;
+  align-items: center;
+  padding: 0 4px;
+  line-height: 16px;
+  display: inline-flex;
+  position: absolute;
+  top: -2px;
+  right: -6px;
+}
+
+.mobile-sidebar__badge {
+  background: var(--badge-count-bg);
+  min-width: 20px;
+  height: 18px;
+  color: var(--badge-count-fg);
+  text-align: center;
+  border-radius: 999px;
+  justify-content: center;
+  align-items: center;
+  margin-left: auto;
+  padding: 0 6px;
+  font-size: .6875rem;
+  font-weight: 600;
+  line-height: 18px;
+  display: inline-flex;
+}
+
+.sr-only {
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+}
+
+/* [project]/src/app/styles/cert-detail.css [app-client] (css) */
+.cert-detail-page {
+  padding-bottom: 64px;
+}
+
+.app-shell:has(.cert-detail--wide) .app-shell__content {
+  padding: 0;
+}
+
+@media (min-width: 800px) {
+  .app-shell:has(.cert-detail--wide) .app-shell__content {
+    max-width: 1280px;
+  }
+
+  .app-shell:has(.cert-detail--wide.create-cert) .app-shell__content {
+    max-width: 1008px;
+  }
+
+  .cert-detail--wide.page-layout {
+    grid-template-columns: minmax(0, 1fr) 296px;
+  }
+
+  .cert-detail--wide.page-layout > .cert-detail__aside {
+    grid-area: 1 / 2;
+  }
+
+  .cert-detail--wide.page-layout > .cert-detail__main {
+    grid-area: 1 / 1;
+  }
+}
+
+.cert-detail__loading, .cert-detail__error {
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 96px 24px;
+  display: flex;
+}
+
+.cert-detail__error-title {
+  color: var(--fg-primary);
+  margin: 0 0 6px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.cert-detail__error-desc {
+  color: var(--fg-muted);
+  max-width: 32ch;
+  margin: 0;
+  font-size: .875rem;
+  line-height: 1.5;
+}
+
+.cert-detail__aside {
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+  display: flex;
+}
+
+.cert-detail__image {
+  aspect-ratio: 1;
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-subtle);
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  display: flex;
+  position: relative;
+  overflow: hidden;
+}
+
+.cert-detail__image-img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.cert-detail__image--placeholder {
+  background: linear-gradient(135deg,
+    var(--bg-sunken) 0%,
+    var(--overlay-weak) 100%);
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.cert-detail__image-placeholder-icon {
+  color: var(--fg-muted);
+  opacity: .55;
+}
+
+.cert-detail__image--editing {
+  outline: 1.5px dashed var(--border-hover);
+  outline-offset: -2px;
+}
+
+.cert-detail__title-input {
+  min-width: 0;
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  letter-spacing: -.015em;
+  border: 1.5px solid var(--border-hover);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  flex: auto;
+  padding: 4px 10px;
+  font-size: 1.875rem;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.cert-detail__title-input:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.cert-detail__title-input::placeholder, .cert-detail__short-desc-input::placeholder, .cert-detail__meta-input::placeholder {
+  color: var(--fg-muted);
+  opacity: 1;
+}
+
+.cert-detail__meta-input[type="date"]::-webkit-datetime-edit {
+  color: var(--fg-muted);
+}
+
+.cert-detail__short-desc-input {
+  width: 100%;
+  font: inherit;
+  color: var(--fg-secondary);
+  border: 1.5px solid var(--border-hover);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  resize: vertical;
+  min-height: 72px;
+  padding: 10px 12px;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.cert-detail__short-desc-input:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.cert-detail__projects {
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  display: flex;
+}
+
+.cert-detail__section-title--aside {
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.cert-detail__projects-list {
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.cert-detail__project {
+  min-width: 0;
+  display: flex;
+}
+
+.cert-detail__project-link {
+  border-radius: var(--radius);
+  min-width: 0;
+  color: inherit;
+  flex: 1;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  text-decoration: none;
+  display: flex;
+}
+
+.cert-detail__project-link:hover, .cert-detail__project-link:focus-visible {
+  background: var(--overlay-weak);
+}
+
+.cert-detail__project-link--static {
+  cursor: default;
+}
+
+.cert-detail__project-link--static:hover {
+  background: none;
+}
+
+.cert-detail__project-thumb-wrap {
+  flex-shrink: 0;
+}
+
+.cert-detail__project-thumb {
+  border-radius: var(--radius);
+  object-fit: cover;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-subtle);
+  width: 32px;
+  height: 32px;
+  display: block;
+  overflow: hidden;
+}
+
+.cert-detail__project-thumb--placeholder {
+  color: var(--fg-muted);
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.cert-detail__project-meta {
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  line-height: 1.25;
+  display: flex;
+}
+
+.cert-detail__project-name {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .875rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.cert-detail__project-desc {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.cert-detail__main {
+  flex-direction: column;
+  gap: 32px;
+  min-width: 0;
+  display: flex;
+}
+
+.cert-detail__headline {
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+}
+
+.cert-detail__title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  letter-spacing: -.015em;
+  word-break: break-word;
+  margin: 0;
+  font-size: 1.875rem;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.cert-detail__short-desc {
+  color: var(--fg-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.cert-detail__meta-count {
+  color: var(--fg-secondary);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.cert-detail__two-col {
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  margin-top: 4px;
+  padding-top: 24px;
+  display: grid;
+}
+
+.cert-detail__main > .cert-detail__two-col:first-child {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+.cert-detail__main > :not(:first-child).cert-detail__two-col, .cert-detail__main > .cert-detail__two-col + .cert-detail__section {
+  border-top: 1px solid var(--border-subtle);
+}
+
+@media (max-width: 799px) {
+  .cert-detail__two-col {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .cert-detail__two-col > .cert-detail__two-col-cell + .cert-detail__two-col-cell {
+    border-top: 1px solid var(--border-subtle);
+    margin-top: 24px;
+    padding-top: 24px;
+  }
+}
+
+.cert-detail__two-col-cell {
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  display: flex;
+}
+
+.cert-detail__two-col-cell > .cert-detail__section {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+.cert-detail__empty-line {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .875rem;
+}
+
+.cert-detail__read-more {
+  border-radius: var(--radius);
+  border: 1px solid var(--border-default);
+  color: var(--fg-primary);
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast);
+  background: none;
+  align-self: flex-start;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  padding: 6px 16px;
+  font-size: .8125rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.cert-detail__read-more:hover {
+  border-color: var(--border-hover);
+  background: var(--bg-sunken);
+}
+
+.cert-detail__read-more:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.cert-detail__title-row {
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  display: flex;
+}
+
+.cert-detail__title-row .cert-detail__title {
+  flex: auto;
+  min-width: 0;
+}
+
+.cert-detail__edit-btn {
+  border-radius: var(--radius);
+  border: 1px solid var(--border-default);
+  background: var(--bg-elevated);
+  height: 32px;
+  color: var(--fg-primary);
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  flex-shrink: 0;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  font-size: .8125rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.cert-detail__edit-btn:hover {
+  background: var(--bg-sunken);
+  border-color: var(--border-hover);
+}
+
+.cert-detail__edit-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.cert-detail__delete-btn {
+  border-radius: var(--radius);
+  border: 1px solid var(--border-default);
+  background: var(--bg-elevated);
+  width: 32px;
+  height: 32px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
+}
+
+.cert-detail__delete-btn:hover {
+  background: var(--bg-sunken);
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+
+.cert-detail__delete-btn:focus-visible {
+  outline: 2px solid var(--color-error);
+  outline-offset: 2px;
+}
+
+.cert-detail__headline-byline {
+  color: var(--fg-secondary);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-size: .875rem;
+  display: flex;
+}
+
+.cert-detail__headline-date {
+  color: var(--fg-secondary);
+  font-feature-settings: "tnum" 1;
+}
+
+.cert-detail__headline-label, .cert-detail__headline-by {
+  color: var(--fg-muted);
+}
+
+.cert-detail__headline-author {
+  color: inherit;
+  border-radius: var(--radius);
+  align-items: center;
+  gap: 8px;
+  margin: -2px -4px;
+  padding: 2px 4px;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.cert-detail__headline-author:hover, .cert-detail__headline-author:focus-visible {
+  background: var(--overlay-weak);
+}
+
+.cert-detail__headline-author > div:first-child {
+  width: 24px;
+  height: 24px;
+}
+
+.cert-detail__headline-author-meta {
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.15;
+  display: inline-flex;
+}
+
+.cert-detail__headline-name {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  font-size: .875rem;
+  font-weight: 500;
+}
+
+.cert-detail__headline-handle {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  font-size: .75rem;
+}
+
+.cert-detail__headline-author--skeleton {
+  cursor: default;
+}
+
+.cert-detail__headline-avatar-skel {
+  background: var(--overlay-weak);
+  border-radius: 999px;
+  width: 24px;
+  height: 24px;
+}
+
+.cert-detail__headline-name-skel {
+  border-radius: var(--radius);
+  background: var(--overlay-weak);
+  width: 90px;
+  height: 10px;
+  margin-bottom: 4px;
+  display: block;
+}
+
+.cert-detail__headline-handle-skel {
+  border-radius: var(--radius);
+  background: var(--overlay-weak);
+  width: 60px;
+  height: 9px;
+  display: block;
+}
+
+.cert-detail__meta {
+  flex-direction: column;
+  gap: 20px;
+  margin: 0;
+  padding: 0;
+  display: flex;
+}
+
+.cert-detail__meta-row {
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  display: flex;
+}
+
+.cert-detail__meta-label {
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--fg-muted);
+  align-items: center;
+  gap: 4px;
+  font-size: .6875rem;
+  font-weight: 600;
+  display: inline-flex;
+}
+
+.cert-detail__meta-label--with-action {
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  display: flex;
+}
+
+.cert-detail__meta-label-text {
+  align-items: center;
+  gap: 4px;
+  display: inline-flex;
+}
+
+.cert-detail__meta-value {
+  color: var(--fg-primary);
+  word-break: break-word;
+  font-size: .875rem;
+  line-height: 1.4;
+}
+
+.cert-detail__meta-aux {
+  color: var(--fg-muted);
+  margin-left: 4px;
+  font-size: .75rem;
+}
+
+.cert-detail__meta-edit {
+  align-items: center;
+  gap: 6px;
+  display: inline-flex;
+}
+
+.cert-detail__meta-input {
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-hover);
+  border-radius: var(--radius);
+  min-width: 0;
+  max-width: 100%;
+  padding: 2px 6px;
+  font-size: .8125rem;
+}
+
+.cert-detail__meta-input:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.cert-detail__uri {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--fg-secondary);
+  word-break: break-all;
+  font-size: .75rem;
+}
+
+.cert-detail__section {
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 4px;
+  padding-top: 24px;
+  display: flex;
+}
+
+.cert-detail__main > .cert-detail__section:first-child {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+.cert-detail__main > .cert-detail__section + .cert-detail__section {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.cert-detail__section-header {
+  align-items: baseline;
+  gap: 12px;
+  display: flex;
+}
+
+.cert-detail__section-header > .cert-detail__section-title {
+  margin-right: 0;
+}
+
+.cert-detail__section-see-all {
+  color: var(--fg-secondary);
+  transition: color var(--transition-fast);
+  margin-left: auto;
+  font-size: .75rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.cert-detail__section-see-all:hover {
+  color: var(--fg-primary);
+  text-underline-offset: 2px;
+  text-decoration: underline;
+}
+
+.cert-detail__section-see-all-footer {
+  text-align: center;
+  color: var(--fg-secondary);
+  border-radius: var(--radius);
+  transition: background var(--transition-fast), color var(--transition-fast);
+  margin: 8px auto 0;
+  padding: 8px 12px;
+  font-size: .8125rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: block;
+}
+
+.cert-detail__section-see-all-footer:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.cert-detail__section-see-all-footer:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.cert-detail__section-title {
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .8125rem;
+  font-weight: 600;
+}
+
+.cert-detail__section-count {
+  color: var(--fg-muted);
+  background: var(--overlay-weak);
+  font-feature-settings: "tnum" 1;
+  border-radius: 999px;
+  padding: 1px 8px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.cert-detail__contributors {
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.cert-detail__contributors-weight-header {
+  color: var(--fg-muted);
+  cursor: help;
+  justify-content: flex-end;
+  padding: 0 13px 4px 0;
+  font-size: .6875rem;
+  font-weight: 600;
+  display: flex;
+}
+
+.cert-detail__contributors--aside {
+  gap: 0;
+}
+
+.cert-detail__contributors--aside .cert-detail__contributor {
+  padding: 4px 6px;
+}
+
+.cert-detail__aside-see-all {
+  color: var(--fg-secondary);
+  border-radius: var(--radius);
+  transition: background var(--transition-fast),
+    color var(--transition-fast);
+  margin-top: 4px;
+  padding: 2px 6px;
+  font-size: .8125rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.cert-detail__aside-see-all:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.cert-detail__aside-see-all:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.cert-detail__contributor {
+  border-radius: var(--radius);
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 6px 8px;
+  display: flex;
+}
+
+.cert-detail__contributor-link {
+  min-width: 0;
+  color: inherit;
+  flex: 1;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  display: flex;
+}
+
+:is(.cert-detail__contributor:has(.cert-detail__contributor-link:hover), .cert-detail__contributor:has(.cert-detail__contributor-link:focus-visible)) {
+  background: var(--overlay-weak);
+}
+
+.cert-detail__contributor-link--static {
+  cursor: default;
+}
+
+.cert-detail__contributor-meta {
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  line-height: 1.2;
+  display: flex;
+}
+
+.cert-detail__contributor-name {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .875rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.cert-detail__contributor-handle {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.cert-detail__contributor-role {
+  color: var(--fg-muted);
+  font-size: .75rem;
+  font-weight: 400;
+}
+
+.cert-detail__contributor-weight {
+  color: var(--fg-secondary);
+  background: var(--overlay-weak);
+  font-feature-settings: "tnum" 1;
+  border-radius: 999px;
+  flex-shrink: 0;
+  padding: 1px 7px;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.cert-detail__contributor--skeleton {
+  pointer-events: none;
+}
+
+.cert-detail__contributor-avatar-skel {
+  background: var(--overlay-weak);
+  border-radius: 999px;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+}
+
+.cert-detail__contributor-name-skel {
+  border-radius: var(--radius);
+  background: var(--overlay-weak);
+  width: 100px;
+  height: 10px;
+  margin-bottom: 4px;
+}
+
+.cert-detail__contributor-handle-skel {
+  border-radius: var(--radius);
+  background: var(--overlay-weak);
+  width: 64px;
+  height: 9px;
+}
+
+.cert-detail__description {
+  color: var(--fg-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  font-size: .9375rem;
+  line-height: 1.65;
+}
+
+.cert-detail__full-disclosure {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.cert-detail__full-disclosure summary {
+  color: var(--fg-muted);
+  cursor: pointer;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 0;
+  font-size: .8125rem;
+  font-weight: 500;
+  list-style: none;
+  display: inline-flex;
+}
+
+.cert-detail__full-disclosure summary::-webkit-details-marker {
+  display: none;
+}
+
+.cert-detail__full-disclosure summary:before {
+  content: "▸";
+  color: var(--fg-muted);
+  font-size: .625rem;
+  transition: transform .15s;
+  display: inline-block;
+}
+
+.cert-detail__full-disclosure[open] summary:before {
+  transform: rotate(90deg);
+}
+
+.cert-detail__full-disclosure summary:hover, .cert-detail__full-disclosure[open] summary {
+  color: var(--fg-primary);
+}
+
+.cert-detail__full-body {
+  padding-top: 8px;
+}
+
+.cert-detail .leaflet-doc {
+  color: var(--fg-secondary);
+  word-break: break-word;
+  gap: 14px;
+  font-size: .9375rem;
+  line-height: 1.65;
+}
+
+.cert-detail__map-wrap {
+  flex-direction: column;
+  gap: 8px;
+  display: flex;
+}
+
+.cert-detail__map {
+  border-radius: var(--radius);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-sunken);
+  width: 100%;
+  overflow: hidden;
+}
+
+.cert-detail__map--skeleton {
+  background: linear-gradient(135deg,
+    var(--bg-sunken) 0%,
+    var(--overlay-weak) 100%);
+  height: 320px;
+}
+
+.cert-detail__map--empty {
+  height: 120px;
+  color: var(--fg-muted);
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  font-size: .8125rem;
+  display: flex;
+}
+
+.cert-detail__map--empty p {
+  margin: 0;
+}
+
+.cert-detail__map-other {
+  color: var(--fg-secondary);
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  font-size: .8125rem;
+  list-style: none;
+  display: flex;
+}
+
+.cert-detail__map-other-item {
+  border-radius: var(--radius);
+  background: var(--overlay-weak);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 4px 8px;
+  display: flex;
+}
+
+.cert-detail__map-other-name {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.cert-detail__map-other-detail {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.cert-detail__map-locations {
+  color: var(--fg-secondary);
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  font-size: .8125rem;
+  list-style: none;
+  display: flex;
+}
+
+.cert-detail__map-locations-item {
+  border-radius: var(--radius);
+  background: var(--overlay-weak);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 4px 8px;
+  display: flex;
+}
+
+.cert-detail__map-locations-item > svg {
+  flex-shrink: 0;
+}
+
+.cert-detail__map-locations-name {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.cert-detail__map-locations-detail {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.cert-detail__map-locations-plus {
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  color: var(--fg-muted);
+  font-family: var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, monospace;
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast),
+    background var(--transition-fast);
+  background: none;
+  flex-shrink: 0;
+  padding: 1px 6px;
+  font-size: .7rem;
+}
+
+.cert-detail__map-locations-plus:hover {
+  color: var(--fg-primary);
+  background: var(--overlay-weak);
+  border-color: var(--border-hover);
+}
+
+.cert-detail__map-locations-plus:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.cert-detail__headline-cols {
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 4px 32px;
+  display: flex;
+}
+
+.cert-detail__headline-col {
+  flex-direction: column;
+  flex: none;
+  gap: 4px;
+  min-width: 0;
+  max-width: 100%;
+  display: flex;
+}
+
+.cert-detail__headline-col-value {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  min-width: 0;
+  font-size: .875rem;
+  line-height: 1.4;
+  overflow: hidden;
+}
+
+.cert-detail__headline-col-value--skel {
+  border-radius: var(--radius);
+  background: var(--overlay-weak);
+  height: 32px;
+  display: block;
+}
+
+.cert-detail__headline-project-value {
+  min-width: 0;
+}
+
+.cert-detail__headline-project-link {
+  color: var(--fg-primary);
+  border-radius: var(--radius);
+  min-width: 0;
+  transition: background var(--transition-fast);
+  align-items: center;
+  gap: 8px;
+  margin: -2px -4px;
+  padding: 2px 4px;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.cert-detail__headline-project-link:hover, .cert-detail__headline-project-link:focus-visible {
+  background: var(--overlay-weak);
+}
+
+.cert-detail__headline-project-link--static {
+  cursor: default;
+}
+
+.cert-detail__headline-project-link--static:hover {
+  background: none;
+}
+
+.cert-detail__headline-project-thumb {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  overflow: hidden;
+}
+
+.cert-detail__headline-project-thumb-img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.cert-detail__headline-project-title {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  overflow: hidden;
+}
+
+@media (max-width: 799px) {
+  .cert-detail__headline-cols {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+}
+
+.cert-detail__meta-input.create-cert__field--full {
+  width: 100%;
+}
+
+.create-cert .cert-detail__title-input {
+  font-size: 1.375rem;
+}
+
+.create-cert__date-row {
+  align-items: center;
+  gap: 6px;
+  display: flex;
+}
+
+.create-cert__date-row .cert-detail__meta-input {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.create-cert__contrib-actions {
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  display: flex;
+}
+
+.create-cert__counter {
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+  align-self: flex-end;
+  margin: 0;
+  font-size: .75rem;
+}
+
+.create-cert__counter--over, .create-cert__counter--under {
+  color: var(--color-error);
+}
+
+.create-cert__counter--over {
+  font-weight: 600;
+}
+
+.create-cert__input-with-counter {
+  flex-direction: column;
+  gap: 4px;
+  display: flex;
+}
+
+.create-cert__auth-loading {
+  justify-content: center;
+  align-items: center;
+  min-height: 50vh;
+  display: flex;
+}
+
+.create-cert__contrib-list {
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.create-cert__contrib-row {
+  grid-template-columns: 2fr 1.5fr 170px auto;
+  align-items: center;
+  gap: 8px;
+  display: grid;
+}
+
+.create-cert__contrib-weight {
+  text-align: left;
+}
+
+.create-cert__contrib-id {
+  min-width: 0;
+  position: relative;
+}
+
+.create-cert__contrib-card {
+  border-radius: var(--radius);
+  background: none;
+  border: none;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  height: 32px;
+  padding: 4px 8px 4px 4px;
+  display: flex;
+}
+
+.create-cert__contrib-card-meta {
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  line-height: 1.1;
+  display: flex;
+}
+
+.create-cert__contrib-card-name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .8125rem;
+  font-weight: 600;
+  overflow: hidden;
+}
+
+.create-cert__contrib-card-handle {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .6875rem;
+  overflow: hidden;
+}
+
+.create-cert__contrib-card-clear {
+  width: 22px;
+  height: 22px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  border-radius: 50%;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
+}
+
+.create-cert__contrib-card-clear:hover, .create-cert__contrib-card-clear:focus-visible {
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+}
+
+.create-cert__contrib-id input {
+  width: 100%;
+}
+
+.create-cert__contrib-id-input--invalid {
+  border-color: var(--color-error);
+}
+
+.create-cert__contrib-id-input--invalid:focus {
+  border-color: var(--color-error);
+  box-shadow: 0 0 0 2px #b91c1c26;
+}
+
+.create-cert__contrib-error {
+  color: var(--color-error);
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: .75rem;
+}
+
+.create-cert__contrib-id-spinner {
+  border: 2px solid var(--border-medium);
+  border-top-color: var(--fg-primary);
+  pointer-events: none;
+  border-radius: 50%;
+  width: 12px;
+  height: 12px;
+  animation: .6s linear infinite spin;
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+}
+
+.create-cert__contrib-id-dropdown {
+  z-index: 60;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  max-height: 220px;
+  box-shadow: var(--shadow-md);
+  margin: 4px 0 0;
+  padding: 4px;
+  list-style: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  overflow-y: auto;
+}
+
+.create-cert__contrib-id-option {
+  border-radius: var(--radius);
+  cursor: pointer;
+  flex-direction: column;
+  gap: 1px;
+  padding: 6px 10px;
+  display: flex;
+}
+
+.create-cert__contrib-id-option--active {
+  background: var(--overlay-weak);
+}
+
+.create-cert__contrib-id-name {
+  color: var(--fg-primary);
+  font-size: .875rem;
+  font-weight: 500;
+}
+
+.create-cert__contrib-id-handle {
+  color: var(--fg-muted);
+  font-size: .75rem;
+}
+
+.create-cert__contrib-remove {
+  border-radius: var(--radius);
+  border: 1px solid var(--border-default);
+  background: var(--bg-elevated);
+  width: 32px;
+  height: 32px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.create-cert__contrib-remove:hover {
+  background: var(--bg-sunken);
+  color: var(--color-error);
+  border-color: var(--color-error);
+}
+
+@media (max-width: 799px) {
+  .create-cert__contrib-row {
+    grid-template-columns: 1fr auto;
+    gap: 6px;
+  }
+
+  .create-cert__contrib-row > input:nth-child(2), .create-cert__contrib-row > input:nth-child(3) {
+    grid-column: 1 / 2;
+  }
+}
+
+.create-project__quick-pick-label {
+  color: var(--fg-muted);
+  margin: 0 0 6px;
+  font-size: .75rem;
+}
+
+.create-project__inline-link {
+  color: var(--fg-secondary);
+  text-underline-offset: 2px;
+  text-decoration: underline;
+}
+
+.create-project__inline-link:hover, .create-project__inline-link:focus-visible {
+  color: var(--fg-primary);
+}
+
+.create-project__quick-pick-list {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  flex-direction: column;
+  gap: 2px;
+  max-height: 280px;
+  margin: 0 0 12px;
+  padding: 6px;
+  list-style: none;
+  display: flex;
+  overflow-y: auto;
+}
+
+.create-project__quick-pick-row {
+  border-radius: var(--radius);
+  transition: background var(--transition-fast);
+  align-items: center;
+  display: flex;
+}
+
+.create-project__quick-pick-row:hover {
+  background: var(--overlay-weak);
+}
+
+.create-project__quick-pick-row--added {
+  opacity: .6;
+}
+
+.create-project__quick-pick-label-inner {
+  cursor: pointer;
+  min-width: 0;
+  color: var(--fg-primary);
+  flex: 1;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  font-size: .875rem;
+  display: flex;
+}
+
+.create-project__quick-pick-title {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.create-project__cert-picker {
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 8px;
+  display: flex;
+}
+
+.create-project__cert-list {
+  flex-direction: column;
+  gap: 6px;
+  margin: 0 0 8px;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.create-project__cert-row {
+  background: var(--overlay-weak);
+  border-radius: var(--radius);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 8px 12px;
+  display: flex;
+}
+
+.create-project__cert-title {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  color: var(--fg-primary);
+  flex: 1;
+  font-size: .875rem;
+  overflow: hidden;
+}
+
+.create-project__cert-remove {
+  width: 22px;
+  height: 22px;
+  color: var(--fg-muted);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    color var(--transition-fast);
+  background: none;
+  border: 0;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
+}
+
+.create-project__cert-remove:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.create-cert__followup-note {
+  color: var(--fg-secondary);
+  background: var(--bg-sunken);
+  border-radius: var(--radius);
+  border: 1px dashed var(--border-default);
+  margin: 0;
+  padding: 12px 14px;
+  font-size: .8125rem;
+}
+
+.create-cert__loc-list {
+  flex-direction: column;
+  gap: 4px;
+  margin: 0 0 6px;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.create-cert__loc-row {
+  background: var(--overlay-weak);
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 4px 6px;
+  font-size: .8125rem;
+  display: flex;
+}
+
+.create-cert__loc-name {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.create-cert__loc-remove {
+  width: 18px;
+  height: 18px;
+  color: var(--fg-muted);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: 0;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
+}
+
+.create-cert__loc-remove:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.create-cert__loc-dialog-body {
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 20px 20px;
+  display: flex;
+}
+
+.create-cert__loc-combobox {
+  min-width: 0;
+  position: relative;
+}
+
+.create-cert__loc-combobox:has(.create-cert__loc-search-again) > input {
+  padding-right: 32px;
+}
+
+.create-cert__loc-search-again {
+  border-radius: var(--radius);
+  width: 22px;
+  height: 22px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    color var(--transition-fast);
+  background: none;
+  border: 0;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  transform: translateY(-50%);
+}
+
+.create-cert__loc-search-again:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.create-cert__loc-suggestions {
+  z-index: var(--z-popover);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  max-height: 220px;
+  box-shadow: var(--shadow-md);
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  overflow-y: auto;
+}
+
+.create-cert__loc-suggestion {
+  border-radius: var(--radius);
+  cursor: pointer;
+  flex-direction: column;
+  gap: 1px;
+  padding: 6px 10px;
+  display: flex;
+}
+
+.create-cert__loc-suggestion--active {
+  background: var(--overlay-weak);
+}
+
+.create-cert__loc-suggestion-primary {
+  color: var(--fg-primary);
+  font-size: .875rem;
+  font-weight: 500;
+}
+
+.create-cert__loc-suggestion-secondary {
+  color: var(--fg-muted);
+  font-size: .75rem;
+}
+
+.create-cert__loc-map {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.create-cert__loc-hint {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .75rem;
+}
+
+.create-cert__loc-reused {
+  color: var(--fg-secondary);
+  background: var(--overlay-weak);
+  border-radius: var(--radius);
+  margin: 0;
+  padding: 8px 12px;
+  font-size: .8125rem;
+}
+
+.create-cert__loc-uri-label {
+  color: var(--fg-secondary);
+  font-size: .8125rem;
+}
+
+.create-cert__loc-uri-label code {
+  background: var(--bg-sunken);
+  border-radius: var(--radius);
+  padding: 1px 4px;
+  font-size: .75rem;
+}
+
+.create-cert__loc-actions {
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 4px;
+  display: flex;
+}
+
+.create-cert__actions {
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 12px;
+  display: flex;
+}
+
+.cert-detail__map {
+  position: relative;
+}
+
+.cert-detail__map-expand-btn {
+  z-index: 500;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  width: 30px;
+  height: 30px;
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+.cert-detail__map-expand-btn:hover {
+  background: var(--bg-sunken);
+  border-color: var(--border-hover);
+}
+
+.cert-detail__map-expand-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.cert-detail__map-modal-body {
+  flex-direction: column;
+  gap: 12px;
+  padding: 0 20px 20px;
+  display: flex;
+}
+
+.cert-detail__map--modal {
+  width: 100%;
+  height: min(720px, 70vh);
+}
+
+@media (max-width: 799px) {
+  .cert-detail__title {
+    font-size: 1.5rem;
+  }
+}
+
+/* [project]/src/app/styles/profile-endorsements.css [app-client] (css) */
+.profile-endorsements-v2 {
+  flex-direction: column;
+  display: flex;
+}
+
+.profile-endorsements-v2__toolbar {
+  border-bottom: 1px solid var(--border-subtle);
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+  display: flex;
+}
+
+.profile-endorsements-v2__controls {
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  padding-bottom: 8px;
+  display: inline-flex;
+}
+
+.profile-endorsements-v2__search {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  height: 36px;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  display: inline-flex;
+}
+
+.profile-endorsements-v2__search:focus-within {
+  border-color: var(--fg-primary);
+}
+
+.profile-endorsements-v2__search-icon {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+.profile-endorsements-v2__search-input {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  background: none;
+  border: none;
+  outline: none;
+  width: 200px;
+  font-size: .875rem;
+}
+
+.profile-endorsements-v2__search-input::placeholder {
+  color: var(--fg-muted);
+}
+
+.profile-endorsements-v2__search-input::-webkit-search-cancel-button {
+  appearance: none;
+}
+
+.profile-endorsements-v2__sort-wrap {
+  display: inline-flex;
+  position: relative;
+}
+
+.profile-endorsements-v2__sort-btn {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  width: 36px;
+  height: 36px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.profile-endorsements-v2__sort-btn:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.profile-endorsements-v2__sort-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.profile-endorsements-v2__endorse-add {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  width: 36px;
+  height: 36px;
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.profile-endorsements-v2__endorse-add:hover {
+  background: var(--overlay-weak);
+  border-color: var(--border-hover);
+}
+
+.profile-endorsements-v2__endorse-add:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.profile-endorsements-v2__sort-menu {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  min-width: 200px;
+  box-shadow: var(--shadow-md);
+  z-index: 30;
+  padding: 4px;
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+}
+
+.profile-endorsements-v2__sort-item {
+  border-radius: var(--radius);
+  width: 100%;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  background: none;
+  border: none;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  font-size: .875rem;
+  display: flex;
+}
+
+.profile-endorsements-v2__sort-item:hover {
+  background: var(--overlay-weak);
+}
+
+.profile-endorsements-v2__sort-item-check {
+  width: 14px;
+  height: 14px;
+  color: var(--fg-primary);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.profile-endorsements-v2__grid {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+}
+
+.profile-endorsements-v2__error {
+  color: var(--fg-muted);
+  margin: 16px 0;
+  font-size: .875rem;
+}
+
+.profile-endorsements-v2__loading {
+  justify-content: center;
+  padding: 32px 0;
+  display: flex;
+}
+
+.profile-endorsements-v2__card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  transition: background var(--transition-fast), border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+  align-items: stretch;
+  padding: 16px 18px;
+  display: flex;
+  position: relative;
+}
+
+.profile-endorsements-v2__card:hover {
+  background: var(--overlay-weak);
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-sm);
+}
+
+.profile-endorsements-v2__card-link {
+  min-width: 0;
+  color: inherit;
+  flex: 1;
+  align-items: flex-start;
+  gap: 14px;
+  text-decoration: none;
+  display: flex;
+}
+
+.profile-endorsements-v2__card-link:hover .profile-endorsements-v2__card-name {
+  text-decoration: none;
+}
+
+.profile-endorsements-v2__card-avatar-skel {
+  background: var(--overlay-weak);
+  border-radius: 50%;
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+}
+
+.profile-endorsements-v2__card-body {
+  flex-direction: column;
+  flex: 1;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-endorsements-v2__card-name {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .9375rem;
+  font-weight: 600;
+  line-height: 1.25;
+  overflow: hidden;
+}
+
+.profile-endorsements-v2__card-handle {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .8125rem;
+  line-height: 1.25;
+  overflow: hidden;
+}
+
+.profile-endorsements-v2__card-date {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  font-size: .75rem;
+  line-height: 1.25;
+}
+
+.profile-endorsements-v2__card-list {
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-default);
+  color: var(--fg-secondary);
+  letter-spacing: .02em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: 999px;
+  align-self: flex-start;
+  max-width: 100%;
+  margin-top: 2px;
+  padding: 1px 8px;
+  font-size: .6875rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.profile-endorsements-v2__card-note {
+  color: var(--fg-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  margin: 6px 0 0;
+  font-size: .875rem;
+  line-height: 1.5;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.profile-endorsements-v2__card-menu {
+  z-index: 1;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.profile-endorsements-v2__card:has(.profile-endorsements-v2__card-menu) .profile-endorsements-v2__card-link {
+  padding-right: 40px;
+}
+
+.profile-endorsements-v2__given-revoke {
+  border-radius: var(--radius);
+  width: 24px;
+  height: 24px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+  background: none;
+  border: 1px solid #0000;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.profile-endorsements-v2__given-revoke:hover {
+  background: var(--overlay-weak);
+  border-color: var(--border-default);
+  color: var(--color-error);
+}
+
+.profile-endorsements-v2__given-revoke:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+@media (min-width: 800px) {
+  .profile-endorsements-v2__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+  }
+}
+
+@media (min-width: 1300px) {
+  .profile-endorsements-v2__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.profile-endorsements-v2__grid > .empty-state {
+  grid-column: 1 / -1;
+  padding: 32px 0;
+}
+
+.profile-endorsements-v2__endorse-row {
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  display: flex;
+}
+
+.profile-endorsements-v2__endorse-btn {
+  border-radius: var(--radius);
+  border: 1px solid var(--border-default);
+  color: var(--fg-primary);
+  cursor: pointer;
+  background: none;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: .8125rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background .15s, color .15s, border-color .15s;
+  display: inline-flex;
+}
+
+.profile-endorsements-v2__endorse-btn:hover:not(:disabled) {
+  background: var(--overlay-weak);
+  border-color: var(--fg-primary);
+}
+
+.profile-endorsements-v2__endorse-btn:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+
+.profile-endorsements-v2__endorse-btn--active {
+  background: var(--overlay-weak);
+  border-color: var(--fg-primary);
+  color: var(--fg-primary);
+}
+
+.profile-endorsements-v2__endorse-error {
+  color: var(--color-error);
+  margin-top: 4px;
+  font-size: .75rem;
+  display: block;
+}
+
+.endorsement-lists {
+  border-bottom: 1px solid var(--border-default);
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 28px;
+  padding-bottom: 24px;
+  display: flex;
+}
+
+.endorsement-lists__header {
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  display: flex;
+}
+
+.endorsement-lists__header--detail {
+  gap: 4px;
+}
+
+.endorsement-lists__detail-lede {
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  display: inline-flex;
+}
+
+.endorsement-lists__title {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: .9375rem;
+  font-weight: 600;
+  display: inline-flex;
+}
+
+.endorsement-lists__title-count {
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-default);
+  min-width: 22px;
+  color: var(--fg-secondary);
+  border-radius: 999px;
+  justify-content: center;
+  align-items: center;
+  padding: 1px 6px;
+  font-size: .75rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.endorsement-lists__back {
+  border-radius: var(--radius);
+  width: 28px;
+  height: 28px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.endorsement-lists__back:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.endorsement-lists__back:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.endorsement-lists__actions {
+  align-items: center;
+  gap: 8px;
+  display: inline-flex;
+}
+
+.endorsement-lists__sort-wrap {
+  display: inline-flex;
+  position: relative;
+}
+
+.endorsement-lists__sort-btn {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  width: 32px;
+  height: 32px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.endorsement-lists__sort-btn:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.endorsement-lists__sort-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.endorsement-lists__loading {
+  justify-content: center;
+  padding: 24px 0;
+  display: flex;
+}
+
+.endorsement-lists__empty-inline {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.endorsement-lists__rows {
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.endorsement-lists__row {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  display: flex;
+}
+
+.endorsement-lists__row:hover {
+  border-color: var(--border-hover);
+  background: var(--overlay-weak);
+}
+
+.endorsement-lists__row:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.endorsement-lists__row-main {
+  flex-direction: column;
+  flex: 1;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.endorsement-lists__row-title {
+  color: var(--fg-primary);
+  font-size: .9375rem;
+  font-weight: 600;
+}
+
+.endorsement-lists__row-desc {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: .8125rem;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.endorsement-lists__row-meta {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  flex: none;
+  align-items: center;
+  gap: 12px;
+  font-size: .75rem;
+  display: inline-flex;
+}
+
+.endorsement-lists__row-count {
+  color: var(--fg-secondary);
+  font-weight: 500;
+}
+
+.endorsement-lists__detail-meta {
+  flex-direction: column;
+  gap: 4px;
+  display: flex;
+}
+
+.endorsement-lists__detail-desc {
+  color: var(--fg-secondary);
+  margin: 0;
+  font-size: .875rem;
+}
+
+.endorsement-lists__detail-date {
+  color: var(--fg-muted);
+  font-size: .75rem;
+}
+
+.endorsement-lists__detail-error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.profile-endorsements-v2__response-note {
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  color: var(--fg-secondary);
+  margin: 0 0 8px;
+  padding: 8px 12px;
+  font-size: .75rem;
+  line-height: 1.45;
+}
+
+.endorsement-lists__add-btn {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  width: 32px;
+  height: 32px;
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.endorsement-lists__add-btn:hover {
+  background: var(--overlay-weak);
+  border-color: var(--border-hover);
+}
+
+.endorsement-lists__add-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.endorsement-lists__items {
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+}
+
+.endorsement-lists__item {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  transition: border-color var(--transition-fast);
+  position: relative;
+}
+
+.endorsement-lists__item:hover {
+  border-color: var(--border-hover);
+}
+
+.endorsement-lists__item-link {
+  color: inherit;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  text-decoration: none;
+  display: flex;
+}
+
+.endorsement-lists__item-body {
+  flex-direction: column;
+  flex: 1;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.endorsement-lists__item-id {
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  display: flex;
+}
+
+.endorsement-lists__item-names {
+  flex-direction: column;
+  min-width: 0;
+  display: flex;
+}
+
+.endorsement-lists__item-name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .875rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.endorsement-lists__item-handle {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.endorsement-lists__item-date {
+  color: var(--fg-muted);
+  font-size: .6875rem;
+  line-height: 1.3;
+}
+
+.endorsement-lists__item-remove {
+  border-radius: var(--radius);
+  width: 22px;
+  height: 22px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+  background: none;
+  border: 1px solid #0000;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+.endorsement-lists__item-remove:hover {
+  background: var(--overlay-weak);
+  border-color: var(--border-default);
+  color: var(--color-error);
+}
+
+.endorsement-lists__item-remove:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.endorsement-lists__item:has(.endorsement-lists__item-remove) .endorsement-lists__item-link {
+  padding-right: 36px;
+}
+
+.endorsement-lists__item-note {
+  color: var(--fg-secondary);
+  margin: 4px 0 0;
+  font-size: .8125rem;
+}
+
+.endorsement-lists__revoke-body {
+  flex-direction: column;
+  gap: 14px;
+  display: flex;
+}
+
+.endorsement-lists__revoke-copy {
+  color: var(--fg-secondary);
+  margin: 0;
+  font-size: .875rem;
+  line-height: 1.5;
+}
+
+.endorsement-lists__revoke-error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.endorsement-lists__revoke-actions {
+  flex-wrap: nowrap;
+  justify-content: flex-end;
+  gap: 8px;
+  display: flex;
+}
+
+.endorsement-lists__revoke-dialog {
+  width: min(560px, 100vw - 32px);
+}
+
+.endorsement-lists__create-field {
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 14px;
+  display: flex;
+}
+
+.endorsement-lists__create-label {
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  font-size: .75rem;
+  font-weight: 600;
+}
+
+.endorsement-lists__create-optional {
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--fg-muted);
+  font-weight: 400;
+}
+
+.endorsement-lists__create-input, .endorsement-lists__create-textarea {
+  width: 100%;
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  font-size: .9375rem;
+}
+
+.endorsement-lists__create-textarea {
+  resize: vertical;
+  min-height: 72px;
+  line-height: 1.4;
+}
+
+.endorsement-lists__create-input:focus, .endorsement-lists__create-textarea:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.endorsement-lists__create-error {
+  color: var(--color-error);
+  margin: 0 0 12px;
+  font-size: .8125rem;
+}
+
+.endorsement-lists__create-footer {
+  justify-content: flex-end;
+  gap: 8px;
+  display: flex;
+}
+
+.endorse-people-modal__subtitle {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.endorse-people-modal__reason {
+  flex-direction: column;
+  gap: 4px;
+  display: flex;
+}
+
+.endorse-people-modal__reason-label {
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  font-size: .75rem;
+  font-weight: 600;
+}
+
+.endorse-people-modal__reason-hint {
+  color: var(--fg-muted);
+  font-size: .75rem;
+  line-height: 1.45;
+}
+
+.endorse-people-modal__reason-textarea {
+  width: 100%;
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  resize: vertical;
+  min-height: 60px;
+  padding: 8px 12px;
+  font-size: .9375rem;
+  line-height: 1.4;
+}
+
+.endorse-people-modal__reason-textarea:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.endorse-people-modal__reason-counter {
+  color: var(--fg-muted);
+  align-self: flex-end;
+  font-size: .6875rem;
+}
+
+.endorse-people-modal__reason-counter--warn {
+  color: var(--color-warning);
+}
+
+.endorse-people-modal__body {
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+}
+
+.endorse-people-modal__search {
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  display: flex;
+}
+
+.endorse-people-modal__search:focus-within {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+}
+
+.endorse-people-modal__search-icon {
+  color: var(--fg-muted);
+  flex: none;
+}
+
+.endorse-people-modal__search-input {
+  min-width: 0;
+  font: inherit;
+  color: var(--fg-primary);
+  background: none;
+  border: none;
+  outline: none;
+  flex: 1;
+  font-size: .9375rem;
+}
+
+.endorse-people-modal__search-input::placeholder {
+  color: var(--fg-muted);
+}
+
+.endorse-people-modal__search-input::-webkit-search-cancel-button {
+  appearance: none;
+}
+
+.endorse-people-modal__hint {
+  text-align: center;
+  color: var(--fg-muted);
+  margin: 0;
+  padding: 16px 12px;
+  font-size: .8125rem;
+}
+
+.endorse-people-modal__loading {
+  justify-content: center;
+  padding: 16px 12px;
+  display: flex;
+}
+
+.endorse-people-modal__results {
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  max-height: 280px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+}
+
+.endorse-people-modal__result {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.endorse-people-modal__result:last-child {
+  border-bottom: none;
+}
+
+.endorse-people-modal__result-btn {
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+  color: inherit;
+  transition: background var(--transition-fast);
+  background: none;
+  border: none;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  display: flex;
+}
+
+.endorse-people-modal__result-btn:hover:not(:disabled) {
+  background: var(--overlay-weak);
+}
+
+.endorse-people-modal__result-btn:disabled {
+  cursor: default;
+  opacity: .55;
+}
+
+.endorse-people-modal__result--selected .endorse-people-modal__result-btn {
+  background: var(--overlay-weak);
+}
+
+.endorse-people-modal__result-info {
+  flex-direction: column;
+  flex: 1;
+  gap: 1px;
+  min-width: 0;
+  display: flex;
+}
+
+.endorse-people-modal__result-name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .875rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.endorse-people-modal__result-handle {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.endorse-people-modal__result-status {
+  color: var(--fg-muted);
+  flex: none;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.endorse-people-modal__result-selected-chip {
+  color: var(--fg-primary);
+  align-items: center;
+  gap: 4px;
+  display: inline-flex;
+}
+
+.endorse-people-modal__selected {
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 4px;
+}
+
+.endorse-people-modal__selected-title {
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin: 0 0 8px;
+  font-size: .75rem;
+  font-weight: 600;
+}
+
+.endorse-people-modal__selected-list {
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 8px;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.endorse-people-modal__chip {
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: 999px;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px 4px 4px;
+  font-size: .8125rem;
+  display: inline-flex;
+}
+
+.endorse-people-modal__chip-name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 160px;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.endorse-people-modal__chip-failed {
+  color: var(--color-error);
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.endorse-people-modal__chip-remove {
+  width: 18px;
+  height: 18px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  border-radius: 999px;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.endorse-people-modal__chip-remove:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.endorse-people-modal__selected-hint {
+  color: var(--fg-muted);
+  align-items: center;
+  gap: 4px;
+  margin: 0;
+  font-size: .6875rem;
+  display: flex;
+}
+
+.endorse-people-modal__error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.endorse-people-modal__footer {
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+  display: flex;
+}
+
+.endorse-reason-modal__body {
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+}
+
+.endorse-reason-modal__field {
+  flex-direction: column;
+  gap: 6px;
+  display: flex;
+}
+
+.endorse-reason-modal__prompt {
+  color: var(--fg-secondary);
+  font-size: .875rem;
+  line-height: 1.45;
+}
+
+.endorse-reason-modal__acting-as {
+  color: var(--fg-secondary);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  margin: 0;
+  padding: 10px 12px;
+  font-size: .8125rem;
+  line-height: 1.45;
+}
+
+.endorse-reason-modal__acting-as b {
+  color: var(--fg-primary);
+  font-weight: 600;
+}
+
+.endorse-reason-modal__textarea {
+  width: 100%;
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  resize: vertical;
+  min-height: 96px;
+  padding: 8px 12px;
+  font-size: .9375rem;
+  line-height: 1.45;
+}
+
+.endorse-reason-modal__textarea:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.endorse-reason-modal__counter {
+  color: var(--fg-muted);
+  align-self: flex-end;
+  font-size: .6875rem;
+  line-height: 1;
+}
+
+.endorse-reason-modal__counter--warn {
+  color: var(--color-warning);
+}
+
+.endorse-reason-modal__select {
+  width: 100%;
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  appearance: none;
+  background-image: linear-gradient(45deg, #0000 50%, currentColor 50%), linear-gradient(135deg, currentColor 50%, #0000 50%);
+  background-position: calc(100% - 16px), calc(100% - 11px);
+  background-repeat: no-repeat;
+  background-size: 5px 5px;
+  padding: 8px 32px 8px 12px;
+  font-size: .9375rem;
+  line-height: 1.45;
+}
+
+.endorse-reason-modal__select:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.endorse-reason-modal__select:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+
+.endorse-reason-modal__error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.endorse-reason-modal__footer {
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+  display: flex;
+}
+
+/* [project]/src/app/styles/profile-lists.css [app-client] (css) */
+.profile-lists {
+  flex-direction: column;
+  gap: 32px;
+  padding: 0;
+  display: flex;
+}
+
+.profile-lists__loading {
+  justify-content: center;
+  padding: 48px 0;
+  display: flex;
+}
+
+.profile-lists__section {
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+}
+
+.profile-lists__section-head {
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.profile-lists__section-title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  letter-spacing: -.005em;
+  color: var(--fg-primary);
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.profile-lists__create-btn {
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius);
+  width: 30px;
+  height: 30px;
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
+}
+
+.profile-lists__create-btn:hover {
+  background: var(--bg-sunken);
+}
+
+.profile-lists__create-btn:focus-visible {
+  box-shadow: 0 0 0 2px var(--focus-ring, var(--fg-primary));
+  outline: none;
+}
+
+.profile-lists__empty {
+  color: var(--fg-muted);
+  margin: 0;
+  padding: 12px 0;
+  font-size: .875rem;
+}
+
+.profile-lists__rows {
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.profile-lists__row {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  color: var(--fg-primary);
+  background: none;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  display: flex;
+}
+
+.profile-lists__row:hover {
+  background: var(--bg-sunken);
+  border-color: var(--border-medium);
+}
+
+.profile-lists__row-body {
+  flex-direction: column;
+  flex: 1;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-lists__row-title {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .9375rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.profile-lists__row-desc {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .8125rem;
+  overflow: hidden;
+}
+
+.profile-lists__row-meta {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  font-size: .75rem;
+}
+
+.profile-lists__detail-head {
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+  display: flex;
+}
+
+.profile-lists__back {
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius);
+  width: 30px;
+  height: 30px;
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  background: none;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.profile-lists__back:hover {
+  background: var(--bg-sunken);
+}
+
+.profile-lists__detail-title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  flex: 1;
+  align-items: baseline;
+  gap: 10px;
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  display: flex;
+}
+
+.profile-lists__detail-count {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-muted);
+  font-size: .8125rem;
+  font-weight: 500;
+}
+
+.profile-lists__detail-actions {
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.profile-lists__detail-desc {
+  color: var(--fg-secondary);
+  margin: 0 0 12px;
+  font-size: .875rem;
+  line-height: 1.5;
+}
+
+.profile-lists__bulk-bar {
+  border-bottom: 1px solid var(--border-subtle);
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+  padding: 6px 4px 8px;
+  display: flex;
+}
+
+.profile-lists__bulk-select-all {
+  color: var(--fg-secondary);
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+  align-items: center;
+  gap: 8px;
+  font-size: .8125rem;
+  display: inline-flex;
+}
+
+.profile-lists__bulk-select-all input {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--fg-primary);
+  cursor: pointer;
+}
+
+.profile-lists__items {
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.profile-lists__items-row {
+  align-items: center;
+  gap: 10px;
+  display: flex;
+}
+
+.profile-lists__items-check {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--fg-primary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.profile-lists__items-row-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.profile-lists__item {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  transition: background var(--transition-fast);
+  background: none;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  display: flex;
+}
+
+.profile-lists__item:hover {
+  background: var(--bg-sunken);
+}
+
+.profile-lists__item-link {
+  min-width: 0;
+  color: inherit;
+  flex: 1;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  display: flex;
+}
+
+.profile-lists__item-body {
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-lists__item-title {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .9375rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.profile-lists__item-subtitle {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .8125rem;
+  overflow: hidden;
+}
+
+.profile-lists__item-remove {
+  border-radius: var(--radius);
+  width: 26px;
+  height: 26px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: 1px solid #0000;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  margin-right: 8px;
+  padding: 0;
+  display: inline-flex;
+}
+
+.profile-lists__item-remove:hover {
+  background: var(--bg-sunken);
+  color: var(--color-error);
+}
+
+.profile-lists__item-remove:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.profile-lists__project {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  background: none;
+  align-items: center;
+  gap: 0;
+  display: flex;
+  overflow: hidden;
+}
+
+.profile-lists__project .feed-card__author {
+  margin-bottom: 0;
+}
+
+.profile-lists__project:hover {
+  border-color: var(--border-medium);
+}
+
+.profile-lists__project-row {
+  flex: 1;
+  min-width: 0;
+}
+
+.profile-lists__project .cert-list-row {
+  padding: 10px 14px;
+}
+
+.profile-lists__project:hover .cert-list-row {
+  background: var(--bg-sunken);
+}
+
+.profile-lists__project--loading {
+  align-items: center;
+  min-height: 60px;
+  padding: 10px 14px;
+}
+
+.profile-lists__project-skel {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  flex: 1;
+  height: 40px;
+  display: block;
+}
+
+.profile-lists__thumb {
+  border-radius: var(--radius);
+  object-fit: cover;
+  background: var(--bg-sunken);
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  display: block;
+}
+
+.profile-lists__thumb--placeholder {
+  border: 1px solid var(--border-subtle);
+}
+
+.profile-lists__create-form {
+  flex-direction: column;
+  gap: 14px;
+  display: flex;
+}
+
+.profile-lists__create-field {
+  flex-direction: column;
+  gap: 6px;
+  display: flex;
+}
+
+.profile-lists__create-label {
+  color: var(--fg-secondary);
+  font-size: .8125rem;
+  font-weight: 500;
+}
+
+.profile-lists__create-input, .profile-lists__create-textarea {
+  width: 100%;
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  font-size: .9375rem;
+}
+
+.profile-lists__create-textarea {
+  resize: vertical;
+  min-height: 72px;
+}
+
+.profile-lists__create-input:focus, .profile-lists__create-textarea:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.profile-lists__create-error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.profile-lists__create-actions {
+  justify-content: flex-end;
+  gap: 8px;
+  display: flex;
+}
+
+.add-to-list {
+  display: inline-flex;
+  position: relative;
+}
+
+.add-to-list__trigger {
+  border-radius: var(--radius);
+  width: 28px;
+  height: 28px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: 0;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
+}
+
+.add-to-list__trigger:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.add-to-list__trigger:focus-visible {
+  box-shadow: 0 0 0 2px var(--focus-ring, var(--fg-primary));
+  outline: none;
+}
+
+.add-to-list__pop {
+  z-index: 50;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius);
+  min-width: 168px;
+  box-shadow: var(--shadow-md);
+  padding: 4px;
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+}
+
+.add-to-list__pop-item {
+  border-radius: var(--radius);
+  width: 100%;
+  color: var(--fg-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  background: none;
+  border: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  font-size: .875rem;
+  font-weight: 400;
+  display: flex;
+}
+
+.add-to-list__pop-item:hover {
+  background: var(--bg-sunken);
+}
+
+.add-to-list__body {
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+}
+
+.add-to-list__loading {
+  justify-content: center;
+  padding: 16px 0;
+  display: flex;
+}
+
+.add-to-list__empty {
+  color: var(--fg-secondary);
+  margin: 0;
+  font-size: .875rem;
+}
+
+.add-to-list__list {
+  flex-direction: column;
+  gap: 4px;
+  max-height: 280px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  overflow-y: auto;
+}
+
+.add-to-list__row {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  display: flex;
+}
+
+.add-to-list__row-title {
+  min-width: 0;
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  font-size: .9375rem;
+  overflow: hidden;
+}
+
+.add-to-list__error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.add-to-list__create-btn {
+  border: 1px dashed var(--border-medium);
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  font: inherit;
+  cursor: pointer;
+  background: none;
+  align-self: flex-start;
+  padding: 6px 10px;
+  font-size: .875rem;
+  display: inline-flex;
+}
+
+.add-to-list__create-btn:hover {
+  background: var(--bg-sunken);
+}
+
+.add-to-list__create-btn:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.add-to-list__create {
+  flex-direction: column;
+  gap: 8px;
+  display: flex;
+}
+
+.add-to-list__create-input {
+  width: 100%;
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  font-size: .9375rem;
+}
+
+.add-to-list__create-input:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.add-to-list__create-actions {
+  justify-content: flex-end;
+  gap: 8px;
+  display: flex;
+}
+
+.profile-lists__paste-body {
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+}
+
+.profile-lists__paste-help {
+  color: var(--fg-secondary);
+  margin: 0;
+  font-size: .875rem;
+  line-height: 1.5;
+}
+
+.profile-lists__paste-nsid {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+  padding: 1px 5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: .8125rem;
+}
+
+.profile-lists__paste-textarea {
+  width: 100%;
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  resize: vertical;
+  min-height: 96px;
+  padding: 10px 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: .8125rem;
+  line-height: 1.5;
+}
+
+.profile-lists__paste-textarea:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.profile-lists__paste-progress {
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 0;
+  display: flex;
+}
+
+.profile-lists__paste-progress-row {
+  align-items: center;
+  gap: 10px;
+  font-size: .8125rem;
+  display: flex;
+}
+
+.profile-lists__paste-progress-label {
+  color: var(--fg-primary);
+  flex: 1;
+}
+
+.profile-lists__paste-progress-percent {
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-secondary);
+}
+
+.profile-lists__paste-progress-bar {
+  background: var(--bg-sunken);
+  border-radius: 999px;
+  width: 100%;
+  height: 4px;
+  position: relative;
+  overflow: hidden;
+}
+
+.profile-lists__paste-progress-bar-fill {
+  background: var(--fg-primary);
+  border-radius: 999px;
+  transition: width .2s ease-out;
+  position: absolute;
+  inset: 0 auto 0 0;
+}
+
+.profile-lists__paste-results {
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  flex-direction: column;
+  gap: 2px;
+  max-height: 240px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  overflow-y: auto;
+}
+
+.profile-lists__paste-row {
+  grid-template-columns: 84px 1fr;
+  align-items: baseline;
+  gap: 2px 10px;
+  padding: 6px 4px;
+  font-size: .8125rem;
+  display: grid;
+}
+
+.profile-lists__paste-status {
+  color: var(--fg-muted);
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.profile-lists__paste-row--added .profile-lists__paste-status {
+  color: var(--color-success);
+}
+
+.profile-lists__paste-row--already .profile-lists__paste-status, .profile-lists__paste-row--wrong-type .profile-lists__paste-status, .profile-lists__paste-row--missing .profile-lists__paste-status, .profile-lists__paste-row--error .profile-lists__paste-status {
+  color: var(--color-error);
+}
+
+.profile-lists__paste-row--writing .profile-lists__paste-status {
+  color: var(--fg-primary);
+}
+
+.profile-lists__paste-uri {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.profile-lists__paste-message {
+  color: var(--fg-muted);
+  grid-column: 2;
+  font-size: .75rem;
+}
+
+.profile-lists__paste-actions {
+  justify-content: flex-end;
+  gap: 8px;
+  display: flex;
+}
+
+.profile-lists__add-body {
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+}
+
+.profile-lists__add-search {
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  background: var(--bg-canvas);
+  color: var(--fg-secondary);
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  display: flex;
+}
+
+.profile-lists__add-search:focus-within {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+}
+
+.profile-lists__add-input {
+  font: inherit;
+  color: var(--fg-primary);
+  background: none;
+  border: 0;
+  outline: none;
+  flex: 1;
+  font-size: .9375rem;
+}
+
+.profile-lists__add-spinner {
+  justify-content: center;
+  padding: 16px 0;
+  display: flex;
+}
+
+.profile-lists__add-empty {
+  color: var(--fg-muted);
+  text-align: center;
+  margin: 0;
+  padding: 8px 0;
+  font-size: .875rem;
+}
+
+.profile-lists__add-error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.profile-lists__add-results {
+  flex-direction: column;
+  gap: 4px;
+  max-height: 340px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  overflow-y: auto;
+}
+
+.profile-lists__add-row {
+  border-radius: var(--radius);
+  border: 1px solid var(--border-subtle);
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  display: flex;
+}
+
+.profile-lists__add-row:hover {
+  background: var(--bg-sunken);
+}
+
+.profile-lists__add-avatar {
+  flex-shrink: 0;
+  display: inline-flex;
+}
+
+.profile-lists__add-body {
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-lists__add-title {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .9375rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.profile-lists__add-subtitle {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .8125rem;
+  overflow: hidden;
+}
+
+/* [project]/src/app/styles/profile-edit.css [app-client] (css) */
+.pe {
+  flex-direction: column;
+  padding: 0 0 96px;
+  display: flex;
+}
+
+.pe__loading {
+  justify-content: center;
+  align-items: center;
+  min-height: 50vh;
+  display: flex;
+}
+
+.pe__back {
+  margin: 4px 0 16px;
+}
+
+.pe__back-link {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-muted);
+  transition: color var(--transition-fast);
+  align-items: center;
+  gap: 4px;
+  padding: 4px 0;
+  font-size: .8125rem;
+  font-weight: 450;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.pe__back-link:hover {
+  color: var(--fg-primary);
+}
+
+.pe__back-link > svg {
+  flex-shrink: 0;
+  margin-left: -2px;
+}
+
+.pe__back-handle {
+  color: var(--fg-secondary, var(--fg-primary));
+  font-weight: 500;
+}
+
+.pe__back-link:hover .pe__back-handle {
+  color: var(--fg-primary);
+}
+
+.pe__media {
+  margin-bottom: 56px;
+  position: relative;
+}
+
+.pe .profile-card__banner {
+  border-radius: var(--radius);
+  height: 140px;
+  margin: 0;
+}
+
+.pe__avatar-slot {
+  background: var(--bg-default);
+  box-shadow: 0 0 0 1px var(--border-subtle);
+  border-radius: 999px;
+  padding: 4px;
+  line-height: 0;
+  position: absolute;
+  bottom: -36px;
+  left: 16px;
+}
+
+.pe__section {
+  border-top: 1px solid var(--border-subtle);
+  flex-direction: column;
+  gap: 16px;
+  padding: 28px 0;
+  display: flex;
+}
+
+.pe__section:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+
+.pe__section-head {
+  flex-direction: column;
+  gap: 4px;
+  display: flex;
+}
+
+.pe__section-title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  letter-spacing: -.005em;
+  color: var(--fg-primary);
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.pe__hint {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .8125rem;
+  line-height: 1.55;
+}
+
+.pe__fields, .pe__row {
+  flex-direction: column;
+  gap: 16px;
+  display: flex;
+}
+
+@media (min-width: 800px) {
+  .pe__row--split {
+    grid-template-columns: 1fr 160px;
+    align-items: start;
+    gap: 16px;
+    display: grid;
+  }
+}
+
+.pe__field {
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  display: flex;
+}
+
+.pe__label {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  font-size: .8125rem;
+  font-weight: 500;
+  display: flex;
+}
+
+.pe__label-count {
+  color: var(--fg-muted);
+  letter-spacing: .02em;
+  font-variant-numeric: tabular-nums;
+  font-size: .6875rem;
+  font-weight: 400;
+}
+
+.pe__field-error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .75rem;
+}
+
+.pe__url-list {
+  flex-direction: column;
+  gap: 10px;
+  display: flex;
+}
+
+.pe__url-item {
+  flex-direction: column;
+  gap: 4px;
+  display: flex;
+}
+
+.pe__url-row {
+  grid-template-columns: minmax(0, 1fr) 130px auto;
+  align-items: start;
+  gap: 8px;
+  display: grid;
+}
+
+.pe__url-remove {
+  border-radius: var(--radius);
+  width: 36px;
+  height: 36px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    color var(--transition-fast);
+  background: none;
+  border: 1px solid #0000;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.pe__url-remove:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.pe__url-add {
+  border-radius: var(--radius);
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-secondary, var(--fg-primary));
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  background: none;
+  border: none;
+  align-self: flex-start;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  padding: 6px 8px;
+  font-size: .8125rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.pe__url-add:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.pe__url-empty {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .8125rem;
+  font-style: italic;
+}
+
+.pe__error {
+  margin: 16px 0 0;
+}
+
+.pe__footer {
+  padding: 12px 32px calc(env(safe-area-inset-bottom, 0px) + 12px);
+  background: var(--bg-default);
+  border-top: 1px solid var(--border-subtle);
+  -webkit-backdrop-filter: saturate(180%) blur(8px);
+  z-index: 5;
+  margin: 24px -32px 0;
+  position: sticky;
+  bottom: 0;
+}
+
+.pe__footer-inner {
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.pe__action-btn {
+  border-radius: var(--radius);
+  height: 36px;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    opacity var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  padding: 0 14px;
+  font-size: .8125rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.pe__action-btn--ghost {
+  border: 1px solid var(--border-default);
+  color: var(--fg-secondary, var(--fg-primary));
+  background: none;
+}
+
+.pe__action-btn--ghost:hover:not(:disabled) {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.pe__action-btn--primary {
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-fg);
+  border: 1px solid var(--btn-primary-bg);
+}
+
+.pe__action-btn--primary:hover:not(:disabled) {
+  opacity: .92;
+}
+
+.pe__action-btn:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 799px) {
+  .pe {
+    padding: 0 0 96px;
+  }
+
+  .pe .profile-card__banner {
+    height: 112px;
+  }
+
+  .pe__avatar-slot {
+    bottom: -32px;
+    left: 12px;
+  }
+
+  .pe__url-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas: "url remove"
+                         "label label";
+    gap: 6px;
+  }
+
+  .pe__url-row > :first-child {
+    grid-area: url;
+  }
+
+  .pe__url-row > :nth-child(2) {
+    grid-area: label;
+  }
+
+  .pe__url-row > :nth-child(3) {
+    grid-area: remove;
+  }
+
+  .pe__footer-inner {
+    flex-direction: column-reverse;
+    gap: 8px;
+  }
+
+  .pe__footer-inner > * {
+    width: 100%;
+  }
+}
+
+/* [project]/src/app/styles/profile-inline-edit.css [app-client] (css) */
+.profile-sidebar__avatar--editing {
+  position: relative;
+}
+
+.profile-sidebar__avatar-edit-btn {
+  color: var(--color-white);
+  font-family: var(--font-inter), system-ui, sans-serif;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: background var(--transition-fast);
+  z-index: 1;
+  background: #111111c7;
+  border: none;
+  border-radius: 999px;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: .75rem;
+  font-weight: 500;
+  display: inline-flex;
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+}
+
+.profile-sidebar__avatar-edit-btn:hover {
+  background: #111111eb;
+}
+
+.profile-sidebar__avatar-edit-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.profile-sidebar__avatar-edit-btn:disabled {
+  cursor: progress;
+  opacity: .9;
+}
+
+.profile-sidebar__avatar-edit-label {
+  white-space: nowrap;
+}
+
+.profile-sidebar__avatar-edit-input {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+}
+
+.profile-sidebar__website-edit {
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.profile-sidebar__website-input, .profile-sidebar__name-input {
+  width: 100%;
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-hover);
+  border-radius: var(--radius);
+  padding: 6px 10px;
+}
+
+.profile-sidebar__website-input {
+  flex: 1;
+  min-width: 0;
+  font-size: .875rem;
+}
+
+.profile-sidebar__name-input {
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+}
+
+.profile-sidebar__website-input:focus, .profile-sidebar__name-input:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.edit-banner {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  align-items: center;
+  gap: 12px;
+  margin: 16px 24px 0;
+  padding: 10px 16px;
+  display: flex;
+}
+
+.edit-banner__label {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  letter-spacing: .01em;
+  font-size: .8125rem;
+  font-weight: 600;
+}
+
+.edit-banner__error {
+  color: var(--color-error);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  font-size: .8125rem;
+  overflow: hidden;
+}
+
+.edit-banner__actions {
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  display: inline-flex;
+}
+
+.edit-banner__btn {
+  border-radius: var(--radius);
+  border: 1px solid var(--border-default);
+  background: var(--bg-elevated);
+  height: 32px;
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  padding: 0 14px;
+  font-family: inherit;
+  font-size: .8125rem;
+  font-weight: 500;
+  line-height: 1;
+  display: inline-flex;
+}
+
+.edit-banner__btn:hover:not(:disabled) {
+  background: var(--overlay-weak);
+}
+
+.edit-banner__btn:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+
+.edit-banner__btn--primary {
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-fg);
+  border-color: var(--btn-primary-bg);
+}
+
+.edit-banner__btn--primary:hover:not(:disabled) {
+  background: var(--btn-primary-bg);
+  border-color: var(--btn-primary-bg);
+  opacity: .92;
+}
+
+.profile-overview__banner--editing {
+  margin-bottom: 16px;
+  background: none !important;
+}
+
+.profile-overview__banner-edit-slot {
+  height: 100%;
+}
+
+.profile-overview__banner-edit-slot .profile-banner-upload, .profile-overview__banner-edit-slot .profile-banner-upload__box {
+  width: 100%;
+  height: 100%;
+}
+
+.profile-banner-upload {
+  flex-direction: column;
+  gap: 6px;
+  display: flex;
+}
+
+.profile-banner-upload__box {
+  aspect-ratio: 3;
+  border-radius: var(--radius);
+  background: linear-gradient(135deg,
+    var(--bg-sunken) 0%,
+    var(--bg-raised) 100%);
+  width: 100%;
+  max-height: 220px;
+  position: relative;
+  overflow: hidden;
+}
+
+.profile-banner-upload__box--empty {
+  outline: 1.5px dashed var(--border-hover);
+  outline-offset: -2px;
+}
+
+.profile-banner-upload__img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.profile-banner-upload__btn-row {
+  z-index: 1;
+  align-items: center;
+  gap: 6px;
+  display: inline-flex;
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+}
+
+.profile-banner-upload__btn {
+  color: var(--color-white);
+  font-family: var(--font-inter), system-ui, sans-serif;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: background var(--transition-fast), transform var(--transition-fast);
+  background: #111111c7;
+  border: none;
+  border-radius: 999px;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: .75rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.profile-banner-upload__btn:hover {
+  background: #111111eb;
+}
+
+.profile-banner-upload__btn--ghost {
+  color: var(--color-primary);
+  background: #ffffffeb;
+}
+
+.profile-banner-upload__btn--ghost:hover {
+  background: var(--color-white);
+}
+
+.profile-banner-upload__btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.profile-banner-upload__btn:disabled {
+  cursor: progress;
+  opacity: .9;
+}
+
+.profile-banner-upload__btn-label {
+  white-space: nowrap;
+}
+
+.profile-banner-upload__input {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+}
+
+.profile-banner-upload__error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .75rem;
+}
+
+.profile-overview__about-textarea {
+  width: 100%;
+  min-height: 96px;
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-hover);
+  border-radius: var(--radius);
+  resize: none;
+  padding: 10px 12px;
+  overflow: hidden;
+}
+
+.profile-overview__about-textarea:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.profile-sidebar__org-field-edit {
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.profile-sidebar__org-field-label {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+  font-size: .8125rem;
+}
+
+.profile-sidebar__details-header {
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin: 8px 0 4px;
+  font-size: .6875rem;
+  font-weight: 600;
+  list-style: none;
+}
+
+.profile-sidebar__details-header:first-child {
+  margin-top: 0;
+}
+
+.profile-sidebar__org-input {
+  min-width: 0;
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  flex: 1;
+  padding: 6px 10px;
+  font-size: .875rem;
+}
+
+.profile-sidebar__org-input:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.profile-sidebar__org-url-edit {
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.profile-sidebar__org-url-actions {
+  flex: none;
+  align-items: center;
+  gap: 2px;
+  display: inline-flex;
+}
+
+.profile-sidebar__org-url-remove, .profile-sidebar__org-url-move {
+  border-radius: var(--radius);
+  width: 24px;
+  height: 24px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    color var(--transition-fast);
+  background: none;
+  border: 1px solid #0000;
+  flex: none;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.profile-sidebar__org-url-remove:hover, .profile-sidebar__org-url-move:hover:not(:disabled) {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.profile-sidebar__org-url-move:disabled {
+  opacity: .35;
+  cursor: not-allowed;
+}
+
+.profile-sidebar__org-url-add-row {
+  padding-left: 0;
+  list-style: none;
+}
+
+.profile-sidebar__org-url-add {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-secondary, var(--fg-primary));
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+  background: none;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  font-size: .8125rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.profile-sidebar__org-url-add:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+  border-color: var(--fg-primary);
+}
+
+.profile-sidebar__org-url-add:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.profile-overview__long-desc-textarea {
+  min-height: 180px;
+}
+
+.profile-overview__long-desc-body {
+  white-space: pre-wrap;
+}
+
+.profile-overview__website-input {
+  width: 100%;
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  margin-top: 8px;
+  padding: 8px 12px;
+  font-size: 14px;
+}
+
+.profile-overview__website-input:focus {
+  border-color: var(--focus-ring);
+  box-shadow: 0 0 0 2px var(--focus-ring);
+  outline: none;
+}
+
+.profile-overview__website-label {
+  color: var(--fg-secondary);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.profile-overview__type-chip-list {
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.profile-overview__type-chip {
+  font: inherit;
+  color: var(--fg-secondary);
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-hover);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+  border-radius: 999px;
+  align-items: center;
+  padding: 4px 12px;
+  font-size: .8125rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.profile-overview__type-chip:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.profile-overview__type-chip--active, .profile-overview__type-chip--active:hover {
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-fg);
+  border-color: var(--btn-primary-bg);
+}
+
+.profile-overview__type-chip:focus-visible {
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.profile-overview__type-other-input {
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-hover);
+  border-radius: var(--radius);
+  max-width: 360px;
+  margin-top: 4px;
+  padding: 6px 10px;
+  font-size: .875rem;
+}
+
+.profile-overview__type-other-input:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.profile-overview__location-input {
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-hover);
+  border-radius: var(--radius);
+  width: 100%;
+  min-width: 0;
+  padding: 6px 10px;
+  font-size: .875rem;
+}
+
+.profile-overview__location-input:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.profile-overview__location--editing .profile-overview__location-map {
+  border-color: var(--border-hover);
+}
+
+/* [project]/src/app/styles/profile-projects.css [app-client] (css) */
+.profile-projects {
+  flex-direction: column;
+  gap: 24px;
+  display: flex;
+}
+
+.profile-projects__loading {
+  justify-content: center;
+  padding: 48px 0;
+  display: flex;
+}
+
+.profile-projects__toolbar {
+  justify-content: flex-end;
+  display: flex;
+}
+
+.profile-projects__box {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  flex-direction: column;
+  display: flex;
+  overflow: hidden;
+}
+
+.profile-projects__box-head {
+  border-bottom: 1px solid var(--border-subtle);
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  display: flex;
+}
+
+@media (min-width: 800px) {
+  .profile-projects__box-head {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+}
+
+.profile-projects__box-image-wrap {
+  flex-shrink: 0;
+}
+
+.profile-projects__box-image {
+  aspect-ratio: 1;
+  object-fit: cover;
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-subtle);
+  width: 100%;
+  max-width: 100%;
+  display: block;
+}
+
+@media (min-width: 800px) {
+  .profile-projects__box-image {
+    width: 200px;
+    height: 200px;
+  }
+}
+
+.profile-projects__box-image--placeholder {
+  color: var(--fg-muted);
+  background: linear-gradient(135deg,
+    var(--bg-sunken) 0%,
+    var(--overlay-weak) 100%);
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.profile-projects__box-meta {
+  flex-direction: column;
+  flex: auto;
+  gap: 6px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-projects__box-titleline {
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-projects__box-head--link {
+  color: inherit;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  text-decoration: none;
+}
+
+.profile-projects__box-head--link:hover {
+  background: var(--overlay-weak);
+}
+
+.profile-projects__box-head--link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.profile-projects__box-title {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.profile-projects__box-desc {
+  color: var(--fg-secondary);
+  margin: 0;
+  font-size: .9375rem;
+  line-height: 1.5;
+}
+
+.profile-projects__box-when {
+  color: var(--fg-muted);
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: .75rem;
+  display: inline-flex;
+}
+
+.profile-projects__box-when svg {
+  flex-shrink: 0;
+}
+
+.profile-projects__box-certs {
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  display: flex;
+}
+
+.profile-projects__box-certs-head {
+  align-items: center;
+  gap: 8px;
+  display: inline-flex;
+}
+
+.profile-projects__box-certs-title {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .8125rem;
+  font-weight: 600;
+}
+
+.profile-projects__box-certs-count {
+  color: var(--fg-secondary);
+  background: var(--overlay-weak);
+  border-radius: 999px;
+  padding: 1px 7px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.profile-projects__box-see-all {
+  color: var(--fg-secondary);
+  transition: color var(--transition-fast);
+  align-self: flex-start;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 0 0;
+  font-size: .8125rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.profile-projects__box-see-all:hover {
+  color: var(--fg-primary);
+}
+
+.profile-projects__section-loading {
+  justify-content: center;
+  padding: 24px 0;
+  display: flex;
+}
+
+.profile-projects__section-empty {
+  color: var(--fg-muted);
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 12px 0;
+  font-size: .875rem;
+  display: inline-flex;
+}
+
+.profile-projects__cert-list {
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.profile-projects__cert-row {
+  display: block;
+}
+
+.profile-projects__cert-link {
+  border-radius: var(--radius);
+  color: inherit;
+  transition: background var(--transition-fast);
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  padding: 8px;
+  text-decoration: none;
+  display: flex;
+}
+
+.profile-projects__cert-link:hover {
+  background: var(--overlay-weak);
+}
+
+.profile-projects__cert-thumb {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+  display: inline-flex;
+  overflow: hidden;
+}
+
+.profile-projects__cert-thumb img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.profile-projects__cert-thumb--placeholder {
+  color: var(--fg-muted);
+  background: linear-gradient(135deg,
+    var(--bg-sunken) 0%,
+    var(--overlay-weak) 100%);
+}
+
+.profile-projects__cert-meta {
+  flex-direction: column;
+  flex: auto;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-projects__cert-title {
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .875rem;
+  font-weight: 500;
+  line-height: 1.3;
+  overflow: hidden;
+}
+
+.profile-projects__cert-period {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  align-items: center;
+  gap: 4px;
+  font-size: .75rem;
+  line-height: 1.4;
+  display: inline-flex;
+  overflow: hidden;
+}
+
+.profile-projects__cert-period svg {
+  flex-shrink: 0;
+}
+
+/* [project]/src/app/styles/social-graph-sync.css [app-client] (css) */
+.social-graph-sync {
+  flex-direction: column;
+  gap: 14px;
+  display: flex;
+}
+
+.social-graph-sync__stats {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  display: grid;
+}
+
+@media (max-width: 799px) {
+  .social-graph-sync__stats {
+    grid-template-columns: 1fr;
+  }
+}
+
+.social-graph-sync__tile {
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 12px 14px;
+  display: flex;
+}
+
+.social-graph-sync__tile--highlight {
+  border-color: var(--border-hover);
+  background: var(--overlay-weak);
+}
+
+.social-graph-sync__tile-value {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  font-variant-numeric: tabular-nums;
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.social-graph-sync__tile-label {
+  color: var(--fg-secondary);
+  font-size: .75rem;
+  line-height: 1.3;
+}
+
+.social-graph-sync__summary, .social-graph-sync__error {
+  margin: 0;
+  font-size: .8125rem;
+  line-height: 1.4;
+}
+
+.social-graph-sync__summary {
+  color: var(--fg-muted);
+}
+
+.social-graph-sync__error {
+  color: var(--color-error);
+}
+
+.social-graph-sync__actions {
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  display: flex;
+}
+
+.social-graph-sync__hint {
+  color: var(--fg-muted);
+  font-size: .75rem;
+  line-height: 1.4;
+}
+
+.social-graph-sync__modal-body {
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+}
+
+.social-graph-sync__modal-title-row {
+  align-items: center;
+  display: inline-flex;
+}
+
+.social-graph-sync__modal-back {
+  border-radius: var(--radius);
+  width: 24px;
+  height: 24px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: 1px solid #0000;
+  justify-content: center;
+  align-items: center;
+  margin-right: 8px;
+  display: inline-flex;
+}
+
+.social-graph-sync__modal-back:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.social-graph-sync__modal-back:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.social-graph-sync__modal-lede {
+  color: var(--fg-primary);
+  margin: 0;
+  font-size: .9375rem;
+  line-height: 1.5;
+}
+
+.social-graph-sync__modal-lede strong {
+  font-weight: 600;
+}
+
+.social-graph-sync__modal-choices {
+  grid-template-columns: 1fr;
+  gap: 8px;
+  display: grid;
+}
+
+@media (min-width: 800px) {
+  .social-graph-sync__modal-choices {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.social-graph-sync__modal-choice {
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 12px 14px;
+  display: flex;
+}
+
+.social-graph-sync__modal-choice:hover:not(:disabled) {
+  border-color: var(--border-hover);
+  background: var(--overlay-weak);
+}
+
+.social-graph-sync__modal-choice:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.social-graph-sync__modal-choice:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+
+.social-graph-sync__modal-choice-title {
+  color: var(--fg-primary);
+  font-size: .9375rem;
+  font-weight: 600;
+}
+
+.social-graph-sync__modal-choice-desc {
+  color: var(--fg-secondary);
+  font-size: .8125rem;
+  line-height: 1.4;
+}
+
+.social-graph-sync__modal-error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.social-graph-sync__modal-footer {
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  display: flex;
+}
+
+.social-graph-sync__modal-progress {
+  color: var(--fg-secondary);
+  align-items: center;
+  gap: 6px;
+  font-size: .8125rem;
+  display: inline-flex;
+}
+
+.social-graph-sync__modal-meta {
+  color: var(--fg-muted);
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  font-size: .75rem;
+  display: flex;
+}
+
+.social-graph-sync__modal-select-page {
+  font: inherit;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  text-underline-offset: 2px;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: .75rem;
+  text-decoration: underline;
+}
+
+.social-graph-sync__modal-select-page:hover:not(:disabled) {
+  color: var(--fg-primary);
+}
+
+.social-graph-sync__modal-select-page:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.social-graph-sync__modal-counter {
+  color: var(--fg-secondary);
+  font-weight: 500;
+}
+
+.social-graph-sync__modal-list {
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  max-height: 280px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+}
+
+.social-graph-sync__modal-row {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.social-graph-sync__modal-row:last-child {
+  border-bottom: none;
+}
+
+.social-graph-sync__modal-row-label {
+  transition: background var(--transition-fast);
+  padding: 8px 12px;
+}
+
+.social-graph-sync__modal-row-label:hover {
+  background: var(--overlay-weak);
+}
+
+.social-graph-sync__modal-row-label label {
+  flex: 1;
+  min-width: 0;
+}
+
+.social-graph-sync__modal-row-content {
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  display: flex;
+}
+
+.social-graph-sync__modal-row-info {
+  flex-direction: column;
+  flex: 1;
+  gap: 1px;
+  min-width: 0;
+  display: flex;
+}
+
+.social-graph-sync__modal-row-name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .875rem;
+  font-weight: 500;
+  overflow: hidden;
+}
+
+.social-graph-sync__modal-row-handle {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .75rem;
+  overflow: hidden;
+}
+
+.social-graph-sync__modal-empty {
+  color: var(--fg-muted);
+  text-align: center;
+  padding: 16px 12px;
+  font-size: .8125rem;
+  list-style: none;
+}
+
+.social-graph-sync__modal-pagination {
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.social-graph-sync__modal-page-status {
+  color: var(--fg-muted);
+  font-size: .75rem;
+}
+
+.social-graph-sync__result {
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  display: flex;
+}
+
+.social-graph-sync__result-icon {
+  color: var(--fg-primary);
+  flex: none;
+}
+
+.social-graph-sync__result-text {
+  color: var(--fg-primary);
+  margin: 0;
+  font-size: .875rem;
+  line-height: 1.5;
+}
+
+.social-graph-sync__result-text strong {
+  font-weight: 600;
+}
+
+.social-graph-sync__result-failed {
+  color: var(--color-error);
+}
+
+.social-graph-sync__result-details {
+  color: var(--fg-secondary);
+  font-size: .8125rem;
+}
+
+.social-graph-sync__result-details summary {
+  cursor: pointer;
+  color: var(--fg-secondary);
+  margin-bottom: 6px;
+}
+
+.social-graph-sync__result-details code {
+  word-break: break-all;
+  font-size: .75rem;
+}
+
+/* [project]/src/app/styles/project-detail.css [app-client] (css) */
+.project-detail-page {
+  padding: 0 0 64px;
+}
+
+.project-detail {
+  flex-direction: column;
+  max-width: 720px;
+  margin: 16px auto 0;
+  padding: 0 16px;
+  display: flex;
+}
+
+@media (min-width: 800px) {
+  .app-shell:has(.project-detail--wide) .app-shell__content {
+    max-width: 1280px;
+  }
+
+  .project-detail {
+    max-width: 960px;
+  }
+}
+
+.project-detail__loading, .project-detail__error {
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 80px 24px;
+  display: flex;
+}
+
+.project-detail__error-title {
+  color: var(--fg-primary);
+  margin: 0 0 6px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.project-detail__error-desc {
+  color: var(--fg-muted);
+  max-width: 32ch;
+  margin: 0;
+  font-size: .875rem;
+  line-height: 1.5;
+}
+
+.project-detail__head-bar {
+  align-items: center;
+  gap: 16px;
+  margin: 0 0 20px;
+  display: flex;
+}
+
+.project-detail__head-title-group {
+  flex-direction: column;
+  flex: auto;
+  align-items: flex-start;
+  min-width: 0;
+  display: flex;
+}
+
+.project-detail__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--fg-muted);
+  font-size: .6875rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.project-detail__head-actions {
+  flex: none;
+  align-items: center;
+  gap: 12px;
+  margin-left: auto;
+  display: flex;
+}
+
+.project-detail__head-actions .feed-card__author {
+  border-radius: var(--radius);
+  transition: background var(--transition-fast);
+  margin: 0;
+  padding: 4px 6px;
+}
+
+.project-detail__head-actions .feed-card__author:hover {
+  background: var(--overlay-weak);
+}
+
+.project-detail__head-actions .feed-card__author:hover .feed-card__author-name {
+  text-decoration: none;
+}
+
+.project-detail__hero {
+  aspect-ratio: 3;
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-subtle);
+  width: 100%;
+  margin: 0 0 24px;
+  position: relative;
+  overflow: hidden;
+}
+
+@media (min-width: 800px) {
+  .project-detail__hero {
+    margin-bottom: 32px;
+  }
+}
+
+.project-detail__hero-img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.project-detail__hero--placeholder {
+  background: linear-gradient(135deg,
+    var(--bg-sunken) 0%,
+    var(--overlay-weak) 100%);
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.project-detail__hero-placeholder-icon {
+  color: var(--fg-muted);
+  opacity: .55;
+}
+
+.project-detail__title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  letter-spacing: -.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  max-width: 100%;
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+  overflow: hidden;
+}
+
+@media (min-width: 800px) {
+  .project-detail__title {
+    font-size: 1.75rem;
+  }
+}
+
+.project-detail__lead {
+  color: var(--fg-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  font-size: 1.0625rem;
+  font-style: italic;
+  line-height: 1.55;
+}
+
+.project-detail__lead-row {
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  display: flex;
+}
+
+.project-detail__lead-row .project-detail__lead, .project-detail__lead--empty {
+  flex: 1;
+  min-width: 0;
+}
+
+@media (min-width: 800px) {
+  .project-detail__lead {
+    font-size: 1.125rem;
+  }
+}
+
+.project-detail__prose {
+  margin: 0 0 28px;
+}
+
+.project-detail__tab-empty {
+  color: var(--fg-muted);
+  background: var(--bg-elevated);
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius);
+  text-align: center;
+  margin: 8px 0 24px;
+  padding: 16px;
+  font-size: .875rem;
+}
+
+.project-detail__meta {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  grid-template-columns: 1fr;
+  gap: 14px 24px;
+  margin: 0 0 32px;
+  padding: 16px;
+  display: grid;
+}
+
+@media (min-width: 640px) {
+  .project-detail__meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 800px) {
+  .project-detail__meta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.project-detail__meta-row {
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  display: flex;
+}
+
+.project-detail__meta-row--wide {
+  grid-column: 1 / -1;
+}
+
+.project-detail__meta-label {
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--fg-muted);
+  align-items: center;
+  gap: 4px;
+  font-size: .6875rem;
+  font-weight: 600;
+  display: inline-flex;
+}
+
+.project-detail__meta-value {
+  color: var(--fg-primary);
+  word-break: break-word;
+  font-size: .875rem;
+}
+
+.project-detail__contributors {
+  flex-direction: column;
+  gap: 8px;
+  margin: 4px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.project-detail__certs {
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 8px;
+  padding-top: 24px;
+}
+
+.project-detail__certs-header {
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 16px;
+  display: flex;
+}
+
+.project-detail__certs-title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  letter-spacing: -.005em;
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.project-detail__certs-count {
+  color: var(--fg-muted);
+  background: var(--overlay-weak);
+  border-radius: 999px;
+  padding: 1px 8px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.project-detail__see-all {
+  color: var(--fg-primary);
+  margin-left: auto;
+  font-size: .8125rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.project-detail__see-all:hover {
+  text-underline-offset: 2px;
+  text-decoration: underline;
+}
+
+.project-detail__certs--preview {
+  border-top: none;
+  padding-top: 0;
+}
+
+.project-detail__certs .feed {
+  grid-template-columns: minmax(0, 1fr);
+  justify-content: start;
+  gap: 12px;
+  display: grid;
+}
+
+@media (min-width: 600px) {
+  .project-detail__certs .feed {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 900px) {
+  .project-detail__certs .feed {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.project-detail__certs .feed-card {
+  border-radius: var(--radius);
+  transition: background var(--transition-fast);
+  border-bottom: none;
+  flex-direction: column;
+  padding: 10px;
+  display: flex;
+}
+
+.project-detail__certs .feed-card:hover {
+  background: var(--overlay-weak);
+}
+
+.project-detail__certs .feed-card__body:hover .feed-card__title {
+  text-decoration: none;
+}
+
+.project-detail__certs .feed-card__body {
+  flex-direction: column;
+  flex: 1;
+  display: flex;
+}
+
+.project-detail__certs .feed-card__title {
+  white-space: normal;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  min-height: 2.925rem;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.project-detail__certs .feed-card__desc {
+  -webkit-line-clamp: 2;
+  min-height: 2.8rem;
+}
+
+.project-detail__certs .feed-card__meta {
+  margin-top: auto;
+}
+
+.project-detail__hero--editing {
+  outline: 1.5px dashed var(--border-hover);
+  outline-offset: -2px;
+}
+
+.project-detail__hero-placeholder {
+  background: linear-gradient(135deg,
+    var(--bg-sunken) 0%,
+    var(--overlay-weak) 100%);
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  display: flex;
+}
+
+.project-detail__edit-btn {
+  background: var(--bg-elevated);
+  height: 32px;
   color: var(--fg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius);
-  height: 44px; padding: 0 16px; font: inherit; font-size: 0.875rem;
-  transition: all 150ms;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  flex: none;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  font-family: inherit;
+  font-size: .8125rem;
+  font-weight: 500;
+  line-height: 1;
+  display: inline-flex;
 }
-textarea.ui-field { height: auto; padding: 12px 16px; resize: vertical; min-height: 84px; }
-.ui-field::placeholder { color: var(--fg-muted); }
-.ui-field:focus { outline: none; border-color: var(--focus-ring); box-shadow: 0 0 0 1px color-mix(in srgb, var(--focus-ring) 20%, transparent); }
-.ui-field--error { border-color: var(--color-error-border); }
-.ui-field:disabled { cursor: not-allowed; opacity: 0.6; background: var(--bg-sunken); }
-.ui-field--underline { border: 0; border-bottom: 1px solid var(--border-medium); border-radius: 0; background: transparent; }
-.ui-field--underline:focus { box-shadow: none; border-color: var(--fg-primary); }
-.ui-field--inline { border-width: 1.5px; border-color: var(--border-hover); }
-.ui-field-label { display: block; margin-bottom: 6px; font-size: 0.75rem; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-muted); }
-.ui-field-err  { margin: 6px 0 0; font-size: 0.75rem; color: var(--color-error); }
-.ui-field-help { margin: 6px 0 0; font-size: 0.75rem; color: var(--fg-muted); }
-.ui-field-wrap { position: relative; width: 100%; }
-.ui-field-icon { position: absolute; top: 50%; transform: translateY(-50%); color: var(--fg-muted); display: inline-flex; pointer-events: none; }
-.ui-field-icon--lead { left: 16px; }
-.ui-field-icon--trail { right: 16px; }
-.ui-field--padlead  { padding-left: 44px; }
-.ui-field--padtrail { padding-right: 44px; }
-/* trailingButton slot — interactive (keeps pointer events, not aria-hidden) */
-.ui-field-btn { position: absolute; top: 50%; right: 16px; transform: translateY(-50%); display: inline-flex; }
-.ui-field-btn button { display: inline-flex; align-items: center; justify-content: center; height: 24px; width: 24px; padding: 0; border: none; border-radius: var(--radius); background: none; color: var(--fg-muted); cursor: pointer; }
-.ui-field-btn button:hover { background: var(--overlay-weak); color: var(--fg-primary); }
-.ui-field-btn button:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
-select.ui-field { appearance: none; -webkit-appearance: none; padding-right: 40px; }
-.ui-select-wrap { position: relative; width: 100%; }
-.ui-select-chevron { position: absolute; right: 16px; top: 50%; transform: translateY(-50%); color: var(--fg-muted); pointer-events: none; }
 
-/* ---- Checkbox (checkbox.tsx) ---- */
-.ui-check-row { display: flex; align-items: center; gap: 8px; }
-.ui-check-box {
-  height: 16px; width: 16px; flex: none;
-  display: inline-flex; align-items: center; justify-content: center;
-  border: 1px solid var(--border-hover); border-radius: var(--radius);
-  background: var(--bg-elevated); color: transparent; transition: 150ms;
+.project-detail__edit-btn:hover {
+  background: var(--overlay-weak);
+  border-color: var(--border-hover);
 }
-.ui-check-box--checked { border-color: var(--btn-primary-bg); background: var(--btn-primary-bg); color: var(--btn-primary-fg); }
-.ui-check-box--error { border-color: var(--color-error-border); }
-.ui-check-box svg { width: 12px; height: 12px; }
-.ui-check-label { font-size: 0.875rem; color: var(--fg-primary); cursor: pointer; }
-.ui-check-row--disabled .ui-check-box { opacity: 0.5; }
-.ui-check-row--disabled .ui-check-label { opacity: 0.5; cursor: not-allowed; }
 
-/* ---- Radio / SegmentedControl (radio.tsx) ---- */
-.ui-radiogroup { display: inline-flex; gap: 12px; }
-.ui-radio {
-  display: inline-flex; align-items: center; gap: 8px;
-  border-radius: var(--radius); font-size: 0.875rem; color: var(--fg-primary);
-  background: none; border: none; cursor: pointer; font: inherit; padding: 0;
+.project-detail__edit-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
-.ui-radio:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
-.ui-radio__dot { width: 16px; height: 16px; border-radius: 999px; border: 1.5px solid var(--border-hover); display: inline-flex; align-items: center; justify-content: center; }
-.ui-radio--checked .ui-radio__dot { border-color: var(--btn-primary-bg); }
-.ui-radio--checked .ui-radio__dot::after { content: ""; width: 8px; height: 8px; border-radius: 999px; background: var(--btn-primary-bg); }
-.ui-radio--disabled { opacity: 0.5; cursor: not-allowed; }
 
-/* ---- Switch (switch.tsx) ---- */
-.ui-switch { position: relative; display: inline-flex; align-items: center; height: 20px; width: 36px; flex: none; border: 1px solid transparent; border-radius: 999px; background: var(--border-hover); transition: background 150ms; cursor: pointer; padding: 0; }
-.ui-switch--on { background: var(--btn-primary-bg); }
-.ui-switch__thumb { position: absolute; left: 0; height: 16px; width: 16px; border-radius: 999px; background: var(--bg-elevated); box-shadow: var(--shadow-sm); transition: transform 150ms; transform: translateX(2px); }
-.ui-switch--on .ui-switch__thumb { transform: translateX(16px); }
-.ui-switch-row { display: inline-flex; align-items: center; gap: 8px; }
+.project-detail__delete-btn {
+  border-radius: var(--radius);
+  border: 1px solid var(--border-default);
+  background: var(--bg-elevated);
+  width: 32px;
+  height: 32px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
+}
 
-/* ---- ThemeToggle segmented (theme-toggle.tsx) ---- */
-.theme-toggle-group { display: inline-flex; align-items: stretch; gap: 2px; border: 1px solid var(--border-default); background: var(--bg-sunken); padding: 3px; border-radius: var(--radius); }
-.tt-option { flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 6px; padding: 8px 12px; font: inherit; font-size: 13px; font-weight: 500; border: none; background: none; cursor: pointer; border-radius: var(--radius); color: var(--fg-muted); }
-.tt-option:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
-.tt-option:hover { color: var(--fg-primary); }
-.tt-option--selected { background: var(--bg-elevated); color: var(--fg-primary); box-shadow: var(--shadow-sm); }
-.theme-toggle-cycle { display: inline-flex; align-items: center; justify-content: center; height: 40px; width: 40px; border: 1px solid var(--border-default); background: var(--bg-elevated); color: var(--fg-primary); border-radius: var(--radius); cursor: pointer; }
+.project-detail__delete-btn:hover {
+  background: var(--bg-sunken);
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
 
-/* ---- SmartLink (smart-link.tsx) ---- */
-.smart-link { display: inline-flex; align-items: center; gap: 8px; }
-.smart-link a { color: var(--fg-primary); text-decoration: underline; text-underline-offset: 2px; text-decoration-color: var(--border-hover); }
-.smart-link svg { color: var(--fg-muted); }
+.project-detail__delete-btn:focus-visible {
+  outline: 2px solid var(--color-error);
+  outline-offset: 2px;
+}
 
-/* ---- Card (card.tsx) ---- */
-.ui-card--row      { background: transparent; border: 0; border-bottom: 1px solid var(--border-subtle); border-radius: 0; padding: 20px 0; }
-.ui-card--elevated { background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: var(--radius); padding: 24px; }
-.ui-card--inset    { background: var(--bg-canvas); border: 1px solid var(--border-default); border-radius: var(--radius); padding: 24px; }
-.ui-card__title { font-family: Georgia, serif; font-weight: 700; color: var(--fg-primary); margin: 0 0 4px; font-size: 1.0625rem; }
-.ui-card__desc { margin: 0; font-size: 0.875rem; color: var(--fg-secondary); }
+.project-detail__inline-created {
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 12px;
+  display: inline-flex;
+}
 
-/* ---- Badge / FeedLabelPill (badge.tsx) ---- */
-.ui-badge { border-radius: 999px; display: inline-flex; align-items: center; gap: 6px; }
-.ui-badge--lg { padding: 4px 12px; font-size: 0.875rem; font-weight: 500; }
-.ui-badge--sm { padding: 2px 8px; font-size: 0.75rem; font-weight: 600; letter-spacing: 0.05em; }
-.ui-badge svg { width: 16px; height: 16px; }
-.ui-badge--verified  { background: var(--badge-success-bg); color: var(--badge-success-fg); }
-.ui-badge--pending   { background: var(--badge-warning-bg); color: var(--badge-warning-fg); }
-.ui-badge--unverified{ background: var(--badge-neutral-bg); color: var(--badge-neutral-fg); border: 1px solid var(--badge-neutral-border); }
-.ui-badge--tag   { background: var(--bg-sunken); color: var(--fg-secondary); text-transform: uppercase; letter-spacing: 0.05em; }
-.ui-badge--role  { background: var(--bg-canvas); color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.05em; }
-.ui-badge--count { background: var(--badge-count-bg); color: var(--badge-count-fg); font-weight: 600; }
-/* count + tone="neutral" — muted pill instead of the red attention pill */
-.ui-badge--count-neutral { background: var(--bg-sunken); color: var(--fg-muted); font-weight: 600; }
-/* count-bare (tone neutral/default) — chromeless muted tabular number, no pill */
-.ui-badge--count-bare { padding: 0; color: var(--fg-muted); font-weight: 600; font-variant-numeric: tabular-nums; text-transform: none; letter-spacing: 0.05em; }
-.ui-badge--hq    { background: var(--badge-success-bg); color: var(--badge-success-fg); }
-.ui-badge--standard { background: var(--bg-sunken); color: var(--fg-secondary); }
-.ui-badge--draft { background: var(--badge-warning-bg); color: var(--badge-warning-fg); }
-.ui-badge--test  { background: var(--bg-raised); color: var(--fg-muted); }
-/* shape="square" — small 2px rounded tag chip (one palette per tone) */
-.ui-badge--square { border-radius: var(--radius); text-transform: uppercase; letter-spacing: 0.05em; }
-.ui-badge--sq-neutral { background: var(--bg-sunken); color: var(--fg-secondary); border: 1px solid var(--border-medium); }
-.ui-badge--sq-error   { background: transparent; color: var(--color-error); border: 1px solid var(--color-error); }
-.ui-badge--sq-warn    { background: transparent; color: var(--color-error); border: 1px solid var(--color-error); }
-.ui-badge--sq-success { background: var(--color-success-bg); color: var(--color-success-text); border: 1px solid var(--color-success-text); }
+.project-detail__inline-created-value {
+  color: var(--fg-primary);
+  font-variant-numeric: tabular-nums;
+  font-size: .875rem;
+}
 
-/* ---- Avatar (avatar.tsx) ---- */
-.ui-avatar { border-radius: 50%; overflow: hidden; display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border-subtle); background: var(--color-surface-container-high); color: var(--fg-primary); font-weight: 600; }
-.ui-avatar--sm { height: 32px; width: 32px; font-size: 0.875rem; }
-.ui-avatar--md { height: 48px; width: 48px; font-size: 1rem; }
-.ui-avatar--lg { height: 64px; width: 64px; font-size: 1.125rem; }
-.ui-avatar--xl { height: 96px; width: 96px; font-size: 1.375rem; }
-.ui-avatar--2xl { height: 120px; width: 120px; font-size: 2rem; } /* shown at 120px here; real 2xl is 240px / text-display */
+.project-detail__title-input {
+  width: 100%;
+  min-width: 0;
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  letter-spacing: -.01em;
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-hover);
+  border-radius: var(--radius);
+  word-break: break-word;
+  padding: 4px 10px;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
 
-/* ---- Brandmark (brandmark.tsx) ---- */
-.brandmark { color: var(--fg-primary); }
+@media (min-width: 800px) {
+  .project-detail__title-input {
+    font-size: 1.75rem;
+  }
+}
 
-/* ---- Tabs (tabs.tsx) ---- */
-.ui-tablist { display: inline-flex; gap: 16px; border-bottom: 1px solid var(--border-subtle); }
-.ui-tab { display: inline-flex; align-items: center; gap: 8px; padding: 12px 4px; font: inherit; font-size: 0.875rem; background: none; border: none; border-bottom: 2px solid transparent; color: var(--fg-muted); cursor: pointer; }
-.ui-tab:hover { color: var(--fg-primary); }
-.ui-tab--active { color: var(--fg-primary); border-bottom-color: var(--fg-primary); font-weight: 600; }
-.ui-tab--disabled { opacity: 0.5; cursor: not-allowed; }
-.ui-tab:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
-/* link tabs render as <a> but share the underline look */
-a.ui-tab { text-decoration: none; }
-/* variant="segmented" — sunken pill container, active tab is a raised pill */
-.ui-tablist--segmented { display: inline-flex; gap: 4px; border-bottom: 0; padding: 4px; background: var(--bg-sunken); border-radius: var(--radius); }
-.ui-tab--seg { padding: 6px 12px; border-bottom: 0; border-radius: var(--radius); justify-content: center; }
-.ui-tab--seg.ui-tab--active { color: var(--fg-primary); background: var(--bg-elevated); box-shadow: var(--shadow-sm); border-bottom: 0; font-weight: 600; }
+.project-detail__title-input:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
 
-/* ---- Popover (popover.tsx) ---- */
-.ui-popover { background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: var(--radius); box-shadow: var(--shadow-md); padding: 4px; min-width: 200px; }
-.ui-popover__item { display: block; width: 100%; text-align: left; padding: 8px 12px; font: inherit; font-size: 0.875rem; color: var(--fg-primary); background: none; border: none; border-radius: var(--radius); cursor: pointer; }
-.ui-popover__item:hover, .ui-popover__item:focus { background: var(--overlay-weak); outline: none; }
-.ui-popover__item:disabled { opacity: 0.5; cursor: not-allowed; }
-/* role="menuitemradio" item — reserved leading checkmark column, paints when selected */
-.ui-popover__item--radio { display: flex; align-items: center; gap: 8px; text-align: left; }
-.ui-popover__item--radio svg { width: 14px; height: 14px; flex: none; }
-.ui-popover__item--radio svg.is-off { opacity: 0; }
-.ui-popover__item--radio span { flex: 1; text-align: left; }
+.project-detail__lead-input {
+  width: 100%;
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-hover);
+  border-radius: var(--radius);
+  resize: vertical;
+  min-height: 60px;
+  padding: 8px 12px;
+  font-size: 1.0625rem;
+  line-height: 1.55;
+}
 
-/* ---- Dialog surface representation (app-dialog.tsx etc.) ---- */
-.dialog-surface { width: 100%; max-width: 440px; background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: var(--radius); box-shadow: var(--shadow-lg); overflow: hidden; }
-.dialog-surface--wide { max-width: 520px; }
-.signin-modal__header { display: flex; align-items: center; justify-content: space-between; padding: 20px 40px 12px 24px; }
-.signin-modal__title { font-size: 1.0625rem; font-weight: 600; color: var(--fg-primary); }
-.signin-modal__close { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: var(--radius); border: none; background: none; color: var(--fg-muted); cursor: pointer; }
-.signin-modal__close:hover { background: var(--overlay-weak); color: var(--fg-primary); }
-.signin-modal__body { padding: 0 20px 20px; }
-.delete-record-dialog__warning { margin: 0 0 16px; font-size: 0.875rem; line-height: 1.5; color: var(--fg-secondary); }
-.delete-record-dialog__warning strong { color: var(--color-error); }
-.delete-record-dialog__label { font-size: 0.75rem; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--fg-muted); display: block; margin-bottom: 6px; }
-.delete-record-dialog__target { display: block; font-family: var(--sg-mono); font-size: 0.8125rem; color: var(--fg-primary); background: var(--bg-sunken); border: 1px solid var(--border-subtle); border-radius: var(--radius); padding: 6px 10px; word-break: break-all; margin-bottom: 8px; }
-.dialog-footer { display: flex; justify-content: flex-end; gap: 8px; margin-top: 20px; }
+@media (min-width: 800px) {
+  .project-detail__lead-input {
+    font-size: 1.125rem;
+  }
+}
 
-/* Bottom-sheet representation */
-.sheet-surface { width: 100%; max-width: 440px; background: var(--sheet-bg); border: 1px solid var(--border-default); border-radius: 16px 16px var(--radius) var(--radius); box-shadow: var(--shadow-lg); padding-bottom: 16px; }
-.sheet-surface__handle { width: 40px; height: 4px; border-radius: 999px; background: var(--border-hover); margin: 12px auto 4px; }
-.sheet-surface__header { display: flex; align-items: center; justify-content: space-between; padding: 8px 20px 12px; }
-.sheet-surface__title { font-family: Georgia, serif; font-size: 1.125rem; color: var(--fg-primary); }
-.sheet-surface__content { padding: 0 20px; color: var(--fg-secondary); font-size: 0.875rem; }
+.project-detail__lead-input:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
 
-/* Drawer representation */
-.drawer-frame { position: relative; height: 220px; border: 1px dashed var(--border-hover); border-radius: var(--radius); overflow: hidden; background: var(--bg-canvas); }
-.drawer-frame__scrim { position: absolute; inset: 0; background: var(--navy-overlay-30); }
-.drawer-panel { position: absolute; top: 0; bottom: 0; left: 0; width: 78%; max-width: 280px; background: var(--bg-elevated); box-shadow: var(--shadow-lg); padding: 20px; display: flex; flex-direction: column; gap: 10px; }
-.drawer-panel__row { font-size: 0.875rem; color: var(--fg-secondary); padding: 6px 0; border-bottom: 1px solid var(--border-subtle); }
+.project-detail__desc-preserve {
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  color: var(--fg-secondary);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px 14px;
+  font-size: .875rem;
+  display: flex;
+}
 
-/* ---- Status & feedback ---- */
-/* LoadingSpinner — pulsing brandmark */
-.spinner-pulse { color: var(--fg-primary); animation: sg-pulse 1.5s ease-in-out infinite; }
-@keyframes sg-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
-@media (prefers-reduced-motion: reduce) { .spinner-pulse { animation: none; } }
+.project-detail__desc-preserve p {
+  margin: 0;
+  line-height: 1.45;
+}
 
-/* Skeleton (skeleton.tsx) */
-.skeleton { background: var(--overlay-weak); border-radius: var(--radius); animation: sg-pulse 1.5s ease-in-out infinite; }
-@media (prefers-reduced-motion: reduce) { .skeleton { animation: none; } }
-.skeleton--circle { border-radius: 999px; flex: none; }
-/* animate={false} / noAnimate — flat static token surface, no pulse */
-.skeleton--static { animation: none; }
+.project-detail__desc-preserve-cta {
+  font: inherit;
+  color: var(--fg-primary);
+  cursor: pointer;
+  text-underline-offset: 2px;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: .8125rem;
+  font-weight: 500;
+  text-decoration: underline;
+}
 
-/* EmptyState (empty-state.tsx + components.css) */
-.empty-state { text-align: center; padding: 48px 16px; display: flex; flex-direction: column; align-items: center; }
-.empty-state__icon { color: var(--fg-muted); margin-bottom: 16px; opacity: 0.5; }
-.empty-state__title { font-family: Georgia, serif; font-size: 1.125rem; font-weight: 600; color: var(--fg-primary); margin: 0 0 8px; }
-.empty-state__desc { font-size: 0.875rem; line-height: 1.6; color: var(--fg-muted); max-width: 320px; margin: 0; }
-.empty-state__actions { margin-top: 20px; }
-/* inline variant (and its "compact" alias) — single muted line, no icon/headline/container */
-.empty-state--inline, .empty-state--compact { margin: 0; font-size: 0.875rem; color: var(--fg-muted); }
-.empty-state--inline .empty-state__inline-cta { margin-left: 4px; }
+.project-detail__desc-preserve-cta:hover {
+  color: var(--fg-primary);
+  text-decoration: none;
+}
 
-/* ErrorMessage (error-message.tsx) */
-.error-message { border: 1px solid var(--color-error-border); background: var(--color-error-bg); border-radius: var(--radius); padding: 24px; display: flex; gap: 16px; }
-.error-message svg { color: var(--color-error); flex: none; margin-top: 2px; }
-.error-message__title { font-size: 0.875rem; font-weight: 600; letter-spacing: 0.05em; color: var(--fg-primary); margin: 0 0 4px; }
-.error-message__msg { font-size: 0.875rem; color: var(--fg-secondary); margin: 0; }
+.project-detail__add-cert-btn {
+  background: var(--bg-elevated);
+  height: 30px;
+  color: var(--fg-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast);
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  padding: 0 12px;
+  font-family: inherit;
+  font-size: .8125rem;
+  font-weight: 500;
+  line-height: 1;
+  display: inline-flex;
+}
 
-/* ErrorBoundaryFallback — uses dashboard chrome */
-.dashboard { border: 1px solid var(--border-default); border-radius: var(--radius); overflow: hidden; }
-.dashboard__topbar { padding: 16px 20px; border-bottom: 1px solid var(--border-subtle); background: var(--bg-raised); }
-.dashboard__page-title { font-family: Georgia, serif; font-size: 1.25rem; color: var(--fg-primary); margin: 0; }
-.dash-card { background: transparent; border-bottom: 1px solid var(--border-light); padding: 24px 20px; }
-.dash-card__desc { font-size: 0.8125rem; line-height: 1.6; color: var(--fg-muted); margin: 0 0 12px; }
+.project-detail__add-cert-btn:hover {
+  background: var(--overlay-weak);
+  border-color: var(--border-hover);
+}
 
-/* ProviderRedirectOverlay — loading-screen representation */
-.loading-screen-demo { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; padding: 48px; background: var(--bg-canvas); border: 1px solid var(--border-subtle); border-radius: var(--radius); }
+.project-detail__add-cert-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
 
-/* Toast (toast.tsx) */
-.toast { display: flex; align-items: flex-start; gap: 12px; border-radius: var(--radius); border: 1px solid var(--border-default); padding: 12px 16px; box-shadow: var(--shadow-md); min-width: 280px; max-width: 26rem; background: var(--bg-elevated); color: var(--fg-primary); }
-.toast--success { background: var(--color-success-bg); border-color: var(--border-default); }
-.toast--error   { background: var(--color-error-bg); border-color: var(--color-error-border); }
-.toast svg { flex: none; }
-.toast__title { font-size: 0.875rem; font-weight: 500; margin: 0; }
-.toast__desc { font-size: 0.75rem; color: var(--fg-muted); margin: 2px 0 0; }
-.toast__action { margin-left: auto; align-self: center; background: none; border: none; font: inherit; font-size: 0.75rem; font-weight: 600; color: var(--fg-primary); text-decoration: underline; text-underline-offset: 2px; cursor: pointer; }
-.toast__close { background: none; border: none; color: var(--fg-muted); cursor: pointer; padding: 2px; }
+.project-detail__add-cert-picker {
+  align-items: stretch;
+  gap: 8px;
+  margin: 0 0 12px;
+  display: flex;
+}
 
-/* Banner (banner.tsx) */
-.banner { display: flex; gap: 12px; border-radius: var(--radius); border: 1px solid; padding: 16px; font-size: 0.875rem; color: var(--fg-primary); }
-.banner--info    { background: var(--bg-sunken);          border-color: var(--border-default); }
-.banner--warning { background: var(--color-warning-bg);   border-color: var(--color-warning-border); }
-.banner--success { background: var(--color-success-bg);   border-color: var(--border-default); }
-.banner--error   { background: var(--color-error-bg);     border-color: var(--color-error-border); }
-.banner__icon--info    { color: var(--fg-muted); }
-.banner__icon--warning { color: var(--color-warning-text); }
-.banner__icon--success { color: var(--color-success-text); }
-.banner__icon--error   { color: var(--color-error); }
-.banner__icon { flex: none; margin-top: 1px; }
-.banner__title { font-weight: 600; letter-spacing: 0.05em; margin: 0 0 4px; color: var(--fg-primary); }
-.banner__body { color: var(--fg-secondary); margin: 0; }
+.project-detail__add-cert-picker .cert-search {
+  flex: auto;
+  min-width: 0;
+}
 
-/* LoadMoreSentinel — just a secondary Button by default */
+.project-detail__add-cert-cancel {
+  font: inherit;
+  color: var(--fg-secondary);
+  border-radius: var(--radius);
+  cursor: pointer;
+  background: none;
+  border: 1px solid #0000;
+  flex: none;
+  align-self: center;
+  padding: 8px 14px;
+  font-size: .8125rem;
+}
 
-/* ==========================================================================
-   TOKEN GALLERY
-   ========================================================================== */
-.swatch-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px; }
-.swatch { border: 1px solid var(--border-default); border-radius: var(--radius); overflow: hidden; background: var(--bg-elevated); }
-.swatch__chip { height: 56px; border-bottom: 1px solid var(--border-subtle); }
-.swatch__meta { padding: 8px 10px; }
-.swatch__name { font-family: var(--sg-mono); font-size: 0.6875rem; color: var(--fg-primary); display: block; word-break: break-all; }
-.swatch__val { font-family: var(--sg-mono); font-size: 0.625rem; color: var(--fg-muted); display: block; }
-.scale-row { display: flex; align-items: baseline; gap: 16px; padding: 12px 0; border-bottom: 1px solid var(--border-subtle); }
-.scale-row__tag { font-family: var(--sg-mono); font-size: 0.6875rem; color: var(--fg-muted); width: 110px; flex: none; }
-.space-row { display: flex; align-items: center; gap: 16px; padding: 6px 0; }
-.space-row__tag { font-family: var(--sg-mono); font-size: 0.6875rem; color: var(--fg-muted); width: 80px; flex: none; }
-.space-bar { height: 14px; background: var(--fg-primary); border-radius: var(--radius); }
-.radius-row { display: flex; align-items: center; gap: 16px; padding: 6px 0; }
-.radius-box { width: 48px; height: 48px; background: var(--bg-sunken); border: 1px solid var(--border-hover); }
+.project-detail__add-cert-cancel:hover {
+  color: var(--fg-primary);
+  background: var(--overlay-weak);
+}
 
-.sg-note { font-size: 0.8125rem; color: var(--fg-muted); margin-top: 8px; }
-.sg-icon { display: inline-block; vertical-align: middle; }
-hr.sg-hr { border: 0; border-top: 1px solid var(--border-default); margin: 56px 0 0; }
+.project-detail__certs-loading {
+  color: var(--fg-muted);
+  text-align: center;
+  margin: 0;
+  padding: 24px 0;
+  font-size: .875rem;
+}
+
+.project-detail__cert-cell {
+  display: flex;
+  position: relative;
+}
+
+.project-detail__cert-cell > .feed-card {
+  flex: auto;
+  min-width: 0;
+}
+
+.project-detail__cert-menu {
+  z-index: 1;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+.project-detail__cert-menu-btn {
+  width: 28px;
+  height: 28px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  border-radius: 999px;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
+}
+
+.project-detail__cert-menu-btn:hover, .project-detail__cert-menu-btn:focus-visible, .project-detail__cert-menu-btn[aria-expanded="true"] {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+  outline: none;
+}
+
+.create-group__identity-row {
+  grid-template-columns: 1fr 3fr;
+  align-items: stretch;
+  gap: 20px;
+  margin-bottom: 24px;
+  display: grid;
+}
+
+.create-group__avatar-tile {
+  aspect-ratio: 1;
+  background: var(--bg-sunken);
+  border-radius: 50%;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  display: flex;
+  position: relative;
+}
+
+.create-group__avatar-tile--placeholder {
+  border: 2px dashed var(--border-medium);
+  background: var(--bg-sunken);
+}
+
+.create-group__avatar-img {
+  object-fit: cover;
+  border-radius: 50%;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.create-group__avatar-placeholder-icon {
+  color: var(--fg-muted);
+}
+
+.create-group__banner-tile {
+  width: 100%;
+  min-width: 0;
+  margin: 0;
+}
+
+/* [project]/src/app/styles/context-updates.css [app-client] (css) */
+.context-updates {
+  border-top: 1px solid var(--border-subtle);
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 4px;
+  padding-top: 24px;
+  display: flex;
+}
+
+.context-updates__head {
+  align-items: baseline;
+  gap: 12px;
+  display: flex;
+}
+
+.context-updates__icon {
+  display: none;
+}
+
+.context-updates__heading {
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--fg-muted);
+  align-items: center;
+  margin: 0;
+  font-size: .6875rem;
+  font-weight: 600;
+  line-height: 1;
+  display: inline-flex;
+}
+
+.context-updates__count {
+  color: var(--fg-muted);
+  background: var(--overlay-weak);
+  font-feature-settings: "tnum" 1;
+  border-radius: 999px;
+  padding: 1px 8px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.context-updates__loading {
+  justify-content: center;
+  align-items: center;
+  padding: 12px 0;
+  display: flex;
+}
+
+.context-updates__list {
+  flex-direction: column;
+  gap: 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.context-updates__item {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  display: flex;
+}
+
+.context-updates__item-head {
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  display: flex;
+}
+
+.context-updates__title {
+  letter-spacing: -.005em;
+  color: var(--fg-primary);
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  font-size: .95rem;
+  font-weight: 600;
+}
+
+.context-updates__when {
+  color: var(--fg-secondary);
+  white-space: nowrap;
+  font-size: .75rem;
+}
+
+.context-updates__doc-wrap {
+  display: block;
+}
+
+.context-updates__doc-wrap--clamped {
+  max-height: 6em;
+  position: relative;
+  overflow: hidden;
+}
+
+.context-updates__doc-wrap--clamped:after {
+  content: "";
+  background: linear-gradient(to bottom,
+    transparent,
+    var(--bg-elevated));
+  pointer-events: none;
+  height: 1.6em;
+  position: absolute;
+  inset: auto 0 0;
+}
+
+.context-updates__doc {
+  color: var(--fg-secondary);
+  font-size: .875rem;
+  line-height: 1.5;
+}
+
+.context-updates__expand {
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  background: none;
+  border: 0;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  padding: 0;
+  font-size: .8125rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.context-updates__expand:hover {
+  color: var(--fg-primary);
+}
+
+.context-updates__see-all {
+  color: var(--fg-secondary);
+  transition: color var(--transition-fast);
+  margin-left: auto;
+  font-size: .75rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.context-updates__see-all:hover {
+  color: var(--fg-primary);
+  text-underline-offset: 2px;
+  text-decoration: underline;
+}
+
+.context-updates__empty {
+  color: var(--fg-secondary);
+  margin: 0;
+  font-size: .875rem;
+}
+
+.context-updates__attachments {
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 4px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.context-updates__attachment {
+  display: flex;
+}
+
+.context-updates__attachment-link {
+  color: inherit;
+  border-radius: var(--radius);
+  transition: border-color var(--transition-fast),
+    background var(--transition-fast);
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  display: flex;
+}
+
+.context-updates__attachment--image .context-updates__attachment-link {
+  background: var(--bg-sunken);
+  width: 88px;
+  height: 88px;
+  padding: 0;
+  display: block;
+  overflow: hidden;
+}
+
+.context-updates__attachment-img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.context-updates__attachment--image .context-updates__attachment-link:hover {
+  outline: 2px solid var(--border-hover);
+  outline-offset: -2px;
+}
+
+.context-updates__attachment--video .context-updates__attachment-link {
+  flex-direction: column;
+  gap: 4px;
+  width: 156px;
+  padding: 0;
+  display: flex;
+}
+
+.context-updates__attachment-thumb {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  width: 156px;
+  height: 88px;
+  display: block;
+  position: relative;
+  overflow: hidden;
+}
+
+.context-updates__attachment-thumb-img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.context-updates__attachment-thumb-overlay {
+  pointer-events: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  position: absolute;
+  inset: 0;
+}
+
+.context-updates__attachment-play {
+  width: 32px;
+  height: 32px;
+  color: var(--color-white);
+  background: var(--navy-overlay-70);
+  border-radius: 999px;
+  padding: 6px;
+}
+
+.context-updates__attachment-host {
+  color: var(--fg-secondary);
+  font-size: .75rem;
+  line-height: 1.3;
+}
+
+.context-updates__attachment--video .context-updates__attachment-link:hover .context-updates__attachment-thumb {
+  outline: 2px solid var(--border-hover);
+  outline-offset: -2px;
+}
+
+.context-updates__attachment--file .context-updates__attachment-link, .context-updates__attachment--uri .context-updates__attachment-link {
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+  max-width: 260px;
+  padding: 8px 12px;
+}
+
+.context-updates__attachment--file .context-updates__attachment-link:hover, .context-updates__attachment--uri .context-updates__attachment-link:hover {
+  border-color: var(--border-hover);
+  background: var(--bg-sunken);
+}
+
+.context-updates__attachment-icon {
+  color: var(--fg-secondary);
+  flex-shrink: 0;
+}
+
+.context-updates__attachment-meta {
+  flex-direction: column;
+  min-width: 0;
+  display: flex;
+}
+
+.context-updates__attachment-label {
+  color: var(--fg-primary);
+  font-size: .8125rem;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.context-updates__attachment-size, .context-updates__attachment-uri {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .75rem;
+  line-height: 1.3;
+  overflow: hidden;
+}
+
+@media (max-width: 799px) {
+  .context-updates__item {
+    padding: 12px;
+  }
+
+  .context-updates__attachment--image .context-updates__attachment-link {
+    width: 72px;
+    height: 72px;
+  }
+
+  .context-updates__attachment--video .context-updates__attachment-link, .context-updates__attachment-thumb {
+    width: 128px;
+  }
+
+  .context-updates__attachment-thumb {
+    height: 72px;
+  }
+}
+
+/* [project]/src/app/styles/workspace.css [app-client] (css) */
+.workspace-page {
+  padding: 24px 16px 64px;
+}
+
+@media (min-width: 800px) {
+  .app-shell:has(.workspace-page) .app-shell__content {
+    max-width: 1280px;
+  }
+}
+
+.workspace__head {
+  margin-bottom: 20px;
+}
+
+.workspace__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--fg-secondary);
+  font-size: .75rem;
+}
+
+.workspace__title {
+  letter-spacing: -.01em;
+  color: var(--fg-primary);
+  margin: 4px 0 6px;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.workspace__subtitle {
+  max-width: 56ch;
+  color: var(--fg-secondary);
+  margin: 0;
+  font-size: .875rem;
+}
+
+.workspace__loading {
+  justify-content: center;
+  padding: 32px 0;
+  display: flex;
+}
+
+.wks-pane {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  display: flex;
+}
+
+.wks-pane__head {
+  color: var(--fg-primary);
+  align-items: center;
+  gap: 8px;
+  display: flex;
+}
+
+.wks-pane__heading {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.wks-pane__lede {
+  color: var(--fg-secondary);
+  margin: 0;
+  font-size: .9rem;
+}
+
+.wks-pane__grid {
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+}
+
+.wks-pane__grid-item {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  flex-direction: column;
+  padding: 10px 12px;
+  display: flex;
+}
+
+.wks-pane__grid-label {
+  color: var(--fg-secondary);
+  font-size: .75rem;
+}
+
+.wks-pane__grid-count {
+  color: var(--fg-primary);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.wks-pane__hint {
+  color: var(--fg-secondary);
+  margin: 0;
+  font-size: .8125rem;
+}
+
+.wks-pane__cta {
+  border-radius: var(--radius);
+  background: var(--fg-primary);
+  color: var(--bg-canvas);
+  align-self: flex-start;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  font-size: .85rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.wks-pane__cta:hover {
+  opacity: .9;
+}
+
+.wks-breadcrumb {
+  position: relative;
+}
+
+.wks-breadcrumb__bar {
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 14px;
+  font-size: .875rem;
+  display: flex;
+}
+
+.wks-breadcrumb__crumb {
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  font-size: inherit;
+  cursor: pointer;
+  border-radius: 999px;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  display: inline-flex;
+}
+
+.wks-breadcrumb__crumb:hover {
+  background: var(--bg-sunken);
+}
+
+.wks-breadcrumb__menu {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  max-width: 360px;
+  max-height: 320px;
+  box-shadow: var(--shadow-md);
+  margin: 0 0 12px;
+  padding: 6px;
+  list-style: none;
+  overflow-y: auto;
+}
+
+.wks-breadcrumb__menu-item {
+  border-radius: var(--radius);
+  text-align: left;
+  width: 100%;
+  color: var(--fg-primary);
+  cursor: pointer;
+  background: none;
+  border: 0;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: .85rem;
+  display: flex;
+}
+
+.wks-breadcrumb__menu-item:hover {
+  background: var(--bg-sunken);
+}
+
+.wks-breadcrumb__main {
+  min-height: 200px;
+}
+
+.wks-notion {
+  grid-template-columns: 240px 1fr;
+  align-items: start;
+  gap: 20px;
+  display: grid;
+}
+
+.wks-notion__rail {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  flex-direction: column;
+  gap: 14px;
+  padding: 10px;
+  font-size: .85rem;
+  display: flex;
+}
+
+.wks-notion__section-label {
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--fg-secondary);
+  padding: 0 8px 4px;
+  font-size: .7rem;
+}
+
+.wks-notion__list {
+  flex-direction: column;
+  gap: 1px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.wks-notion__node {
+  border-radius: var(--radius);
+  text-align: left;
+  width: 100%;
+  font-size: inherit;
+  color: var(--fg-primary);
+  cursor: pointer;
+  background: none;
+  border: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  display: flex;
+}
+
+.wks-notion__node:hover {
+  background: var(--bg-sunken);
+}
+
+.wks-notion__node--active {
+  background: var(--fg-primary);
+  color: var(--bg-canvas);
+}
+
+.wks-notion__node-label {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  overflow: hidden;
+}
+
+.wks-notion__node-count {
+  opacity: .7;
+  font-size: .7rem;
+}
+
+.wks-notion__avatar {
+  background: var(--bg-sunken);
+  object-fit: cover;
+  border-radius: 50%;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.wks-notion__avatar--ph {
+  background: var(--bg-raised);
+}
+
+.wks-mail {
+  grid-template-columns: 260px 1fr;
+  align-items: start;
+  gap: 20px;
+  display: grid;
+}
+
+.wks-mail__rail {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  font-size: .85rem;
+  display: flex;
+}
+
+.wks-mail__network {
+  border-radius: var(--radius);
+  width: 100%;
+  color: var(--fg-primary);
+  font-size: inherit;
+  cursor: pointer;
+  background: none;
+  border: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  font-weight: 500;
+  display: flex;
+}
+
+.wks-mail__network:hover {
+  background: var(--bg-sunken);
+}
+
+.wks-mail__network--active {
+  background: var(--fg-primary);
+  color: var(--bg-canvas);
+}
+
+.wks-mail__accounts {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.wks-mail__account-head {
+  border-radius: var(--radius);
+  text-align: left;
+  width: 100%;
+  font-size: inherit;
+  color: var(--fg-primary);
+  cursor: pointer;
+  background: none;
+  border: 0;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  font-weight: 500;
+  display: flex;
+}
+
+.wks-mail__account-head:hover, .wks-mail__account-head--active {
+  background: var(--bg-sunken);
+}
+
+.wks-mail__avatar {
+  background: var(--bg-sunken);
+  object-fit: cover;
+  border-radius: 50%;
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+}
+
+.wks-mail__avatar--ph {
+  background: var(--bg-raised);
+}
+
+.wks-mail__account-label {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.wks-mail__folders {
+  flex-direction: column;
+  gap: 1px;
+  margin: 2px 0 6px 26px;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.wks-mail__folder {
+  border-radius: var(--radius);
+  text-align: left;
+  width: 100%;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  background: none;
+  border: 0;
+  align-items: center;
+  padding: 3px 8px;
+  font-size: .8rem;
+  display: flex;
+}
+
+.wks-mail__folder:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.wks-mail__folder--active {
+  background: var(--fg-primary);
+  color: var(--bg-canvas);
+}
+
+.wks-mail__folder-label {
+  flex: 1;
+}
+
+.wks-mail__folder-count {
+  opacity: .7;
+  font-size: .7rem;
+}
+
+.wks-blue {
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+  position: relative;
+}
+
+.wks-blue__head {
+  position: relative;
+}
+
+.wks-blue__switcher {
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  cursor: pointer;
+  border-radius: 999px;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: .9rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.wks-blue__switcher:hover {
+  background: var(--bg-sunken);
+}
+
+.wks-blue__avatar {
+  background: var(--bg-sunken);
+  object-fit: cover;
+  border-radius: 50%;
+  width: 22px;
+  height: 22px;
+}
+
+.wks-blue__avatar--ph {
+  background: var(--bg-raised);
+}
+
+.wks-blue__menu {
+  z-index: 10;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  min-width: 280px;
+  max-height: 360px;
+  box-shadow: var(--shadow-md);
+  margin: 0;
+  padding: 6px;
+  list-style: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  overflow-y: auto;
+}
+
+.wks-blue__menu-item {
+  border-radius: var(--radius);
+  text-align: left;
+  width: 100%;
+  color: var(--fg-primary);
+  cursor: pointer;
+  background: none;
+  border: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  font-size: .85rem;
+  display: flex;
+}
+
+.wks-blue__menu-item:hover {
+  background: var(--bg-sunken);
+}
+
+.wks-blue__chips {
+  flex-wrap: wrap;
+  gap: 6px;
+  display: flex;
+}
+
+.wks-slack {
+  grid-template-columns: 60px 220px 1fr;
+  align-items: start;
+  gap: 16px;
+  display: grid;
+}
+
+.wks-slack__icons {
+  border-right: 1px solid var(--border-subtle);
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 0;
+  display: flex;
+}
+
+.wks-slack__icon {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  width: 40px;
+  height: 40px;
+  color: var(--fg-primary);
+  cursor: pointer;
+  border: 0;
+  justify-content: center;
+  align-self: center;
+  align-items: center;
+  display: flex;
+  overflow: hidden;
+}
+
+.wks-slack__icon:hover {
+  outline: 2px solid var(--fg-secondary);
+  outline-offset: -2px;
+}
+
+.wks-slack__icon--active {
+  outline: 2px solid var(--fg-primary);
+  outline-offset: -2px;
+}
+
+.wks-slack__avatar {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}
+
+.wks-slack__initial {
+  font-size: .95rem;
+  font-weight: 600;
+}
+
+.wks-slack__lexicons {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 10px;
+  font-size: .85rem;
+}
+
+.wks-slack__lexicons-head {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-bottom: 8px;
+  font-size: .95rem;
+  font-weight: 600;
+  overflow: hidden;
+}
+
+.wks-slack__lex-list {
+  flex-direction: column;
+  gap: 1px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.wks-slack__lex {
+  border-radius: var(--radius);
+  text-align: left;
+  width: 100%;
+  font-size: inherit;
+  color: var(--fg-primary);
+  cursor: pointer;
+  background: none;
+  border: 0;
+  padding: 4px 8px;
+  display: flex;
+}
+
+.wks-slack__lex:hover {
+  background: var(--bg-sunken);
+}
+
+.wks-slack__lex--active {
+  background: var(--fg-primary);
+  color: var(--bg-canvas);
+}
+
+.wks-slack__lex-label {
+  flex: 1;
+}
+
+.wks-slack__lex-count {
+  opacity: .7;
+  font-size: .7rem;
+}
+
+.wks-slack__lex-empty {
+  color: var(--fg-secondary);
+  margin: 0;
+  font-size: .8rem;
+}
+
+@media (max-width: 799px) {
+  .wks-notion, .wks-mail, .wks-slack {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* [project]/src/app/styles/explore.css [app-client] (css) */
+.explore-page {
+  padding: 24px 16px 64px;
+}
+
+@media (min-width: 800px) {
+  .explore-page {
+    padding: 0;
+  }
+}
+
+.explore-page {
+  --explore-sidebar-width: clamp(256px, 22vw, 296px);
+  position: relative;
+}
+
+.explore__layout {
+  grid-template-columns: var(--explore-sidebar-width) 1fr;
+  align-items: start;
+  gap: 0;
+  display: grid;
+}
+
+.explore-page:before {
+  content: "";
+  top: 0;
+  bottom: 0;
+  left: var(--explore-sidebar-width);
+  background: var(--border-medium);
+  pointer-events: none;
+  width: 1px;
+  position: absolute;
+}
+
+@media (max-width: 799px) {
+  .explore__layout {
+    grid-template-columns: 1fr;
+    padding: 0 16px;
+  }
+}
+
+.explore__sidebar {
+  flex-direction: column;
+  gap: 16px;
+  padding: 32px 12px;
+  display: flex;
+}
+
+.explore__filter-list {
+  flex-direction: column;
+  gap: 1px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.explore__filter-heading {
+  color: var(--fg-secondary);
+  margin: 0;
+  padding: 0 10px;
+  font-size: .85rem;
+  font-weight: 500;
+}
+
+.explore__filter-divider {
+  border: 0;
+  border-top: 1px solid var(--border-subtle);
+  margin: 12px 10px;
+}
+
+.explore__filter-list--indented {
+  padding-left: 18px;
+}
+
+.explore__filter {
+  border-radius: var(--radius);
+  text-align: left;
+  width: 100%;
+  color: var(--fg-primary);
+  cursor: pointer;
+  background: none;
+  border: 0;
+  padding: 6px 10px;
+  font-size: .85rem;
+  display: block;
+}
+
+.explore__filter:hover {
+  background: var(--bg-sunken);
+}
+
+.explore__filter--active, .explore__filter--active:hover {
+  background: var(--fg-primary);
+  color: var(--bg-canvas);
+}
+
+.explore__main {
+  width: 100%;
+  min-width: 0;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 20px 24px 32px;
+}
+
+.explore__sub-dropdown-trigger {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast);
+  flex-shrink: 0;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  font-size: .85rem;
+  font-weight: 500;
+  display: inline-flex;
+}
+
+.explore__sub-dropdown-trigger:hover {
+  background: var(--bg-sunken);
+  border-color: var(--fg-secondary);
+}
+
+.explore__sub-dropdown-label {
+  color: var(--fg-primary);
+}
+
+@media (max-width: 799px) {
+  .explore__main {
+    padding: 0;
+  }
+}
+
+.explore__chrome {
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  display: flex;
+}
+
+.explore__search-field {
+  flex: 1;
+  min-width: 200px;
+}
+
+.explore__chrome-actions {
+  gap: 6px;
+  display: flex;
+}
+
+.explore__chrome-btn {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  cursor: pointer;
+  white-space: nowrap;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  font-size: .85rem;
+  display: inline-flex;
+}
+
+.explore__chrome-btn:hover {
+  background: var(--bg-sunken);
+}
+
+.explore__chrome-btn--icon {
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+}
+
+.explore__chrome-btn--active {
+  border-color: var(--fg-primary);
+  background: var(--bg-sunken);
+}
+
+.explore__loading {
+  justify-content: center;
+  padding: 48px 0;
+  display: flex;
+}
+
+.explore__load-more {
+  justify-content: center;
+  padding: 24px 0;
+  display: flex;
+}
+
+.explore__load-more-btn {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast);
+  padding: 8px 18px;
+  font-size: .85rem;
+  font-weight: 500;
+}
+
+.explore__load-more-btn:hover:not(:disabled) {
+  background: var(--bg-sunken);
+}
+
+.explore__load-more-btn:disabled {
+  color: var(--fg-secondary);
+  cursor: progress;
+}
+
+.popover__item {
+  border-radius: var(--radius);
+  text-align: left;
+  color: var(--fg-primary);
+  cursor: pointer;
+  background: none;
+  border: 0;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: .85rem;
+  display: flex;
+}
+
+.popover__item:hover {
+  background: var(--bg-sunken);
+}
+
+.popover__item--check {
+  cursor: pointer;
+}
+
+.popover__section-heading {
+  color: var(--fg-secondary);
+  margin: 4px 0 2px;
+  padding: 0 8px;
+  font-size: .85rem;
+  font-weight: 500;
+}
+
+.popover__divider {
+  border: 0;
+  border-top: 1px solid var(--border-subtle);
+  margin: 6px 8px;
+}
+
+.popover__reset-btn {
+  border-radius: var(--radius);
+  text-align: left;
+  width: 100%;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    color var(--transition-fast);
+  background: none;
+  border: 0;
+  margin: 0;
+  padding: 6px 12px;
+  font-size: .78rem;
+  font-weight: 500;
+  display: block;
+}
+
+.popover__reset-btn:hover:not(:disabled) {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.popover__reset-btn:disabled {
+  color: var(--fg-muted);
+  cursor: default;
+}
+
+.explore__degree-reset {
+  border-radius: var(--radius);
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    color var(--transition-fast);
+  background: none;
+  border: 0;
+  margin-left: 4px;
+  padding: 4px 10px;
+  font-size: .78rem;
+  font-weight: 500;
+}
+
+.explore__degree-reset:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.explore__list {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow: hidden;
+}
+
+.explore__list > li + li .cert-list-row {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.cert-list-row {
+  transition: background var(--transition-fast);
+  grid-template-columns: 1fr 200px 84px;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 14px;
+  display: grid;
+}
+
+.cert-list-row:hover {
+  background: var(--bg-sunken);
+}
+
+.cert-list-row__link {
+  min-width: 0;
+  color: inherit;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  display: flex;
+}
+
+.cert-list-row__thumb {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  width: 40px;
+  height: 40px;
+  color: var(--fg-secondary);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  overflow: hidden;
+}
+
+.cert-list-row__img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.cert-list-row__body {
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.cert-list-row__title {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0;
+  font-size: .9rem;
+  font-weight: 600;
+  line-height: 1.3;
+  overflow: hidden;
+}
+
+.cert-list-row__meta {
+  color: var(--fg-secondary);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: .75rem;
+  line-height: 1.3;
+  display: flex;
+  overflow: hidden;
+}
+
+.cert-list-row__meta-item {
+  white-space: nowrap;
+  align-items: center;
+  gap: 6px;
+  display: inline-flex;
+}
+
+.cert-list-row__meta-sep {
+  color: var(--fg-muted);
+}
+
+.cert-list-row__meta-icon {
+  color: var(--fg-secondary);
+}
+
+.cert-list-row__author-col {
+  justify-content: flex-start;
+  align-items: center;
+  min-width: 0;
+  font-size: .8rem;
+  display: flex;
+}
+
+.cert-list-row__time {
+  color: var(--fg-secondary);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  font-size: .75rem;
+}
+
+@media (max-width: 799px) {
+  .cert-list-row {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 10px 12px;
+  }
+
+  .cert-list-row__author-col, .cert-list-row__time {
+    text-align: left;
+    justify-self: start;
+  }
+}
+
+.explore__grid {
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+}
+
+.explore__grid--users {
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.explore__grid--projects {
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+}
+
+.explore__grid--certs {
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.explore-user-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  color: inherit;
+  transition: border-color var(--transition-fast), background var(--transition-fast),
+    box-shadow var(--transition-fast);
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  padding: 16px;
+  text-decoration: none;
+  display: flex;
+}
+
+.explore-user-card:hover {
+  border-color: var(--fg-secondary);
+  background: var(--bg-sunken);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--fg-primary) 6%, transparent);
+}
+
+.explore-user-card__head {
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  display: flex;
+}
+
+.explore-user-card__avatar {
+  flex-shrink: 0;
+}
+
+.explore-user-card__id {
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.explore-user-card__name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0;
+  font-size: .95rem;
+  font-weight: 600;
+  line-height: 1.2;
+  overflow: hidden;
+}
+
+.explore-user-card__handle {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  margin: 0;
+  font-size: .78rem;
+  overflow: hidden;
+}
+
+.explore-user-card__handle--did {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  color: var(--fg-muted);
+  align-items: center;
+  gap: 4px;
+  display: inline-flex;
+}
+
+.explore-user-card__desc {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  margin: 0;
+  font-size: .82rem;
+  line-height: 1.45;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.account-list-row {
+  transition: background var(--transition-fast);
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 14px;
+  display: grid;
+}
+
+.explore__list > li + li .account-list-row {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.account-list-row:hover {
+  background: var(--bg-sunken);
+}
+
+.account-list-row__link {
+  min-width: 0;
+  color: inherit;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  display: flex;
+}
+
+.account-list-row__avatar {
+  flex-shrink: 0;
+}
+
+.account-list-row__body {
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  display: flex;
+}
+
+.account-list-row__name {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: .9rem;
+  font-weight: 600;
+  line-height: 1.3;
+  overflow: hidden;
+}
+
+.account-list-row__handle {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  font-size: .78rem;
+  line-height: 1.3;
+  overflow: hidden;
+}
+
+.account-list-row__handle--did {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  color: var(--fg-muted);
+  align-items: center;
+  gap: 4px;
+  display: inline-flex;
+}
+
+.account-list-row__badge {
+  flex-shrink: 0;
+  align-items: center;
+  display: inline-flex;
+}
+
+.account-list-row__joined {
+  color: var(--fg-secondary);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  flex-shrink: 0;
+  font-size: .75rem;
+}
+
+@media (max-width: 799px) {
+  .account-list-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 6px;
+  }
+
+  .account-list-row__badge, .account-list-row__joined {
+    justify-self: start;
+  }
+}
+
+.explore-project-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  color: inherit;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  text-decoration: none;
+  display: flex;
+}
+
+.explore-project-card:hover {
+  border-color: var(--fg-secondary);
+  background: var(--bg-sunken);
+}
+
+.explore-project-card__image-wrap {
+  aspect-ratio: 3;
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  overflow: hidden;
+}
+
+.explore-project-card__image {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.explore-project-card__image--placeholder {
+  color: var(--fg-secondary);
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.explore-project-card__body {
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  display: flex;
+}
+
+.explore-project-card__title {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  margin: 0;
+  font-size: .95rem;
+  font-weight: 600;
+  line-height: 1.3;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.explore-project-card__desc {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  margin: 0;
+  font-size: .8rem;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.explore-project-card__meta {
+  color: var(--fg-secondary);
+  align-items: center;
+  gap: 12px;
+  margin-top: 2px;
+  font-size: .75rem;
+  display: flex;
+}
+
+.explore-project-card__count {
+  font-weight: 500;
+}
+
+.explore-project-card__when {
+  margin-left: auto;
+}
+
+.explore__degree-bar {
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+  padding: 12px 0 6px;
+  display: flex;
+}
+
+.explore__degree-pills {
+  gap: 4px;
+  display: inline-flex;
+}
+
+.explore__degree-truncated {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: 12px;
+  font-style: italic;
+}
+
+.endorsement-row-badge__degree {
+  letter-spacing: .02em;
+  border: 1px solid #0000;
+  border-radius: 999px;
+  align-items: center;
+  height: 16px;
+  padding: 0 6px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  display: inline-flex;
+}
+
+.endorsement-row-badge__degree--d1 {
+  background: var(--fg-primary);
+  color: var(--bg-canvas);
+  border-color: var(--fg-primary);
+}
+
+.endorsement-row-badge__degree--d2 {
+  background: var(--bg-raised);
+  color: var(--fg-primary);
+  border-color: var(--border-default);
+}
+
+.endorsement-row-badge__degree--d3 {
+  background: var(--bg-sunken);
+  color: var(--fg-secondary);
+  border-color: var(--border-subtle);
+}
+
+.endorsement-row-badge__sep {
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 1;
+}
+
+/* [project]/src/app/styles/home.css [app-client] (css) */
+.home-page {
+  padding: 24px 16px 64px;
+  position: relative;
+}
+
+@media (min-width: 800px) {
+  .home-page {
+    padding: 0;
+  }
+}
+
+.home-page {
+  --home-sidebar-width: clamp(256px, 22vw, 296px);
+}
+
+.home__layout {
+  grid-template-columns: var(--home-sidebar-width) 1fr;
+  align-items: start;
+  gap: 0;
+  display: grid;
+}
+
+.home-page:before {
+  content: "";
+  top: 0;
+  bottom: 0;
+  left: var(--home-sidebar-width);
+  background: var(--border-medium);
+  pointer-events: none;
+  width: 1px;
+  position: absolute;
+}
+
+@media (max-width: 799px) {
+  .home-page:before {
+    display: none;
+  }
+
+  .home__layout {
+    grid-template-columns: 1fr;
+    padding: 0 16px;
+  }
+}
+
+.home__sidebar {
+  flex-direction: column;
+  gap: 28px;
+  min-width: 0;
+  padding: 32px 16px 32px 28px;
+  display: flex;
+}
+
+@media (max-width: 799px) {
+  .home__sidebar {
+    padding: 16px 12px 24px;
+  }
+}
+
+.home-section {
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  display: flex;
+}
+
+.home-section__head {
+  color: var(--fg-secondary);
+  align-items: center;
+  gap: 8px;
+  padding: 0 4px 4px;
+  display: flex;
+}
+
+.home-section__title-link {
+  color: inherit;
+  border-radius: var(--radius);
+  transition: background var(--transition-fast);
+  margin: -2px -6px;
+  padding: 2px 6px;
+  text-decoration: none;
+}
+
+.home-section__title-link:hover {
+  background: var(--bg-sunken);
+  text-decoration: none;
+}
+
+.home-section__title-link:hover .home-section__title {
+  color: var(--fg-primary);
+}
+
+.home-section__title {
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--fg-secondary);
+  transition: color var(--transition-fast);
+  margin: 0;
+  font-size: .7rem;
+  font-weight: 600;
+}
+
+.home-section__count {
+  margin-left: auto;
+}
+
+.home-section__list {
+  flex-direction: column;
+  gap: 1px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.home-row {
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  min-width: 0;
+  transition: background var(--transition-fast);
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  text-decoration: none;
+  display: flex;
+}
+
+.home-row:hover {
+  background: var(--bg-sunken);
+}
+
+.home-row__thumb {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  width: 22px;
+  height: 22px;
+  color: var(--fg-secondary);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  overflow: hidden;
+}
+
+.home-row__thumb img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.home-row__thumb-icon {
+  color: var(--fg-secondary);
+}
+
+.home-row__label {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  font-size: .85rem;
+  line-height: 1.25;
+  overflow: hidden;
+}
+
+.home-section__empty {
+  padding: 2px 8px;
+}
+
+.home-section__loading {
+  align-items: center;
+  padding: 6px 8px;
+  display: flex;
+}
+
+.home-section__more {
+  color: var(--fg-secondary);
+  border-radius: var(--radius);
+  transition: color var(--transition-fast), background var(--transition-fast);
+  align-self: flex-start;
+  align-items: center;
+  gap: 4px;
+  margin-top: 2px;
+  padding: 4px 8px;
+  font-size: .78rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.home-section__more:hover {
+  color: var(--fg-primary);
+  background: var(--bg-sunken);
+}
+
+.home__main {
+  width: 100%;
+  min-width: 0;
+  padding: 20px 24px 32px;
+}
+
+@media (max-width: 799px) {
+  .home__main {
+    padding: 16px;
+  }
+}
+
+.home__split {
+  grid-template-columns: minmax(0, 1fr) 320px;
+  align-items: start;
+  gap: 32px;
+  max-width: 1400px;
+  margin: 0 auto;
+  display: grid;
+}
+
+@media (max-width: 1199.98px) {
+  .home__split {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0;
+  }
+
+  .home__news {
+    display: none;
+  }
+}
+
+.home__feed {
+  min-width: 0;
+}
+
+.home-feed__header {
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 12px;
+  display: flex;
+}
+
+.home-feed__header-actions {
+  align-items: center;
+  gap: 4px;
+  display: flex;
+}
+
+.home-feed__heading {
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--fg-secondary);
+  margin: 0;
+  font-size: .7rem;
+  font-weight: 600;
+}
+
+.home__news {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  min-width: 0;
+  padding: 16px 18px 18px;
+}
+
+.home-feed {
+  border-top: 1px solid var(--border-subtle);
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.home-feed__item {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.home-feed__row {
+  color: var(--fg-primary);
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 12px;
+  padding: 12px 6px;
+  font-size: .875rem;
+  display: grid;
+}
+
+.home-feed__row:hover {
+  background: var(--bg-sunken);
+}
+
+.home-feed__avatar {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  margin-top: 1px;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.home-feed__content {
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  padding-top: 1px;
+  display: flex;
+}
+
+.home-feed__sentence {
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  min-width: 0;
+  margin: 0;
+  line-height: 1.35;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.home-feed__actor {
+  color: var(--fg-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.home-feed__actor:hover {
+  text-decoration: underline;
+}
+
+.home-feed__target {
+  color: var(--fg-primary);
+  border-bottom: 1px solid #0000;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.home-feed__target:hover {
+  border-bottom-color: var(--fg-primary);
+}
+
+.home-feed__time {
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-secondary);
+  white-space: nowrap;
+  padding-top: 2px;
+  font-size: .75rem;
+}
+
+.home-feed__group-toggle {
+  align-self: flex-start;
+}
+
+.home-feed__loading {
+  justify-content: center;
+  padding: 48px 0;
+  display: flex;
+}
+
+.home-feed__preview {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  color: inherit;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  grid-template-columns: 56px minmax(0, 1fr);
+  gap: 12px;
+  padding: 10px 12px;
+  text-decoration: none;
+  display: grid;
+}
+
+.home-feed__preview--no-image {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+a.home-feed__preview:hover {
+  border-color: var(--fg-secondary);
+  background: var(--bg-sunken);
+}
+
+.home-feed__preview-thumb {
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  width: 56px;
+  height: 56px;
+  color: var(--fg-secondary);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  overflow: hidden;
+}
+
+.home-feed__preview-thumb img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.home-feed__preview-thumb--placeholder {
+  color: var(--fg-secondary);
+}
+
+.home-feed__preview-body {
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.home-feed__preview-title-row {
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  display: flex;
+}
+
+.home-feed__preview-title {
+  color: var(--fg-primary);
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: .9rem;
+  font-weight: 600;
+  line-height: 1.3;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.home-feed__preview-desc {
+  color: var(--fg-secondary);
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: .8rem;
+  line-height: 1.4;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.home-feed__preview-meta {
+  color: var(--fg-muted);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 10px;
+  margin-top: 2px;
+  font-size: .72rem;
+  display: inline-flex;
+}
+
+.home-feed__preview-meta-item {
+  white-space: nowrap;
+  align-items: center;
+  gap: 4px;
+  display: inline-flex;
+}
+
+@media (max-width: 799px) {
+  .home-feed__row {
+    grid-template-columns: 32px minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .home-feed__time {
+    grid-column: 2 / 3;
+    align-self: start;
+    padding-top: 0;
+  }
+
+  .home-feed__sentence {
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+  }
+
+  .home-feed__preview {
+    grid-template-columns: 44px minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .home-feed__preview-thumb {
+    width: 44px;
+    height: 44px;
+  }
+}
+
+.home__loading {
+  justify-content: center;
+  align-items: center;
+  min-height: 50vh;
+  display: flex;
+}
+
+.home__signed-out {
+  max-width: 480px;
+  margin: 64px auto;
+  padding: 0 16px;
+}
+
+.home-feed__filter {
+  position: relative;
+}
+
+.home-feed__filter-btn {
+  border-radius: var(--radius);
+  width: 26px;
+  height: 26px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+  background: none;
+  border: 1px solid #0000;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
+}
+
+.home-feed__filter-btn:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.home-feed__filter-btn:focus-visible {
+  box-shadow: 0 0 0 2px var(--focus-ring);
+  outline: none;
+}
+
+.home-feed__filter-btn--active {
+  color: var(--fg-primary);
+  border-color: var(--border-medium);
+  background: var(--bg-sunken);
+}
+
+.home-feed__filter-pop {
+  z-index: var(--z-popover);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius);
+  min-width: 184px;
+  box-shadow: var(--shadow-md);
+  padding: 10px 8px 8px;
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+}
+
+.home-feed__filter-title {
+  color: var(--fg-secondary);
+  margin: 0 4px 6px;
+  font-size: .8125rem;
+  font-weight: 500;
+}
+
+.home-feed__filter-help {
+  color: var(--fg-secondary);
+  margin: 0 4px 8px;
+  font-size: .75rem;
+  line-height: 1.4;
+}
+
+.home-feed__filter-list {
+  flex-direction: column;
+  gap: 1px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.home-feed__filter-item {
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+  transition: background var(--transition-fast);
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  font-size: .8125rem;
+  display: flex;
+}
+
+.home-feed__filter-item:hover {
+  background: var(--bg-sunken);
+}
+
+.home-feed__filter-item input {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--fg-primary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.home-feed__filter-reset {
+  border: 0;
+  border-top: 1px solid var(--border-subtle);
+  text-align: left;
+  width: calc(100% - 8px);
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    color var(--transition-fast);
+  background: none;
+  border-radius: 0;
+  margin: 8px 4px 0;
+  padding: 6px 8px;
+  font-size: .78rem;
+  font-weight: 500;
+  display: block;
+}
+
+.home-feed__filter-reset:hover:not(:disabled) {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.home-feed__filter-reset:disabled {
+  color: var(--fg-muted);
+  cursor: default;
+}
+
+.home-feed__filter-pop--evaluators {
+  min-width: 248px;
+}
+
+.home-feed__evaluator-row {
+  border-radius: var(--radius);
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px 4px 8px;
+  display: flex;
+}
+
+.home-feed__evaluator-check {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--fg-primary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.home-feed__evaluator-link {
+  border-radius: var(--radius);
+  min-width: 0;
+  color: var(--fg-primary);
+  transition: background var(--transition-fast);
+  flex: 1;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  text-decoration: none;
+  display: flex;
+}
+
+.home-feed__evaluator-link:hover {
+  background: var(--bg-sunken);
+}
+
+.home-feed__evaluator-link:focus-visible {
+  box-shadow: 0 0 0 2px var(--focus-ring);
+  outline: none;
+}
+
+.home-feed__evaluator-name {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  font-size: .8125rem;
+  line-height: 1.3;
+  overflow: hidden;
+}
+
+.home-feed__load-more {
+  justify-content: center;
+  padding: 16px 0 32px;
+  display: flex;
+}
+
+.home-feed__load-more-btn {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: color var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
+  background: none;
+  padding: 8px 14px;
+  font-size: .8125rem;
+  font-weight: 500;
+}
+
+.home-feed__load-more-btn:hover {
+  color: var(--fg-primary);
+  background: var(--bg-sunken);
+  border-color: var(--border-hover);
+}
+
+.home-feed__load-more-btn:disabled {
+  cursor: default;
+  opacity: .6;
+}
+
+/* [project]/src/app/styles/site-drawer.css [app-client] (css) */
+.desktop-top-bar__menu {
+  border-radius: var(--radius);
+  width: 36px;
+  height: 36px;
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  background: none;
+  border: 0;
+  justify-content: center;
+  align-items: center;
+  margin-right: 4px;
+  display: inline-flex;
+}
+
+.desktop-top-bar__menu:hover {
+  background: var(--bg-sunken);
+}
+
+.site-drawer__head {
+  border-bottom: 1px solid var(--border-subtle);
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  display: flex;
+}
+
+.site-drawer__brand {
+  align-items: center;
+  text-decoration: none;
+  display: inline-flex;
+}
+
+.site-drawer__wordmark {
+  width: auto;
+  height: 24px;
+  display: block;
+}
+
+.site-drawer__close {
+  border-radius: var(--radius);
+  width: 36px;
+  height: 36px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: 0;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.site-drawer__close:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.site-drawer__nav {
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 8px;
+  display: flex;
+}
+
+.site-drawer__item {
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  text-align: left;
+  background: none;
+  border: 0;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  font-size: .95rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: flex;
+}
+
+.site-drawer__item:hover {
+  background: var(--bg-sunken);
+}
+
+.site-drawer__item--active {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.site-drawer__item--disabled {
+  color: var(--fg-muted);
+  cursor: not-allowed;
+}
+
+.site-drawer__item--disabled:hover {
+  background: none;
+}
+
+/* [project]/src/app/styles/profile-groups.css [app-client] (css) */
+.profile-groups {
+  flex-direction: column;
+  display: flex;
+}
+
+.profile-groups__toolbar {
+  border-bottom: 1px solid var(--border-subtle);
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+  display: flex;
+}
+
+.profile-groups__title {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 12px 4px;
+  font-size: .875rem;
+  font-weight: 600;
+  display: inline-flex;
+  position: relative;
+}
+
+.profile-groups__title:after {
+  content: "";
+  background: var(--fg-primary);
+  border-radius: var(--radius);
+  height: 2px;
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  right: 0;
+}
+
+.profile-groups__count {
+  color: var(--fg-muted);
+  background: var(--overlay-weak);
+  border-radius: 999px;
+  padding: 1px 7px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.profile-groups__controls {
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  padding-bottom: 8px;
+  display: inline-flex;
+}
+
+.profile-groups__search {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  height: 36px;
+  transition: border-color var(--transition-fast);
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  display: inline-flex;
+}
+
+.profile-groups__search:focus-within {
+  border-color: var(--fg-primary);
+}
+
+.profile-groups__search-icon {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+.profile-groups__search-input {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  background: none;
+  border: none;
+  outline: none;
+  width: 200px;
+  font-size: .875rem;
+}
+
+.profile-groups__search-input::placeholder {
+  color: var(--fg-muted);
+}
+
+.profile-groups__search-input::-webkit-search-cancel-button {
+  appearance: none;
+}
+
+.profile-groups__sort-wrap {
+  display: inline-flex;
+  position: relative;
+}
+
+.profile-groups__sort-btn {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  width: 36px;
+  height: 36px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.profile-groups__sort-btn:hover {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.profile-groups__sort-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.profile-groups__sort-menu {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  min-width: 180px;
+  box-shadow: var(--shadow-md);
+  z-index: 30;
+  padding: 4px;
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+}
+
+.profile-groups__sort-item {
+  border-radius: var(--radius);
+  width: 100%;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  background: none;
+  border: none;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  font-size: .875rem;
+  display: flex;
+}
+
+.profile-groups__sort-item:hover {
+  background: var(--overlay-weak);
+}
+
+.profile-groups__sort-item-check {
+  width: 14px;
+  height: 14px;
+  color: var(--fg-primary);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.profile-groups__loading {
+  justify-content: center;
+  padding: 48px 0;
+  display: flex;
+}
+
+.profile-groups__error {
+  border-radius: var(--radius);
+  background: var(--overlay-weak);
+  border: 1px solid var(--border-subtle);
+  color: var(--fg-primary);
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  font-size: .8125rem;
+}
+
+.profile-groups__subtabs {
+  gap: 0;
+  display: flex;
+}
+
+.profile-groups__subtab {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  white-space: nowrap;
+  background: none;
+  border: none;
+  align-items: center;
+  gap: 8px;
+  margin-right: 20px;
+  padding: 12px 4px;
+  font-size: .875rem;
+  font-weight: 500;
+  display: inline-flex;
+  position: relative;
+}
+
+.profile-groups__subtab:hover {
+  color: var(--fg-primary);
+}
+
+.profile-groups__subtab--active {
+  color: var(--fg-primary);
+  font-weight: 600;
+}
+
+.profile-groups__subtab--active:after {
+  content: "";
+  background: var(--fg-primary);
+  border-radius: var(--radius);
+  height: 2px;
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  right: 0;
+}
+
+.profile-groups__subtab:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 4px;
+  border-radius: 2px;
+}
+
+.profile-groups__subtab-count {
+  color: var(--fg-muted);
+  background: var(--overlay-weak);
+  border-radius: 999px;
+  padding: 1px 7px;
+  font-size: .75rem;
+  font-weight: 500;
+}
+
+.profile-groups__subtab--active .profile-groups__subtab-count {
+  color: var(--fg-primary);
+}
+
+.profile-groups__list {
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.profile-groups__item {
+  list-style: none;
+}
+
+.profile-groups__row {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  background: none;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  display: flex;
+}
+
+.profile-groups__row:hover {
+  background: var(--overlay-weak);
+  border-color: var(--border-hover-soft);
+}
+
+.profile-groups__row-link {
+  min-width: 0;
+  color: inherit;
+  flex: 1;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  display: flex;
+}
+
+.profile-groups__meta {
+  flex-direction: column;
+  flex: 1;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-groups__identity {
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  display: flex;
+}
+
+.profile-groups__name {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .9375rem;
+  font-weight: 600;
+  overflow: hidden;
+}
+
+.profile-groups__handle {
+  color: var(--fg-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: .8125rem;
+  overflow: hidden;
+}
+
+.profile-groups__description {
+  color: var(--fg-secondary);
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  margin: 0;
+  font-size: .8125rem;
+  line-height: 1.4;
+  display: -webkit-box;
+  overflow: hidden;
+}
+
+.profile-groups__joined {
+  color: var(--fg-muted);
+  margin-top: 2px;
+  font-size: .75rem;
+}
+
+.profile-groups__row-actions {
+  flex-shrink: 0;
+  align-items: center;
+  gap: 8px;
+  display: inline-flex;
+}
+
+.profile-groups__role {
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  background: var(--overlay-weak);
+  border-radius: 999px;
+  padding: 1px 6px;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.profile-groups__action-btn {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  height: 30px;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  font-size: .8125rem;
+  display: inline-flex;
+}
+
+.profile-groups__action-btn:hover:not(:disabled) {
+  background: var(--overlay-weak);
+  border-color: var(--border-hover-soft);
+}
+
+.profile-groups__action-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.profile-groups__action-btn:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+
+/* [project]/src/app/styles/smart-link.css [app-client] (css) */
+.smart-link__anchor {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* [project]/src/app/styles/settings-page.css [app-client] (css) */
+.sx {
+  padding: 0 0 64px;
+}
+
+.sx .sr-only {
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+}
+
+.app-shell:has(.sx) .app-shell__content {
+  padding: 0;
+}
+
+@media (min-width: 800px) {
+  .app-shell:has(.sx) .app-shell__content {
+    max-width: 1280px;
+  }
+}
+
+.sx__menu {
+  min-width: 0;
+  top: calc(var(--top-bar-total) + 16px);
+  max-height: calc(100vh - var(--top-bar-total) - 32px);
+  flex-direction: column;
+  gap: 16px;
+  padding: 0;
+  display: flex;
+  position: sticky;
+  overflow-y: auto;
+}
+
+@media (max-width: 799px) {
+  .sx__menu {
+    max-height: none;
+    position: static;
+    overflow: visible;
+  }
+}
+
+.sx-menu {
+  flex-direction: column;
+  gap: 1px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+}
+
+.sx-menu__item {
+  border-radius: var(--radius);
+  text-align: left;
+  width: 100%;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  color: var(--fg-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: 0;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  font-size: .85rem;
+  font-weight: 450;
+  line-height: 1.3;
+  text-decoration: none;
+  display: flex;
+}
+
+.sx-menu__item:hover, .sx-menu__item:focus-visible {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+  outline: none;
+}
+
+.sx-menu__item:focus-visible {
+  box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+.sx-menu__item--active, .sx-menu__item--active:hover, .sx-menu__item--active:focus-visible {
+  background: var(--fg-primary);
+  color: var(--bg-canvas);
+  font-weight: 500;
+}
+
+.sx-menu__icon {
+  width: 18px;
+  height: 18px;
+  color: var(--fg-muted);
+  transition: color var(--transition-fast);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.sx-menu__item:hover .sx-menu__icon {
+  color: var(--fg-primary);
+}
+
+.sx-menu__item--active .sx-menu__icon, .sx-menu__item--active:hover .sx-menu__icon {
+  color: var(--bg-canvas);
+}
+
+.sx-menu__label {
+  flex: auto;
+  min-width: 0;
+}
+
+.sx__panel {
+  gap: 48px;
+}
+
+.sx-section {
+  scroll-margin-top: calc(var(--top-bar-row1) + var(--top-bar-row2) + 24px);
+  border-radius: var(--radius);
+  transition: background var(--transition-fast), box-shadow var(--transition-fast);
+  flex-direction: column;
+  gap: 20px;
+  display: flex;
+}
+
+.sx-section--flash > .sx-panel__header, .sx-section--flash .sx-section__title, .sx-section--flash h2:first-child {
+  border-radius: var(--radius);
+  animation: 1.4s ease-out sx-section-flash-heading;
+}
+
+@keyframes sx-section-flash-heading {
+  0% {
+    background: var(--overlay-weak);
+  }
+
+  100% {
+    background: none;
+  }
+}
+
+.sx-panel__header {
+  border-bottom: 1px solid var(--border-subtle);
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 16px;
+  display: flex;
+}
+
+.sx-panel__title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  letter-spacing: -.01em;
+  color: var(--fg-primary);
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.sx-panel__desc {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: .875rem;
+  line-height: 1.55;
+}
+
+.sx-panel__body {
+  flex-direction: column;
+  gap: 16px;
+  display: flex;
+}
+
+.sx-panel__body .dash-card {
+  box-shadow: none;
+  background: none;
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sx-panel__body .dash-card__title, .sx-panel__body .email-section__header h2 {
+  display: none;
+}
+
+@media (max-width: 799px) {
+  .sx-panel__title {
+    font-size: 1.25rem;
+  }
+
+  .sx-menu__item {
+    padding: 10px;
+    font-size: .9375rem;
+  }
+}
+
+/* [project]/src/app/styles/leaflet.css [app-client] (css) */
+.leaflet-doc {
+  color: var(--fg-primary);
+  flex-direction: column;
+  gap: 12px;
+  display: flex;
+}
+
+.leaflet-doc__para {
+  color: var(--fg-secondary);
+  white-space: pre-wrap;
+  margin: 0;
+  font-size: .9375rem;
+  line-height: 1.6;
+}
+
+.leaflet-doc__heading {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  letter-spacing: -.01em;
+  color: var(--fg-primary);
+  margin: 8px 0 0;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.leaflet-doc__heading:first-child {
+  margin-top: 0;
+}
+
+h2.leaflet-doc__heading {
+  font-size: 1.25rem;
+}
+
+h3.leaflet-doc__heading {
+  font-size: 1.125rem;
+}
+
+h4.leaflet-doc__heading {
+  font-size: 1rem;
+}
+
+h5.leaflet-doc__heading, h6.leaflet-doc__heading {
+  font-size: .9375rem;
+}
+
+.leaflet-doc__list {
+  color: var(--fg-secondary);
+  margin: 0;
+  padding-left: 1.4em;
+  font-size: .9375rem;
+  line-height: 1.55;
+  list-style-position: outside;
+}
+
+ul.leaflet-doc__list {
+  list-style: outside;
+}
+
+ol.leaflet-doc__list {
+  list-style: decimal;
+}
+
+.leaflet-doc__list li + li, .leaflet-doc__list .leaflet-doc__list {
+  margin-top: 4px;
+}
+
+.leaflet-doc__link {
+  color: var(--fg-primary);
+  text-underline-offset: 2px;
+  text-decoration: underline;
+}
+
+.leaflet-doc__link:hover {
+  text-decoration-thickness: 2px;
+}
+
+.leaflet-doc__image {
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  display: flex;
+}
+
+.leaflet-doc__image img {
+  object-fit: contain;
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  width: 100%;
+  height: auto;
+  max-height: 520px;
+  display: block;
+}
+
+.leaflet-doc__image--full-bleed img {
+  border-radius: 0;
+  max-height: none;
+}
+
+.leaflet-doc__image-caption {
+  color: var(--fg-muted);
+  text-align: center;
+  font-size: .8125rem;
+}
+
+.leaflet-doc__image--placeholder {
+  border: 1.5px dashed var(--border-hover);
+  border-radius: var(--radius);
+  color: var(--fg-muted);
+  text-align: center;
+  padding: 24px;
+}
+
+.leaflet-doc__image--selected img {
+  outline: 2px solid var(--focus-ring, var(--fg-primary));
+  outline-offset: 2px;
+}
+
+.leaflet-doc__embed {
+  border-radius: var(--radius);
+  background: var(--media-letterbox);
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.leaflet-doc__embed iframe {
+  border: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.leaflet-doc__embed--selected {
+  outline: 2px solid var(--focus-ring, var(--fg-primary));
+  outline-offset: 2px;
+}
+
+.leaflet-doc__embed--unsupported {
+  background: var(--bg-sunken);
+  color: var(--fg-muted);
+  text-align: center;
+  word-break: break-all;
+  padding: 24px;
+}
+
+.leaflet-doc__embed-fallback {
+  word-break: break-all;
+  margin: 0;
+  font-size: .875rem;
+}
+
+.leaflet-editor {
+  flex-direction: column;
+  gap: 8px;
+  display: flex;
+}
+
+.leaflet-editor__toolbar {
+  flex-wrap: wrap;
+  gap: 2px;
+  width: fit-content;
+  display: inline-flex;
+}
+
+.leaflet-editor__btn {
+  width: 30px;
+  height: 30px;
+  color: var(--fg-secondary);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+}
+
+.leaflet-editor__btn:hover:not(:disabled) {
+  background: var(--overlay-weak);
+  color: var(--fg-primary);
+}
+
+.leaflet-editor__btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.leaflet-editor__btn--active, .leaflet-editor__btn--active:hover {
+  background: var(--fg-primary);
+  color: var(--btn-primary-fg, var(--color-white));
+}
+
+.leaflet-editor__btn:disabled {
+  opacity: .45;
+  cursor: not-allowed;
+}
+
+.leaflet-editor__content {
+  border: 1.5px solid var(--border-hover);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  min-height: 220px;
+  transition: border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+  padding: 14px 16px;
+}
+
+.leaflet-editor__content:focus-within {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+}
+
+.leaflet-editor__surface {
+  color: var(--fg-primary);
+  outline: none;
+  font-size: .9375rem;
+  line-height: 1.6;
+}
+
+.leaflet-editor__surface, .leaflet-editor__surface *, .leaflet-editor__surface :focus, .leaflet-editor__surface :focus-visible, .leaflet-editor__surface .ProseMirror-selectednode {
+  outline: 0 !important;
+}
+
+.leaflet-editor__surface > *, .leaflet-editor__surface > :focus, .leaflet-editor__surface > :focus-visible {
+  box-shadow: none !important;
+}
+
+.leaflet-editor__surface p {
+  min-height: 1.6em;
+  margin: 0;
+}
+
+.leaflet-editor__surface br.ProseMirror-trailingBreak {
+  width: 0;
+  height: 1em;
+  display: inline-block;
+}
+
+.leaflet-editor__surface > * + :not(h1):not(h2):not(h3) {
+  margin-top: 10px;
+}
+
+.leaflet-editor__surface h1, .leaflet-editor__surface h2, .leaflet-editor__surface h3 {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  letter-spacing: -.01em;
+  margin: 0;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.leaflet-editor__surface h1 {
+  font-size: 1.5rem;
+}
+
+.leaflet-editor__surface h2 {
+  font-size: 1.25rem;
+}
+
+.leaflet-editor__surface h3 {
+  font-size: 1.0625rem;
+}
+
+.leaflet-editor__surface > h1 {
+  margin-top: 24px;
+  margin-bottom: 6px;
+}
+
+.leaflet-editor__surface > h2 {
+  margin-top: 20px;
+  margin-bottom: 4px;
+}
+
+.leaflet-editor__surface > h3 {
+  margin-top: 16px;
+  margin-bottom: 4px;
+}
+
+.leaflet-editor__surface > h1:first-child, .leaflet-editor__surface > h2:first-child, .leaflet-editor__surface > h3:first-child {
+  margin-top: 0;
+}
+
+.leaflet-editor__surface ul, .leaflet-editor__surface ol {
+  margin: 0;
+  padding-left: 1.4em;
+}
+
+.leaflet-editor__surface ul {
+  list-style: outside;
+}
+
+.leaflet-editor__surface ol {
+  list-style: decimal;
+}
+
+.leaflet-editor__surface li + li {
+  margin-top: 4px;
+}
+
+.leaflet-editor__surface a {
+  color: var(--fg-primary);
+  text-underline-offset: 2px;
+  text-decoration: underline;
+}
+
+.leaflet-editor__surface .leaflet-doc__image, .leaflet-editor__surface .leaflet-doc__embed {
+  margin: 0;
+}
+
+.leaflet-editor__image-input {
+  display: none;
+}
+
+.leaflet-editor__error {
+  color: var(--color-error);
+  margin: 4px 0 0;
+  font-size: .75rem;
+}
+
+.leaflet-editor__surface p.is-editor-empty:first-child:before {
+  content: attr(data-placeholder);
+  color: var(--fg-muted);
+  pointer-events: none;
+  float: left;
+  height: 0;
+}
+
+.link-dialog__field {
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+  display: flex;
+}
+
+.link-dialog__label {
+  letter-spacing: .04em;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  font-size: .75rem;
+  font-weight: 600;
+}
+
+.link-dialog__input {
+  font: inherit;
+  color: var(--fg-primary);
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-hover);
+  border-radius: var(--radius);
+  width: 100%;
+  min-width: 0;
+  padding: 8px 12px;
+  font-size: .9375rem;
+}
+
+.link-dialog__input:focus {
+  border-color: var(--fg-primary);
+  box-shadow: 0 0 0 2px var(--overlay-weak);
+  outline: none;
+}
+
+.link-dialog__hint {
+  color: var(--fg-muted);
+  font-size: .75rem;
+  line-height: 1.4;
+}
+
+.link-dialog__error {
+  color: var(--color-error);
+  margin: 0;
+  font-size: .8125rem;
+  line-height: 1.4;
+}
+
+.link-dialog__actions {
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  display: flex;
+}
+
+.link-dialog__actions-right {
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  display: flex;
+}
+
+.profile-overview__more-link {
+  font: inherit;
+  color: var(--fg-primary);
+  text-underline-offset: 2px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  text-decoration: underline;
+  display: inline;
+}
+
+.profile-overview__more-link:hover {
+  text-decoration-thickness: 2px;
+}
+
+.profile-overview__more-link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius);
+}
+
+.profile-page__about {
+  flex-direction: column;
+  gap: 16px;
+  display: flex;
+}
+
+.profile-page__about-doc {
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.profile-page__about-doc .leaflet-doc__heading:first-child {
+  margin-top: 0;
+}
+
+.long-description-modal {
+  border-radius: var(--radius);
+  max-width: min(720px, 100% - 32px);
+}
+
+.long-description-modal__title-block {
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  display: flex;
+}
+
+.long-description-modal__subtitle {
+  color: var(--fg-muted);
+  font-size: .75rem;
+}
+
+.long-description-modal__body {
+  padding-top: 8px;
+}
+
+.long-description-modal__doc {
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.long-description-modal__doc .leaflet-doc__heading {
+  margin-top: 18px;
+}
+
+.long-description-modal__doc .leaflet-doc__heading:first-child {
+  margin-top: 0;
+}
+
+/* [project]/src/app/styles/landing.css [app-client] (css) */
+.hero {
+  background: var(--color-surface);
+  min-height: 920px;
+  padding: calc(var(--navbar-height) + 48px) 32px 48px;
+  align-items: center;
+  display: flex;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero__pattern {
+  z-index: 0;
+  opacity: .25;
+  pointer-events: none;
+  color: var(--color-navy);
+  position: absolute;
+  inset: 0;
+}
+
+.hero__pattern svg {
+  width: 100%;
+  height: 100%;
+}
+
+.hero__inner {
+  z-index: 1;
+  text-align: center;
+  width: 100%;
+  max-width: 1536px;
+  margin: 0 auto;
+  position: relative;
+}
+
+.hero__label {
+  letter-spacing: .2em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  margin-bottom: 24px;
+  font-size: .875rem;
+  font-weight: 500;
+  display: block;
+}
+
+.hero__title {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--color-navy);
+  letter-spacing: -.02em;
+  margin-bottom: 32px;
+  font-size: clamp(5rem, 7vw + 1rem, 7rem);
+  font-weight: 700;
+  line-height: .9;
+}
+
+.hero__title-accent {
+  font-family: var(--font-serif-alt), "Instrument Serif", serif;
+  font-style: italic;
+  font-weight: 400;
+}
+
+.hero__subtitle {
+  color: var(--color-dark-gray);
+  max-width: 640px;
+  margin-bottom: 48px;
+  margin-left: auto;
+  margin-right: auto;
+  font-size: clamp(1.125rem, 1.5vw + .5rem, 1.5rem);
+  font-weight: 400;
+  line-height: 1.6;
+}
+
+.hero__actions {
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 24px;
+  display: flex;
+}
+
+.hero__btn-signin {
+  cursor: pointer;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.hero__btn-signin:hover {
+  opacity: .9;
+}
+
+.hero__btn-signin:active {
+  transform: scale(.97);
+}
+
+.hero__btn-signin-img {
+  height: 48px;
+  display: block;
+}
+
+.hero__btn-icon {
+  border-radius: var(--radius);
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.hero-reveal {
+  opacity: 0;
+  animation: .5s cubic-bezier(.16, 1, .3, 1) forwards fadeUp;
+}
+
+.hero__inner > .hero-reveal:first-child {
+  animation-delay: 0s;
+}
+
+.hero__inner > .hero-reveal:nth-child(2) {
+  animation-delay: .1s;
+}
+
+.hero__inner > .hero-reveal:nth-child(3) {
+  animation-delay: .2s;
+}
+
+.hero__inner > .hero__label {
+  animation: .5s cubic-bezier(.16, 1, .3, 1) forwards fadeUp;
+}
+
+.hero__inner > .hero__title {
+  opacity: 0;
+  animation: .5s cubic-bezier(.16, 1, .3, 1) 50ms forwards fadeUp;
+}
+
+.hero__inner > .hero__subtitle {
+  opacity: 0;
+  animation: .5s cubic-bezier(.16, 1, .3, 1) .15s forwards fadeUp;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-reveal, .hero__inner > .hero__label, .hero__inner > .hero__title, .hero__inner > .hero__subtitle {
+    opacity: 1;
+    animation: none;
+    transform: none;
+  }
+}
+
+.hero--landing {
+  min-height: 100vh;
+}
+
+@media (max-width: 799px) {
+  .hero {
+    padding: calc(var(--navbar-height) + 32px) 20px 32px;
+    min-height: auto;
+  }
+
+  .hero--landing {
+    min-height: 100vh;
+  }
+}
+
+.landing-footer {
+  background: var(--color-surface-container-low);
+  padding: 24px 32px;
+}
+
+.landing-footer__bar {
+  justify-content: space-between;
+  align-items: flex-end;
+  max-width: 1536px;
+  margin: 0 auto;
+  display: flex;
+}
+
+.landing-footer__left {
+  flex-direction: column;
+  gap: 16px;
+  display: flex;
+}
+
+.landing-footer__logo-img {
+  object-fit: contain;
+  object-position: left;
+  width: auto;
+  height: 18px;
+  display: block;
+}
+
+.landing-footer__copy {
+  color: var(--color-mid-gray);
+  font-size: .6875rem;
+}
+
+.landing-footer__links {
+  gap: 0;
+  display: flex;
+}
+
+.landing-footer__links a + a {
+  border-left: 1px solid var(--color-light-gray);
+  margin-left: 16px;
+  padding-left: 16px;
+}
+
+.landing-footer__links a {
+  color: var(--color-mid-gray);
+  transition: color var(--transition-fast);
+  font-size: .6875rem;
+  text-decoration: none;
+}
+
+.landing-footer__links a:hover {
+  color: var(--color-navy);
+}
+
+@media (max-width: 799px) {
+  .landing-footer {
+    padding: 24px 20px;
+  }
+
+  .landing-footer__bar {
+    flex-direction: column;
+    align-items: center;
+    gap: 0;
+  }
+
+  .landing-footer__left {
+    text-align: center;
+    align-items: center;
+    margin-bottom: 12px;
+  }
+
+  .landing-footer__links {
+    margin-top: 4px;
+  }
+}
+
+.signin-modal__backdrop {
+  z-index: 100;
+  background: var(--navy-overlay-70);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  justify-content: center;
+  align-items: center;
+  animation: .2s ease-out modalFadeIn;
+  display: flex;
+  position: fixed;
+  inset: 0;
+}
+
+.signin-modal {
+  background: var(--color-off-white);
+  border-radius: var(--radius);
+  width: 90vw;
+  max-width: 420px;
+  box-shadow: 0 24px 64px var(--navy-overlay-30);
+  border: 1px solid var(--border-default);
+  flex-direction: column;
+  animation: .3s cubic-bezier(.16, 1, .3, 1) modalSlideUp;
+  display: flex;
+  overflow: hidden;
+}
+
+.signin-modal__header {
+  border-bottom: 1px solid var(--color-light-gray);
+  flex-shrink: 0;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 24px;
+  display: flex;
+}
+
+.signin-modal__logo {
+  width: 22px;
+  height: 22px;
+}
+
+.signin-modal__title {
+  color: var(--color-navy);
+  letter-spacing: .02em;
+  flex: 1;
+  font-size: .8125rem;
+  font-weight: 600;
+}
+
+.signin-modal__close {
+  width: 32px;
+  height: 32px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: 0;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  display: inline-flex;
+}
+
+.signin-modal__close:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.signin-modal__close:focus-visible {
+  box-shadow: 0 0 0 2px var(--focus-ring, var(--fg-primary));
+  outline: none;
+}
+
+.signin-modal__close:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.signin-modal__body {
+  padding: 24px;
+}
+
+.signin-modal__form {
+  flex-direction: column;
+  display: flex;
+}
+
+.signin-modal__label {
+  letter-spacing: .06em;
+  color: var(--color-mid-gray);
+  margin-bottom: 8px;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.signin-modal__input {
+  border: 1.5px solid var(--color-light-gray);
+  border-radius: var(--radius);
+  width: 100%;
+  height: 48px;
+  color: var(--color-navy);
+  background: var(--color-off-white);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  outline: none;
+  padding: 0 16px;
+  font-size: 1rem;
+}
+
+.signin-modal__input::placeholder {
+  color: var(--color-mid-gray);
+}
+
+.signin-modal__input:focus {
+  border-color: var(--color-focus-green);
+  box-shadow: 0 0 0 3px #94bb5126;
+}
+
+.signin-modal__input:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+
+.signin-modal__error {
+  color: var(--color-error);
+  margin-top: 8px;
+  margin-bottom: 0;
+  font-size: .8125rem;
+  line-height: 1.4;
+}
+
+.signin-modal__submit {
+  border-radius: var(--radius);
+  width: 100%;
+  height: 48px;
+  color: var(--color-off-white);
+  background: var(--color-navy);
+  cursor: pointer;
+  transition: background var(--transition-fast), opacity var(--transition-fast);
+  border: none;
+  margin-top: 16px;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.signin-modal__submit:hover:not(:disabled) {
+  opacity: .9;
+}
+
+.signin-modal__submit:focus-visible {
+  outline: 2px solid var(--color-navy);
+  outline-offset: 2px;
+}
+
+.signin-modal__submit:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.signin-modal__switch {
+  text-align: center;
+  margin-top: 20px;
+}
+
+.signin-modal__switch-btn {
+  color: var(--color-mid-gray);
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: color var(--transition-fast);
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  font-size: .8125rem;
+}
+
+.signin-modal__switch-btn:hover {
+  color: var(--color-accent);
+}
+
+.signin-modal__switch-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+@keyframes modalFadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes modalSlideUp {
+  from {
+    opacity: 0;
+    transform: translateY(16px)scale(.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .signin-modal__backdrop, .signin-modal {
+    animation: none;
+  }
+}
+
+@media (max-width: 799px) {
+  .signin-modal {
+    border-radius: 0;
+    width: 100%;
+    max-width: none;
+    min-height: auto;
+  }
+}
+
+.feedback-trigger {
+  z-index: calc(var(--z-skip-nav) - 1);
+  background: var(--color-navy);
+  color: var(--color-off-white);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast), box-shadow var(--transition-fast), bottom .15s ease-out;
+  border: none;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  font-size: .8125rem;
+  font-weight: 500;
+  display: flex;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  box-shadow: 0 2px 12px #00000026;
+}
+
+.feedback-trigger:hover {
+  background: var(--color-accent);
+  box-shadow: 0 4px 16px #0003;
+}
+
+.feedback-modal__backdrop {
+  z-index: var(--z-feedback);
+  background: var(--navy-overlay-70);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  justify-content: flex-end;
+  align-items: flex-end;
+  padding: 20px;
+  animation: .2s ease-out modalFadeIn;
+  display: flex;
+  position: fixed;
+  inset: 0;
+}
+
+.feedback-modal {
+  background: var(--color-off-white);
+  border-radius: var(--radius);
+  width: 420px;
+  max-width: 90vw;
+  max-height: calc(100vh - 40px);
+  box-shadow: 0 24px 64px var(--navy-overlay-30);
+  border: 1px solid var(--border-default);
+  animation: .3s cubic-bezier(.16, 1, .3, 1) modalSlideUp;
+  overflow-y: auto;
+}
+
+.feedback-modal--expanded {
+  width: 640px;
+}
+
+.feedback-modal--expanded .feedback-modal__textarea {
+  min-height: 400px;
+}
+
+.feedback-modal__header {
+  border-bottom: 1px solid var(--color-gray-100);
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  display: flex;
+}
+
+.feedback-modal__expand {
+  border-radius: var(--radius);
+  width: 28px;
+  height: 28px;
+  color: var(--color-mid-gray);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  margin-right: 8px;
+  display: flex;
+}
+
+.feedback-modal__expand:hover {
+  background: var(--color-gray-100);
+  color: var(--color-navy);
+}
+
+.feedback-modal__title {
+  color: var(--color-navy);
+  font-size: .875rem;
+  font-weight: 600;
+}
+
+.feedback-modal__close {
+  border-radius: var(--radius);
+  width: 32px;
+  height: 32px;
+  color: var(--color-mid-gray);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.feedback-modal__close:hover {
+  background: var(--color-gray-100);
+  color: var(--color-navy);
+}
+
+.feedback-modal__body {
+  padding: 24px;
+}
+
+.feedback-modal__label {
+  color: var(--color-dark-gray);
+  margin-bottom: 8px;
+  font-size: .8125rem;
+  line-height: 1.4;
+  display: block;
+}
+
+.feedback-modal__label--email {
+  margin-top: 16px;
+}
+
+.feedback-modal__error {
+  color: var(--color-error);
+  margin-top: 4px;
+  font-size: .75rem;
+}
+
+.feedback-modal__submit {
+  background: var(--color-navy);
+  width: 100%;
+  height: 44px;
+  color: var(--color-off-white);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  border: none;
+  margin-top: 20px;
+  font-size: .875rem;
+  font-weight: 500;
+}
+
+.feedback-modal__submit:hover:not(:disabled) {
+  background: var(--color-accent);
+}
+
+.feedback-modal__submit:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.feedback-modal__success {
+  text-align: center;
+  padding: 20px 0;
+}
+
+.feedback-modal__success p {
+  color: var(--color-navy);
+  margin-bottom: 16px;
+  font-size: .9375rem;
+  font-weight: 500;
+}
+
+.feedback-modal__done {
+  background: var(--color-navy);
+  color: var(--color-off-white);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  border: none;
+  padding: 8px 24px;
+  font-size: .875rem;
+  font-weight: 500;
+}
+
+.feedback-modal__done:hover {
+  background: var(--color-accent);
+}
+
+.feedback-modal__success-actions {
+  justify-content: center;
+  gap: 10px;
+  display: flex;
+}
+
+.feedback-modal__more {
+  color: var(--color-navy);
+  border: 1px solid var(--color-light-gray);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  background: none;
+  padding: 8px 24px;
+  font-size: .875rem;
+  font-weight: 500;
+}
+
+.feedback-modal__more:hover {
+  background: var(--color-off-white);
+  border-color: var(--color-mid-gray);
+}
+
+.feedback-bottom-sheet__backdrop, .feedback-bottom-sheet {
+  display: none;
+}
+
+@media (max-width: 799px) {
+  .feedback-trigger {
+    padding: 8px 12px;
+    font-size: .75rem;
+    bottom: 16px;
+    right: 16px;
+  }
+
+  .feedback-modal__backdrop--desktop {
+    display: none;
+  }
+
+  .feedback-bottom-sheet__backdrop {
+    z-index: var(--z-feedback);
+    display: block;
+  }
+
+  .feedback-bottom-sheet {
+    z-index: var(--z-feedback-above);
+    display: flex;
+  }
+
+  .feedback-bottom-sheet .feedback-modal__textarea {
+    resize: none;
+    min-height: 80px;
+    font-size: 16px;
+  }
+
+  .feedback-bottom-sheet.bottom-sheet--expanded .feedback-modal__textarea {
+    min-height: 120px;
+  }
+
+  .feedback-bottom-sheet .feedback-modal__input {
+    font-size: 16px;
+  }
+
+  .feedback-bottom-sheet .feedback-modal__body {
+    padding: 16px 20px;
+  }
+
+  .feedback-modal__expand {
+    display: none;
+  }
+}
+
+.app-page {
+  padding-top: var(--navbar-height);
+  background: var(--color-off-white);
+  min-height: 100vh;
+}
+
+.app-page__inner {
+  max-width: 1024px;
+  margin: 0 auto;
+  padding: 32px 24px;
+}
+
+.app-card {
+  background: var(--color-off-white);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  transition: border-color var(--transition-fast);
+  padding: 24px;
+}
+
+.app-card:hover {
+  border-color: var(--border-hover-soft);
+}
+
+.app-card__label {
+  letter-spacing: .08em;
+  color: var(--color-mid-gray);
+  margin-bottom: 8px;
+  font-size: .6875rem;
+  font-weight: 600;
+}
+
+.footer {
+  border-top: 1px solid var(--border-subtle);
+  background: var(--color-off-white);
+  padding: 24px 0;
+}
+
+.footer__inner {
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 24px;
+  display: flex;
+}
+
+.footer__copy {
+  color: var(--color-mid-gray);
+  font-size: .6875rem;
+}
+
+.footer__links {
+  gap: 20px;
+  display: flex;
+}
+
+.footer__links a {
+  color: var(--color-mid-gray);
+  transition: color var(--transition-fast);
+  font-size: .6875rem;
+  text-decoration: none;
+}
+
+.footer__links a:hover {
+  color: var(--color-navy);
+}
+
+.landing-cta {
+  text-align: center;
+  padding: 96px 32px;
+}
+
+.landing-cta .landing-label {
+  justify-content: center;
+}
+
+.landing-cta h2 {
+  margin-bottom: 16px;
+}
+
+.landing-cta > p {
+  color: var(--color-mid-gray);
+  max-width: 480px;
+  margin-bottom: 40px;
+  margin-left: auto;
+  margin-right: auto;
+  font-size: 1.125rem;
+}
+
+.landing-cta__actions {
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+  display: flex;
+}
+
+.landing-cta__btn {
+  color: var(--color-off-white);
+  background: var(--color-navy);
+  cursor: pointer;
+  border: none;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 40px;
+  font-size: 1.125rem;
+  font-weight: 500;
+  transition: all .2s;
+  display: inline-flex;
+}
+
+.landing-cta__btn:hover {
+  opacity: .9;
+}
+
+.landing-cta__btn:active {
+  transform: scale(.97);
+}
+
+.landing-cta__arrow {
+  font-size: 1.25rem;
+}
+
+.landing-network {
+  background: var(--color-surface-container-high);
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  margin-top: 32px;
+  margin-bottom: 24px;
+  display: grid;
+}
+
+.landing-network__cell {
+  background: var(--color-off-white);
+  transition: background var(--transition-fast);
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  padding: 40px 24px;
+  text-decoration: none;
+  display: flex;
+}
+
+.landing-network__cell:hover {
+  background: var(--color-surface-container-low);
+}
+
+.landing-network__logo {
+  object-fit: cover;
+  filter: grayscale();
+  opacity: .7;
+  width: 40px;
+  height: 40px;
+  transition: all var(--transition-fast);
+  border-radius: 50%;
+}
+
+.landing-network__cell:hover .landing-network__logo {
+  filter: grayscale(0%);
+  opacity: 1;
+}
+
+.landing-network__name {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--color-outline-variant);
+  transition: color var(--transition-fast);
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.landing-network__cell:hover .landing-network__name {
+  color: var(--color-navy);
+}
+
+.landing-network__desc {
+  color: var(--color-mid-gray);
+  text-align: center;
+  opacity: 0;
+  max-width: 180px;
+  transition: opacity var(--transition-fast);
+  font-size: .75rem;
+  line-height: 1.4;
+}
+
+.landing-network__cell:hover .landing-network__desc {
+  opacity: 1;
+}
+
+@media (max-width: 799px) {
+  .landing-network {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.landing-footnote {
+  color: var(--color-mid-gray);
+  margin-top: 8px;
+  font-size: .75rem;
+}
+
+.landing-footnote--center {
+  text-align: center;
+}
+
+.landing-prose {
+  color: var(--color-mid-gray);
+  max-width: 640px;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.landing-section {
+  padding: 96px 32px;
+}
+
+.landing-section--light {
+  background: var(--color-off-white);
+  color: var(--color-dark-gray);
+}
+
+.landing-section--light h2 {
+  color: var(--color-navy);
+}
+
+.landing-section--dark {
+  background: var(--color-navy);
+  color: var(--color-off-white);
+}
+
+.landing-section--dark h2 {
+  color: var(--color-off-white);
+}
+
+.landing-section--subtle {
+  background: var(--color-surface-container-low);
+  color: var(--color-dark-gray);
+}
+
+.landing-section--subtle h2 {
+  color: var(--color-navy);
+}
+
+.landing-section--gray {
+  background: var(--color-gray-100);
+  color: var(--color-dark-gray);
+}
+
+.landing-section--gray h2 {
+  color: var(--color-navy);
+}
+
+.landing-section__inner {
+  max-width: 1536px;
+  margin: 0 auto;
+}
+
+.landing-section h2 {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  letter-spacing: -.02em;
+  margin-bottom: 32px;
+  font-size: clamp(2rem, 3vw + .5rem, 3rem);
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.landing-section__header {
+  margin-bottom: 40px;
+}
+
+.landing-section__header--center {
+  text-align: center;
+}
+
+.landing-section__header--center .landing-label {
+  justify-content: center;
+}
+
+.landing-section--pattern {
+  position: relative;
+  overflow: hidden;
+}
+
+.landing-section__pattern {
+  z-index: 0;
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+}
+
+.landing-section__pattern--light {
+  color: #ffffff26;
+}
+
+.landing-section__pattern--dark {
+  color: #0000001f;
+}
+
+.landing-section--pattern .landing-section__inner {
+  z-index: 1;
+  position: relative;
+}
+
+.landing-label {
+  letter-spacing: .2em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  align-items: center;
+  margin-bottom: 12px;
+  font-size: .6875rem;
+  font-weight: 500;
+  display: flex;
+}
+
+.landing-label--light {
+  color: #ffffff80;
+}
+
+@media (max-width: 799px) {
+  .landing-section {
+    padding: 64px 20px;
+  }
+}
+
+.landing-bento {
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
+  display: grid;
+}
+
+@media (max-width: 799px) {
+  .landing-bento {
+    grid-template-columns: 1fr;
+  }
+}
+
+.landing-bento__card {
+  background: var(--color-off-white);
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 200px;
+  padding: 32px;
+  transition: box-shadow .5s;
+  display: flex;
+}
+
+.landing-bento__card:hover {
+  box-shadow: 0 20px 60px #0000000f;
+}
+
+.landing-bento__card--highlight {
+  background: var(--color-navy);
+  color: var(--color-off-white);
+}
+
+.landing-bento__card--highlight h3 {
+  color: var(--color-off-white);
+}
+
+.landing-bento__card--highlight p {
+  color: #ffffffb3;
+}
+
+.landing-bento__card--highlight .landing-bento__icon {
+  color: var(--color-off-white);
+}
+
+.landing-bento__icon {
+  color: var(--color-navy);
+  margin-bottom: 24px;
+}
+
+.landing-bento__card h3 {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--color-navy);
+  margin-bottom: 12px;
+  font-size: 1.375rem;
+  font-weight: 700;
+}
+
+.landing-bento__card p {
+  color: var(--color-mid-gray);
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.landing-faq {
+  flex-direction: column;
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+}
+
+.landing-faq-item {
+  border-bottom: 1px solid var(--color-light-gray);
+}
+
+.landing-faq-item:first-child {
+  border-top: 1px solid var(--color-light-gray);
+}
+
+.landing-faq-btn {
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  color: var(--color-navy);
+  transition: color var(--transition-fast);
+  background: none;
+  border: none;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 0;
+  font-family: inherit;
+  font-size: 1.0625rem;
+  font-weight: 500;
+  display: flex;
+}
+
+.landing-faq-btn:hover {
+  color: var(--color-mid-gray);
+}
+
+.landing-faq-btn:focus-visible {
+  outline: 2px solid var(--color-navy);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.landing-faq-icon {
+  width: 18px;
+  height: 18px;
+  color: var(--color-mid-gray);
+  transition: transform var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.landing-faq-icon--open {
+  transform: rotate(45deg);
+}
+
+.landing-faq-answer {
+  max-height: 0;
+  transition: max-height var(--transition-base);
+  overflow: hidden;
+}
+
+.landing-faq-answer--open {
+  max-height: 300px;
+}
+
+.landing-faq-answer p {
+  color: var(--color-mid-gray);
+  margin: 0;
+  padding: 0 0 24px;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.landing-section__header--center .landing-protocol__intro {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.landing-protocol__intro {
+  color: var(--color-mid-gray);
+  margin-bottom: 40px;
+  font-size: 1.125rem;
+  line-height: 1.6;
+}
+
+.landing-protocol__steps {
+  flex-direction: column;
+  gap: 32px;
+  max-width: 560px;
+  margin: 0 auto;
+  display: flex;
+}
+
+.landing-protocol__step {
+  align-items: flex-start;
+  gap: 24px;
+  display: flex;
+}
+
+.landing-protocol__num {
+  font-family: var(--font-serif-alt), "Instrument Serif", serif;
+  color: var(--color-outline-variant);
+  transition: color var(--transition-fast);
+  flex-shrink: 0;
+  font-size: 2.25rem;
+  font-style: italic;
+  line-height: 1;
+}
+
+.landing-protocol__step:hover .landing-protocol__num {
+  color: var(--color-navy);
+}
+
+.landing-protocol__step h4 {
+  color: var(--color-navy);
+  margin-bottom: 4px;
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.landing-protocol__step p {
+  color: var(--color-mid-gray);
+  margin: 0;
+  font-size: .9375rem;
+  line-height: 1.6;
+}
+
+.landing-protocol__visual {
+  position: relative;
+}
+
+.landing-protocol__card {
+  background: var(--color-off-white);
+  z-index: 1;
+  aspect-ratio: 4 / 5;
+  border: 1px solid var(--color-surface-container-high);
+  justify-content: center;
+  align-items: center;
+  padding: 8px;
+  display: flex;
+  position: relative;
+  transform: rotate(2deg);
+  box-shadow: 0 25px 80px #00000014;
+}
+
+.landing-protocol__card-inner {
+  border: 12px solid var(--color-surface-container-low);
+  flex-direction: column;
+  justify-content: space-between;
+  width: 100%;
+  height: 100%;
+  padding: 40px;
+  display: flex;
+}
+
+.landing-protocol__card-header {
+  border-bottom: 2px solid var(--color-navy);
+  justify-content: space-between;
+  align-items: flex-start;
+  padding-bottom: 24px;
+  display: flex;
+}
+
+.landing-protocol__card-logo {
+  font-family: var(--font-serif-alt), "Instrument Serif", serif;
+  color: var(--color-navy);
+  font-size: 1.75rem;
+  font-style: italic;
+}
+
+.landing-protocol__card-ref {
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  text-align: right;
+  color: var(--color-mid-gray);
+  font-family: monospace;
+  font-size: .5625rem;
+  line-height: 1.4;
+}
+
+.landing-protocol__card-body {
+  padding: 32px 0;
+}
+
+.landing-protocol__card-line {
+  background: var(--color-surface-container-high);
+  height: 3px;
+  margin-bottom: 12px;
+}
+
+.landing-protocol__card-seal {
+  justify-content: center;
+  padding: 24px 0;
+  display: flex;
+}
+
+.landing-protocol__card-footer {
+  justify-content: space-between;
+  align-items: flex-end;
+  display: flex;
+}
+
+.landing-protocol__card-sig-label {
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--color-mid-gray);
+  margin-bottom: 4px;
+  font-size: .5rem;
+}
+
+.landing-protocol__card-sig {
+  font-family: var(--font-serif-alt), "Instrument Serif", serif;
+  color: var(--color-navy);
+  font-size: 1.25rem;
+  font-style: italic;
+}
+
+.landing-protocol__card-qr {
+  background: var(--color-navy);
+  width: 56px;
+  height: 56px;
+  color: var(--color-off-white);
+  border-radius: 50%;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.landing-protocol__dots {
+  z-index: 0;
+  background-image: radial-gradient(circle at 2px 2px, var(--color-outline-variant) 1px, transparent 0);
+  opacity: .3;
+  background-size: 40px 40px;
+  width: 120%;
+  height: 120%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+@media (max-width: 799px) {
+  .landing-protocol__card-inner {
+    border-width: 8px;
+    padding: 24px;
+  }
+
+  .landing-protocol__card {
+    aspect-ratio: auto;
+    min-height: 400px;
+  }
+}
+
+.landing-reassurance {
+  text-align: center;
+  color: var(--color-mid-gray);
+  margin-top: 16px;
+  font-size: .875rem;
+}
+
+.landing-trust {
+  grid-template-columns: repeat(3, 1fr);
+  gap: 32px;
+  max-width: 1200px;
+  display: grid;
+}
+
+@media (max-width: 799px) {
+  .landing-trust {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+}
+
+.landing-trust__item {
+  align-items: flex-start;
+  gap: 16px;
+  display: flex;
+}
+
+.landing-trust__check {
+  color: #fff6;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+  display: flex;
+}
+
+.landing-trust__item h4 {
+  color: var(--color-off-white);
+  margin-bottom: 6px;
+  font-size: 1.0625rem;
+  font-weight: 600;
+}
+
+.landing-trust__item p {
+  color: #ffffff80;
+  margin: 0;
+  font-size: .9375rem;
+  line-height: 1.6;
+}
+
+.network-stats__grid {
+  grid-template-columns: 1fr;
+  gap: 12px;
+  margin: 32px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+}
+
+@media (min-width: 600px) {
+  .network-stats__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 900px) {
+  .network-stats__grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
+
+.network-stats__tile {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  min-width: 0;
+  padding: 24px 20px;
+  display: flex;
+  position: relative;
+}
+
+.network-stats__value-row {
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  display: inline-flex;
+}
+
+.network-stats__value {
+  font-family: var(--font-headline), "Noto Serif", serif;
+  color: var(--fg-primary);
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.05;
+}
+
+@media (min-width: 900px) {
+  .network-stats__value {
+    font-size: 2.25rem;
+  }
+}
+
+.network-stats__value[data-loading="true"] {
+  color: var(--fg-muted);
+}
+
+.network-stats__label {
+  color: var(--fg-secondary);
+  letter-spacing: .01em;
+  font-size: .875rem;
+}
+
+.network-stats__new {
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  height: 18px;
+  color: var(--bg-canvas, #fff);
+  background: var(--color-success, #2c8a3e);
+  border-radius: 999px;
+  align-items: center;
+  padding: 0 8px;
+  font-size: .625rem;
+  font-weight: 700;
+  display: inline-flex;
+  transform: translateY(-2px);
+}
+
+.welcome-footer {
+  background: var(--color-off-white);
+  padding: 0;
+}
+
+/* [project]/src/app/globals.css [app-client] (css) */
+*, :before, :after, ::backdrop {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: #3b82f680;
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+*, :before, :after {
+  box-sizing: border-box;
+  border: 0 solid #e5e7eb;
+}
+
+:before, :after {
+  --tw-content: "";
+}
+
+html, :host {
+  -webkit-text-size-adjust: 100%;
+  tab-size: 4;
+  font-feature-settings: normal;
+  font-variation-settings: normal;
+  -webkit-tap-highlight-color: transparent;
+  font-family: Inter, system-ui, -apple-system, sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  line-height: inherit;
+  margin: 0;
+}
+
+hr {
+  height: 0;
+  color: inherit;
+  border-top-width: 1px;
+}
+
+abbr:where([title]) {
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+a {
+  color: inherit;
+  -webkit-text-decoration: inherit;
+  text-decoration: inherit;
+}
+
+b, strong {
+  font-weight: bolder;
+}
+
+code, kbd, samp, pre {
+  font-feature-settings: normal;
+  font-variation-settings: normal;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 1em;
+}
+
+small {
+  font-size: 80%;
+}
+
+sub, sup {
+  vertical-align: baseline;
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+}
+
+sub {
+  bottom: -.25em;
+}
+
+sup {
+  top: -.5em;
+}
+
+table {
+  text-indent: 0;
+  border-color: inherit;
+  border-collapse: collapse;
+}
+
+button, input, optgroup, select, textarea {
+  font-feature-settings: inherit;
+  font-variation-settings: inherit;
+  font-family: inherit;
+  font-size: 100%;
+  font-weight: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+  margin: 0;
+  padding: 0;
+}
+
+button, select {
+  text-transform: none;
+}
+
+button, input:where([type="button"]), input:where([type="reset"]), input:where([type="submit"]) {
+  -webkit-appearance: button;
+  background-color: #0000;
+  background-image: none;
+}
+
+:-moz-focusring {
+  outline: auto;
+}
+
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+
+progress {
+  vertical-align: baseline;
+}
+
+::-webkit-inner-spin-button {
+  height: auto;
+}
+
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+[type="search"] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+summary {
+  display: list-item;
+}
+
+blockquote, dl, dd, h1, h2, h3, h4, h5, h6, hr, figure, p, pre {
+  margin: 0;
+}
+
+fieldset {
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  padding: 0;
+}
+
+ol, ul, menu {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+dialog {
+  padding: 0;
+}
+
+textarea {
+  resize: vertical;
+}
+
+input::placeholder, textarea::placeholder {
+  opacity: 1;
+  color: #9ca3af;
+}
+
+button, [role="button"] {
+  cursor: pointer;
+}
+
+:disabled {
+  cursor: default;
+}
+
+img, svg, video, canvas, audio, iframe, embed, object {
+  vertical-align: middle;
+  display: block;
+}
+
+img, video {
+  max-width: 100%;
+  height: auto;
+}
+
+[hidden]:where(:not([hidden="until-found"])) {
+  display: none;
+}
+
+.container {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+
+.sr-only {
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+}
+
+.pointer-events-none {
+  pointer-events: none;
+}
+
+.pointer-events-auto {
+  pointer-events: auto;
+}
+
+.visible {
+  visibility: visible;
+}
+
+.invisible {
+  visibility: hidden;
+}
+
+.collapse {
+  visibility: collapse;
+}
+
+.static {
+  position: static;
+}
+
+.fixed {
+  position: fixed;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.relative {
+  position: relative;
+}
+
+.sticky {
+  position: sticky;
+}
+
+.inset-0 {
+  inset: 0;
+}
+
+.inset-x-0 {
+  left: 0;
+  right: 0;
+}
+
+.bottom-0 {
+  bottom: 0;
+}
+
+.left-0 {
+  left: 0;
+}
+
+.left-1\/2 {
+  left: 50%;
+}
+
+.left-3 {
+  left: .75rem;
+}
+
+.left-4 {
+  left: 1rem;
+}
+
+.left-5 {
+  left: 1.25rem;
+}
+
+.right-0 {
+  right: 0;
+}
+
+.right-3 {
+  right: .75rem;
+}
+
+.right-4 {
+  right: 1rem;
+}
+
+.right-5 {
+  right: 1.25rem;
+}
+
+.top-0 {
+  top: 0;
+}
+
+.top-1\/2 {
+  top: 50%;
+}
+
+.top-full {
+  top: 100%;
+}
+
+.z-\[1\] {
+  z-index: 1;
+}
+
+.z-\[var\(--z-feedback\)\] {
+  z-index: var(--z-feedback);
+}
+
+.z-\[var\(--z-popover\)\] {
+  z-index: var(--z-popover);
+}
+
+.z-\[var\(--z-portal-sheet\)\] {
+  z-index: var(--z-portal-sheet);
+}
+
+.m-0 {
+  margin: 0;
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.-mr-1 {
+  margin-right: -.25rem;
+}
+
+.-mt-1 {
+  margin-top: -.25rem;
+}
+
+.mb-1 {
+  margin-bottom: .25rem;
+}
+
+.mb-1\.5 {
+  margin-bottom: .375rem;
+}
+
+.mb-2 {
+  margin-bottom: .5rem;
+}
+
+.mb-3 {
+  margin-bottom: .75rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.mb-5 {
+  margin-bottom: 1.25rem;
+}
+
+.mb-8 {
+  margin-bottom: 2rem;
+}
+
+.ml-1 {
+  margin-left: .25rem;
+}
+
+.ml-1\.5 {
+  margin-left: .375rem;
+}
+
+.mt-0\.5 {
+  margin-top: .125rem;
+}
+
+.mt-1 {
+  margin-top: .25rem;
+}
+
+.mt-1\.5 {
+  margin-top: .375rem;
+}
+
+.mt-2 {
+  margin-top: .5rem;
+}
+
+.mt-3 {
+  margin-top: .75rem;
+}
+
+.mt-4 {
+  margin-top: 1rem;
+}
+
+.mt-5 {
+  margin-top: 1.25rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
+}
+
+.mt-px {
+  margin-top: 1px;
+}
+
+.\!block {
+  display: block !important;
+}
+
+.block {
+  display: block;
+}
+
+.inline-block {
+  display: inline-block;
+}
+
+.inline {
+  display: inline;
+}
+
+.flex {
+  display: flex;
+}
+
+.inline-flex {
+  display: inline-flex;
+}
+
+.table {
+  display: table;
+}
+
+.grid {
+  display: grid;
+}
+
+.contents {
+  display: contents;
+}
+
+.list-item {
+  display: list-item;
+}
+
+.hidden {
+  display: none;
+}
+
+.h-10 {
+  height: 2.5rem;
+}
+
+.h-11 {
+  height: 2.75rem;
+}
+
+.h-12 {
+  height: 3rem;
+}
+
+.h-14 {
+  height: 3.5rem;
+}
+
+.h-16 {
+  height: 4rem;
+}
+
+.h-24 {
+  height: 6rem;
+}
+
+.h-3 {
+  height: .75rem;
+}
+
+.h-3\.5 {
+  height: .875rem;
+}
+
+.h-4 {
+  height: 1rem;
+}
+
+.h-5 {
+  height: 1.25rem;
+}
+
+.h-6 {
+  height: 1.5rem;
+}
+
+.h-7 {
+  height: 1.75rem;
+}
+
+.h-8 {
+  height: 2rem;
+}
+
+.h-9 {
+  height: 2.25rem;
+}
+
+.h-\[240px\] {
+  height: 240px;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.max-h-64 {
+  max-height: 16rem;
+}
+
+.max-h-\[70vh\] {
+  max-height: 70vh;
+}
+
+.min-h-screen {
+  min-height: 100vh;
+}
+
+.\!w-auto {
+  width: auto !important;
+}
+
+.w-10 {
+  width: 2.5rem;
+}
+
+.w-12 {
+  width: 3rem;
+}
+
+.w-16 {
+  width: 4rem;
+}
+
+.w-24 {
+  width: 6rem;
+}
+
+.w-3 {
+  width: .75rem;
+}
+
+.w-3\.5 {
+  width: .875rem;
+}
+
+.w-4 {
+  width: 1rem;
+}
+
+.w-5 {
+  width: 1.25rem;
+}
+
+.w-6 {
+  width: 1.5rem;
+}
+
+.w-7 {
+  width: 1.75rem;
+}
+
+.w-8 {
+  width: 2rem;
+}
+
+.w-9 {
+  width: 2.25rem;
+}
+
+.w-\[240px\] {
+  width: 240px;
+}
+
+.w-\[83\.33\%\] {
+  width: 83.33%;
+}
+
+.w-auto {
+  width: auto;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.min-w-0 {
+  min-width: 0;
+}
+
+.max-w-\[280px\] {
+  max-width: 280px;
+}
+
+.max-w-\[320px\] {
+  max-width: 320px;
+}
+
+.max-w-\[360px\] {
+  max-width: 360px;
+}
+
+.max-w-\[720px\] {
+  max-width: 720px;
+}
+
+.max-w-full {
+  max-width: 100%;
+}
+
+.max-w-none {
+  max-width: none;
+}
+
+.max-w-xs {
+  max-width: 20rem;
+}
+
+.flex-1 {
+  flex: 1;
+}
+
+.flex-\[1_1_0\] {
+  flex: 1 1 0;
+}
+
+.flex-\[1_1_auto\] {
+  flex: auto;
+}
+
+.flex-shrink-0 {
+  flex-shrink: 0;
+}
+
+.shrink {
+  flex-shrink: 1;
+}
+
+.shrink-0 {
+  flex-shrink: 0;
+}
+
+.grow {
+  flex-grow: 1;
+}
+
+.-translate-x-1\/2 {
+  --tw-translate-x: -50%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.-translate-x-full {
+  --tw-translate-x: -100%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.-translate-y-1\/2 {
+  --tw-translate-y: -50%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.translate-x-0 {
+  --tw-translate-x: 0px;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.translate-x-0\.5 {
+  --tw-translate-x: .125rem;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.translate-x-4 {
+  --tw-translate-x: 1rem;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.translate-x-full {
+  --tw-translate-x: 100%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.transform {
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.\!animate-none {
+  animation: none !important;
+}
+
+.animate-\[toast-in_150ms_ease-out\] {
+  animation: .15s ease-out toast-in;
+}
+
+@keyframes pulse {
+  50% {
+    opacity: .5;
+  }
+}
+
+.animate-pulse {
+  animation: 2s cubic-bezier(.4, 0, .6, 1) infinite pulse;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.animate-spin {
+  animation: 1s linear infinite spin;
+}
+
+.cursor-not-allowed {
+  cursor: not-allowed;
+}
+
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.resize-y {
+  resize: vertical;
+}
+
+.resize {
+  resize: both;
+}
+
+.list-decimal {
+  list-style-type: decimal;
+}
+
+.list-disc {
+  list-style-type: disc;
+}
+
+.appearance-none {
+  appearance: none;
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
+.items-start {
+  align-items: flex-start;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.items-stretch {
+  align-items: stretch;
+}
+
+.justify-end {
+  justify-content: flex-end;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.gap-0\.5 {
+  gap: .125rem;
+}
+
+.gap-1 {
+  gap: .25rem;
+}
+
+.gap-1\.5 {
+  gap: .375rem;
+}
+
+.gap-12 {
+  gap: 3rem;
+}
+
+.gap-2 {
+  gap: .5rem;
+}
+
+.gap-3 {
+  gap: .75rem;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.gap-6 {
+  gap: 1.5rem;
+}
+
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(.5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+}
+
+.self-start {
+  align-self: flex-start;
+}
+
+.self-end {
+  align-self: flex-end;
+}
+
+.self-center {
+  align-self: center;
+}
+
+.overflow-auto {
+  overflow: auto;
+}
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+.overflow-y-auto {
+  overflow-y: auto;
+}
+
+.truncate {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.whitespace-nowrap {
+  white-space: nowrap;
+}
+
+.rounded {
+  border-radius: 2px;
+}
+
+.rounded-\[999px\] {
+  border-radius: 999px;
+}
+
+.rounded-\[var\(--radius\)\] {
+  border-radius: var(--radius);
+}
+
+.rounded-full {
+  border-radius: 9999px;
+}
+
+.rounded-none {
+  border-radius: 0;
+}
+
+.border {
+  border-width: 1px;
+}
+
+.border-0 {
+  border-width: 0;
+}
+
+.border-2 {
+  border-width: 2px;
+}
+
+.border-\[1\.5px\] {
+  border-width: 1.5px;
+}
+
+.border-b {
+  border-bottom-width: 1px;
+}
+
+.border-b-2 {
+  border-bottom-width: 2px;
+}
+
+.border-l {
+  border-left-width: 1px;
+}
+
+.border-t {
+  border-top-width: 1px;
+}
+
+.border-none {
+  border-style: none;
+}
+
+.\!border-\[var\(--color-error\)\] {
+  border-color: var(--color-error) !important;
+}
+
+.border-\[var\(--badge-neutral-border\)\] {
+  border-color: var(--badge-neutral-border);
+}
+
+.border-\[var\(--bg-elevated\)\] {
+  border-color: var(--bg-elevated);
+}
+
+.border-\[var\(--border-default\)\] {
+  border-color: var(--border-default);
+}
+
+.border-\[var\(--border-hover\)\] {
+  border-color: var(--border-hover);
+}
+
+.border-\[var\(--border-medium\)\] {
+  border-color: var(--border-medium);
+}
+
+.border-\[var\(--border-subtle\)\] {
+  border-color: var(--border-subtle);
+}
+
+.border-\[var\(--color-error\)\] {
+  border-color: var(--color-error);
+}
+
+.border-\[var\(--color-error-border\)\] {
+  border-color: var(--color-error-border);
+}
+
+.border-\[var\(--color-success-text\)\] {
+  border-color: var(--color-success-text);
+}
+
+.border-\[var\(--color-warning-border\)\] {
+  border-color: var(--color-warning-border);
+}
+
+.border-\[var\(--fg-primary\)\] {
+  border-color: var(--fg-primary);
+}
+
+.border-transparent {
+  border-color: #0000;
+}
+
+.bg-\[var\(--badge-count-bg\)\] {
+  background-color: var(--badge-count-bg);
+}
+
+.bg-\[var\(--badge-neutral-bg\)\] {
+  background-color: var(--badge-neutral-bg);
+}
+
+.bg-\[var\(--badge-success-bg\)\] {
+  background-color: var(--badge-success-bg);
+}
+
+.bg-\[var\(--badge-warning-bg\)\] {
+  background-color: var(--badge-warning-bg);
+}
+
+.bg-\[var\(--bg-canvas\)\] {
+  background-color: var(--bg-canvas);
+}
+
+.bg-\[var\(--bg-elevated\)\] {
+  background-color: var(--bg-elevated);
+}
+
+.bg-\[var\(--bg-raised\)\] {
+  background-color: var(--bg-raised);
+}
+
+.bg-\[var\(--bg-sunken\)\] {
+  background-color: var(--bg-sunken);
+}
+
+.bg-\[var\(--border-hover\)\] {
+  background-color: var(--border-hover);
+}
+
+.bg-\[var\(--btn-primary-bg\)\] {
+  background-color: var(--btn-primary-bg);
+}
+
+.bg-\[var\(--color-error-bg\)\] {
+  background-color: var(--color-error-bg);
+}
+
+.bg-\[var\(--color-success-bg\)\] {
+  background-color: var(--color-success-bg);
+}
+
+.bg-\[var\(--color-surface-container-high\)\] {
+  background-color: var(--color-surface-container-high);
+}
+
+.bg-\[var\(--color-warning-bg\)\] {
+  background-color: var(--color-warning-bg);
+}
+
+.bg-\[var\(--navy-overlay-30\)\] {
+  background-color: var(--navy-overlay-30);
+}
+
+.bg-\[var\(--navy-overlay-70\)\] {
+  background-color: var(--navy-overlay-70);
+}
+
+.bg-\[var\(--overlay-medium\)\] {
+  background-color: var(--overlay-medium);
+}
+
+.bg-\[var\(--overlay-weak\)\] {
+  background-color: var(--overlay-weak);
+}
+
+.bg-transparent {
+  background-color: #0000;
+}
+
+.object-cover {
+  object-fit: cover;
+}
+
+.p-0 {
+  padding: 0;
+}
+
+.p-1 {
+  padding: .25rem;
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.p-6 {
+  padding: 1.5rem;
+}
+
+.p-\[3px\] {
+  padding: 3px;
+}
+
+.\!px-2\.5 {
+  padding-left: .625rem !important;
+  padding-right: .625rem !important;
+}
+
+.px-0 {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.px-1 {
+  padding-left: .25rem;
+  padding-right: .25rem;
+}
+
+.px-1\.5 {
+  padding-left: .375rem;
+  padding-right: .375rem;
+}
+
+.px-2 {
+  padding-left: .5rem;
+  padding-right: .5rem;
+}
+
+.px-2\.5 {
+  padding-left: .625rem;
+  padding-right: .625rem;
+}
+
+.px-3 {
+  padding-left: .75rem;
+  padding-right: .75rem;
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.px-5 {
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.px-8 {
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.py-0\.5 {
+  padding-top: .125rem;
+  padding-bottom: .125rem;
+}
+
+.py-1 {
+  padding-top: .25rem;
+  padding-bottom: .25rem;
+}
+
+.py-1\.5 {
+  padding-top: .375rem;
+  padding-bottom: .375rem;
+}
+
+.py-12 {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+.py-2 {
+  padding-top: .5rem;
+  padding-bottom: .5rem;
+}
+
+.py-2\.5 {
+  padding-top: .625rem;
+  padding-bottom: .625rem;
+}
+
+.py-3 {
+  padding-top: .75rem;
+  padding-bottom: .75rem;
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.py-5 {
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+}
+
+.pb-3 {
+  padding-bottom: .75rem;
+}
+
+.pb-5 {
+  padding-bottom: 1.25rem;
+}
+
+.pl-11 {
+  padding-left: 2.75rem;
+}
+
+.pl-12 {
+  padding-left: 3rem;
+}
+
+.pl-3 {
+  padding-left: .75rem;
+}
+
+.pl-4 {
+  padding-left: 1rem;
+}
+
+.pl-5 {
+  padding-left: 1.25rem;
+}
+
+.pl-6 {
+  padding-left: 1.5rem;
+}
+
+.pl-9 {
+  padding-left: 2.25rem;
+}
+
+.pr-10 {
+  padding-right: 2.5rem;
+}
+
+.pr-11 {
+  padding-right: 2.75rem;
+}
+
+.pr-12 {
+  padding-right: 3rem;
+}
+
+.pr-9 {
+  padding-right: 2.25rem;
+}
+
+.pt-4 {
+  padding-top: 1rem;
+}
+
+.pt-8 {
+  padding-top: 2rem;
+}
+
+.pt-\[120px\] {
+  padding-top: 120px;
+}
+
+.text-left {
+  text-align: left;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.font-\[inherit\] {
+  font-family: inherit;
+}
+
+.font-headline {
+  font-family: var(--font-headline), Noto Serif, Georgia, serif;
+}
+
+.font-sans {
+  font-family: Inter, system-ui, -apple-system, sans-serif;
+}
+
+.\!text-5xl {
+  font-size: 3rem !important;
+  line-height: 1 !important;
+}
+
+.\!text-\[1\.375rem\] {
+  font-size: 1.375rem !important;
+}
+
+.\!text-\[1\.875rem\] {
+  font-size: 1.875rem !important;
+}
+
+.text-\[0\.6875rem\] {
+  font-size: .6875rem;
+}
+
+.text-\[0\.8125rem\] {
+  font-size: .8125rem;
+}
+
+.text-\[13px\] {
+  font-size: 13px;
+}
+
+.text-\[length\:inherit\] {
+  font-size: inherit;
+}
+
+.text-base {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.text-body {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.6;
+}
+
+.text-body-sm {
+  font-size: .875rem;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+.text-caption {
+  letter-spacing: .05em;
+  font-size: .75rem;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.text-display {
+  letter-spacing: -.03em;
+  font-size: 3rem;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.text-h1 {
+  letter-spacing: -.02em;
+  font-size: 2.25rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.text-h2 {
+  letter-spacing: -.01em;
+  font-size: 1.75rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.text-h3 {
+  font-size: 1.375rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.text-h4 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.text-sm {
+  font-size: .875rem;
+  line-height: 1.25rem;
+}
+
+.text-xs {
+  font-size: .75rem;
+  line-height: 1rem;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.font-medium {
+  font-weight: 500;
+}
+
+.font-semibold {
+  font-weight: 600;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+.lowercase {
+  text-transform: lowercase;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.tabular-nums {
+  --tw-numeric-spacing: tabular-nums;
+  font-variant-numeric: var(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) var(--tw-numeric-fraction);
+}
+
+.\!leading-\[1\.15\] {
+  line-height: 1.15 !important;
+}
+
+.leading-\[inherit\] {
+  line-height: inherit;
+}
+
+.leading-none {
+  line-height: 1;
+}
+
+.tracking-\[-0\.015em\] {
+  letter-spacing: -.015em;
+}
+
+.tracking-tight {
+  letter-spacing: -.025em;
+}
+
+.tracking-wide {
+  letter-spacing: .025em;
+}
+
+.tracking-wider {
+  letter-spacing: .05em;
+}
+
+.text-\[var\(--badge-count-fg\)\] {
+  color: var(--badge-count-fg);
+}
+
+.text-\[var\(--badge-neutral-fg\)\] {
+  color: var(--badge-neutral-fg);
+}
+
+.text-\[var\(--badge-success-fg\)\] {
+  color: var(--badge-success-fg);
+}
+
+.text-\[var\(--badge-warning-fg\)\] {
+  color: var(--badge-warning-fg);
+}
+
+.text-\[var\(--btn-primary-fg\)\] {
+  color: var(--btn-primary-fg);
+}
+
+.text-\[var\(--color-accent\)\] {
+  color: var(--color-accent);
+}
+
+.text-\[var\(--color-error\)\] {
+  color: var(--color-error);
+}
+
+.text-\[var\(--color-success-text\)\] {
+  color: var(--color-success-text);
+}
+
+.text-\[var\(--color-warning-text\)\] {
+  color: var(--color-warning-text);
+}
+
+.text-\[var\(--color-white\)\] {
+  color: var(--color-white);
+}
+
+.text-\[var\(--fg-muted\)\] {
+  color: var(--fg-muted);
+}
+
+.text-\[var\(--fg-primary\)\] {
+  color: var(--fg-primary);
+}
+
+.text-\[var\(--fg-secondary\)\] {
+  color: var(--fg-secondary);
+}
+
+.text-error {
+  --tw-text-opacity: 1;
+  color: rgb(231 76 60 / var(--tw-text-opacity, 1));
+}
+
+.text-transparent {
+  color: #0000;
+}
+
+.underline {
+  text-decoration-line: underline;
+}
+
+.underline-offset-2 {
+  text-underline-offset: 2px;
+}
+
+.opacity-0 {
+  opacity: 0;
+}
+
+.opacity-100 {
+  opacity: 1;
+}
+
+.opacity-50 {
+  opacity: .5;
+}
+
+.shadow {
+  --tw-shadow: 0 1px 3px 0 #0000001a, 0 1px 2px -1px #0000001a;
+  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-md {
+  --tw-shadow: var(--shadow-md);
+  --tw-shadow-colored: var(--shadow-md);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-sm {
+  --tw-shadow: var(--shadow-sm);
+  --tw-shadow-colored: var(--shadow-sm);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-\[var\(--shadow-lg\)\] {
+  --tw-shadow-color: var(--shadow-lg);
+  --tw-shadow: var(--tw-shadow-colored);
+}
+
+.shadow-\[var\(--shadow-md\)\] {
+  --tw-shadow-color: var(--shadow-md);
+  --tw-shadow: var(--tw-shadow-colored);
+}
+
+.shadow-\[var\(--shadow-sm\)\] {
+  --tw-shadow-color: var(--shadow-sm);
+  --tw-shadow: var(--tw-shadow-colored);
+}
+
+.outline {
+  outline-style: solid;
+}
+
+.ring {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.blur {
+  --tw-blur: blur(8px);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.filter {
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.transition {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter, backdrop-filter;
+  transition-duration: .15s;
+  transition-timing-function: cubic-bezier(.4, 0, .2, 1);
+}
+
+.transition-all {
+  transition-property: all;
+  transition-duration: .15s;
+  transition-timing-function: cubic-bezier(.4, 0, .2, 1);
+}
+
+.transition-colors {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-duration: .15s;
+  transition-timing-function: cubic-bezier(.4, 0, .2, 1);
+}
+
+.transition-opacity {
+  transition-property: opacity;
+  transition-duration: .15s;
+  transition-timing-function: cubic-bezier(.4, 0, .2, 1);
+}
+
+.transition-transform {
+  transition-property: transform;
+  transition-duration: .15s;
+  transition-timing-function: cubic-bezier(.4, 0, .2, 1);
+}
+
+.duration-150 {
+  transition-duration: .15s;
+}
+
+.duration-300 {
+  transition-duration: .3s;
+}
+
+.ease-in-out {
+  transition-timing-function: cubic-bezier(.4, 0, .2, 1);
+}
+
+.ease-out {
+  transition-timing-function: cubic-bezier(0, 0, .2, 1);
+}
+
+.\[scrollbar-gutter\:stable\] {
+  scrollbar-gutter: stable;
+}
+
+.placeholder\:text-\[var\(--fg-muted\)\]::placeholder {
+  color: var(--fg-muted);
+}
+
+.hover\:border-\[var\(--border-hover\)\]:hover {
+  border-color: var(--border-hover);
+}
+
+.hover\:border-\[var\(--border-hover-soft\)\]:hover {
+  border-color: var(--border-hover-soft);
+}
+
+.hover\:bg-\[var\(--overlay-weak\)\]:hover {
+  background-color: var(--overlay-weak);
+}
+
+.hover\:text-\[var\(--color-accent-hover\)\]:hover {
+  color: var(--color-accent-hover);
+}
+
+.hover\:text-\[var\(--fg-primary\)\]:hover {
+  color: var(--fg-primary);
+}
+
+.hover\:underline:hover {
+  text-decoration-line: underline;
+}
+
+.hover\:opacity-90:hover {
+  opacity: .9;
+}
+
+.hover\:shadow-sm:hover {
+  --tw-shadow: var(--shadow-sm);
+  --tw-shadow-colored: var(--shadow-sm);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\:\!border-\[var\(--color-error\)\]:focus {
+  border-color: var(--color-error) !important;
+}
+
+.focus\:border-\[var\(--fg-primary\)\]:focus {
+  border-color: var(--fg-primary);
+}
+
+.focus\:border-\[var\(--focus-ring\)\]:focus {
+  border-color: var(--focus-ring);
+}
+
+.focus\:bg-\[var\(--overlay-weak\)\]:focus {
+  background-color: var(--overlay-weak);
+}
+
+.focus\:outline-none:focus {
+  outline-offset: 2px;
+  outline: 2px solid #0000;
+}
+
+.focus\:\!ring-2:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color) !important;
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color) !important;
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000) !important;
+}
+
+.focus\:ring-1:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\:ring-2:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\:ring-\[var\(--overlay-weak\)\]:focus {
+  --tw-ring-color: var(--overlay-weak);
+}
+
+.focus-visible\:outline-2:focus-visible {
+  outline-width: 2px;
+}
+
+.focus-visible\:-outline-offset-2:focus-visible {
+  outline-offset: -2px;
+}
+
+.focus-visible\:outline-offset-2:focus-visible {
+  outline-offset: 2px;
+}
+
+.focus-visible\:outline-\[var\(--focus-ring\)\]:focus-visible {
+  outline-color: var(--focus-ring);
+}
+
+.disabled\:cursor-not-allowed:disabled {
+  cursor: not-allowed;
+}
+
+.disabled\:resize-none:disabled {
+  resize: none;
+}
+
+.disabled\:bg-\[var\(--bg-sunken\)\]:disabled {
+  background-color: var(--bg-sunken);
+}
+
+.disabled\:opacity-50:disabled {
+  opacity: .5;
+}
+
+.disabled\:opacity-60:disabled {
+  opacity: .6;
+}
+
+.peer:checked ~ .peer-checked\:border-\[var\(--btn-primary-bg\)\] {
+  border-color: var(--btn-primary-bg);
+}
+
+.peer:checked ~ .peer-checked\:bg-\[var\(--btn-primary-bg\)\] {
+  background-color: var(--btn-primary-bg);
+}
+
+.peer:checked ~ .peer-checked\:text-\[var\(--btn-primary-fg\)\] {
+  color: var(--btn-primary-fg);
+}
+
+.peer:indeterminate ~ .peer-indeterminate\:border-\[var\(--btn-primary-bg\)\] {
+  border-color: var(--btn-primary-bg);
+}
+
+.peer:indeterminate ~ .peer-indeterminate\:bg-\[var\(--btn-primary-bg\)\] {
+  background-color: var(--btn-primary-bg);
+}
+
+.peer:indeterminate ~ .peer-indeterminate\:text-\[var\(--btn-primary-fg\)\] {
+  color: var(--btn-primary-fg);
+}
+
+.peer:focus-visible ~ .peer-focus-visible\:outline-2 {
+  outline-width: 2px;
+}
+
+.peer:focus-visible ~ .peer-focus-visible\:outline-offset-2 {
+  outline-offset: 2px;
+}
+
+.peer:focus-visible ~ .peer-focus-visible\:outline-\[var\(--focus-ring\)\] {
+  outline-color: var(--focus-ring);
+}
+
+.peer:disabled ~ .peer-disabled\:opacity-50 {
+  opacity: .5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .motion-reduce\:animate-none {
+    animation: none;
+  }
+
+  .motion-reduce\:transition-none {
+    transition-property: none;
+  }
+}
+
+@media (max-width: 799px) {
+  .max-\[799px\]\:items-stretch {
+    align-items: stretch;
+  }
+}
+
+@media (min-width: 768px) {
+  .md\:text-sm {
+    font-size: .875rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width: 800px) {
+  .min-\[800px\]\:inset-x-auto {
+    left: auto;
+    right: auto;
+  }
+
+  .min-\[800px\]\:bottom-4 {
+    bottom: 1rem;
+  }
+
+  .min-\[800px\]\:right-4 {
+    right: 1rem;
+  }
+
+  .min-\[800px\]\:w-auto {
+    width: auto;
+  }
+
+  .min-\[800px\]\:min-w-\[20rem\] {
+    min-width: 20rem;
+  }
+
+  .min-\[800px\]\:max-w-\[26rem\] {
+    max-width: 26rem;
+  }
+
+  .min-\[800px\]\:items-end {
+    align-items: flex-end;
+  }
+}
+
+.\[\&\>option\]\:bg-\[var\(--bg-elevated\)\] > option {
+  background-color: var(--bg-elevated);
+}
+
+.\[\&\>option\]\:text-\[var\(--fg-primary\)\] > option {
+  color: var(--fg-primary);
+}
+
+/*# sourceMappingURL=%5Broot-of-the-server%5D__09be3ul._.css.map*/
+
+/* ---- inline <style> ---- */
+@font-face{font-family:'__nextjs-Geist';font-style:normal;font-weight:400 600;font-display:swap;src:url(http://127.0.0.1:3000/__nextjs_font/geist-latin-ext.woff2) format('woff2');unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}@font-face{font-family:'__nextjs-Geist Mono';font-style:normal;font-weight:400 600;font-display:swap;src:url(http://127.0.0.1:3000/__nextjs_font/geist-mono-latin-ext.woff2) format('woff2');unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}@font-face{font-family:'__nextjs-Geist';font-style:normal;font-weight:400 600;font-display:swap;src:url(http://127.0.0.1:3000/__nextjs_font/geist-latin.woff2) format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}@font-face{font-family:'__nextjs-Geist Mono';font-style:normal;font-weight:400 600;font-display:swap;src:url(http://127.0.0.1:3000/__nextjs_font/geist-mono-latin.woff2) format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}
+
+/* ---- inline <style> ---- */
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+
+/* ---- inline <style> ---- */
+:host {
+  all: initial;
+
+  /* the direction property is not reset by 'all' */
+  direction: ltr;
+}
+
+/*!
+ * Bootstrap Reboot v4.4.1 (https://getbootstrap.com/)
+ * Copyright 2011-2019 The Bootstrap Authors
+ * Copyright 2011-2019 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md)
+ */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+:host {
+  font-family: sans-serif;
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+article,
+aside,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+nav,
+section {
+  display: block;
+}
+
+:host {
+  margin: 0;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--color-font);
+  text-align: left;
+}
+
+:host:not(button) {
+  background-color: #fff;
+}
+
+[tabindex='-1']:focus:not(:focus-visible) {
+  outline: 0 !important;
+}
+
+hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+abbr[title],
+abbr[data-original-title] {
+  text-decoration: underline;
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+  cursor: help;
+  border-bottom: 0;
+  -webkit-text-decoration-skip-ink: none;
+  text-decoration-skip-ink: none;
+}
+
+address {
+  margin-bottom: 16px;
+  font-style: normal;
+  line-height: inherit;
+}
+
+ol,
+ul,
+dl {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+ol ol,
+ul ul,
+ol ul,
+ul ol {
+  margin-bottom: 0;
+}
+
+dt {
+  font-weight: 700;
+}
+
+dd {
+  margin-bottom: 8px;
+  margin-left: 0;
+}
+
+blockquote {
+  margin: 0 0 16px;
+}
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+small {
+  font-size: 80%;
+}
+
+sub,
+sup {
+  position: relative;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+a {
+  color: #007bff;
+  text-decoration: none;
+  background-color: transparent;
+}
+
+a:hover {
+  color: #0056b3;
+  text-decoration: underline;
+}
+
+a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:not([href]):hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+pre,
+code,
+kbd,
+samp {
+  font-family:
+    SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  font-size: 1em;
+}
+
+pre {
+  margin-top: 0;
+  margin-bottom: 16px;
+  overflow: auto;
+}
+
+figure {
+  margin: 0 0 16px;
+}
+
+img {
+  vertical-align: middle;
+  border-style: none;
+}
+
+svg {
+  overflow: hidden;
+  vertical-align: middle;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+caption {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  color: #6c757d;
+  text-align: left;
+  caption-side: bottom;
+}
+
+th {
+  text-align: inherit;
+}
+
+label {
+  display: inline-block;
+  margin-bottom: 8px;
+}
+
+button {
+  border-radius: 0;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  background: none;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+button:focus {
+  outline: 1px dotted;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+button:focus:not(:focus-visible) {
+  outline: none;
+}
+
+input,
+button,
+select,
+optgroup,
+textarea {
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+button,
+input {
+  overflow: visible;
+}
+
+button,
+select {
+  text-transform: none;
+}
+
+select {
+  word-wrap: normal;
+}
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  -webkit-appearance: button;
+}
+
+button:not(:disabled),
+[type='button']:not(:disabled),
+[type='reset']:not(:disabled),
+[type='submit']:not(:disabled) {
+  cursor: pointer;
+}
+
+button::-moz-focus-inner,
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner {
+  padding: 0;
+  border-style: none;
+}
+
+input[type='radio'],
+input[type='checkbox'] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+input[type='date'],
+input[type='time'],
+input[type='datetime-local'],
+input[type='month'] {
+  -webkit-appearance: listbox;
+}
+
+textarea {
+  overflow: auto;
+  resize: vertical;
+}
+
+fieldset {
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+legend {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  padding: 0;
+  margin-bottom: 8px;
+  font-size: 24px;
+  line-height: inherit;
+  color: inherit;
+  white-space: normal;
+}
+
+progress {
+  vertical-align: baseline;
+}
+
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
+  height: auto;
+}
+
+[type='search'] {
+  outline-offset: -2px;
+  -webkit-appearance: none;
+}
+
+[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+::-webkit-file-upload-button {
+  font: inherit;
+  -webkit-appearance: button;
+}
+
+output {
+  display: inline-block;
+}
+
+summary {
+  display: list-item;
+  cursor: pointer;
+}
+
+template {
+  display: none;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+
+/* ---- inline <style> ---- */
+:host {
+  /* 
+   * Although the style applied to the shadow host is isolated,
+   * the element that attached the shadow host (i.e. "nextjs-portal")
+   * is still affected by the parent's style (e.g. "body"). This may
+   * occur style conflicts like "display: flex", with other children
+   * elements therefore give the shadow host an absolute position.
+   */
+  position: absolute;
+
+  --color-font: #757575;
+  --color-backdrop: rgba(250, 250, 250, 0.8);
+  --color-border-shadow: rgba(0, 0, 0, 0.145);
+
+  --color-title-color: #1f1f1f;
+  --color-stack-notes: #777;
+
+  --color-accents-1: #808080;
+  --color-accents-2: #222222;
+  --color-accents-3: #404040;
+
+  --font-stack-monospace:
+    '__nextjs-Geist Mono', 'Geist Mono', 'SFMono-Regular', Consolas,
+    'Liberation Mono', Menlo, Courier, monospace;
+  --font-stack-sans:
+    '__nextjs-Geist', 'Geist', -apple-system, 'Source Sans Pro', sans-serif;
+
+  font-family: var(--font-stack-sans);
+  font-variant-ligatures: none;
+
+  /* TODO: Remove replaced ones. */
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --shadow-xl:
+    0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+  --shadow-inner: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
+  --shadow-none: 0 0 #0000;
+
+  --shadow-small: 0px 2px 2px rgba(0, 0, 0, 0.04);
+  --shadow-menu:
+    0px 1px 1px rgba(0, 0, 0, 0.02), 0px 4px 8px -4px rgba(0, 0, 0, 0.04),
+    0px 16px 24px -8px rgba(0, 0, 0, 0.06);
+
+  --focus-color: var(--color-blue-800);
+  --focus-ring: 2px solid var(--focus-color);
+
+  --timing-swift: cubic-bezier(0.23, 0.88, 0.26, 0.92);
+  --timing-overlay: cubic-bezier(0.175, 0.885, 0.32, 1.1);
+  /* prettier-ignore */
+  --timing-bounce: linear(0 0%, 0.005871 1%, 0.022058 2%, 0.046612 3%, 0.077823 4%, 0.114199 5%, 0.154441 6%, 0.197431 7.000000000000001%, 0.242208 8%, 0.287959 9%, 0.333995 10%, 0.379743 11%, 0.424732 12%, 0.46858 13%, 0.510982 14.000000000000002%, 0.551702 15%, 0.590564 16%, 0.627445 17%, 0.662261 18%, 0.694971 19%, 0.725561 20%, 0.754047 21%, 0.780462 22%, 0.804861 23%, 0.82731 24%, 0.847888 25%, 0.866679 26%, 0.883775 27%, 0.899272 28.000000000000004%, 0.913267 28.999999999999996%, 0.925856 30%, 0.937137 31%, 0.947205 32%, 0.956153 33%, 0.96407 34%, 0.971043 35%, 0.977153 36%, 0.982479 37%, 0.987094 38%, 0.991066 39%, 0.994462 40%, 0.997339 41%, 0.999755 42%, 1.001761 43%, 1.003404 44%, 1.004727 45%, 1.00577 46%, 1.006569 47%, 1.007157 48%, 1.007563 49%, 1.007813 50%, 1.007931 51%, 1.007939 52%, 1.007855 53%, 1.007697 54%, 1.007477 55.00000000000001%, 1.00721 56.00000000000001%, 1.006907 56.99999999999999%, 1.006576 57.99999999999999%, 1.006228 59%, 1.005868 60%, 1.005503 61%, 1.005137 62%, 1.004776 63%, 1.004422 64%, 1.004078 65%, 1.003746 66%, 1.003429 67%, 1.003127 68%, 1.00284 69%, 1.002571 70%, 1.002318 71%, 1.002082 72%, 1.001863 73%, 1.00166 74%, 1.001473 75%, 1.001301 76%, 1.001143 77%, 1.001 78%, 1.000869 79%, 1.000752 80%, 1.000645 81%, 1.00055 82%, 1.000464 83%, 1.000388 84%, 1.000321 85%, 1.000261 86%, 1.000209 87%, 1.000163 88%, 1.000123 89%, 1.000088 90%);
+
+  --rounded-none: 0px;
+  --rounded-sm: 2px;
+  --rounded-md: 4px;
+  --rounded-md-2: 6px;
+  --rounded-lg: 8px;
+  --rounded-xl: 12px;
+  --rounded-2xl: 16px;
+  --rounded-3xl: 24px;
+  --rounded-4xl: 32px;
+  --rounded-full: 9999px;
+
+  /* 
+    This value gets set from the Dev Tools preferences,
+    and we use the following --size-* variables to 
+    scale the relevant elements.
+
+    The reason why we don't rely on rem values is because
+    if an app sets their root font size to something tiny, 
+    it feels unexpected to have the app root size leak 
+    into a Next.js surface.
+
+    https://github.com/vercel/next.js/discussions/76812
+  */
+  --nextjs-dev-tools-scale: 1;
+  --size-1: calc(1px / var(--nextjs-dev-tools-scale));
+  --size-2: calc(2px / var(--nextjs-dev-tools-scale));
+  --size-3: calc(3px / var(--nextjs-dev-tools-scale));
+  --size-4: calc(4px / var(--nextjs-dev-tools-scale));
+  --size-5: calc(5px / var(--nextjs-dev-tools-scale));
+  --size-6: calc(6px / var(--nextjs-dev-tools-scale));
+  --size-7: calc(7px / var(--nextjs-dev-tools-scale));
+  --size-8: calc(8px / var(--nextjs-dev-tools-scale));
+  --size-9: calc(9px / var(--nextjs-dev-tools-scale));
+  --size-10: calc(10px / var(--nextjs-dev-tools-scale));
+  --size-11: calc(11px / var(--nextjs-dev-tools-scale));
+  --size-12: calc(12px / var(--nextjs-dev-tools-scale));
+  --size-13: calc(13px / var(--nextjs-dev-tools-scale));
+  --size-14: calc(14px / var(--nextjs-dev-tools-scale));
+  --size-15: calc(15px / var(--nextjs-dev-tools-scale));
+  --size-16: calc(16px / var(--nextjs-dev-tools-scale));
+  --size-17: calc(17px / var(--nextjs-dev-tools-scale));
+  --size-18: calc(18px / var(--nextjs-dev-tools-scale));
+  --size-20: calc(20px / var(--nextjs-dev-tools-scale));
+  --size-22: calc(22px / var(--nextjs-dev-tools-scale));
+  --size-24: calc(24px / var(--nextjs-dev-tools-scale));
+  --size-26: calc(26px / var(--nextjs-dev-tools-scale));
+  --size-28: calc(28px / var(--nextjs-dev-tools-scale));
+  --size-30: calc(30px / var(--nextjs-dev-tools-scale));
+  --size-32: calc(32px / var(--nextjs-dev-tools-scale));
+  --size-34: calc(34px / var(--nextjs-dev-tools-scale));
+  --size-36: calc(36px / var(--nextjs-dev-tools-scale));
+  --size-38: calc(38px / var(--nextjs-dev-tools-scale));
+  --size-40: calc(40px / var(--nextjs-dev-tools-scale));
+  --size-42: calc(42px / var(--nextjs-dev-tools-scale));
+  --size-44: calc(44px / var(--nextjs-dev-tools-scale));
+  --size-46: calc(46px / var(--nextjs-dev-tools-scale));
+  --size-48: calc(48px / var(--nextjs-dev-tools-scale));
+
+  @media print {
+    display: none;
+  }
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-bottom: 8px;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+a {
+  color: var(--color-blue-900);
+  &:hover {
+    color: var(--color-blue-900);
+  }
+  &:focus-visible {
+    outline: var(--focus-ring);
+  }
+}
+
+
+/* ---- inline <style> ---- */
+:host(.dark) {
+  --color-font: white;
+  --color-backdrop: rgba(0, 0, 0, 0.8);
+  --color-border-shadow: rgba(255, 255, 255, 0.145);
+
+  --color-title-color: #fafafa;
+  --color-stack-notes: #a9a9a9;
+
+  /* Background Dark */
+  --color-background-100: #0a0a0a;
+  --color-background-200: #000000;
+
+  /* Syntax Dark */
+  --color-syntax-comment: #a0a0a0;
+  --color-syntax-constant: #ededed;
+  --color-syntax-function: #52a9ff;
+  --color-syntax-keyword: #f76e99;
+  --color-syntax-link: #0ac5b2;
+  --color-syntax-parameter: #f1a10d;
+  --color-syntax-punctuation: #ededed;
+  --color-syntax-string: #0ac5b2;
+  --color-syntax-string-expression: #0ac5b2;
+
+  /* Gray Scale Dark */
+  --color-gray-100: #1a1a1a;
+  --color-gray-200: #1f1f1f;
+  --color-gray-300: #292929;
+  --color-gray-400: #2e2e2e;
+  --color-gray-500: #454545;
+  --color-gray-600: #878787;
+  --color-gray-700: #8f8f8f;
+  --color-gray-800: #7d7d7d;
+  --color-gray-900: #a0a0a0;
+  --color-gray-1000: #ededed;
+
+  /* Gray Alpha Scale Dark */
+  --color-gray-alpha-100: rgba(255, 255, 255, 0.066);
+  --color-gray-alpha-200: rgba(255, 255, 255, 0.087);
+  --color-gray-alpha-300: rgba(255, 255, 255, 0.125);
+  --color-gray-alpha-400: rgba(255, 255, 255, 0.145);
+  --color-gray-alpha-500: rgba(255, 255, 255, 0.239);
+  --color-gray-alpha-600: rgba(255, 255, 255, 0.506);
+  --color-gray-alpha-700: rgba(255, 255, 255, 0.54);
+  --color-gray-alpha-800: rgba(255, 255, 255, 0.47);
+  --color-gray-alpha-900: rgba(255, 255, 255, 0.61);
+  --color-gray-alpha-1000: rgba(255, 255, 255, 0.923);
+
+  /* Blue Scale Dark */
+  --color-blue-100: #0f1b2d;
+  --color-blue-200: #10243e;
+  --color-blue-300: #0f3058;
+  --color-blue-400: #0d3868;
+  --color-blue-500: #0a4481;
+  --color-blue-600: #0091ff;
+  --color-blue-700: #0070f3;
+  --color-blue-800: #0060d1;
+  --color-blue-900: #52a9ff;
+  --color-blue-1000: #eaf6ff;
+
+  /* Red Scale Dark */
+  --color-red-100: #2a1314;
+  --color-red-200: #3d1719;
+  --color-red-300: #551a1e;
+  --color-red-400: #671e22;
+  --color-red-500: #822025;
+  --color-red-600: #e5484d;
+  --color-red-700: #e5484d;
+  --color-red-800: #da3036;
+  --color-red-900: #ff6369;
+  --color-red-1000: #ffecee;
+
+  /* Amber Scale Dark */
+  --color-amber-100: #271700;
+  --color-amber-200: #341c00;
+  --color-amber-300: #4a2900;
+  --color-amber-400: #573300;
+  --color-amber-500: #693f05;
+  --color-amber-600: #e79c13;
+  --color-amber-700: #ffb224;
+  --color-amber-800: #ff990a;
+  --color-amber-900: #f1a10d;
+  --color-amber-1000: #fef3dd;
+
+  /* Green Scale Dark */
+  --color-green-100: #0b2211;
+  --color-green-200: #0f2c17;
+  --color-green-300: #11351b;
+  --color-green-400: #0c461b;
+  --color-green-500: #126427;
+  --color-green-600: #1a9338;
+  --color-green-700: #46a758;
+  --color-green-800: #388e4a;
+  --color-green-900: #63c174;
+  --color-green-1000: #e5fbeb;
+
+  /* Turbopack Dark - Temporary */
+  --color-turbopack-text-red: #ff6d92;
+  --color-turbopack-text-blue: #45b2ff;
+  --color-turbopack-border-red: #6e293b;
+  --color-turbopack-border-blue: #284f80;
+  --color-turbopack-background-red: #250d12;
+  --color-turbopack-background-blue: #0a1723;
+}
+
+@media (prefers-color-scheme: dark) {
+  :host(:not(.light)) {
+    --color-font: white;
+    --color-backdrop: rgba(0, 0, 0, 0.8);
+    --color-border-shadow: rgba(255, 255, 255, 0.145);
+
+    --color-title-color: #fafafa;
+    --color-stack-notes: #a9a9a9;
+
+    /* Background Dark */
+    --color-background-100: #0a0a0a;
+    --color-background-200: #000000;
+
+    /* Syntax Dark */
+    --color-syntax-comment: #a0a0a0;
+    --color-syntax-constant: #ededed;
+    --color-syntax-function: #52a9ff;
+    --color-syntax-keyword: #f76e99;
+    --color-syntax-link: #0ac5b2;
+    --color-syntax-parameter: #f1a10d;
+    --color-syntax-punctuation: #ededed;
+    --color-syntax-string: #0ac5b2;
+    --color-syntax-string-expression: #0ac5b2;
+
+    /* Gray Scale Dark */
+    --color-gray-100: #1a1a1a;
+    --color-gray-200: #1f1f1f;
+    --color-gray-300: #292929;
+    --color-gray-400: #2e2e2e;
+    --color-gray-500: #454545;
+    --color-gray-600: #878787;
+    --color-gray-700: #8f8f8f;
+    --color-gray-800: #7d7d7d;
+    --color-gray-900: #a0a0a0;
+    --color-gray-1000: #ededed;
+
+    /* Gray Alpha Scale Dark */
+    --color-gray-alpha-100: rgba(255, 255, 255, 0.066);
+    --color-gray-alpha-200: rgba(255, 255, 255, 0.087);
+    --color-gray-alpha-300: rgba(255, 255, 255, 0.125);
+    --color-gray-alpha-400: rgba(255, 255, 255, 0.145);
+    --color-gray-alpha-500: rgba(255, 255, 255, 0.239);
+    --color-gray-alpha-600: rgba(255, 255, 255, 0.506);
+    --color-gray-alpha-700: rgba(255, 255, 255, 0.54);
+    --color-gray-alpha-800: rgba(255, 255, 255, 0.47);
+    --color-gray-alpha-900: rgba(255, 255, 255, 0.61);
+    --color-gray-alpha-1000: rgba(255, 255, 255, 0.923);
+
+    /* Blue Scale Dark */
+    --color-blue-100: #0f1b2d;
+    --color-blue-200: #10243e;
+    --color-blue-300: #0f3058;
+    --color-blue-400: #0d3868;
+    --color-blue-500: #0a4481;
+    --color-blue-600: #0091ff;
+    --color-blue-700: #0070f3;
+    --color-blue-800: #0060d1;
+    --color-blue-900: #52a9ff;
+    --color-blue-1000: #eaf6ff;
+
+    /* Red Scale Dark */
+    --color-red-100: #2a1314;
+    --color-red-200: #3d1719;
+    --color-red-300: #551a1e;
+    --color-red-400: #671e22;
+    --color-red-500: #822025;
+    --color-red-600: #e5484d;
+    --color-red-700: #e5484d;
+    --color-red-800: #da3036;
+    --color-red-900: #ff6369;
+    --color-red-1000: #ffecee;
+
+    /* Amber Scale Dark */
+    --color-amber-100: #271700;
+    --color-amber-200: #341c00;
+    --color-amber-300: #4a2900;
+    --color-amber-400: #573300;
+    --color-amber-500: #693f05;
+    --color-amber-600: #e79c13;
+    --color-amber-700: #ffb224;
+    --color-amber-800: #ff990a;
+    --color-amber-900: #f1a10d;
+    --color-amber-1000: #fef3dd;
+
+    /* Green Scale Dark */
+    --color-green-100: #0b2211;
+    --color-green-200: #0f2c17;
+    --color-green-300: #11351b;
+    --color-green-400: #0c461b;
+    --color-green-500: #126427;
+    --color-green-600: #1a9338;
+    --color-green-700: #46a758;
+    --color-green-800: #388e4a;
+    --color-green-900: #63c174;
+    --color-green-1000: #e5fbeb;
+
+    /* Turbopack Dark - Temporary */
+    --color-turbopack-text-red: #ff6d92;
+    --color-turbopack-text-blue: #45b2ff;
+    --color-turbopack-border-red: #6e293b;
+    --color-turbopack-border-blue: #284f80;
+    --color-turbopack-background-red: #250d12;
+    --color-turbopack-background-blue: #0a1723;
+  }
+}
+
+
+/* ---- inline <style> ---- */
+:host {
+  /*
+   * CAUTION: THIS IS A WORKAROUND!
+   * The code frame renderer (next-code-frame) uses hardcoded ANSI colors that don't match
+   * our theme colors. We do a workaround mapping to change the ANSI color matching the theme.
+   *
+   * next-code-frame color scheme:
+   *   cyan (36m):    keywords (const, function, return, etc.)
+   *   yellow (33m):  capitalized identifiers (Component names, types)
+   *   magenta (35m): numbers, regex literals
+   *   green (32m):   strings
+   *   gray (90m):    comments, gutter
+   */
+  /* cyan: keyword */
+  --color-ansi-cyan: var(--color-syntax-keyword);
+  /* yellow: capitalized identifiers */
+  --color-ansi-yellow: var(--color-syntax-function);
+  /* magenta: number, regex */
+  --color-ansi-magenta: var(--color-syntax-keyword);
+  /* green: string */
+  --color-ansi-green: var(--color-syntax-string);
+  /* gray (bright black): comment, gutter */
+  --color-ansi-bright-black: var(--color-syntax-comment);
+
+  /* Ansi - Temporary */
+  --color-ansi-selection: var(--color-gray-alpha-300);
+  --color-ansi-bg: var(--color-background-200);
+  --color-ansi-fg: var(--color-gray-1000);
+
+  --color-ansi-white: var(--color-gray-700);
+  --color-ansi-black: var(--color-gray-200);
+  --color-ansi-blue: var(--color-blue-700);
+  --color-ansi-red: var(--color-red-700);
+  --color-ansi-bright-white: var(--color-gray-1000);
+  --color-ansi-bright-blue: var(--color-blue-800);
+  --color-ansi-bright-cyan: var(--color-blue-800);
+  --color-ansi-bright-green: var(--color-green-800);
+  --color-ansi-bright-magenta: var(--color-blue-800);
+  --color-ansi-bright-red: var(--color-red-800);
+  --color-ansi-bright-yellow: var(--color-amber-900);
+
+  /* Background Light */
+  --color-background-100: #ffffff;
+  --color-background-200: #fafafa;
+
+  /* Syntax Light */
+  --color-syntax-comment: #545454;
+  --color-syntax-constant: #171717;
+  --color-syntax-function: #0054ad;
+  --color-syntax-keyword: #a51850;
+  --color-syntax-link: #066056;
+  --color-syntax-parameter: #8f3e00;
+  --color-syntax-punctuation: #171717;
+  --color-syntax-string: #036157;
+  --color-syntax-string-expression: #066056;
+
+  /* Gray Scale Light */
+  --color-gray-100: #f2f2f2;
+  --color-gray-200: #ebebeb;
+  --color-gray-300: #e6e6e6;
+  --color-gray-400: #eaeaea;
+  --color-gray-500: #c9c9c9;
+  --color-gray-600: #a8a8a8;
+  --color-gray-700: #8f8f8f;
+  --color-gray-800: #7d7d7d;
+  --color-gray-900: #666666;
+  --color-gray-1000: #171717;
+
+  /* Gray Alpha Scale Light */
+  --color-gray-alpha-100: rgba(0, 0, 0, 0.05);
+  --color-gray-alpha-200: rgba(0, 0, 0, 0.081);
+  --color-gray-alpha-300: rgba(0, 0, 0, 0.1);
+  --color-gray-alpha-400: rgba(0, 0, 0, 0.08);
+  --color-gray-alpha-500: rgba(0, 0, 0, 0.21);
+  --color-gray-alpha-600: rgba(0, 0, 0, 0.34);
+  --color-gray-alpha-700: rgba(0, 0, 0, 0.44);
+  --color-gray-alpha-800: rgba(0, 0, 0, 0.51);
+  --color-gray-alpha-900: rgba(0, 0, 0, 0.605);
+  --color-gray-alpha-1000: rgba(0, 0, 0, 0.91);
+
+  /* Blue Scale Light */
+  --color-blue-100: #f0f7ff;
+  --color-blue-200: #edf6ff;
+  --color-blue-300: #e1f0ff;
+  --color-blue-400: #cde7ff;
+  --color-blue-500: #99ceff;
+  --color-blue-600: #52aeff;
+  --color-blue-700: #0070f3;
+  --color-blue-800: #0060d1;
+  --color-blue-900: #0067d6;
+  --color-blue-1000: #0025ad;
+
+  /* Red Scale Light */
+  --color-red-100: #fff0f0;
+  --color-red-200: #ffebeb;
+  --color-red-300: #ffe5e5;
+  --color-red-400: #fdd8d8;
+  --color-red-500: #f8baba;
+  --color-red-600: #f87274;
+  --color-red-700: #e5484d;
+  --color-red-800: #da3036;
+  --color-red-900: #ca2a30;
+  --color-red-1000: #381316;
+
+  /* Amber Scale Light */
+  --color-amber-100: #fff6e5;
+  --color-amber-200: #fff4d5;
+  --color-amber-300: #fef0cd;
+  --color-amber-400: #ffddbf;
+  --color-amber-500: #ffc96b;
+  --color-amber-600: #f5b047;
+  --color-amber-700: #ffb224;
+  --color-amber-800: #ff990a;
+  --color-amber-900: #a35200;
+  --color-amber-1000: #4e2009;
+
+  /* Green Scale Light */
+  --color-green-100: #effbef;
+  --color-green-200: #eafaea;
+  --color-green-300: #dcf6dc;
+  --color-green-400: #c8f1c9;
+  --color-green-500: #99e59f;
+  --color-green-600: #6cda76;
+  --color-green-700: #46a758;
+  --color-green-800: #388e4a;
+  --color-green-900: #297c3b;
+  --color-green-1000: #18311e;
+
+  /* Turbopack Light - Temporary */
+  --color-turbopack-text-red: #ff1e56;
+  --color-turbopack-text-blue: #0096ff;
+  --color-turbopack-border-red: #f0adbe;
+  --color-turbopack-border-blue: #adccea;
+  --color-turbopack-background-red: #fff7f9;
+  --color-turbopack-background-blue: #f6fbff;
+}
+
+
+/* ---- inline <style> ---- */
+/* devtool global css variables */
+:host {
+  /* variables */
+  --top-z-index: 2147483647;
+}
+
+/* global styles */
+* {
+  -webkit-font-smoothing: antialiased;
+}
+
+/* global reset for draggable content scrollbar styles */
+[data-nextjs-scrollable-content],
+[data-nextjs-scrollable-content] * {
+  &::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+    border-radius: 0 0 1rem 1rem;
+    margin-bottom: 1rem;
+  }
+
+  &::-webkit-scrollbar-button {
+    display: none;
+  }
+
+  &::-webkit-scrollbar-track {
+    border-radius: 0 0 1rem 1rem;
+    background-color: var(--color-background-100);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 1rem;
+    background-color: var(--color-gray-500);
+  }
+}
+
+/* Place overflow: hidden on this so we can break out from [data-nextjs-dialog] */
+[data-nextjs-scrollable-content] {
+  overflow: hidden;
+  border-radius: inherit;
+}
+
+
+/* ---- inline <style> ---- */
+.nextjs-toast {
+  position: fixed;
+  z-index: var(--top-z-index);
+  max-width: 420px;
+  box-shadow: 0px 16px 32px rgba(0, 0, 0, 0.25);
+}
+
+.nextjs-toast-errors-parent {
+  padding: 16px;
+  border-radius: var(--rounded-4xl);
+  font-weight: 500;
+  color: var(--color-ansi-bright-white);
+  background-color: var(--color-ansi-red);
+}
+
+
+/* ---- inline <style> ---- */
+[data-nextjs-toast] {
+  &[data-hidden='true'] {
+    display: none;
+  }
+}
+
+.dev-tools-indicator-menu {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  background: var(--color-background-100);
+  border: 1px solid var(--color-gray-alpha-400);
+  background-clip: padding-box;
+  box-shadow: var(--shadow-menu);
+  border-radius: var(--rounded-xl);
+  position: absolute;
+  font-family: var(--font-stack-sans);
+  z-index: 3;
+  overflow: hidden;
+  opacity: 0;
+  outline: 0;
+  min-width: 248px;
+  transition: opacity var(--animate-out-duration-ms)
+    var(--animate-out-timing-function);
+
+  &[data-rendered='true'] {
+    opacity: 1;
+    scale: 1;
+  }
+}
+
+.dev-tools-indicator-inner {
+  padding: 6px;
+  width: 100%;
+}
+
+.dev-tools-indicator-item {
+  display: flex;
+  align-items: center;
+  padding: 8px 6px;
+  height: var(--size-36);
+  border-radius: 6px;
+  text-decoration: none !important;
+  user-select: none;
+  white-space: nowrap;
+
+  svg {
+    width: var(--size-16);
+    height: var(--size-16);
+  }
+
+  &:focus-visible {
+    outline: 0;
+  }
+}
+
+.dev-tools-indicator-footer {
+  background: var(--color-background-200);
+  padding: 6px;
+  border-top: 1px solid var(--color-gray-400);
+  width: 100%;
+}
+
+.dev-tools-indicator-item[data-selected='true'] {
+  cursor: pointer;
+  background-color: var(--color-gray-200);
+}
+
+.dev-tools-indicator-label {
+  font-size: var(--size-14);
+  line-height: var(--size-20);
+  color: var(--color-gray-1000);
+}
+
+.dev-tools-indicator-value {
+  font-size: var(--size-14);
+  line-height: var(--size-20);
+  color: var(--color-gray-900);
+  margin-left: auto;
+}
+
+.dev-tools-indicator-issue-count {
+  --color-primary: var(--color-gray-800);
+  --color-secondary: var(--color-gray-100);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-width: var(--size-40);
+  height: var(--size-24);
+  background: var(--color-background-100);
+  border: 1px solid var(--color-gray-alpha-400);
+  background-clip: padding-box;
+  box-shadow: var(--shadow-small);
+  padding: 2px;
+  color: var(--color-gray-1000);
+  border-radius: 128px;
+  font-weight: 500;
+  font-size: var(--size-13);
+  font-variant-numeric: tabular-nums;
+
+  &[data-has-issues='true'] {
+    --color-primary: var(--color-red-800);
+    --color-secondary: var(--color-red-100);
+  }
+
+  .dev-tools-indicator-issue-count-indicator {
+    width: var(--size-8);
+    height: var(--size-8);
+    background: var(--color-primary);
+    box-shadow: 0 0 0 2px var(--color-secondary);
+    border-radius: 50%;
+  }
+}
+
+.dev-tools-indicator-shortcut {
+  display: flex;
+  gap: 4px;
+
+  kbd {
+    width: var(--size-20);
+    height: var(--size-20);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: var(--rounded-md);
+    border: 1px solid var(--color-gray-400);
+    font-family: var(--font-stack-sans);
+    background: var(--color-background-100);
+    color: var(--color-gray-1000);
+    text-align: center;
+    font-size: var(--size-12);
+    line-height: var(--size-16);
+  }
+}
+
+.dev-tools-grabbing {
+  cursor: grabbing;
+
+  > * {
+    pointer-events: none;
+  }
+}
+
+
+/* ---- inline <style> ---- */
+.resize-container {
+  position: absolute;
+  /* todo: better z index */
+  z-index: 10;
+  /* todo: is this needed */
+  background: transparent;
+}
+
+.resize-line {
+  position: absolute;
+  /* todo smarter z index */
+  z-index: -1;
+  pointer-events: none;
+  /* a normal exit animation curve- at this point the exit animation is */
+  /* immediately responsive so we don't need a bespoke curve */
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  /* todo: better var? */
+  border: 1px solid var(--color-gray-400);
+}
+
+/* start really fast because we start super hidden initially behind the panel, otherwise feels like an unintended animation delay */
+.resize-container:hover ~ .resize-line {
+  transition: transform 0.25s cubic-bezier(0.23, 1, 0.32, 0.9);
+}
+
+.resize-container.right,
+.resize-container.left {
+  top: 0;
+  height: 100%;
+  width: 22px;
+  cursor: ew-resize;
+}
+
+/* todo: don't hard code all these values/use vars */
+
+.resize-container.bottom,
+.resize-container.top {
+  left: 0;
+  width: 100%;
+  height: 22px;
+  cursor: ns-resize;
+}
+
+.resize-container.top {
+  top: -7px;
+}
+.resize-container.bottom {
+  bottom: -7px;
+}
+.resize-container.left {
+  left: -7px;
+}
+.resize-container.right {
+  right: -7px;
+}
+
+.resize-container.top-left,
+.resize-container.top-right,
+.resize-container.bottom-left,
+.resize-container.bottom-right {
+  width: 26px;
+  height: 26px;
+  z-index: 15;
+}
+
+.resize-container.top-left {
+  top: -5px;
+  left: -5px;
+  cursor: nwse-resize;
+}
+.resize-container.top-right {
+  top: -5px;
+  right: -5px;
+  cursor: nesw-resize;
+}
+.resize-container.bottom-left {
+  bottom: -5px;
+  left: -5px;
+  cursor: nesw-resize;
+}
+.resize-container.bottom-right {
+  bottom: -5px;
+  right: -5px;
+  cursor: nwse-resize;
+}
+
+.resize-line.top,
+.resize-line.bottom {
+  height: 18px;
+  width: 100%;
+  background-color: var(--color-background-200);
+}
+
+.resize-line.left,
+.resize-line.right {
+  width: 18px;
+  height: 100%;
+  background-color: var(--color-background-200);
+}
+
+.resize-line.top {
+  top: -7px;
+  left: calc(-1 * var(--border-left, 2px));
+  width: calc(100% + var(--border-horizontal, 4px));
+  border-radius: var(--rounded-lg) var(--rounded-lg) 0 0;
+  transform: translateY(18px);
+}
+
+.resize-line.bottom {
+  bottom: -7px;
+  left: calc(-1 * var(--border-left, 2px));
+  width: calc(100% + var(--border-horizontal, 4px));
+  border-radius: 0 0 var(--rounded-lg) var(--rounded-lg);
+  transform: translateY(-18px);
+}
+
+.resize-line.left {
+  top: calc(-1 * var(--border-top, 2px));
+  left: -7px;
+  height: calc(100% + var(--border-vertical, 4px));
+  border-radius: var(--rounded-lg) 0 0 var(--rounded-lg);
+  transform: translateX(18px);
+}
+
+.resize-line.right {
+  top: calc(-1 * var(--border-top, 2px));
+  right: -7px;
+  height: calc(100% + var(--border-vertical, 4px));
+  border-radius: 0 var(--rounded-lg) var(--rounded-lg) 0;
+  transform: translateX(-18px);
+}
+
+.resize-container.right:hover ~ .resize-line.right,
+.resize-container.left:hover ~ .resize-line.left,
+.resize-line.right.dragging,
+.resize-line.left.dragging {
+  transform: translateX(0);
+}
+
+.resize-container.bottom:hover ~ .resize-line.bottom,
+.resize-container.top:hover ~ .resize-line.top,
+.resize-line.bottom.dragging,
+.resize-line.top.dragging {
+  transform: translateY(0);
+}
+
+/* make sure that we don't show multiple handles at once
+ * we should only ever show the currently resizing handle
+ * regardless of hover state 
+ */
+.resize-container.no-hover.right:hover ~ .resize-line.right {
+  transform: translateX(-20px);
+}
+.resize-container.no-hover.left:hover ~ .resize-line.left {
+  transform: translateX(20px);
+}
+.resize-container.no-hover.bottom:hover ~ .resize-line.bottom {
+  transform: translateY(-20px);
+}
+.resize-container.no-hover.top:hover ~ .resize-line.top {
+  transform: translateY(20px);
+}
+
+
+/* ---- inline <style> ---- */
+/* Panel container base styles with dynamic positioning and sizing */
+.dynamic-panel-container {
+  position: fixed;
+  z-index: 2147483646;
+  outline: none;
+  top: var(--panel-top, auto);
+  bottom: var(--panel-bottom, auto);
+  left: var(--panel-left, auto);
+  right: var(--panel-right, auto);
+  width: var(--panel-width);
+  height: var(--panel-height);
+  min-width: var(--panel-min-width);
+  min-height: var(--panel-min-height);
+  max-width: var(--panel-max-width);
+  max-height: var(--panel-max-height);
+}
+
+/* Panel content container styles */
+.panel-content-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border: 1px solid var(--color-gray-alpha-400);
+  border-radius: var(--rounded-xl);
+  background: var(--color-background-100);
+  display: flex;
+  flex-direction: column;
+}
+
+/* Draggable content area styles */
+.draggable-content {
+  flex: 1;
+  overflow: auto;
+}
+
+
+/* ---- inline <style> ---- */
+.segment-explorer-content {
+  font-size: var(--size-14);
+  padding: 0 8px;
+  width: 100%;
+  height: 100%;
+}
+
+.segment-explorer-page-route-bar {
+  display: flex;
+  align-items: center;
+  padding: 14px 16px;
+  background-color: var(--color-background-200);
+  gap: 12px;
+}
+
+.segment-explorer-page-route-bar-path {
+  font-size: var(--size-14);
+  font-weight: 500;
+  color: var(--color-gray-1000);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  line-height: 20px;
+}
+
+.segment-explorer-item {
+  margin: 4px 0;
+  border-radius: 6px;
+}
+
+.segment-explorer-item:nth-child(even) {
+  background-color: var(--color-background-200);
+}
+.segment-explorer-item-row {
+  display: flex;
+  flex-direction: column;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-right: 4px;
+}
+.segment-explorer-item-row-main {
+  display: flex;
+  align-items: center;
+  white-space: pre;
+  color: var(--color-gray-1000);
+}
+
+.segment-explorer-children--intended {
+  padding-left: 16px;
+}
+
+.segment-explorer-filename {
+  display: inline-flex;
+  width: 100%;
+  align-items: center;
+}
+
+.segment-explorer-filename select {
+  margin-left: auto;
+}
+.segment-explorer-filename--path {
+  margin-right: 8px;
+}
+.segment-explorer-filename--path small {
+  display: inline-block;
+  width: 0;
+  opacity: 0;
+}
+.segment-explorer-filename--name {
+  color: var(--color-gray-800);
+}
+
+.segment-explorer-files {
+  display: inline-flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.segment-explorer-files + .segment-boundary-trigger {
+  margin-left: 8px;
+}
+
+.segment-explorer-file-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 6px;
+  height: 20px;
+  border-radius: 16px;
+  line-height: 16px;
+  font-size: var(--size-12);
+  font-weight: 500;
+  background-color: var(--color-gray-300);
+  color: var(--color-gray-1000);
+}
+.segment-explorer-file-label-text {
+  display: inline-flex;
+  align-items: center;
+}
+
+.segment-explorer-file-label--overridden {
+  background-color: var(--color-amber-300);
+  color: var(--color-amber-900);
+}
+
+.segment-explorer-file-label .code-icon {
+  opacity: 0;
+  margin-left: 0;
+  width: 0;
+  transition: all 0.15s ease-in-out;
+}
+.segment-explorer-file-label:hover .code-icon {
+  opacity: 1;
+  width: 12px;
+  margin-left: 4px;
+}
+
+.segment-explorer-file-label:hover {
+  filter: brightness(0.95);
+}
+
+.segment-explorer-file-label--builtin {
+  background-color: transparent;
+  color: var(--color-gray-900);
+  border: 1px dashed var(--color-gray-500);
+  height: 24px;
+  cursor: default;
+}
+.segment-explorer-file-label--builtin svg {
+  margin-left: 4px;
+  margin-right: -4px;
+}
+
+/* Footer styles */
+.segment-explorer-footer {
+  padding: 8px;
+  border-top: 1px solid var(--color-gray-400);
+  user-select: none;
+}
+
+.segment-explorer-footer-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px;
+  background: var(--color-background-100);
+  border: 1px solid var(--color-gray-400);
+  border-radius: 6px;
+  color: var(--color-gray-1000);
+  font-size: var(--size-14);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.segment-explorer-footer-button:hover:not(:disabled) {
+  background: var(--color-gray-200);
+}
+
+.segment-explorer-footer-button--disabled {
+  cursor: not-allowed;
+}
+
+.segment-explorer-footer-text {
+  text-align: center;
+}
+
+.segment-explorer-footer-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  background: var(--color-amber-300);
+  color: var(--color-amber-900);
+  border-radius: 10px;
+  font-size: var(--size-12);
+  font-weight: 600;
+  line-height: 1;
+}
+
+.segment-explorer-file-label-tooltip--sm {
+  white-space: nowrap;
+}
+
+.segment-explorer-file-label-tooltip--lg {
+  min-width: 200px;
+}
+
+.segment-explorer-suggestions {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.segment-explorer-suggestions-tooltip {
+  width: 200px;
+}
+
+
+/* ---- inline <style> ---- */
+.segment-boundary-trigger {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  line-height: 16px;
+  font-weight: 500;
+  color: var(--color-gray-1000);
+  border-radius: 999px;
+  border: none;
+  font-size: var(--size-12);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.segment-boundary-trigger-text {
+  font-size: var(--size-12);
+  font-weight: 500;
+  user-select: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.segment-boundary-trigger-text .plus-icon {
+  transition: transform 0.25s ease;
+}
+
+.segment-boundary-trigger-text:hover .plus-icon {
+  color: var(--color-gray-800);
+}
+
+.segment-boundary-trigger svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  vertical-align: middle;
+}
+
+.segment-boundary-trigger:hover svg {
+  color: var(--color-gray-700);
+}
+
+.segment-boundary-trigger[disabled] svg,
+.segment-boundary-trigger[disabled]:hover svg {
+  color: var(--color-gray-400);
+  cursor: not-allowed;
+}
+
+.segment-boundary-dropdown {
+  padding: 8px;
+  background: var(--color-background-100);
+  border: 1px solid var(--color-gray-400);
+  border-radius: 16px;
+  min-width: 120px;
+  user-select: none;
+  cursor: default;
+  box-shadow: 0px 4px 8px -4px
+    color-mix(in srgb, var(--color-gray-900) 4%, transparent);
+}
+
+.segment-boundary-dropdown-positioner {
+  z-index: var(--top-z-index);
+}
+
+.segment-boundary-dropdown-item {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  line-height: 20px;
+  font-size: 14px;
+  border-radius: 6px;
+  color: var(--color-gray-1000);
+  cursor: pointer;
+  min-width: 220px;
+  border: none;
+  background: none;
+  width: 100%;
+}
+
+.segment-boundary-dropdown-item[data-disabled] {
+  color: var(--color-gray-400);
+  cursor: not-allowed;
+}
+
+.segment-boundary-dropdown-item svg {
+  margin-right: 12px;
+  color: currentColor;
+}
+
+.segment-boundary-dropdown-item:hover {
+  background: var(--color-gray-200);
+}
+
+.segment-boundary-dropdown-item:first-child {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.segment-boundary-dropdown-item:last-child {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.segment-boundary-group-label {
+  padding: 8px;
+  font-size: 13px;
+  line-height: 16px;
+  font-weight: 400;
+  color: var(--color-gray-900);
+}
+
+
+/* ---- inline <style> ---- */
+.tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+  line-height: 1;
+}
+
+.tooltip {
+  position: relative;
+  padding: 6px 12px;
+  border-radius: 8px;
+  font-size: 14px;
+  line-height: 1.4;
+  pointer-events: none;
+  color: var(--color-gray-100);
+  background-color: var(--color-gray-1000);
+}
+
+.tooltip-arrow {
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: var(--arrow-size, 6px);
+  border-color: transparent;
+}
+
+.tooltip-arrow--top {
+  border-width: var(--arrow-size, 6px) var(--arrow-size, 6px) 0
+    var(--arrow-size, 6px);
+  border-top-color: var(--color-gray-1000);
+  bottom: 0;
+  transform: translateY(100%);
+}
+
+.tooltip-arrow--bottom {
+  border-width: 0 var(--arrow-size, 6px) var(--arrow-size, 6px)
+    var(--arrow-size, 6px);
+  border-bottom-color: var(--color-gray-1000);
+  top: 0;
+  transform: translateY(-100%);
+}
+
+.tooltip-arrow--left {
+  border-width: var(--arrow-size, 6px) 0 var(--arrow-size, 6px)
+    var(--arrow-size, 6px);
+  border-left-color: var(--color-gray-1000);
+  right: 0;
+  transform: translateX(100%);
+}
+
+.tooltip-arrow--right {
+  border-width: var(--arrow-size, 6px) var(--arrow-size, 6px)
+    var(--arrow-size, 6px) 0;
+  border-right-color: var(--color-gray-1000);
+  left: 0;
+  transform: translateX(-100%);
+}
+
+.tooltip-positioner {
+  z-index: var(--top-z-index);
+}
+
+
+/* ---- inline <style> ---- */
+.instant-nav-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.instant-nav-content {
+  flex: 1;
+  padding: 12px 20px 0;
+}
+
+/* Waiting state: preference-style sections */
+.instant-nav-section {
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--color-gray-400);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+}
+
+.instant-nav-section:last-child {
+  border-bottom: none;
+}
+
+.instant-nav-section-header {
+  flex: 1;
+}
+
+.instant-nav-section-header label {
+  font-size: var(--size-14);
+  font-weight: 500;
+  color: var(--color-gray-1000);
+  margin: 0;
+}
+
+.instant-nav-section-description {
+  color: var(--color-gray-900);
+  font-size: var(--size-14);
+  margin: 0;
+}
+
+.instant-nav-section-control {
+  flex-shrink: 0;
+}
+
+.instant-nav-section-control .action-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--color-background-100);
+  border: 1px solid var(--color-gray-400);
+  border-radius: var(--rounded-lg);
+  font-weight: 400;
+  font-size: var(--size-14);
+  color: var(--color-gray-1000);
+  padding: 6px 8px;
+  cursor: pointer;
+  transition: border-color 150ms var(--timing-swift);
+}
+
+.instant-nav-section-control .action-button:hover {
+  border-color: var(--color-gray-500);
+}
+
+.instant-nav-section-control .action-button svg {
+  width: 14px;
+  height: 14px;
+  overflow: visible;
+}
+
+.instant-nav-helper-text {
+  font-size: var(--size-14);
+  color: var(--color-gray-900);
+  font-style: italic;
+  white-space: nowrap;
+}
+
+/* Result states (client-nav, initial-load) */
+.instant-nav-status-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-gray-900);
+}
+
+.instant-nav-urls {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.instant-nav-url-row {
+  display: flex;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.instant-nav-url-label {
+  color: var(--color-gray-700);
+  flex-shrink: 0;
+}
+
+.instant-nav-url-value {
+  color: var(--color-gray-900);
+  word-break: break-all;
+  font-family: var(--font-mono);
+}
+
+.instant-nav-actions {
+  margin-top: 8px;
+  display: flex;
+}
+
+.instant-nav-share-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--color-gray-alpha-400);
+  background: var(--color-background-200);
+  color: var(--color-gray-900);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.instant-nav-share-button:hover {
+  background: var(--color-gray-alpha-200);
+}
+
+.instant-nav-helper-description {
+  color: var(--color-gray-900);
+  font-size: var(--size-14);
+  margin: 8px 0 0;
+}
+
+/* Footer (pinned to bottom, matching segment-explorer-footer) */
+.instant-nav-footer {
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  border-top: 1px solid var(--color-gray-400);
+  user-select: none;
+}
+
+.instant-nav-footer-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: 8px;
+  padding: 6px;
+  background: var(--color-background-100);
+  border: 1px solid var(--color-gray-400);
+  border-radius: 6px;
+  color: var(--color-gray-1000);
+  font-size: var(--size-14);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.instant-nav-footer-button:hover {
+  background: var(--color-gray-200);
+}
+
+/* Shimmer skeleton for pending "to" route */
+@keyframes instant-nav-shimmer {
+  0% {
+    background-position: -400px 0;
+  }
+  100% {
+    background-position: 400px 0;
+  }
+}
+
+.instant-nav-skeleton {
+  display: inline-block;
+  width: 120px;
+  height: 1em;
+  vertical-align: middle;
+  border-radius: 4px;
+  background: linear-gradient(
+    90deg,
+    var(--color-gray-300) 25%,
+    var(--color-blue-300) 50%,
+    var(--color-gray-300) 75%
+  );
+  background-size: 800px 100%;
+  animation: instant-nav-shimmer 1.5s ease-in-out infinite;
+}
+
+
+/* ---- inline <style> ---- */
+/* Panel content padding styles */
+.panel-content {
+  padding: 16px;
+  padding-top: 8px;
+  overflow: hidden;
+}
+
+/* User preferences wrapper styles */
+.user-preferences-wrapper {
+  padding: 20px;
+  padding-top: 8px;
+  overflow: hidden;
+}
+
+/* Panel route base styles */
+.panel-route {
+  opacity: var(--panel-opacity);
+  transition: var(--panel-transition);
+}
+
+.turbopack-upgrade-link {
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+
+/* ---- inline <style> ---- */
+.nextjs-data-copy-button{color:inherit;svg{width:var(--size-16);height:var(--size-16)}}.nextjs-data-copy-button[aria-disabled="true"]{background-color:var(--color-gray-100);cursor:not-allowed}.nextjs-data-copy-button[data-pending="true"]{cursor:wait}.nextjs-data-copy-button--initial:hover:not([aria-disabled="true"]){cursor:pointer}.nextjs-data-copy-button--error:not([aria-disabled="true"]),.nextjs-data-copy-button--error:hover:not([aria-disabled="true"]){color:var(--color-ansi-red)}.nextjs-data-copy-button--success:not([aria-disabled="true"]){color:var(--color-ansi-green)}[data-nextjs-call-stack-frame-no-source]{padding:6px 8px;margin-bottom:4px;border-radius:var(--rounded-lg)}[data-nextjs-call-stack-frame-no-source]:last-child{margin-bottom:0}[data-nextjs-call-stack-frame-ignored="true"]{opacity:0.6}[data-nextjs-call-stack-frame]{user-select:text;display:block;box-sizing:border-box;user-select:text;-webkit-user-select:text;-moz-user-select:text;-ms-user-select:text;padding:6px 8px;border-radius:var(--rounded-lg)}.call-stack-frame-method-name{display:flex;align-items:center;gap:4px;margin-bottom:4px;font-family:var(--font-stack-monospace);color:var(--color-gray-1000);font-size:var(--size-14);font-weight:500;line-height:var(--size-20);svg{width:var(--size-16px);height:var(--size-16px)}}.open-in-editor-button,.source-mapping-error-button{display:flex;align-items:center;justify-content:center;border-radius:var(--rounded-full);padding:4px;color:var(--color-font);svg{width:var(--size-16);height:var(--size-16)}&:focus-visible{outline:var(--focus-ring);outline-offset:-2px}&:hover{background:var(--color-gray-100)}}.call-stack-frame-file{color:var(--color-gray-900);font-size:var(--size-14);line-height:var(--size-20);word-wrap:break-word}[data-nextjs-call-stack-container]{position:relative;margin-top:8px}[data-nextjs-call-stack-header]{display:flex;justify-content:space-between;align-items:center;min-height:var(--size-28);padding:8px 8px 12px 4px;width:100%}[data-nextjs-call-stack-title]{display:flex;justify-content:space-between;align-items:center;gap:8px;margin:0;color:var(--color-gray-1000);font-size:var(--size-16);font-weight:500}[data-nextjs-call-stack-count]{display:flex;justify-content:center;align-items:center;width:var(--size-20);height:var(--size-20);gap:4px;color:var(--color-gray-1000);text-align:center;font-size:var(--size-11);font-weight:500;line-height:var(--size-16);border-radius:var(--rounded-full);background:var(--color-gray-300)}[data-nextjs-call-stack-ignored-list-toggle-button]{all:unset;display:flex;align-items:center;gap:6px;color:var(--color-gray-900);font-size:var(--size-14);line-height:var(--size-20);border-radius:6px;padding:4px 6px;margin-right:-6px;transition:background 150ms ease;&:hover{background:var(--color-gray-100)}&:focus{outline:var(--focus-ring)}svg{width:var(--size-16);height:var(--size-16)}}[data-nextjs-environment-name-label]{padding:2px 6px;margin:0;border-radius:var(--rounded-md-2);background:var(--color-gray-100);font-weight:600;font-size:var(--size-12);color:var(--color-gray-900);font-family:var(--font-stack-monospace);line-height:var(--size-20)}[data-nextjs-dialog-overlay]{position:fixed;top:0;right:0;bottom:0;left:0;z-index:2147483646;display:flex;align-content:center;align-items:center;flex-direction:column;padding:10vh 15px 0;color-scheme:dark light}@media (max-height:812px){[data-nextjs-dialog-overlay]{padding:15px 15px 0}}[data-nextjs-dialog-backdrop]{position:fixed;top:0;right:0;bottom:0;left:0;background-color:var(--color-backdrop);backdrop-filter:blur(10px);pointer-events:all;z-index:-1}[data-nextjs-dialog-backdrop-fixed]{cursor:not-allowed;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px)}[data-nextjs-dialog-root]{--next-dialog-radius:var(--rounded-xl);--next-dialog-max-width:960px;--next-dialog-row-padding:16px;--next-dialog-padding:12px;--next-dialog-notch-height:42px;--next-dialog-border-width:1px;display:flex;flex-direction:column;width:100%;max-height:calc(100% - 56px);max-width:var(--next-dialog-max-width);margin-right:auto;margin-left:auto;scale:0.97;opacity:0;transition-property:scale,opacity;transition-duration:var(--transition-duration);transition-timing-function:var(--timing-overlay);&[data-rendered='true']{opacity:1;scale:1}[data-nextjs-scroll-fader][data-side='top']{left:1px;top:calc( var(--next-dialog-notch-height) + var(--next-dialog-border-width) );width:calc(100% - var(--next-dialog-padding));opacity:0}}[data-nextjs-dialog]{outline:0}[data-nextjs-dialog-backdrop]{opacity:0;transition:opacity var(--transition-duration) var(--timing-overlay)}[data-nextjs-dialog-overlay]{margin:8px}[data-nextjs-dialog-overlay][data-rendered='true'] [data-nextjs-dialog-backdrop]{opacity:1}[data-nextjs-dialog-content]{border:none;margin:0;display:flex;flex-direction:column;position:relative;padding:var(--next-dialog-padding)}[data-nextjs-dialog-content] > [data-nextjs-dialog-header]{flex-shrink:0;margin-bottom:8px}[data-nextjs-dialog-content] > [data-nextjs-dialog-body]{position:relative;flex:1 1 auto}@media (max-height:812px){[data-nextjs-dialog-overlay]{max-height:calc(100% - 15px)}}@media (min-width:576px){[data-nextjs-dialog-root]{--next-dialog-max-width:540px}}@media (min-width:768px){[data-nextjs-dialog-root]{--next-dialog-max-width:720px}}@media (min-width:992px){[data-nextjs-dialog-root]{--next-dialog-max-width:960px}}[data-nextjs-dialog-overlay]{padding:initial;top:10vh}.error-overlay-dialog-container{display:flex;flex-direction:column;background:var(--color-background-100);background-clip:padding-box;border:var(--next-dialog-border-width) solid var(--color-gray-400);border-radius:0 0 var(--next-dialog-radius) var(--next-dialog-radius);box-shadow:var(--shadow-menu);position:relative;overflow:hidden}.error-overlay-dialog-scroll{overflow-y:auto;height:100%}.nextjs-container-errors-header{position:relative}.nextjs-container-errors-header > h1{font-size:var(--size-20);line-height:var(--size-24);font-weight:bold;margin:calc(16px * 1.5) 0;color:var(--color-title-h1)}.nextjs-container-errors-header small{font-size:var(--size-14);color:var(--color-accents-1);margin-left:16px}.nextjs-container-errors-header small > span{font-family:var(--font-stack-monospace)}.nextjs-container-errors-header > div > small{margin:0;margin-top:4px}.nextjs-container-errors-header > p > a{color:inherit;font-weight:bold}.nextjs-container-errors-header > .nextjs-container-build-error-version-status{position:absolute;top:16px;right:16px}[data-nextjs-error-overlay-nav]{--stroke-color:var(--color-gray-400);--background-color:var(--color-background-100);display:flex;justify-content:space-between;align-items:center;width:100%;position:relative;z-index:2;outline:none;translate:var(--next-dialog-border-width) var(--next-dialog-border-width);max-width:var(--next-dialog-max-width);.error-overlay-notch{translate:calc(var(--next-dialog-border-width) * -1);width:auto;height:var(--next-dialog-notch-height);padding:12px;background:var(--background-color);border:var(--next-dialog-border-width) solid var(--stroke-color);border-bottom:none;position:relative;&[data-side='left']{padding-right:0;border-radius:var(--next-dialog-radius) 0 0 0;.error-overlay-notch-tail{right:-54px}> *:not(.error-overlay-notch-tail){margin-right:-10px}}&[data-side='right']{padding-left:0;border-radius:0 var(--next-dialog-radius) 0 0;.error-overlay-notch-tail{left:-54px;transform:rotateY(180deg)}> *:not(.error-overlay-notch-tail){margin-left:-12px}}.error-overlay-notch-tail{position:absolute;top:calc(var(--next-dialog-border-width) * -1);pointer-events:none;z-index:-1;height:calc(100% + var(--next-dialog-border-width))}}}@media (max-width:600px){[data-nextjs-error-overlay-nav]{background:var(--background-color);border-radius:var(--next-dialog-radius) var(--next-dialog-radius) 0 0;border:var(--next-dialog-border-width) solid var(--stroke-color);border-bottom:none;overflow:hidden;translate:0 var(--next-dialog-border-width);.error-overlay-notch{border-radius:0;border:0;&[data-side="left"],&[data-side="right"]{border-radius:0}.error-overlay-notch-tail{display:none}}}}.nextjs__container_errors_label{padding:2px 6px;margin:0;border-radius:var(--rounded-md-2);background:var(--color-red-100);font-weight:600;font-size:var(--size-12);color:var(--color-red-900);font-family:var(--font-stack-monospace);line-height:var(--size-20)}.nextjs__container_errors_label_blocking_page{background:var(--color-blue-100);color:var(--color-blue-900)}.nextjs__container_errors_wrapper{position:relative}.nextjs__container_errors_desc{margin:0;margin-left:4px;color:var(--color-red-900);font-weight:500;font-size:var(--size-16);letter-spacing:-0.32px;line-height:var(--size-24);overflow-wrap:break-word;white-space:pre-wrap}.nextjs__container_errors_desc.truncated{max-height:200px;overflow:hidden}.nextjs__container_errors_gradient_overlay{position:absolute;bottom:0;left:0;right:0;height:85px;background:linear-gradient( 180deg,rgba(250,250,250,0) 0%,var(--color-background-100) 100% )}.nextjs__container_errors_expand_button{position:absolute;bottom:10px;left:50%;transform:translateX(-50%);display:flex;align-items:center;padding:6px 8px;background:var(--color-background-100);border:1px solid var(--color-gray-alpha-400);border-radius:999px;box-shadow:0px 2px 2px var(--color-gray-alpha-100),0px 8px 8px -8px var(--color-gray-alpha-100);font-size:var(--size-13);cursor:pointer;color:var(--color-gray-900);font-weight:500;transition:background-color 0.2s ease}.nextjs__container_errors_expand_button:hover{background:var(--color-gray-100)}.error-overlay-toolbar{display:flex;gap:6px}.nodejs-inspector-button,.copy-error-button,.docs-link-button{display:flex;justify-content:center;align-items:center;width:var(--size-28);height:var(--size-28);background:var(--color-background-100);background-clip:padding-box;border:1px solid var(--color-gray-alpha-400);box-shadow:var(--shadow-small);border-radius:var(--rounded-full);svg{width:var(--size-14);height:var(--size-14)}&:focus{outline:var(--focus-ring)}&:not(:disabled):hover{background:var(--color-gray-alpha-100)}&:not(:disabled):active{background:var(--color-gray-alpha-200)}&:disabled{background-color:var(--color-gray-100);cursor:not-allowed}}.nodejs-inspector-button[data-pending='true']{cursor:wait}.error-overlay-toolbar-button-icon{color:var(--color-gray-900)}[data-nextjs-error-label-group]{display:flex;align-items:center;gap:8px}.error-overlay-footer{display:flex;flex-direction:row;justify-content:space-between;gap:8px;padding:12px;background:var(--color-background-200);border-top:1px solid var(--color-gray-400)}.error-feedback{margin-left:auto;p{font-size:var(--size-14);font-weight:500;margin:0}}.error-feedback{display:flex;align-items:center;gap:8px;white-space:nowrap;color:var(--color-gray-900)}.error-feedback-thanks{height:var(--size-24);display:flex;align-items:center;padding-right:4px}.feedback-button{background:none;border:none;border-radius:var(--rounded-md);width:var(--size-24);height:var(--size-24);display:flex;align-items:center;justify-content:center;cursor:pointer;&:focus{outline:var(--focus-ring)}&:hover{background:var(--color-gray-alpha-100)}&:active{background:var(--color-gray-alpha-200)}}.feedback-button[aria-disabled='true']{opacity:0.7;cursor:not-allowed}.feedback-button.voted{background:var(--color-gray-alpha-200)}.thumbs-up-icon,.thumbs-down-icon{color:var(--color-gray-900);width:var(--size-16);height:var(--size-16)}.error-overlay-bottom-stack-layer{width:100%;height:var(--stack-layer-height);position:relative;border:1px solid var(--color-gray-400);border-radius:var(--rounded-xl);background:var(--color-background-200);transition:translate 350ms var(--timing-swift),box-shadow 350ms var(--timing-swift)}.error-overlay-bottom-stack-layer-1{width:calc(100% - var(--size-24))}.error-overlay-bottom-stack-layer-2{width:calc(100% - var(--size-48));z-index:-1}.error-overlay-bottom-stack{width:100%;position:absolute;bottom:-1px;height:0;overflow:visible}.error-overlay-bottom-stack-stack{--stack-layer-height:44px;--stack-layer-height-half:calc(var(--stack-layer-height) / 2);--stack-layer-trim:13px;--shadow:0px 0.925px 0.925px 0px rgba(0,0,0,0.02),0px 3.7px 7.4px -3.7px rgba(0,0,0,0.04),0px 14.8px 22.2px -7.4px rgba(0,0,0,0.06);display:grid;place-items:center center;width:100%;position:fixed;height:0;overflow:visible;z-index:-1;max-width:var(--next-dialog-max-width);.error-overlay-bottom-stack-layer{grid-area:1 / 1;translate:0 calc(var(--stack-layer-height) * -1)}&[data-stack-count='1'],&[data-stack-count='2']{.error-overlay-bottom-stack-layer-1{translate:0 calc(var(--stack-layer-height-half) * -1 - var(--stack-layer-trim))}}&[data-stack-count='2']{.error-overlay-bottom-stack-layer-2{translate:0 calc(var(--stack-layer-trim) * -1 * 2)}}&[data-stack-count='1'] .error-overlay-bottom-stack-layer-1{box-shadow:var(--shadow)}&[data-stack-count='2']{.error-overlay-bottom-stack-layer-2{box-shadow:var(--shadow)}}}.error-overlay-pagination{-webkit-font-smoothing:antialiased;display:flex;justify-content:center;align-items:center;gap:8px;width:fit-content}.error-overlay-pagination-count{color:var(--color-gray-900);text-align:center;font-size:var(--size-14);font-weight:500;line-height:var(--size-16);font-variant-numeric:tabular-nums}.error-overlay-pagination-button{display:flex;justify-content:center;align-items:center;width:var(--size-24);height:var(--size-24);background:var(--color-gray-300);flex-shrink:0;border:none;border-radius:var(--rounded-full);svg{width:var(--size-16);height:var(--size-16)}&:focus-visible{outline:var(--focus-ring)}&:not(:disabled):active{background:var(--color-gray-500)}&:disabled{opacity:0.5;cursor:not-allowed}}.error-overlay-pagination-button-icon{color:var(--color-gray-1000)}[data-nextjs-codeframe]{--code-frame-padding:12px;--code-frame-line-height:var(--size-16);background-color:var(--color-background-200);color:var(--color-gray-1000);text-overflow:ellipsis;border:1px solid var(--color-gray-400);border-radius:8px;font-family:var(--font-stack-monospace);font-size:var(--size-12);line-height:var(--code-frame-line-height);margin:8px 0;svg{width:var(--size-16);height:var(--size-16)}}.code-frame-link,.code-frame-pre{padding:var(--code-frame-padding)}.code-frame-link svg{flex-shrink:0}.code-frame-lines{min-width:max-content}.code-frame-link [data-text]{text-align:left;margin:auto 6px}.code-frame-header{width:100%;transition:background 100ms ease-out;border-radius:8px 8px 0 0;border-bottom:1px solid var(--color-gray-400)}[data-with-open-in-editor-link-source-file]{padding:4px;margin:-4px 0 -4px auto;border-radius:var(--rounded-full);margin-left:auto;&:focus-visible{outline:var(--focus-ring);outline-offset:-2px}&:hover{background:var(--color-gray-100)}}[data-nextjs-codeframe]::selection,[data-nextjs-codeframe] *::selection{background-color:var(--color-ansi-selection)}[data-nextjs-codeframe] *:not(a){color:inherit;background-color:transparent;font-family:var(--font-stack-monospace)}[data-nextjs-codeframe-line][data-nextjs-codeframe-line--errored="true"]{position:relative;isolation:isolate;> span{position:relative;z-index:1}&::after{content:"";width:calc(100% + var(--code-frame-padding) * 2);height:var(--code-frame-line-height);left:calc(-1 * var(--code-frame-padding));background:var(--color-red-200);box-shadow:2px 0 0 0 var(--color-red-900) inset;position:absolute}}[data-nextjs-codeframe] > *{margin:0}.code-frame-link{display:flex;margin:0;outline:0}.code-frame-link [data-icon='right']{margin-left:auto}[data-nextjs-codeframe] div > pre{overflow:hidden;display:inline-block}[data-nextjs-codeframe] svg{color:var(--color-gray-900)}[data-nextjs-terminal]::selection,[data-nextjs-terminal] *::selection{background-color:var(--color-ansi-selection)}[data-nextjs-terminal] *{color:inherit;background-color:transparent;font-family:var(--font-stack-monospace)}[data-nextjs-terminal] > div > p{display:flex;align-items:center;justify-content:space-between;cursor:pointer;margin:0}[data-nextjs-terminal] > div > p:hover{text-decoration:underline dotted}[data-nextjs-terminal] div > pre{overflow:hidden;display:inline-block}[data-with-open-in-editor-link] svg{width:auto;height:var(--size-14);margin-left:8px}[data-with-open-in-editor-link]{cursor:pointer}[data-with-open-in-editor-link]:hover{text-decoration:underline dotted}[data-with-open-in-editor-link-import-trace]{margin-left:16px}.nextjs-error-with-static{bottom:calc(16px * 4.5)}p.nextjs__container_errors__link{font-size:var(--size-14)}p.nextjs__container_errors__notes{color:var(--color-stack-notes);font-size:var(--size-14);line-height:1.5}.nextjs-container-errors-body > h2:not(:first-child){margin-top:calc(16px + 8px)}.nextjs-container-errors-body > h2{color:var(--color-title-color);margin-bottom:8px;font-size:var(--size-20)}.nextjs-toast-errors-parent{cursor:pointer;transition:transform 0.2s ease}.nextjs-toast-errors-parent:hover{transform:scale(1.1)}.nextjs-toast-errors{display:flex;align-items:center;justify-content:flex-start}.nextjs-toast-errors > svg{margin-right:8px}.nextjs-toast-hide-button{margin-left:24px;border:none;background:none;color:var(--color-ansi-bright-white);padding:0;transition:opacity 0.25s ease;opacity:0.7}.nextjs-toast-hide-button:hover{opacity:1}.nextjs__container_errors__error_title{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px}.error-overlay-notes-container{margin:8px 2px}.error-overlay-notes-container p{white-space:pre-wrap}.nextjs__blocking_page_load_error_description{color:var(--color-stack-notes)}.nextjs__blocking_page_load_error_description_title{color:var(--color-title-color)}.nextjs__blocking_page_load_error_fix_option{background-color:var(--color-background-200);padding:14px;border-radius:var(--rounded-md-2);border:1px solid var(--color-gray-alpha-400)}.external-link,.external-link:hover{color:inherit}[data-nextjs-container-errors-pseudo-html]{padding:8px 0;margin:8px 0;border:1px solid var(--color-gray-400);background:var(--color-background-200);color:var(--color-syntax-constant);font-family:var(--font-stack-monospace);font-size:var(--size-12);line-height:1.33em;border-radius:var(--rounded-md-2)}[data-nextjs-container-errors-pseudo-html-line]{display:inline-block;width:100%;padding-left:40px;line-height:calc(5 / 3)}[data-nextjs-container-errors-pseudo-html--diff='error']{background:var(--color-amber-100);box-shadow:2px 0 0 0 var(--color-amber-900) inset;font-weight:bold}[data-nextjs-container-errors-pseudo-html-collapse-button]{all:unset;margin-left:12px;&:focus{outline:none}}[data-nextjs-container-errors-pseudo-html--diff='add']{background:var(--color-green-300)}[data-nextjs-container-errors-pseudo-html-line-sign]{margin-left:calc(24px * -1);margin-right:24px}[data-nextjs-container-errors-pseudo-html--diff='add'] [data-nextjs-container-errors-pseudo-html-line-sign]{color:var(--color-green-900)}[data-nextjs-container-errors-pseudo-html--diff='remove']{background:var(--color-red-300)}[data-nextjs-container-errors-pseudo-html--diff='remove'] [data-nextjs-container-errors-pseudo-html-line-sign]{color:var(--color-red-900);margin-left:calc(24px * -1);margin-right:24px}[data-nextjs-container-errors-pseudo-html--diff='error'] [data-nextjs-container-errors-pseudo-html-line-sign]{color:var(--color-amber-900)}[data-nextjs-container-errors-pseudo-html--hint]{display:inline-block;font-size:0;height:0}[data-nextjs-container-errors-pseudo-html--tag-adjacent='false']{color:var(--color-accents-1)}.nextjs__container_errors__component-stack{margin:0}[data-nextjs-container-errors-pseudo-html-collapse='true'] .nextjs__container_errors__component-stack code{max-height:120px;mask-image:linear-gradient(to bottom,rgba(0,0,0,0) 0%,black 10%);padding-bottom:40px}.nextjs__container_errors__component-stack code{display:block;width:100%;white-space:pre-wrap;scroll-snap-type:y mandatory;overflow-y:hidden}[data-nextjs-container-errors-pseudo-html--diff]{scroll-snap-align:center}.error-overlay-hydration-error-diff-plus-icon{color:var(--color-green-900)}.error-overlay-hydration-error-diff-minus-icon{color:var(--color-red-900)}[data-nextjs-hydration-diff-header]{display:flex;align-items:center;justify-content:space-between;padding:0 12px 0 0}[data-nextjs-hydration-diff-badge]{display:flex;gap:8px;font-size:var(--size-12)}[data-nextjs-hydration-diff-badge-item]{display:flex;align-items:center;gap:4px;color:var(--color-gray-900)}[data-nextjs-hydration-diff-badge-item='client'] span:first-child{color:var(--color-green-900);font-weight:bold}[data-nextjs-hydration-diff-badge-item='server'] span:first-child{color:var(--color-red-900);font-weight:bold}[data-nextjs-error-cause]{border-top:1px solid var(--color-gray-400);margin-top:16px;padding-top:16px}.error-cause-header{display:flex;align-items:center;margin-bottom:8px}.error-cause-label{padding:2px 6px;margin:0;border-radius:var(--rounded-md-2);background:var(--color-red-100);font-weight:600;font-size:var(--size-12);color:var(--color-red-900);font-family:var(--font-stack-monospace);line-height:var(--size-20)}.error-cause-message{margin:0;margin-left:4px;color:var(--color-red-900);font-weight:500;font-size:var(--size-16);letter-spacing:-0.32px;line-height:var(--size-24);overflow-wrap:break-word;white-space:pre-wrap}.nextjs-container-build-error-version-status{display:flex;justify-content:center;align-items:center;gap:4px;height:var(--size-26);padding:6px 8px 6px 6px;background:var(--color-background-100);background-clip:padding-box;border:1px solid var(--color-gray-alpha-400);box-shadow:var(--shadow-small);border-radius:var(--rounded-full);color:var(--color-gray-900);font-size:var(--size-12);font-weight:500;line-height:var(--size-16)}a.nextjs-container-build-error-version-status{text-decoration:none;color:var(--color-gray-900);&:hover{background:var(--color-gray-100)}&:focus{outline:var(--focus-ring)}}.version-staleness-indicator.fresh{fill:var(--color-green-800);stroke:var(--color-green-300)}.version-staleness-indicator.stale{fill:var(--color-amber-800);stroke:var(--color-amber-300)}.version-staleness-indicator.outdated{fill:var(--color-red-800);stroke:var(--color-red-300)}.version-staleness-indicator.unknown{fill:var(--color-gray-800);stroke:var(--color-gray-300)}.nextjs-container-build-error-version-status > .turbopack-text{background:linear-gradient( to right,var(--color-turbopack-text-red) 0%,var(--color-turbopack-text-blue) 100% );background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent}.preferences-container{width:100%}@media (min-width:576px){.preferences-container{width:480px}}.preference-section:first-child{padding-top:0}.preference-section{padding:12px 0;border-bottom:1px solid var(--color-gray-400);display:flex;justify-content:space-between;align-items:center;gap:24px}.preference-section:last-child{border-bottom:none}.preference-header{margin-bottom:0;flex:1}.preference-header label{font-size:var(--size-14);font-weight:500;color:var(--color-gray-1000);margin:0}.preference-description{color:var(--color-gray-900);font-size:var(--size-14);margin:0}.select-button,.action-button{display:flex;align-items:center;gap:8px;background:var(--color-background-100);border:1px solid var(--color-gray-400);border-radius:var(--rounded-lg);font-weight:400;font-size:var(--size-14);color:var(--color-gray-1000);padding:6px 8px;transition:border-color 150ms var(--timing-swift);&:hover{border-color:var(--color-gray-500)}svg{width:14px;height:14px;overflow:visible}}.select-button{&:focus-within{outline:var(--focus-ring);outline-offset:-1px}select{all:unset}option{color:var(--color-gray-1000);background:var(--color-background-100)}}.preference-section button:disabled{opacity:0.6;cursor:not-allowed}:global(.icon){width:18px;height:18px;color:#666}.nextjs-scroll-fader{--blur:1px;--stop:25%;--height:150px;--color-bg:var(--color-background-100);position:absolute;pointer-events:none;user-select:none;width:100%;height:var(--height);left:0;backdrop-filter:blur(var(--blur));&[data-side="top"]{top:0;background:linear-gradient(to top,transparent,var(--color-bg));mask-image:linear-gradient(to bottom,var(--color-bg) var(--stop),transparent)}}.shortcut-recorder{display:flex;align-items:center;justify-content:center;gap:8px;position:relative;font-family:var(--font-stack-sans);.shortcut-recorder-button{display:flex;align-items:center;gap:4px;background:transparent;border:1px dashed var(--color-gray-500);border-radius:var(--rounded-lg);padding:6px 8px;font-weight:400;font-size:var(--size-14);color:var(--color-gray-1000);transition:border-color 150ms var(--timing-swift);&[data-has-shortcut='true']{border:1px solid var(--color-gray-alpha-400);&:hover{border-color:var(--color-gray-500)}}&:hover{border-color:var(--color-gray-600)}&::placeholder{color:var(--color-gray-900)}&[data-pristine='false']::placeholder{color:transparent}&:focus-visible{outline:var(--focus-ring);outline-offset:-1px}}kbd{display:inline-flex;align-items:center;justify-content:center;font-family:var(--font-stack-sans);background:var(--color-gray-200);min-width:20px;height:20px;font-size:14px;border-radius:4px;color:var(--color-gray-1000);&[data-symbol='false']{padding:0 4px}}.shortcut-recorder-clear-button{cursor:pointer;color:var(--color-gray-1000);width:20px;height:20px;display:flex;align-items:center;justify-content:center;border-radius:4px;transition:background 150ms var(--timing-swift);&:hover{background:var(--color-gray-300)}&:focus-visible{outline:var(--focus-ring)}svg{width:14px;height:14px}}}.shortcut-recorder-keys{pointer-events:none;user-select:none;display:flex;align-items:center;gap:2px}.shortcut-recorder-tooltip{--gap:8px;--background:var(--color-gray-1000);background:var(--background);color:var(--color-background-100);font-size:var(--size-14);padding:4px 8px;border-radius:8px;position:absolute;bottom:calc(100% + var(--gap));text-align:center;opacity:0;scale:0.96;white-space:nowrap;user-select:none;transition:opacity 150ms var(--timing-swift),scale 150ms var(--timing-swift);&[data-show='true']{opacity:1;scale:1}svg{position:absolute;transform:translateX(-50%);bottom:-6px;left:50%}.shortcut-recorder-status{display:flex;align-items:center;gap:6px}.shortcut-recorder-status-icon{width:7px;height:7px;border-radius:50%;flex-shrink:0;background:var(--color-red-700);&[data-success='true']{background:var(--color-green-700)}}}
+
+/* ---- inline <style> ---- */
+[data-next-badge-root]{--timing:cubic-bezier(0.23,0.88,0.26,0.92);--duration-long:250ms;--color-outer-border:#171717;--color-inner-border:hsla(0,0%,100%,0.14);--color-hover-alpha-subtle:hsla(0,0%,100%,0.13);--color-hover-alpha-error:hsla(0,0%,100%,0.2);--color-hover-alpha-error-2:hsla(0,0%,100%,0.25);--mark-size:calc(var(--size) - var(--size-2) * 2);--focus-color:var(--color-blue-800);--focus-ring:2px solid var(--focus-color);&:has([data-next-badge][data-error='true']){--focus-color:#fff}}[data-disabled-icon]{display:flex;align-items:center;justify-content:center;padding-right:4px}[data-next-badge]{width:var(--size);height:var(--size);display:flex;align-items:center;position:relative;background:rgba(0,0,0,0.8);box-shadow:0 0 0 1px var(--color-outer-border),inset 0 0 0 1px var(--color-inner-border),0px 16px 32px -8px rgba(0,0,0,0.24);backdrop-filter:blur(48px);border-radius:var(--rounded-full);user-select:none;cursor:pointer;scale:1;overflow:hidden;will-change:scale,box-shadow,width,background;transition:scale var(--duration-short) var(--timing),width var(--duration-long) var(--timing),box-shadow var(--duration-long) var(--timing),background var(--duration-short) ease;&:active[data-error='false']{scale:0.95}&[data-animate='true']:not(:hover){scale:1.02}&[data-error='false']:has([data-next-mark]:focus-visible){outline:var(--focus-ring);outline-offset:3px}&[data-error='true']{background:#ca2a30;--color-inner-border:#e5484d;[data-next-mark]{background:var(--color-hover-alpha-error);outline-offset:0px;&:focus-visible{outline:var(--focus-ring);outline-offset:-1px}&:hover{background:var(--color-hover-alpha-error-2)}}}&[data-cache-bypassing='true']:not([data-error='true']){background:rgba(217,119,6,0.95);--color-inner-border:rgba(245,158,11,0.9);[data-issues-open]{color:white}}&[data-error-expanded='false'][data-error='true'] ~ [data-dot]{scale:1}> div{display:flex}}[data-issues-collapse]:focus-visible{outline:var(--focus-ring)}[data-issues]:has([data-issues-open]:focus-visible){outline:var(--focus-ring);outline-offset:-1px}[data-dot]{content:'';width:var(--size-8);height:var(--size-8);background:#fff;box-shadow:0 0 0 1px var(--color-outer-border);border-radius:50%;position:absolute;top:2px;right:0px;scale:0;pointer-events:none;transition:scale 200ms var(--timing);transition-delay:var(--duration-short)}[data-issues]{--padding-left:8px;display:flex;gap:2px;align-items:center;padding-left:8px;padding-right:8px;height:var(--size-32);margin-right:2px;border-radius:var(--rounded-full);transition:background var(--duration-short) ease;&:has([data-issues-open]:hover){background:var(--color-hover-alpha-error)}&:has([data-issues-collapse]){padding-right:calc(var(--padding-left) / 2)}}[data-issues-open]{font-size:var(--size-13);color:white;width:fit-content;height:100%;display:flex;gap:2px;align-items:center;margin:0;line-height:var(--size-36);font-weight:500;z-index:2;white-space:nowrap;&:focus-visible{outline:0}}[data-issues-collapse]{width:var(--size-24);height:var(--size-24);display:flex;align-items:center;justify-content:center;border-radius:var(--rounded-full);transition:background var(--duration-short) ease;&:hover{background:var(--color-hover-alpha-error)}}[data-cross]{color:#fff;width:var(--size-12);height:var(--size-12)}[data-next-mark]{width:var(--mark-size);height:var(--mark-size);margin:0 2px;display:flex;align-items:center;border-radius:var(--rounded-full);transition:background var(--duration-long) var(--timing);&:focus-visible{outline:0}&:hover{background:var(--color-hover-alpha-subtle)}svg{flex-shrink:0;width:var(--size-40);height:var(--size-40)}}[data-issues-count-animation]{display:grid;place-items:center center;font-variant-numeric:tabular-nums;&[data-animate='false']{[data-issues-count-exit],[data-issues-count-enter]{animation-duration:0ms}}> *{grid-area:1 / 1}[data-issues-count-exit]{animation:fadeOut 300ms var(--timing) forwards}[data-issues-count-enter]{animation:fadeIn 300ms var(--timing) forwards}}[data-issues-count-plural]{display:inline-block;&[data-animate='true']{animation:fadeIn 300ms var(--timing) forwards}}.paused{stroke-dashoffset:0}@keyframes fadeIn{0%{opacity:0;filter:blur(2px);transform:translateY(8px)}100%{opacity:1;filter:blur(0px);transform:translateY(0)}}@keyframes fadeOut{0%{opacity:1;filter:blur(0px);transform:translateY(0)}100%{opacity:0;transform:translateY(-12px);filter:blur(2px)}}@media (prefers-reduced-motion){[data-issues-count-exit],[data-issues-count-enter],[data-issues-count-plural]{animation-duration:0ms !important}}
 </style>
 </head>
 <body>
-
-<header class="sg-topbar">
-  <div class="sg-topbar__brand">
-    <svg class="brandmark" width="28" height="28" viewBox="0 0 40 40" fill="none" aria-hidden="true">
-      <path d="M0 8C0 3.58172 3.58172 0 8 0H32C36.4183 0 40 3.58172 40 8V32C40 36.4183 36.4183 40 32 40H8C3.58172 40 0 36.4183 0 32V8Z" fill="currentColor"/>
-      <path d="M29.8965 22.5791C29.7197 23.9952 29.2851 25.2627 28.5918 26.3828C27.8974 27.5029 26.9757 28.3863 25.8262 29.0312C24.6754 29.6762 23.3451 29.9999 21.835 30C20.2149 30 18.7905 29.6896 17.5645 29.0693L19.5527 27.167C20.2356 27.404 20.995 27.5273 21.835 27.5273C23.3104 27.5273 24.5302 27.069 25.4961 26.1553C26.4621 25.2414 27.0424 24.0493 27.2354 22.5801V22.5791H29.8965ZM21.6172 22.0518L14.4609 28.8994C13.792 29.5396 12.7408 29.5057 12.1133 28.8232L11.6914 28.3643L9 25.4336L10.8262 23.6875L13.3633 26.4492L19.9062 20.1895L21.6172 22.0518ZM21.833 10C23.2554 10 24.529 10.2916 25.6533 10.874C26.7777 11.4565 27.6864 12.2634 28.3809 13.2939C29.074 14.3244 29.5349 15.4942 29.7637 16.8018H27.1025C26.8564 15.5118 26.2602 14.467 25.3115 13.6699C24.3628 12.8716 23.2381 12.4727 21.833 12.4727C20.4281 12.4727 19.2423 12.8052 18.2764 13.4678C17.3104 14.1304 16.5955 15.0321 16.1299 16.1699C15.6643 17.3089 15.4316 18.5861 15.4316 20.001C15.4317 20.4418 15.4577 20.8677 15.5039 21.2803L15.501 21.2812L13.1689 23.5137C12.8524 22.4183 12.6905 21.2482 12.6904 20.002C12.6904 18.1566 13.0379 16.4762 13.7324 14.9609C14.4257 13.4457 15.4623 12.2409 16.8408 11.3447C18.2192 10.4487 19.8839 10.0001 21.833 10Z" fill="var(--bg-canvas)"/>
-    </svg>
-    <div>
-      <span class="sg-topbar__brand-name">Certified</span>
-      <span class="sg-topbar__brand-sub"> · Component Library</span>
-    </div>
-  </div>
-  <button id="theme-btn" class="sg-theme-toggle" type="button" aria-pressed="false">
-    <span id="theme-icon" aria-hidden="true">☾</span>
-    <span id="theme-label">Dark</span>
+<header class="sg-gen-banner" role="banner">
+  <span class="sg-gen-banner__msg">
+    GENERATED from <code>/dev/gallery</code> — do not edit by hand. Refresh with
+    <code>npm run styleguide:generate</code>. Single source of truth: the
+    gallery TSX, snapshotted here.
+  </span>
+  <button
+    type="button"
+    id="sg-theme-btn"
+    class="sg-gen-banner__toggle"
+    aria-pressed="false"
+    aria-label="Toggle dark theme"
+  >
+    <span id="sg-theme-icon" aria-hidden="true">&#9790;</span>
+    <span id="sg-theme-label">Dark</span>
   </button>
 </header>
-
-<main class="sg-shell">
-
-  <!-- ===================== INTRO ===================== -->
-  <section class="sg-intro" id="top">
-    <h1 class="font-headline text-h1">Component Library</h1>
-    <p>
-      A hand-authored, self-contained styleguide for the <strong>certified-app</strong> primitive
-      library in <code class="tok">src/components/ui/</code>. The primitives are TSX and can't be
-      rendered without a build, so every example below is static HTML that mirrors each primitive's
-      real rendered output (matching its actual class names and token usage). All styling is inline;
-      there is no build step, dev server, or network dependency. Toggle the control above to view every
-      example in light and dark.
-    </p>
-    <p class="sg-note">
-      Fonts: production uses <strong>Inter</strong> (UI) and <strong>Noto Serif</strong> via
-      <code class="tok">font-headline</code> (headlines). With no network access here, this file falls
-      back to <code class="tok">system-ui</code> for body/UI and <code class="tok">Georgia, serif</code>
-      for headlines (the documented tail of the <code class="tok">headline</code> font stack). Only the
-      glyph shapes differ from production — sizes, weights, and tracking are reproduced exactly.
-    </p>
-
-    <div class="sg-principles" aria-label="Design principles">
-      <div class="sg-principle"><h4>Monochrome</h4><p>Near-black primary, warm grays, no brand accent hue. Identity is carried by typography, not color.</p></div>
-      <div class="sg-principle"><h4>Document-like</h4><p>Serif headlines anchor content like a printed title; Inter handles all chrome. Reads like a notary's ledger.</p></div>
-      <div class="sg-principle"><h4>2px radius</h4><p><code class="tok">--radius: 2px</code> everywhere; <code class="tok">999px</code> for pills, <code class="tok">50%</code> for circles. Sharp, deliberate edges.</p></div>
-      <div class="sg-principle"><h4>Mobile-first</h4><p>Every layout is designed for small screens first; desktop is a natural widening of one centered column.</p></div>
-      <div class="sg-principle"><h4>Accessibility-first</h4><p>Skip-nav, global <code class="tok">:focus-visible</code> rings, ARIA roles on tabs/menus/switches, and <code class="tok">prefers-reduced-motion</code> support throughout.</p></div>
-      <div class="sg-principle"><h4>Dark mode</h4><p>Full <code class="tok">data-theme="dark"</code> flip: surfaces invert, the primary button inverts so it always pops off the canvas.</p></div>
-    </div>
-  </section>
-
-  <!-- ===================== TOC ===================== -->
-  <nav class="sg-toc" aria-label="Sections">
-    <a href="#core">Core interactive</a>
-    <a href="#surfaces">Surfaces</a>
-    <a href="#navoverlay">Navigation &amp; overlay</a>
-    <a href="#status">Status &amp; feedback</a>
-    <a href="#tokens">Design tokens</a>
-  </nav>
-
-  <!-- ============================================================= -->
-  <!-- CORE INTERACTIVE                                              -->
-  <!-- ============================================================= -->
-  <section class="sg-category" id="core">
-    <h2 class="font-headline">Core interactive</h2>
-    <p class="sg-category-desc">Buttons, form controls, and the theme + link primitives.</p>
-
-    <!-- Button -->
-    <article class="sg-component" id="button">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Button</span>
-        <span class="sg-component__file">src/components/ui/button.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          The canonical button. Four <strong>variants</strong> (primary / secondary / ghost / destructive)
-          and four <strong>sizes</strong> (sm / md / lg / icon). Renders a real <code class="tok">&lt;button&gt;</code>
-          with <code class="tok">press-scale</code>, a <code class="tok">--focus-ring</code> outline, and
-          <code class="tok">aria-busy</code> while loading. The <code class="tok">icon</code> size is a 40×40 square
-          and its discriminated union <em>requires</em> <code class="tok">aria-label</code>. Pass
-          <code class="tok">pressed</code> to back an <code class="tok">aria-pressed</code> toggle — a truthy value also
-          flips secondary/ghost to an active visual (primary/destructive keep their base look). Reach for this before any raw <code class="tok">&lt;button&gt;</code>.
-        </p>
-
-        <span class="sg-block-label">Variants (size md)</span>
-        <div class="sg-demo">
-          <button class="btn btn--primary btn--md">Primary</button>
-          <button class="btn btn--secondary btn--md">Secondary</button>
-          <button class="btn btn--ghost btn--md">Ghost</button>
-          <button class="btn btn--destructive btn--md">Destructive</button>
-        </div>
-
-        <span class="sg-block-label">Sizes</span>
-        <div class="sg-demo">
-          <button class="btn btn--primary btn--sm">Small</button>
-          <button class="btn btn--primary btn--md">Medium</button>
-          <button class="btn btn--primary btn--lg">Large</button>
-          <button class="btn btn--secondary btn--icon" aria-label="Settings">
-            <svg class="sg-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-          </button>
-          <span class="sg-demo__caption">icon (40×40, requires aria-label)</span>
-        </div>
-
-        <span class="sg-block-label">States</span>
-        <div class="sg-demo">
-          <button class="btn btn--primary btn--md">Hover me</button>
-          <span class="sg-demo__caption">hover → primary opacity 0.9 / secondary border-hover / ghost overlay-weak</span>
-          <button class="btn btn--primary btn--md" disabled>Disabled</button>
-          <button class="btn btn--primary btn--md" aria-busy="true" disabled>
-            <svg class="sg-icon spin" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
-            Loading
-          </button>
-          <button class="btn btn--destructive btn--md" aria-busy="true" disabled>
-            <svg class="sg-icon spin" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
-            Deleting
-          </button>
-        </div>
-
-        <span class="sg-block-label">Toggle (pressed) — secondary / ghost flip to an active visual</span>
-        <div class="sg-demo">
-          <button class="btn btn--secondary btn--md" aria-pressed="false">Off</button>
-          <button class="btn btn--secondary btn--md btn--pressed" aria-pressed="true">On</button>
-          <button class="btn btn--ghost btn--md" aria-pressed="false">Off</button>
-          <button class="btn btn--ghost btn--md btn--pressed" aria-pressed="true">On</button>
-          <span class="sg-demo__caption">pressed sets aria-pressed; secondary/ghost gain an active fill (primary/destructive unchanged)</span>
-        </div>
-
-        <table class="sg-api">
-          <caption>Props</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Default</th><th>Notes</th></tr></thead>
-          <tbody>
-            <tr><td>variant</td><td>"primary" | "secondary" | "ghost" | "destructive"</td><td>"primary"</td><td>destructive uses <code>--color-error-bg/-border</code></td></tr>
-            <tr><td>size</td><td>"sm" | "md" | "lg" | "icon"</td><td>"md"</td><td>icon = 40×40; requires <code>aria-label</code> (union)</td></tr>
-            <tr><td>loading</td><td>boolean</td><td>false</td><td>shows spinner, sets <code>disabled</code> + <code>aria-busy</code></td></tr>
-            <tr><td>pressed</td><td>boolean</td><td>—</td><td>emits <code>aria-pressed</code>; truthy adds active visual on secondary/ghost only</td></tr>
-            <tr><td>disabled</td><td>boolean</td><td>—</td><td>opacity 0.5, not-allowed</td></tr>
-            <tr><td>…rest</td><td>ButtonHTMLAttributes</td><td>—</td><td><code>type</code> defaults to "button"; forwards ref</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- Input -->
-    <article class="sg-component" id="input">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Input</span>
-        <span class="sg-component__file">src/components/ui/input.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          44px text field on <code class="tok">--bg-elevated</code> with a <code class="tok">--border-default</code>
-          border. Focus shifts the border to <code class="tok">--focus-ring</code> with a 20% ring. Supports
-          <strong>label</strong>, <strong>error</strong>, <strong>helperText</strong>, three sizes, three
-          variants (default / underline / inline-edit), and leading/trailing <strong>icon slots</strong>
-          (an absolute wrapper added only when an icon exists). The <code class="tok">trailingButton</code> slot is the
-          interactive sibling of <code class="tok">trailingIcon</code> — it keeps pointer events and is not
-          aria-hidden, so a combobox can hang a real focusable clear/submit <code class="tok">&lt;button&gt;</code> there
-          (it wins the trailing slot over a decorative icon).
-        </p>
-
-        <span class="sg-block-label">Default · with label &amp; helper</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack">
-          <div style="max-width:360px;">
-            <label class="ui-field-label">Display name</label>
-            <input class="ui-field" type="text" placeholder="Jane Doe" />
-            <p class="ui-field-help">Shown on your public profile.</p>
-          </div>
-        </div>
-
-        <span class="sg-block-label">States: disabled · error · icon slots</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack">
-          <div style="max-width:360px;"><input class="ui-field" type="text" value="can't edit" disabled /></div>
-          <div style="max-width:360px;">
-            <input class="ui-field ui-field--error" type="email" value="not-an-email" aria-invalid="true" />
-            <p class="ui-field-err">Enter a valid email address.</p>
-          </div>
-          <div style="max-width:360px;">
-            <div class="ui-field-wrap">
-              <span class="ui-field-icon ui-field-icon--lead" aria-hidden="true">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
-              </span>
-              <input class="ui-field ui-field--padlead" type="search" placeholder="Search" />
-            </div>
-          </div>
-        </div>
-
-        <span class="sg-block-label">Variants: underline · inline-edit</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack">
-          <div style="max-width:360px;"><input class="ui-field ui-field--underline" type="text" placeholder="Typeahead (underline)" /></div>
-          <div style="max-width:360px;"><input class="ui-field ui-field--inline" type="text" value="Editing name (inline-edit)" /></div>
-        </div>
-
-        <span class="sg-block-label">trailingButton slot · combobox usage</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack">
-          <div style="max-width:360px;">
-            <div class="ui-field-wrap" role="combobox" aria-expanded="false" aria-haspopup="listbox">
-              <span class="ui-field-icon ui-field-icon--lead" aria-hidden="true">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
-              </span>
-              <input class="ui-field ui-field--padlead ui-field--padtrail" type="text" value="acme" aria-label="Search organizations" />
-              <span class="ui-field-btn">
-                <button type="button" aria-label="Clear search">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
-                </button>
-              </span>
-            </div>
-          </div>
-          <span class="sg-demo__caption">trailingButton = a real focusable &lt;button&gt; (its own aria-label); keeps pointer events, not aria-hidden</span>
-        </div>
-
-        <table class="sg-api">
-          <caption>Props (extends InputHTMLAttributes, omits native "size")</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Default</th><th>Notes</th></tr></thead>
-          <tbody>
-            <tr><td>label</td><td>string</td><td>—</td><td>renders <code>.app-card__label</code></td></tr>
-            <tr><td>error</td><td>string</td><td>—</td><td>error border + <code>role="alert"</code> message, sets <code>aria-invalid</code></td></tr>
-            <tr><td>helperText</td><td>string</td><td>—</td><td>muted hint (hidden when error present)</td></tr>
-            <tr><td>size</td><td>"sm" | "md" | "lg"</td><td>"md"</td><td>36 / 44 / 56px</td></tr>
-            <tr><td>variant</td><td>"default" | "underline" | "inline-edit"</td><td>"default"</td><td>inline-edit = 1.5px border</td></tr>
-            <tr><td>leadingIcon / trailingIcon</td><td>ReactNode</td><td>—</td><td>decorative (aria-hidden, no pointer events); absolutely positioned, input padded to clear it</td></tr>
-            <tr><td>trailingButton</td><td>ReactNode</td><td>—</td><td>interactive trailing slot (keeps pointer events, not aria-hidden) for a combobox clear/submit button; wins over <code>trailingIcon</code></td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- Textarea -->
-    <article class="sg-component" id="textarea">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Textarea</span>
-        <span class="sg-component__file">src/components/ui/textarea.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Mirrors Input's chrome with <code class="tok">resize-y</code>, a <code class="tok">rows</code> prop,
-          and an optional live <strong>character counter</strong> (<code class="tok">showCount</code> + <code class="tok">maxLength</code>)
-          announced via <code class="tok">aria-live="polite"</code>. Sizes (sm/md/lg) and variants (default/underline) match Input.
-        </p>
-        <span class="sg-block-label">Default · with counter</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack">
-          <div style="max-width:420px;">
-            <label class="ui-field-label">Bio</label>
-            <textarea class="ui-field" rows="3" placeholder="A short bio…"></textarea>
-            <div style="display:flex;justify-content:flex-end;"><span class="ui-field-help">0 / 280</span></div>
-          </div>
-          <div style="max-width:420px;"><textarea class="ui-field" rows="2" disabled>Disabled — resize off</textarea></div>
-          <div style="max-width:420px;">
-            <textarea class="ui-field ui-field--error" rows="2" aria-invalid="true">Too long…</textarea>
-            <p class="ui-field-err">Keep it under 280 characters.</p>
-          </div>
-        </div>
-        <table class="sg-api">
-          <caption>Props (extends TextareaHTMLAttributes)</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Default</th><th>Notes</th></tr></thead>
-          <tbody>
-            <tr><td>label / error / helperText</td><td>string</td><td>—</td><td>same semantics as Input</td></tr>
-            <tr><td>rows</td><td>number</td><td>3</td><td>height driver</td></tr>
-            <tr><td>size / variant</td><td>see Input</td><td>"md" / "default"</td><td>—</td></tr>
-            <tr><td>showCount</td><td>boolean</td><td>false</td><td>live "n / max" counter (works controlled + uncontrolled)</td></tr>
-            <tr><td>maxLength</td><td>number</td><td>—</td><td>forwarded to native + counter denominator</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- Select -->
-    <article class="sg-component" id="select">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Select</span>
-        <span class="sg-component__file">src/components/ui/select.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Native <code class="tok">&lt;select&gt;</code> styled to match Input, with an overlaid
-          <code class="tok">ChevronDown</code> and surface tokens applied to <code class="tok">&lt;option&gt;</code>
-          so platforms that honor them render dark-correct option lists. Label / error / helperText / sizes mirror Input.
-        </p>
-        <span class="sg-block-label">Default · error · disabled</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack">
-          <div style="max-width:320px;">
-            <label class="ui-field-label">Role</label>
-            <div class="ui-select-wrap">
-              <select class="ui-field"><option>Owner</option><option>Editor</option><option>Viewer</option></select>
-              <span class="ui-select-chevron" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"><path d="m6 9 6 6 6-6"/></svg></span>
-            </div>
-          </div>
-          <div style="max-width:320px;">
-            <div class="ui-select-wrap">
-              <select class="ui-field ui-field--error" aria-invalid="true"><option>Choose…</option></select>
-              <span class="ui-select-chevron" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"><path d="m6 9 6 6 6-6"/></svg></span>
-            </div>
-            <p class="ui-field-err">Selection required.</p>
-          </div>
-          <div style="max-width:320px;">
-            <div class="ui-select-wrap">
-              <select class="ui-field" disabled><option>Locked</option></select>
-              <span class="ui-select-chevron" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"><path d="m6 9 6 6 6-6"/></svg></span>
-            </div>
-          </div>
-        </div>
-        <table class="sg-api">
-          <caption>Props (extends SelectHTMLAttributes, omits native "size")</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead>
-          <tbody>
-            <tr><td>label / error / helperText</td><td>string</td><td>—</td></tr>
-            <tr><td>size</td><td>"sm" | "md" | "lg"</td><td>"md"</td></tr>
-            <tr><td>children</td><td>&lt;option&gt; list</td><td>—</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- Checkbox -->
-    <article class="sg-component" id="checkbox">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Checkbox</span>
-        <span class="sg-component__file">src/components/ui/checkbox.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          A visually-hidden native <code class="tok">&lt;input type="checkbox"&gt;</code> (kept in the a11y tree)
-          stacked over a custom box drawn with semantic tokens — deliberately avoiding <code class="tok">accent-color</code>.
-          Supports <strong>indeterminate</strong> (renders a dash + sets the DOM flag), <strong>error</strong>, and disabled.
-          Checked fills with <code class="tok">--btn-primary-bg</code>.
-        </p>
-        <span class="sg-block-label">Unchecked · checked · indeterminate · error · disabled</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack" style="gap:14px;">
-          <div class="ui-check-row"><span class="ui-check-box" aria-hidden="true"></span><span class="ui-check-label">Email notifications</span></div>
-          <div class="ui-check-row"><span class="ui-check-box ui-check-box--checked" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span><span class="ui-check-label">Push notifications</span></div>
-          <div class="ui-check-row"><span class="ui-check-box ui-check-box--checked" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M5 12h14"/></svg></span><span class="ui-check-label">Select all (indeterminate)</span></div>
-          <div class="ui-check-row"><span class="ui-check-box ui-check-box--error" aria-hidden="true"></span><span class="ui-check-label">Accept terms</span></div>
-          <div class="ui-check-row ui-check-row--disabled"><span class="ui-check-box" aria-hidden="true"></span><span class="ui-check-label">Disabled option</span></div>
-        </div>
-        <table class="sg-api">
-          <caption>Props (extends InputHTMLAttributes, omits "type"/"size")</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Notes</th></tr></thead>
-          <tbody>
-            <tr><td>label</td><td>ReactNode</td><td>associated via <code>htmlFor</code></td></tr>
-            <tr><td>indeterminate</td><td>boolean</td><td>tri-state dash; applied via ref effect</td></tr>
-            <tr><td>error</td><td>string</td><td>tints box + <code>role="alert"</code> message</td></tr>
-            <tr><td>checked / disabled / …rest</td><td>native</td><td>forwarded to the input; ref merged</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- Radio -->
-    <article class="sg-component" id="radio">
-      <div class="sg-component__head">
-        <span class="sg-component__title">RadioGroup / Radio</span>
-        <span class="sg-component__file">src/components/ui/radio.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          WAI-ARIA <code class="tok">radiogroup</code> pattern, controlled only (<code class="tok">value</code> +
-          <code class="tok">onValueChange</code>). Roving tabindex: exactly one Radio is tabbable; arrow keys move
-          selection <em>and</em> focus (wrapping), Home/End jump to ends, disabled options are skipped. Doubles as the
-          <strong>SegmentedControl</strong> base — render custom children and style via <code class="tok">className</code>
-          (that's how ThemeToggle's segmented variant is built).
-        </p>
-        <span class="sg-block-label">Vertical radio group</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack">
-          <div class="ui-radiogroup" role="radiogroup" aria-label="Visibility" style="flex-direction:column;align-items:flex-start;gap:12px;">
-            <button class="ui-radio ui-radio--checked" role="radio" aria-checked="true"><span class="ui-radio__dot" aria-hidden="true"></span>Public</button>
-            <button class="ui-radio" role="radio" aria-checked="false"><span class="ui-radio__dot" aria-hidden="true"></span>Followers only</button>
-            <button class="ui-radio ui-radio--disabled" role="radio" aria-checked="false" aria-disabled="true"><span class="ui-radio__dot" aria-hidden="true"></span>Private (disabled)</button>
-          </div>
-        </div>
-        <table class="sg-api">
-          <caption>RadioGroup props</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead>
-          <tbody>
-            <tr><td>value</td><td>string</td><td>—</td></tr>
-            <tr><td>onValueChange</td><td>(value: string) =&gt; void</td><td>—</td></tr>
-            <tr><td>name</td><td>string</td><td>auto id</td></tr>
-            <tr><td>disabled</td><td>boolean</td><td>false</td></tr>
-            <tr><td>orientation</td><td>"horizontal" | "vertical"</td><td>"horizontal"</td></tr>
-          </tbody>
-        </table>
-        <table class="sg-api">
-          <caption>Radio props</caption>
-          <thead><tr><th>Prop</th><th>Type</th></tr></thead>
-          <tbody>
-            <tr><td>value</td><td>string (required)</td></tr>
-            <tr><td>disabled</td><td>boolean</td></tr>
-            <tr><td>children</td><td>ReactNode (label / icon)</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- Switch -->
-    <article class="sg-component" id="switch">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Switch</span>
-        <span class="sg-component__file">src/components/ui/switch.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          ARIA <code class="tok">switch</code> on a real <code class="tok">&lt;button&gt;</code> (free Space/Enter).
-          Controlled (<code class="tok">checked</code> + <code class="tok">onCheckedChange</code>). Track recolors to
-          <code class="tok">--btn-primary-bg</code> when on; the thumb slides (reduced-motion safe). Optional
-          <code class="tok">label</code> renders to the right and labels the control.
-        </p>
-        <span class="sg-block-label">Off · on · with label · disabled</span>
-        <div class="sg-demo" style="gap:24px;">
-          <button class="ui-switch" role="switch" aria-checked="false" aria-label="Off"><span class="ui-switch__thumb"></span></button>
-          <button class="ui-switch ui-switch--on" role="switch" aria-checked="true" aria-label="On"><span class="ui-switch__thumb"></span></button>
-          <span class="ui-switch-row"><button class="ui-switch ui-switch--on" role="switch" aria-checked="true" aria-labelledby="sw-l"><span class="ui-switch__thumb"></span></button><label id="sw-l" class="ui-check-label">Private account</label></span>
-          <span class="ui-switch-row" style="opacity:.5;"><button class="ui-switch" role="switch" aria-checked="false" aria-disabled="true" disabled><span class="ui-switch__thumb"></span></button><span class="ui-check-label">Disabled</span></span>
-        </div>
-        <table class="sg-api">
-          <caption>Props (extends ButtonHTMLAttributes, omits onChange/type/value)</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Notes</th></tr></thead>
-          <tbody>
-            <tr><td>checked</td><td>boolean (required)</td><td>controlled state</td></tr>
-            <tr><td>onCheckedChange</td><td>(checked: boolean) =&gt; void</td><td>fired with the next state</td></tr>
-            <tr><td>label</td><td>ReactNode</td><td>when set, labels via <code>aria-labelledby</code>; else <code>aria-label</code> required</td></tr>
-            <tr><td>disabled</td><td>boolean</td><td>—</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- ThemeToggle -->
-    <article class="sg-component" id="theme-toggle">
-      <div class="sg-component__head">
-        <span class="sg-component__title">ThemeToggle</span>
-        <span class="sg-component__file">src/components/ui/theme-toggle.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Backed by <code class="tok">next-themes</code>. <strong>segmented</strong> (default) is a three-way
-          RadioGroup (Light / Dark / System) — inheriting the Radio primitive's roving-tabindex + focus ring;
-          <code class="tok">compact</code> drops the labels. <strong>cycle</strong> is a single icon button that
-          rotates System → Light → Dark, showing the <em>current</em> selection's icon.
-          (The control in this page's top bar is a standalone analogue.)
-        </p>
-        <span class="sg-block-label">segmented</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack">
-          <div class="theme-toggle-group" role="radiogroup" aria-label="Theme" style="max-width:360px;">
-            <button class="tt-option tt-option--selected" role="radio" aria-checked="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>Light</button>
-            <button class="tt-option" role="radio" aria-checked="false"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>Dark</button>
-            <button class="tt-option" role="radio" aria-checked="false"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>System</button>
-          </div>
-        </div>
-        <span class="sg-block-label">segmented · compact &nbsp;&amp;&nbsp; cycle</span>
-        <div class="sg-demo">
-          <div class="theme-toggle-group" role="radiogroup" aria-label="Theme">
-            <button class="tt-option tt-option--selected" role="radio" aria-checked="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg></button>
-            <button class="tt-option" role="radio" aria-checked="false"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg></button>
-            <button class="tt-option" role="radio" aria-checked="false"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></button>
-          </div>
-          <button class="theme-toggle-cycle" aria-label="Theme: System. Click to switch to Light.">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
-          </button>
-        </div>
-        <table class="sg-api">
-          <caption>Props</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead>
-          <tbody>
-            <tr><td>variant</td><td>"segmented" | "cycle"</td><td>"segmented"</td></tr>
-            <tr><td>compact</td><td>boolean</td><td>false</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- SmartLink -->
-    <article class="sg-component" id="smart-link">
-      <div class="sg-component__head">
-        <span class="sg-component__title">SmartLink</span>
-        <span class="sg-component__file">src/components/ui/smart-link.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Sanctioned external-link primitive. Detects the service from the URL, renders the matching brand glyph
-          (inlined Simple Icons marks, generic link fallback) as the first child plus an <code class="tok">&lt;a target="_blank" rel="noopener noreferrer"&gt;</code>
-          with a friendly display string, an always-appended <code class="tok">--focus-ring</code>, and an sr-only
-          "(opens in new tab)" cue. Non-http(s) URLs render as plain text.
-        </p>
-        <span class="sg-block-label">Examples</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack" style="gap:12px;">
-          <span class="smart-link"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg><a href="#0">example.com</a><span style="position:absolute;left:-9999px;">(opens in new tab)</span></span>
-          <span class="smart-link"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12c0 4.42 2.87 8.17 6.84 9.5.5.09.66-.22.66-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.45-1.16-1.11-1.47-1.11-1.47-.9-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.89 1.52 2.34 1.08 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.65 0 0 .84-.27 2.75 1.02a9.6 9.6 0 0 1 5 0c1.91-1.29 2.75-1.02 2.75-1.02.55 1.38.2 2.4.1 2.65.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.69-4.57 4.94.36.31.68.92.68 1.85v2.74c0 .27.16.58.67.48A10 10 0 0 0 22 12c0-5.52-4.48-10-10-10z"/></svg><a href="#0">github.com/certified</a><span style="position:absolute;left:-9999px;">(opens in new tab)</span></span>
-        </div>
-        <table class="sg-api">
-          <caption>Props</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Notes</th></tr></thead>
-          <tbody>
-            <tr><td>url</td><td>string (required)</td><td>must be http/https or returns plain text</td></tr>
-            <tr><td>className</td><td>string</td><td>focus ring is appended regardless</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-  </section>
-
-  <!-- ============================================================= -->
-  <!-- SURFACES                                                      -->
-  <!-- ============================================================= -->
-  <section class="sg-category" id="surfaces">
-    <h2 class="font-headline">Surfaces</h2>
-    <p class="sg-category-desc">Cards, badges, avatars, and the brand glyphs.</p>
-
-    <!-- Card -->
-    <article class="sg-component" id="card">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Card</span>
-        <span class="sg-component__file">src/components/ui/card.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Three variants. <strong>row</strong>: transparent, bottom-border only (<code class="tok">--border-subtle</code>),
-          no radius, <code class="tok">py-5</code> — list/divider rows. <strong>elevated</strong>: <code class="tok">--bg-elevated</code>,
-          full <code class="tok">--border-default</code>, <code class="tok">--radius</code>, <code class="tok">p-6</code> — "object" cards.
-          <strong>inset</strong>: recessed <code class="tok">--bg-canvas</code> with the same border — details inside an elevated parent.
-          <code class="tok">hoverable</code> adds the per-variant highlight; <code class="tok">as</code> swaps the element.
-        </p>
-        <span class="sg-block-label">elevated</span>
-        <div class="sg-demo sg-demo--stack">
-          <div class="ui-card--elevated">
-            <h4 class="ui-card__title font-headline">Elevated card</h4>
-            <p class="ui-card__desc">bg-elevated, full border, 2px radius, 24px padding. Hover adds border-hover + shadow-sm.</p>
-          </div>
-        </div>
-        <span class="sg-block-label">inset</span>
-        <div class="sg-demo sg-demo--stack">
-          <div class="ui-card--inset">
-            <h4 class="ui-card__title font-headline">Inset card</h4>
-            <p class="ui-card__desc">Recessed bg-canvas with the same border weight — sits inside an elevated parent.</p>
-          </div>
-        </div>
-        <span class="sg-block-label">row (×2, as a list)</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack" style="gap:0;">
-          <div class="ui-card--row"><h4 class="ui-card__title font-headline">First row</h4><p class="ui-card__desc">Bottom-border divider, no radius, no background.</p></div>
-          <div class="ui-card--row"><h4 class="ui-card__title font-headline">Second row</h4><p class="ui-card__desc">Used for feed activity, settings sections, account fields.</p></div>
-        </div>
-        <table class="sg-api">
-          <caption>Props (extends HTMLAttributes&lt;HTMLDivElement&gt;)</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead>
-          <tbody>
-            <tr><td>variant</td><td>"row" | "elevated" | "inset"</td><td>"elevated"</td></tr>
-            <tr><td>hoverable</td><td>boolean</td><td>false</td></tr>
-            <tr><td>unpadded</td><td>boolean</td><td>false</td></tr>
-            <tr><td>as</td><td>"div" | "article" | "li" | "section"</td><td>"div"</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- Badge -->
-    <article class="sg-component" id="badge">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Badge</span>
-        <span class="sg-component__file">src/components/ui/badge.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          One pill shape (<code class="tok">999px</code>) for every semantic. Status badges carry an icon
-          (verified / pending / unverified); neutral chips are label / tag / role / count; quality labels are
-          high-quality / standard / draft / test. <code class="tok">compact</code> overrides density; otherwise
-          each variant picks its natural size. The <code class="tok">count</code> chip takes a
-          <code class="tok">tone</code> (<code class="tok">default</code> red vs <code class="tok">neutral</code> muted);
-          <code class="tok">variant="count-bare"</code> drops all pill chrome for a bare tabular number; and
-          <code class="tok">shape="square"</code> renders a small 2px tag chip whose palette is chosen by
-          <code class="tok">tone</code> (error / warn / success / neutral).
-        </p>
-        <span class="sg-block-label">Status</span>
-        <div class="sg-demo">
-          <span class="ui-badge ui-badge--lg ui-badge--verified"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>Verified</span>
-          <span class="ui-badge ui-badge--lg ui-badge--pending"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>Pending</span>
-          <span class="ui-badge ui-badge--lg ui-badge--unverified">Unverified</span>
-        </div>
-        <span class="sg-block-label">Neutral chips (compact)</span>
-        <div class="sg-demo">
-          <span class="ui-badge ui-badge--sm ui-badge--tag">Design</span>
-          <span class="ui-badge ui-badge--sm ui-badge--role">Owner</span>
-          <span class="ui-badge ui-badge--sm ui-badge--count">3</span>
-        </div>
-        <span class="sg-block-label">Count tones: default (red) · tone="neutral" (muted) · variant="count-bare"</span>
-        <div class="sg-demo">
-          <span class="ui-badge ui-badge--sm ui-badge--count">3</span>
-          <span class="ui-badge ui-badge--sm ui-badge--count-neutral">12</span>
-          <span class="ui-badge ui-badge--sm ui-badge--count-bare">128</span>
-          <span class="sg-demo__caption">count-bare = chromeless tabular number for right-aligned section counts</span>
-        </div>
-        <span class="sg-block-label">Square tags (shape="square") — tone error / warn / success / neutral</span>
-        <div class="sg-demo">
-          <span class="ui-badge ui-badge--sm ui-badge--square ui-badge--sq-error">Error</span>
-          <span class="ui-badge ui-badge--sm ui-badge--square ui-badge--sq-warn">Draft</span>
-          <span class="ui-badge ui-badge--sm ui-badge--square ui-badge--sq-success">Live</span>
-          <span class="ui-badge ui-badge--sm ui-badge--square ui-badge--sq-neutral">Internal</span>
-          <span class="sg-demo__caption">2px radius (var(--radius)); "warn" is error-toned by design</span>
-        </div>
-        <span class="sg-block-label">Quality labels (compact)</span>
-        <div class="sg-demo">
-          <span class="ui-badge ui-badge--sm ui-badge--hq">High quality</span>
-          <span class="ui-badge ui-badge--sm ui-badge--standard">Standard</span>
-          <span class="ui-badge ui-badge--sm ui-badge--draft">Draft</span>
-          <span class="ui-badge ui-badge--sm ui-badge--test">Likely test</span>
-        </div>
-        <table class="sg-api">
-          <caption>Props</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Notes</th></tr></thead>
-          <tbody>
-            <tr><td>variant</td><td>verified | pending | unverified | tag | role | count | count-bare | high-quality | standard | draft | test</td><td>required; <code>count-bare</code> = no pill chrome, bare tabular number</td></tr>
-            <tr><td>tone</td><td>"default" | "neutral" | "error" | "warn" | "success"</td><td>"default". For <code>count</code>: default red vs neutral muted. For <code>shape="square"</code>: picks the tag palette (warn aliases error). Ignored elsewhere.</td></tr>
-            <tr><td>shape</td><td>"pill" | "square"</td><td>"pill" (999px). "square" = 2px tag chip keyed by <code>tone</code>, inherently compact + uppercase.</td></tr>
-            <tr><td>compact</td><td>boolean</td><td>overrides per-variant default density</td></tr>
-            <tr><td>children</td><td>ReactNode</td><td>label text</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- FeedLabelPill -->
-    <article class="sg-component" id="feed-label-pill">
-      <div class="sg-component__head">
-        <span class="sg-component__title">FeedLabelPill</span>
-        <span class="sg-component__file">src/components/ui/feed-label-pill.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Thin wrapper that maps an atproto <code class="tok">LabelValue</code> to the matching Badge quality variant
-          and renders its display string. No styling of its own — it delegates entirely to Badge.
-        </p>
-        <span class="sg-block-label">All four labels</span>
-        <div class="sg-demo">
-          <span class="ui-badge ui-badge--sm ui-badge--hq">High quality</span>
-          <span class="ui-badge ui-badge--sm ui-badge--standard">Standard</span>
-          <span class="ui-badge ui-badge--sm ui-badge--draft">Draft</span>
-          <span class="ui-badge ui-badge--sm ui-badge--test">Likely test</span>
-        </div>
-        <table class="sg-api">
-          <caption>Props</caption>
-          <thead><tr><th>Prop</th><th>Type</th></tr></thead>
-          <tbody>
-            <tr><td>label</td><td>"high-quality" | "standard" | "draft" | "likely-test"</td></tr>
-            <tr><td>className</td><td>string</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- Avatar -->
-    <article class="sg-component" id="avatar">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Avatar</span>
-        <span class="sg-component__file">src/components/ui/avatar.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Always circular (<code class="tok">50%</code>). Five sizes: sm 32 · md 48 · lg 64 · xl 96 · 2xl 240px
-          (profile hero, <code class="tok">text-display</code> initials). Falls back to an initials chip on
-          <code class="tok">--color-surface-container-high</code> when no <code class="tok">src</code> or on image error.
-          <code class="tok">bordered</code> swaps the subtle border for a 2px <code class="tok">--bg-elevated</code> ring.
-        </p>
-        <span class="sg-block-label">Sizes (initials fallback) — 2xl shown at 120px to fit</span>
-        <div class="sg-demo" style="align-items:flex-end;">
-          <span class="ui-avatar ui-avatar--sm">JD</span>
-          <span class="ui-avatar ui-avatar--md">JD</span>
-          <span class="ui-avatar ui-avatar--lg">JD</span>
-          <span class="ui-avatar ui-avatar--xl">JD</span>
-          <span class="ui-avatar ui-avatar--2xl">JD</span>
-        </div>
-        <table class="sg-api">
-          <caption>Props</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead>
-          <tbody>
-            <tr><td>src</td><td>string</td><td>—</td></tr>
-            <tr><td>alt</td><td>string</td><td>""</td></tr>
-            <tr><td>size</td><td>"sm" | "md" | "lg" | "xl" | "2xl"</td><td>"md"</td></tr>
-            <tr><td>fallbackInitials</td><td>string</td><td>"?"</td></tr>
-            <tr><td>bordered</td><td>boolean</td><td>false</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- Brandmark -->
-    <article class="sg-component" id="brandmark">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Brandmark</span>
-        <span class="sg-component__file">src/components/ui/brandmark.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Inline SVG. The rounded square inherits the parent's <code class="tok">color</code> (drive with
-          <code class="tok">--fg-primary</code>); the inner "C" is filled with <code class="tok">--bg-canvas</code>
-          so it inverts in both themes. <code class="tok">decorative</code> hides it from the a11y tree (no role/title)
-          when it sits inside an already-labelled element.
-        </p>
-        <span class="sg-block-label">Sizes (currentColor = --fg-primary)</span>
-        <div class="sg-demo" style="align-items:flex-end;color:var(--fg-primary);">
-          <svg class="brandmark" width="24" height="24" viewBox="0 0 40 40" fill="none" aria-hidden="true"><path d="M0 8C0 3.58172 3.58172 0 8 0H32C36.4183 0 40 3.58172 40 8V32C40 36.4183 36.4183 40 32 40H8C3.58172 40 0 36.4183 0 32V8Z" fill="currentColor"/><path d="M29.8965 22.5791C29.7197 23.9952 29.2851 25.2627 28.5918 26.3828C27.8974 27.5029 26.9757 28.3863 25.8262 29.0312C24.6754 29.6762 23.3451 29.9999 21.835 30C20.2149 30 18.7905 29.6896 17.5645 29.0693L19.5527 27.167C20.2356 27.404 20.995 27.5273 21.835 27.5273C23.3104 27.5273 24.5302 27.069 25.4961 26.1553C26.4621 25.2414 27.0424 24.0493 27.2354 22.5801V22.5791H29.8965ZM21.6172 22.0518L14.4609 28.8994C13.792 29.5396 12.7408 29.5057 12.1133 28.8232L11.6914 28.3643L9 25.4336L10.8262 23.6875L13.3633 26.4492L19.9062 20.1895L21.6172 22.0518ZM21.833 10C23.2554 10 24.529 10.2916 25.6533 10.874C26.7777 11.4565 27.6864 12.2634 28.3809 13.2939C29.074 14.3244 29.5349 15.4942 29.7637 16.8018H27.1025C26.8564 15.5118 26.2602 14.467 25.3115 13.6699C24.3628 12.8716 23.2381 12.4727 21.833 12.4727C20.4281 12.4727 19.2423 12.8052 18.2764 13.4678C17.3104 14.1304 16.5955 15.0321 16.1299 16.1699C15.6643 17.3089 15.4316 18.5861 15.4316 20.001C15.4317 20.4418 15.4577 20.8677 15.5039 21.2803L15.501 21.2812L13.1689 23.5137C12.8524 22.4183 12.6905 21.2482 12.6904 20.002C12.6904 18.1566 13.0379 16.4762 13.7324 14.9609C14.4257 13.4457 15.4623 12.2409 16.8408 11.3447C18.2192 10.4487 19.8839 10.0001 21.833 10Z" fill="var(--bg-canvas)"/></svg>
-          <svg class="brandmark" width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden="true"><path d="M0 8C0 3.58172 3.58172 0 8 0H32C36.4183 0 40 3.58172 40 8V32C40 36.4183 36.4183 40 32 40H8C3.58172 40 0 36.4183 0 32V8Z" fill="currentColor"/><path d="M29.8965 22.5791C29.7197 23.9952 29.2851 25.2627 28.5918 26.3828C27.8974 27.5029 26.9757 28.3863 25.8262 29.0312C24.6754 29.6762 23.3451 29.9999 21.835 30C20.2149 30 18.7905 29.6896 17.5645 29.0693L19.5527 27.167C20.2356 27.404 20.995 27.5273 21.835 27.5273C23.3104 27.5273 24.5302 27.069 25.4961 26.1553C26.4621 25.2414 27.0424 24.0493 27.2354 22.5801V22.5791H29.8965ZM21.6172 22.0518L14.4609 28.8994C13.792 29.5396 12.7408 29.5057 12.1133 28.8232L11.6914 28.3643L9 25.4336L10.8262 23.6875L13.3633 26.4492L19.9062 20.1895L21.6172 22.0518ZM21.833 10C23.2554 10 24.529 10.2916 25.6533 10.874C26.7777 11.4565 27.6864 12.2634 28.3809 13.2939C29.074 14.3244 29.5349 15.4942 29.7637 16.8018H27.1025C26.8564 15.5118 26.2602 14.467 25.3115 13.6699C24.3628 12.8716 23.2381 12.4727 21.833 12.4727C20.4281 12.4727 19.2423 12.8052 18.2764 13.4678C17.3104 14.1304 16.5955 15.0321 16.1299 16.1699C15.6643 17.3089 15.4316 18.5861 15.4316 20.001C15.4317 20.4418 15.4577 20.8677 15.5039 21.2803L15.501 21.2812L13.1689 23.5137C12.8524 22.4183 12.6905 21.2482 12.6904 20.002C12.6904 18.1566 13.0379 16.4762 13.7324 14.9609C14.4257 13.4457 15.4623 12.2409 16.8408 11.3447C18.2192 10.4487 19.8839 10.0001 21.833 10Z" fill="var(--bg-canvas)"/></svg>
-          <svg class="brandmark" width="64" height="64" viewBox="0 0 40 40" fill="none" aria-hidden="true"><path d="M0 8C0 3.58172 3.58172 0 8 0H32C36.4183 0 40 3.58172 40 8V32C40 36.4183 36.4183 40 32 40H8C3.58172 40 0 36.4183 0 32V8Z" fill="currentColor"/><path d="M29.8965 22.5791C29.7197 23.9952 29.2851 25.2627 28.5918 26.3828C27.8974 27.5029 26.9757 28.3863 25.8262 29.0312C24.6754 29.6762 23.3451 29.9999 21.835 30C20.2149 30 18.7905 29.6896 17.5645 29.0693L19.5527 27.167C20.2356 27.404 20.995 27.5273 21.835 27.5273C23.3104 27.5273 24.5302 27.069 25.4961 26.1553C26.4621 25.2414 27.0424 24.0493 27.2354 22.5801V22.5791H29.8965ZM21.6172 22.0518L14.4609 28.8994C13.792 29.5396 12.7408 29.5057 12.1133 28.8232L11.6914 28.3643L9 25.4336L10.8262 23.6875L13.3633 26.4492L19.9062 20.1895L21.6172 22.0518ZM21.833 10C23.2554 10 24.529 10.2916 25.6533 10.874C26.7777 11.4565 27.6864 12.2634 28.3809 13.2939C29.074 14.3244 29.5349 15.4942 29.7637 16.8018H27.1025C26.8564 15.5118 26.2602 14.467 25.3115 13.6699C24.3628 12.8716 23.2381 12.4727 21.833 12.4727C20.4281 12.4727 19.2423 12.8052 18.2764 13.4678C17.3104 14.1304 16.5955 15.0321 16.1299 16.1699C15.6643 17.3089 15.4316 18.5861 15.4316 20.001C15.4317 20.4418 15.4577 20.8677 15.5039 21.2803L15.501 21.2812L13.1689 23.5137C12.8524 22.4183 12.6905 21.2482 12.6904 20.002C12.6904 18.1566 13.0379 16.4762 13.7324 14.9609C14.4257 13.4457 15.4623 12.2409 16.8408 11.3447C18.2192 10.4487 19.8839 10.0001 21.833 10Z" fill="var(--bg-canvas)"/></svg>
-        </div>
-        <table class="sg-api">
-          <caption>Props (extends SVGProps)</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead>
-          <tbody>
-            <tr><td>size</td><td>number | string</td><td>40</td></tr>
-            <tr><td>title</td><td>string</td><td>"Certified"</td></tr>
-            <tr><td>decorative</td><td>boolean</td><td>false</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- CertIcon -->
-    <article class="sg-component" id="cert-icon">
-      <div class="sg-component__head">
-        <span class="sg-component__title">CertIcon</span>
-        <span class="sg-component__file">src/components/ui/cert-icon.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          The single sanctioned <code class="tok">@tabler/icons-react</code> import (<code class="tok">IconCertificate</code>),
-          wrapped to a lucide-compatible API (<code class="tok">strokeWidth</code>, not tabler's <code class="tok">stroke</code>).
-          Hidden from assistive tech by default; pass <code class="tok">title</code>/<code class="tok">aria-label</code> for
-          standalone labelled use. The glyph below is an approximation (no tabler at <code class="tok">file://</code>).
-        </p>
-        <span class="sg-block-label">Sizes (currentColor)</span>
-        <div class="sg-demo" style="color:var(--fg-primary);align-items:center;">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 15l-2 5-1.6-2.4M9 15l2 5 1.6-2.4"/><circle cx="12" cy="8" r="6"/><path d="M9.5 8.5l1.5 1.5 3-3"/></svg>
-          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 15l-2 5-1.6-2.4M9 15l2 5 1.6-2.4"/><circle cx="12" cy="8" r="6"/><path d="M9.5 8.5l1.5 1.5 3-3"/></svg>
-          <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 15l-2 5-1.6-2.4M9 15l2 5 1.6-2.4"/><circle cx="12" cy="8" r="6"/><path d="M9.5 8.5l1.5 1.5 3-3"/></svg>
-        </div>
-        <table class="sg-api">
-          <caption>Props</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead>
-          <tbody>
-            <tr><td>size</td><td>number | string</td><td>24</td></tr>
-            <tr><td>strokeWidth</td><td>number | string</td><td>1.75</td></tr>
-            <tr><td>aria-hidden / title / aria-label</td><td>—</td><td>hidden unless a label is given</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-  </section>
-
-  <!-- ============================================================= -->
-  <!-- NAVIGATION & OVERLAY                                          -->
-  <!-- ============================================================= -->
-  <section class="sg-category" id="navoverlay">
-    <h2 class="font-headline">Navigation &amp; overlay</h2>
-    <p class="sg-category-desc">Tabs, Popover, and the dialog family. Dialogs are shown as static surface representations with behavior notes — they're live modals at runtime.</p>
-
-    <!-- Tabs -->
-    <article class="sg-component" id="tabs">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Tabs / TabList / Tab / TabPanel</span>
-        <span class="sg-component__file">src/components/ui/tabs.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Full WAI-ARIA tablist: <code class="tok">role="tablist/tab/tabpanel"</code> with
-          <code class="tok">aria-controls</code>/<code class="tok">aria-labelledby</code> auto-wired, roving tabindex,
-          and Arrow/Home/End navigation that skips disabled tabs. Two visuals via <code class="tok">variant</code>:
-          <code class="tok">underline</code> (default, underline-on-active) and <code class="tok">segmented</code> (a sunken pill
-          container with the active tab as a raised pill). Tabs accept an optional
-          <code class="tok">count</code> (rendered via the Badge <code class="tok">count</code> chip) and a
-          <code class="tok">disabled</code> flag. A Tab with an <code class="tok">href</code> renders as a Next
-          <code class="tok">&lt;Link&gt;</code> (an anchor) for URL-router tab strips while keeping the same role / roving
-          tabindex / keyboard contract. Controlled via <code class="tok">value</code> + <code class="tok">onChange</code>.
-        </p>
-        <span class="sg-block-label">Tab strip (with count + disabled)</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack">
-          <div class="ui-tablist" role="tablist" aria-label="Profile sections">
-            <button class="ui-tab ui-tab--active" role="tab" aria-selected="true" tabindex="0">Overview</button>
-            <button class="ui-tab" role="tab" aria-selected="false" tabindex="-1">Activity <span class="ui-badge ui-badge--sm ui-badge--count">12</span></button>
-            <button class="ui-tab" role="tab" aria-selected="false" tabindex="-1">Endorsements</button>
-            <button class="ui-tab ui-tab--disabled" role="tab" aria-selected="false" aria-disabled="true" tabindex="-1">Drafts</button>
-          </div>
-          <div role="tabpanel" style="padding-top:16px;font-size:0.875rem;color:var(--fg-secondary);">Active panel content for "Overview".</div>
-        </div>
-        <span class="sg-block-label">variant="segmented" (raised active pill)</span>
-        <div class="sg-demo sg-demo--col" style="align-items:flex-start;">
-          <div class="ui-tablist ui-tablist--segmented" role="tablist" aria-label="View mode">
-            <button class="ui-tab ui-tab--seg ui-tab--active" role="tab" aria-selected="true" tabindex="0">List</button>
-            <button class="ui-tab ui-tab--seg" role="tab" aria-selected="false" tabindex="-1">Grid</button>
-            <button class="ui-tab ui-tab--seg" role="tab" aria-selected="false" tabindex="-1">Map</button>
-          </div>
-        </div>
-        <span class="sg-block-label">Link tabs (Tab href → renders an &lt;a&gt;)</span>
-        <div class="sg-demo sg-demo--col" style="align-items:flex-start;">
-          <div class="ui-tablist" role="tablist" aria-label="Workspace routes">
-            <a class="ui-tab ui-tab--active" role="tab" aria-selected="true" tabindex="0" href="#0">Members</a>
-            <a class="ui-tab" role="tab" aria-selected="false" tabindex="-1" href="#0">Records</a>
-            <a class="ui-tab" role="tab" aria-selected="false" tabindex="-1" href="#0">Settings</a>
-          </div>
-          <span class="sg-demo__caption">each tab is an anchor; onChange still fires on activation so controlled value stays in sync, navigation left to the router</span>
-        </div>
-        <table class="sg-api">
-          <caption>Key props</caption>
-          <thead><tr><th>Component</th><th>Prop</th><th>Type</th></tr></thead>
-          <tbody>
-            <tr><td>Tabs / TabList</td><td>variant</td><td>"underline" | "segmented" (default "underline"; TabList can override Tabs)</td></tr>
-            <tr><td>Tabs</td><td>value / onChange</td><td>string / (next: string) =&gt; void</td></tr>
-            <tr><td>TabList</td><td>aria-label</td><td>string (required)</td></tr>
-            <tr><td>Tab</td><td>value / disabled / count</td><td>string / boolean / number | string</td></tr>
-            <tr><td>Tab</td><td>href</td><td>string — renders a Next &lt;Link&gt; (anchor); ignored when disabled</td></tr>
-            <tr><td>TabPanel</td><td>value / keepMounted</td><td>string / boolean</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- Popover -->
-    <article class="sg-component" id="popover">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Popover</span>
-        <span class="sg-component__file">src/components/ui/popover.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Trigger + Content + Item composition. Click-outside and Esc close (Esc refocuses the trigger);
-          <code class="tok">aria-haspopup/-expanded/-controls</code> wired automatically. Content is a
-          <code class="tok">role="menu"</code> card (<code class="tok">--bg-elevated</code>, <code class="tok">--shadow-md</code>)
-          that focuses the first item on open; Items are <code class="tok">role="menuitem"</code> with arrow-key roving
-          focus (Home/End jump to ends, disabled items skipped). <code class="tok">align</code> = start / center / end.
-          Passing <code class="tok">selected</code> (boolean) to a <code class="tok">PopoverItem</code> opts it into single-select
-          (radio) semantics — <code class="tok">role="menuitemradio"</code> + <code class="tok">aria-checked</code> with a reserved
-          leading checkmark column that paints when selected — the shape a "Sort:" / "pick exactly one" menu needs. Both
-          roles participate in arrow-key roving.
-        </p>
-        <span class="sg-block-label">Open menu (static, align=start)</span>
-        <div class="sg-demo sg-demo--col" style="align-items:flex-start;">
-          <button class="btn btn--secondary btn--sm" aria-haspopup="menu" aria-expanded="true">Account ▾</button>
-          <div class="ui-popover" role="menu">
-            <button class="ui-popover__item" role="menuitem">View profile</button>
-            <button class="ui-popover__item" role="menuitem">Settings</button>
-            <button class="ui-popover__item" role="menuitem" disabled>Switch account (disabled)</button>
-            <button class="ui-popover__item" role="menuitem">Sign out</button>
-          </div>
-        </div>
-        <span class="sg-block-label">Single-select (selected → role="menuitemradio")</span>
-        <div class="sg-demo sg-demo--col" style="align-items:flex-start;">
-          <button class="btn btn--secondary btn--sm" aria-haspopup="menu" aria-expanded="true">Sort: Newest ▾</button>
-          <div class="ui-popover" role="menu">
-            <button class="ui-popover__item ui-popover__item--radio" role="menuitemradio" aria-checked="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M20 6 9 17l-5-5"/></svg><span>Newest first</span>
-            </button>
-            <button class="ui-popover__item ui-popover__item--radio" role="menuitemradio" aria-checked="false">
-              <svg class="is-off" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M20 6 9 17l-5-5"/></svg><span>Oldest first</span>
-            </button>
-            <button class="ui-popover__item ui-popover__item--radio" role="menuitemradio" aria-checked="false">
-              <svg class="is-off" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M20 6 9 17l-5-5"/></svg><span>Most endorsed</span>
-            </button>
-          </div>
-          <span class="sg-demo__caption">checkmark column is reserved on every row so labels stay aligned; aria-checked conveys state</span>
-        </div>
-        <table class="sg-api">
-          <caption>Key props</caption>
-          <thead><tr><th>Component</th><th>Prop</th><th>Type</th></tr></thead>
-          <tbody>
-            <tr><td>Popover</td><td>open / onOpenChange</td><td>boolean / (next) =&gt; void (uncontrolled if omitted)</td></tr>
-            <tr><td>PopoverTrigger</td><td>children</td><td>single focusable element (cloned)</td></tr>
-            <tr><td>PopoverContent</td><td>align / offset / minWidth</td><td>"start"|"center"|"end" / number / number|string</td></tr>
-            <tr><td>PopoverItem</td><td>selected</td><td>boolean — opt into role="menuitemradio" + aria-checked + leading checkmark (omit = plain role="menuitem")</td></tr>
-            <tr><td>PopoverItem</td><td>…ButtonHTMLAttributes</td><td>roving tabindex (-1)</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-
-    <!-- Dialog family -->
-    <article class="sg-component" id="dialogs">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Dialog family</span>
-        <span class="sg-component__file">app-dialog · confirm-dialog · delete-record-dialog · form-dialog · bottom-sheet · responsive-dialog · drawer</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          <strong>AppDialog</strong> is the canonical native-<code class="tok">&lt;dialog&gt;</code> base:
-          <code class="tok">showModal()</code>, native <code class="tok">::backdrop</code>, Esc via the browser close event,
-          gateable backdrop-click close, a full Tab-cycle focus trap, focus save/restore, and optional
-          <code class="tok">autoFocusFirst</code>. It renders the <code class="tok">.signin-modal.app-modal</code> chrome
-          (2px radius, <code class="tok">--shadow-lg</code>). <code class="tok">AppDialogHeader</code> is the shared title + close-X row.
-          The surfaces below are static representations — at runtime these are real modals/sheets/drawers.
-        </p>
-
-        <span class="sg-block-label">AppDialog + AppDialogHeader</span>
-        <div class="sg-demo" style="justify-content:center;">
-          <div class="dialog-surface" role="dialog" aria-label="Edit profile">
-            <div class="signin-modal__header"><span class="signin-modal__title">Edit profile</span><button class="signin-modal__close" aria-label="Close"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg></button></div>
-            <div class="signin-modal__body">
-              <p class="dash-card__desc">Generic modal body. Header + body + actions are the consumer's; AppDialog owns the dialog dance.</p>
-              <div class="dialog-footer"><button class="btn btn--ghost btn--md">Cancel</button><button class="btn btn--primary btn--md">Save</button></div>
-            </div>
-          </div>
-        </div>
-
-        <span class="sg-block-label">ConfirmDialog (role=alertdialog)</span>
-        <div class="sg-demo" style="justify-content:center;">
-          <div class="dialog-surface" role="alertdialog" aria-label="Remove member">
-            <div class="signin-modal__header"><span class="signin-modal__title">Remove member</span><button class="signin-modal__close" aria-label="Close"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg></button></div>
-            <div class="signin-modal__body">
-              <p class="dash-card__desc" style="margin-bottom:20px;">Are you sure you want to remove this member from the group?</p>
-              <div class="dialog-footer"><button class="btn btn--ghost btn--md">Cancel</button><button class="btn btn--destructive btn--md">Confirm</button></div>
-            </div>
-          </div>
-        </div>
-        <p class="sg-note">Thin wrapper over AppDialog. Backdrop-close disabled while confirming; confirm button takes <code class="tok">confirmVariant</code> primary | destructive (default destructive).</p>
-
-        <span class="sg-block-label">DeleteRecordDialog (type-to-confirm)</span>
-        <div class="sg-demo" style="justify-content:center;">
-          <div class="dialog-surface" role="alertdialog" aria-label="Delete this cert">
-            <div class="signin-modal__header"><span class="signin-modal__title">Delete this cert</span><button class="signin-modal__close" aria-label="Close"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg></button></div>
-            <div class="signin-modal__body">
-              <p class="delete-record-dialog__warning">This will permanently delete the cert. This action <strong>cannot be undone</strong>.</p>
-              <span class="delete-record-dialog__label">Type the cert name to confirm:</span>
-              <code class="delete-record-dialog__target">Solidity Audit 2026</code>
-              <input class="ui-field ui-field--inline" type="text" placeholder="Solidity Audit 2026" />
-              <div class="dialog-footer"><button class="btn btn--ghost btn--md">Cancel</button><button class="btn btn--destructive btn--md" disabled>Delete cert</button></div>
-            </div>
-          </div>
-        </div>
-        <p class="sg-note">Delete enables only when the trimmed input matches the record name (case-sensitive). Submit is stopPropagation-guarded so a parent form doesn't catch it.</p>
-
-        <span class="sg-block-label">FormDialog</span>
-        <div class="sg-demo" style="justify-content:center;">
-          <div class="dialog-surface" role="dialog" aria-label="New list">
-            <div class="signin-modal__header"><span class="signin-modal__title">New list</span><button class="signin-modal__close" aria-label="Close"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg></button></div>
-            <div class="signin-modal__body">
-              <label class="ui-field-label">List name</label>
-              <input class="ui-field" type="text" placeholder="e.g. Trusted auditors" />
-              <div class="dialog-footer"><button class="btn btn--ghost btn--md">Cancel</button><button class="btn btn--primary btn--md">Save</button></div>
-            </div>
-          </div>
-        </div>
-        <p class="sg-note">AppDialog chrome + header + body <code class="tok">&lt;form&gt;</code> + the shared ghost-Cancel / primary-Submit footer (<code class="tok">DIALOG_FOOTER_ACTIONS_CLASS = "flex justify-end gap-2"</code>). Owns preventDefault + stopPropagation + autofocus. <code class="tok">submitVariant</code> primary | destructive.</p>
-
-        <span class="sg-block-label">BottomSheet (&lt;800px) — portalled, drag-to-dismiss</span>
-        <div class="sg-demo" style="justify-content:center;">
-          <div class="sheet-surface" role="dialog" aria-modal="true" aria-label="Switch account">
-            <div class="sheet-surface__handle" aria-hidden="true"></div>
-            <div class="sheet-surface__header"><span class="sheet-surface__title font-headline">Switch account</span><button class="signin-modal__close" aria-label="Close"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg></button></div>
-            <div class="sheet-surface__content">Bottom-anchored sheet over <code class="tok">useBottomSheetDrag</code>: drag-to-dismiss/expand, Esc, focus trap, body-scroll-lock. CSS-gated to <code class="tok">display:none</code> at desktop widths.</div>
-          </div>
-        </div>
-
-        <span class="sg-block-label">Drawer (edge-anchored)</span>
-        <div class="sg-demo sg-demo--stack">
-          <div class="drawer-frame">
-            <div class="drawer-frame__scrim" aria-hidden="true"></div>
-            <aside class="drawer-panel" role="dialog" aria-modal="true" aria-label="Menu">
-              <strong style="color:var(--fg-primary);font-size:0.875rem;">Menu</strong>
-              <span class="drawer-panel__row">Home</span>
-              <span class="drawer-panel__row">Explore</span>
-              <span class="drawer-panel__row">Notifications</span>
-            </aside>
-          </div>
-        </div>
-        <p class="sg-note">Portalled <code class="tok">&lt;aside role="dialog" aria-modal&gt;</code> pinned to the left/right edge (83.33% wide, max 320px), sliding via transform. Esc + backdrop close, focus trap, body-scroll-lock, <code class="tok">inert</code> while off-canvas. Folds the mobile-sidebar + site-drawer shells.</p>
-
-        <span class="sg-block-label">ResponsiveDialog</span>
-        <p class="sg-note" style="margin-top:0;">No surface of its own: it renders <strong>AppDialog ≥800px</strong> and <strong>BottomSheet &lt;800px</strong> behind one <code class="tok">open / onClose / header / children</code> API (driven by <code class="tok">useLayoutBreakpoints().isDesktop</code>, SSR-safe). The two paths never co-mount.</p>
-
-        <table class="sg-api">
-          <caption>AppDialog props (base)</caption>
-          <thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead>
-          <tbody>
-            <tr><td>ariaLabel</td><td>string (required)</td><td>—</td></tr>
-            <tr><td>role</td><td>"dialog" | "alertdialog"</td><td>"dialog"</td></tr>
-            <tr><td>onClose</td><td>() =&gt; void</td><td>—</td></tr>
-            <tr><td>disableBackdropClose</td><td>boolean</td><td>false</td></tr>
-            <tr><td>maxWidth</td><td>number | string</td><td>—</td></tr>
-            <tr><td>autoFocusFirst / initialFocusRef</td><td>boolean / Ref</td><td>false / —</td></tr>
-          </tbody>
-        </table>
-      </div>
-    </article>
-  </section>
-
-  <!-- ============================================================= -->
-  <!-- STATUS & FEEDBACK                                             -->
-  <!-- ============================================================= -->
-  <section class="sg-category" id="status">
-    <h2 class="font-headline">Status &amp; feedback</h2>
-    <p class="sg-category-desc">Loading, empty, error, and notification primitives.</p>
-
-    <!-- LoadingSpinner -->
-    <article class="sg-component" id="loading-spinner">
-      <div class="sg-component__head">
-        <span class="sg-component__title">LoadingSpinner</span>
-        <span class="sg-component__file">src/components/ui/loading-spinner.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          A pulsing Brandmark in <code class="tok">currentColor</code> (<code class="tok">--fg-primary</code>),
-          wrapped in <code class="tok">role="status" aria-live="polite"</code> with sr-only "Loading" text and a
-          <code class="tok">&lt;noscript&gt;</code> Loader2 fallback. Three sizes: sm 24 · md 48 · lg 64.
-        </p>
-        <span class="sg-block-label">Sizes</span>
-        <div class="sg-demo" style="align-items:center;color:var(--fg-primary);" role="status" aria-live="polite">
-          <svg class="spinner-pulse" width="24" height="24" viewBox="0 0 40 40" fill="none" aria-hidden="true"><path d="M0 8C0 3.58172 3.58172 0 8 0H32C36.4183 0 40 3.58172 40 8V32C40 36.4183 36.4183 40 32 40H8C3.58172 40 0 36.4183 0 32V8Z" fill="currentColor"/><path d="M29.8965 22.5791C29.7197 23.9952 29.2851 25.2627 28.5918 26.3828C27.8974 27.5029 26.9757 28.3863 25.8262 29.0312C24.6754 29.6762 23.3451 29.9999 21.835 30C20.2149 30 18.7905 29.6896 17.5645 29.0693L19.5527 27.167C20.2356 27.404 20.995 27.5273 21.835 27.5273C23.3104 27.5273 24.5302 27.069 25.4961 26.1553C26.4621 25.2414 27.0424 24.0493 27.2354 22.5801V22.5791H29.8965ZM21.6172 22.0518L14.4609 28.8994C13.792 29.5396 12.7408 29.5057 12.1133 28.8232L11.6914 28.3643L9 25.4336L10.8262 23.6875L13.3633 26.4492L19.9062 20.1895L21.6172 22.0518ZM21.833 10C23.2554 10 24.529 10.2916 25.6533 10.874C26.7777 11.4565 27.6864 12.2634 28.3809 13.2939C29.074 14.3244 29.5349 15.4942 29.7637 16.8018H27.1025C26.8564 15.5118 26.2602 14.467 25.3115 13.6699C24.3628 12.8716 23.2381 12.4727 21.833 12.4727C20.4281 12.4727 19.2423 12.8052 18.2764 13.4678C17.3104 14.1304 16.5955 15.0321 16.1299 16.1699C15.6643 17.3089 15.4316 18.5861 15.4316 20.001C15.4317 20.4418 15.4577 20.8677 15.5039 21.2803L15.501 21.2812L13.1689 23.5137C12.8524 22.4183 12.6905 21.2482 12.6904 20.002C12.6904 18.1566 13.0379 16.4762 13.7324 14.9609C14.4257 13.4457 15.4623 12.2409 16.8408 11.3447C18.2192 10.4487 19.8839 10.0001 21.833 10Z" fill="var(--bg-canvas)"/></svg>
-          <svg class="spinner-pulse" width="48" height="48" viewBox="0 0 40 40" fill="none" aria-hidden="true"><path d="M0 8C0 3.58172 3.58172 0 8 0H32C36.4183 0 40 3.58172 40 8V32C40 36.4183 36.4183 40 32 40H8C3.58172 40 0 36.4183 0 32V8Z" fill="currentColor"/><path d="M29.8965 22.5791C29.7197 23.9952 29.2851 25.2627 28.5918 26.3828C27.8974 27.5029 26.9757 28.3863 25.8262 29.0312C24.6754 29.6762 23.3451 29.9999 21.835 30C20.2149 30 18.7905 29.6896 17.5645 29.0693L19.5527 27.167C20.2356 27.404 20.995 27.5273 21.835 27.5273C23.3104 27.5273 24.5302 27.069 25.4961 26.1553C26.4621 25.2414 27.0424 24.0493 27.2354 22.5801V22.5791H29.8965ZM21.6172 22.0518L14.4609 28.8994C13.792 29.5396 12.7408 29.5057 12.1133 28.8232L11.6914 28.3643L9 25.4336L10.8262 23.6875L13.3633 26.4492L19.9062 20.1895L21.6172 22.0518ZM21.833 10C23.2554 10 24.529 10.2916 25.6533 10.874C26.7777 11.4565 27.6864 12.2634 28.3809 13.2939C29.074 14.3244 29.5349 15.4942 29.7637 16.8018H27.1025C26.8564 15.5118 26.2602 14.467 25.3115 13.6699C24.3628 12.8716 23.2381 12.4727 21.833 12.4727C20.4281 12.4727 19.2423 12.8052 18.2764 13.4678C17.3104 14.1304 16.5955 15.0321 16.1299 16.1699C15.6643 17.3089 15.4316 18.5861 15.4316 20.001C15.4317 20.4418 15.4577 20.8677 15.5039 21.2803L15.501 21.2812L13.1689 23.5137C12.8524 22.4183 12.6905 21.2482 12.6904 20.002C12.6904 18.1566 13.0379 16.4762 13.7324 14.9609C14.4257 13.4457 15.4623 12.2409 16.8408 11.3447C18.2192 10.4487 19.8839 10.0001 21.833 10Z" fill="var(--bg-canvas)"/></svg>
-          <svg class="spinner-pulse" width="64" height="64" viewBox="0 0 40 40" fill="none" aria-hidden="true"><path d="M0 8C0 3.58172 3.58172 0 8 0H32C36.4183 0 40 3.58172 40 8V32C40 36.4183 36.4183 40 32 40H8C3.58172 40 0 36.4183 0 32V8Z" fill="currentColor"/><path d="M29.8965 22.5791C29.7197 23.9952 29.2851 25.2627 28.5918 26.3828C27.8974 27.5029 26.9757 28.3863 25.8262 29.0312C24.6754 29.6762 23.3451 29.9999 21.835 30C20.2149 30 18.7905 29.6896 17.5645 29.0693L19.5527 27.167C20.2356 27.404 20.995 27.5273 21.835 27.5273C23.3104 27.5273 24.5302 27.069 25.4961 26.1553C26.4621 25.2414 27.0424 24.0493 27.2354 22.5801V22.5791H29.8965ZM21.6172 22.0518L14.4609 28.8994C13.792 29.5396 12.7408 29.5057 12.1133 28.8232L11.6914 28.3643L9 25.4336L10.8262 23.6875L13.3633 26.4492L19.9062 20.1895L21.6172 22.0518ZM21.833 10C23.2554 10 24.529 10.2916 25.6533 10.874C26.7777 11.4565 27.6864 12.2634 28.3809 13.2939C29.074 14.3244 29.5349 15.4942 29.7637 16.8018H27.1025C26.8564 15.5118 26.2602 14.467 25.3115 13.6699C24.3628 12.8716 23.2381 12.4727 21.833 12.4727C20.4281 12.4727 19.2423 12.8052 18.2764 13.4678C17.3104 14.1304 16.5955 15.0321 16.1299 16.1699C15.6643 17.3089 15.4316 18.5861 15.4316 20.001C15.4317 20.4418 15.4577 20.8677 15.5039 21.2803L15.501 21.2812L13.1689 23.5137C12.8524 22.4183 12.6905 21.2482 12.6904 20.002C12.6904 18.1566 13.0379 16.4762 13.7324 14.9609C14.4257 13.4457 15.4623 12.2409 16.8408 11.3447C18.2192 10.4487 19.8839 10.0001 21.833 10Z" fill="var(--bg-canvas)"/></svg>
-          <span style="position:absolute;left:-9999px;">Loading</span>
-        </div>
-        <table class="sg-api"><caption>Props</caption><thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead><tbody><tr><td>size</td><td>"sm" | "md" | "lg"</td><td>"md"</td></tr></tbody></table>
-      </div>
-    </article>
-
-    <!-- Skeleton -->
-    <article class="sg-component" id="skeleton">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Skeleton</span>
-        <span class="sg-component__file">src/components/ui/skeleton.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Pulsing placeholder on <code class="tok">--overlay-weak</code>. Variants: line / box / circle / text.
-          <code class="tok">circle</code> sugar forces a round chip; <code class="tok">text</code> stacks
-          <code class="tok">lines</code> bars (last one ragged at 60%); <code class="tok">count</code> repeats N copies;
-          <code class="tok">radius</code> overrides. Set <code class="tok">animate={false}</code> (or the legacy
-          <code class="tok">noAnimate</code> — either one off suppresses the pulse) for a flat static token surface, e.g. an
-          avatar placeholder that should not shimmer. A circle keeps <code class="tok">shrink-0</code> so it holds its size
-          in a flex row. Always <code class="tok">aria-hidden</code>.
-        </p>
-        <span class="sg-block-label">box · line · circle · text(3)</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack" style="gap:18px;">
-          <div class="skeleton" style="width:100%;height:80px;" aria-hidden="true"></div>
-          <div class="skeleton" style="width:60%;height:12px;" aria-hidden="true"></div>
-          <div class="skeleton skeleton--circle" style="width:40px;height:40px;" aria-hidden="true"></div>
-          <div aria-hidden="true" style="display:flex;flex-direction:column;gap:8px;">
-            <div class="skeleton" style="width:100%;height:12px;"></div>
-            <div class="skeleton" style="width:100%;height:12px;"></div>
-            <div class="skeleton" style="width:60%;height:12px;"></div>
-          </div>
-        </div>
-        <span class="sg-block-label">animate={false} (static) · flex circle holds its size in a row</span>
-        <div class="sg-demo sg-demo--stack">
-          <div aria-hidden="true" style="display:flex;align-items:center;gap:12px;">
-            <div class="skeleton skeleton--circle skeleton--static" style="width:48px;height:48px;"></div>
-            <div style="flex:1;display:flex;flex-direction:column;gap:8px;">
-              <div class="skeleton skeleton--static" style="width:60%;height:12px;"></div>
-              <div class="skeleton skeleton--static" style="width:40%;height:12px;"></div>
-            </div>
-          </div>
-          <span class="sg-demo__caption">no pulse (flat surface); the circle keeps shrink-0 so the row text doesn't squeeze it</span>
-        </div>
-        <table class="sg-api"><caption>Props</caption><thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead><tbody>
-          <tr><td>variant</td><td>"line" | "box" | "circle" | "text"</td><td>"box"</td></tr>
-          <tr><td>width / height</td><td>number | string</td><td>variant-dependent</td></tr>
-          <tr><td>circle</td><td>boolean</td><td>false (wins over variant; adds shrink-0)</td></tr>
-          <tr><td>lines</td><td>number (text variant)</td><td>3</td></tr>
-          <tr><td>count</td><td>number</td><td>1</td></tr>
-          <tr><td>radius</td><td>number | string</td><td>—</td></tr>
-          <tr><td>animate</td><td>boolean</td><td>true — false = flat static surface (no pulse)</td></tr>
-          <tr><td>noAnimate</td><td>boolean</td><td>false — legacy alias; either signal off suppresses the pulse</td></tr>
-        </tbody></table>
-      </div>
-    </article>
-
-    <!-- EmptyState -->
-    <article class="sg-component" id="empty-state">
-      <div class="sg-component__head">
-        <span class="sg-component__title">EmptyState</span>
-        <span class="sg-component__file">src/components/ui/empty-state.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          <strong>rich</strong> (default): centered block — optional icon, serif title, description, CTA slot.
-          <strong>inline</strong>: a single muted line (rendered as a bare <code class="tok">&lt;p class="m-0 text-sm
-          text-[var(--fg-muted)]"&gt;</code>) for the ~12 inline <code class="tok">*__empty</code> slots
-          (<code class="tok">home-section__empty</code>, <code class="tok">org-list__empty</code>, …) — no icon, no headline
-          weight, no container, zero margin; the description and CTA slot follow inline so the whole hint reads as one line.
-          <strong>compact</strong> is the back-compat alias of <code class="tok">inline</code>; new code should prefer <code class="tok">inline</code>.
-        </p>
-        <span class="sg-block-label">rich</span>
-        <div class="sg-demo sg-demo--stack">
-          <div class="empty-state">
-            <div class="empty-state__icon" aria-hidden="true"><svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg></div>
-            <h3 class="empty-state__title font-headline">No certs yet</h3>
-            <p class="empty-state__desc">When you receive or issue a certificate, it'll show up here.</p>
-            <div class="empty-state__actions"><button class="btn btn--primary btn--sm">Create a cert</button></div>
-          </div>
-        </div>
-        <span class="sg-block-label">inline (canonical) — single muted line; CTA stays inline</span>
-        <div class="sg-demo sg-demo--stack">
-          <p class="empty-state--inline">No endorsements yet.<a class="empty-state__inline-cta" href="#0" style="color:var(--fg-primary);">Ask for one</a></p>
-        </div>
-        <span class="sg-block-label">compact (alias of inline)</span>
-        <div class="sg-demo sg-demo--stack">
-          <p class="empty-state--compact">No members in this group yet.</p>
-        </div>
-        <table class="sg-api"><caption>Props</caption><thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead><tbody>
-          <tr><td>title</td><td>string (required)</td><td>—</td></tr>
-          <tr><td>description</td><td>string</td><td>—</td></tr>
-          <tr><td>icon</td><td>ComponentType (lucide/cert)</td><td>— (ignored by inline/compact)</td></tr>
-          <tr><td>variant</td><td>"rich" | "inline" | "compact"</td><td>"rich"</td></tr>
-          <tr><td>children</td><td>ReactNode (CTA slot)</td><td>—</td></tr>
-        </tbody></table>
-      </div>
-    </article>
-
-    <!-- ErrorMessage -->
-    <article class="sg-component" id="error-message">
-      <div class="sg-component__head">
-        <span class="sg-component__title">ErrorMessage</span>
-        <span class="sg-component__file">src/components/ui/error-message.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Inline <code class="tok">role="alert"</code> error card on the error-surface tokens
-          (<code class="tok">--color-error-bg/-border</code>), with an AlertCircle, a tracked title, a message, and an
-          optional secondary <strong>Try again</strong> Button when <code class="tok">onRetry</code> is supplied.
-        </p>
-        <span class="sg-block-label">With retry</span>
-        <div class="sg-demo sg-demo--stack">
-          <div class="error-message" role="alert">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/></svg>
-            <div>
-              <h4 class="error-message__title">Something went wrong</h4>
-              <p class="error-message__msg">We couldn't load your activity feed. Check your connection and try again.</p>
-              <div style="margin-top:16px;"><button class="btn btn--secondary btn--sm">Try again</button></div>
-            </div>
-          </div>
-        </div>
-        <table class="sg-api"><caption>Props</caption><thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead><tbody>
-          <tr><td>title</td><td>string</td><td>"Something went wrong"</td></tr>
-          <tr><td>message</td><td>string (required)</td><td>—</td></tr>
-          <tr><td>onRetry</td><td>() =&gt; void</td><td>— (hides button when absent)</td></tr>
-        </tbody></table>
-      </div>
-    </article>
-
-    <!-- ErrorBoundaryFallback -->
-    <article class="sg-component" id="error-boundary-fallback">
-      <div class="sg-component__head">
-        <span class="sg-component__title">ErrorBoundaryFallback</span>
-        <span class="sg-component__file">src/components/ui/error-boundary-fallback.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Shared fallback for Next.js segment <code class="tok">error.tsx</code> files. Renders the
-          <code class="tok">.dashboard</code> chrome with a title, message, optional error <code class="tok">digest</code>
-          reference line, and two Buttons: <strong>Try again</strong> (wired to <code class="tok">onReset</code>) and a
-          <strong>Go home</strong> link.
-        </p>
-        <span class="sg-block-label">Fallback surface</span>
-        <div class="sg-demo sg-demo--stack">
-          <div class="dashboard">
-            <div class="dashboard__topbar"><h1 class="dashboard__page-title font-headline">Couldn't load this section</h1></div>
-            <div class="dash-card">
-              <p class="dash-card__desc">Something went wrong while loading the page. Try again or head back home.</p>
-              <p class="dash-card__desc" style="font-size:0.75rem;color:var(--fg-muted);">Reference: 7f3a9c1e</p>
-              <div style="display:flex;flex-wrap:wrap;gap:12px;"><button class="btn btn--secondary btn--sm">Try again</button><button class="btn btn--ghost btn--sm">Go home</button></div>
-            </div>
-          </div>
-        </div>
-        <table class="sg-api"><caption>Props</caption><thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead><tbody>
-          <tr><td>error</td><td>Error &amp; { digest?: string }</td><td>—</td></tr>
-          <tr><td>onReset</td><td>() =&gt; void</td><td>—</td></tr>
-          <tr><td>title</td><td>string</td><td>"Couldn't load this section"</td></tr>
-          <tr><td>message</td><td>string</td><td>generic load-failure copy</td></tr>
-        </tbody></table>
-      </div>
-    </article>
-
-    <!-- LoadMoreSentinel -->
-    <article class="sg-component" id="load-more-sentinel">
-      <div class="sg-component__head">
-        <span class="sg-component__title">LoadMoreSentinel</span>
-        <span class="sg-component__file">src/components/ui/load-more-sentinel.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          An <code class="tok">IntersectionObserver</code>-tracked div (fires <code class="tok">onLoadMore</code> 200px before
-          it scrolls into view) plus a visible manual button. By default the button is
-          <code class="tok">&lt;Button variant="secondary" size="sm"&gt;</code> with a loading state; surfaces with bespoke
-          chrome can pass <code class="tok">buttonClassName</code> for a raw button instead.
-        </p>
-        <span class="sg-block-label">Idle · loading</span>
-        <div class="sg-demo">
-          <button class="btn btn--secondary btn--sm">Load more</button>
-          <button class="btn btn--secondary btn--sm" aria-busy="true" disabled>
-            <svg class="sg-icon spin" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
-            Loading…
-          </button>
-        </div>
-        <table class="sg-api"><caption>Props</caption><thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead><tbody>
-          <tr><td>onLoadMore</td><td>() =&gt; void</td><td>—</td></tr>
-          <tr><td>isLoading</td><td>boolean</td><td>—</td></tr>
-          <tr><td>label</td><td>string</td><td>"Load more"</td></tr>
-          <tr><td>className / buttonClassName</td><td>string</td><td>— (raw-button escape hatch)</td></tr>
-        </tbody></table>
-      </div>
-    </article>
-
-    <!-- ProviderRedirectOverlay -->
-    <article class="sg-component" id="provider-redirect-overlay">
-      <div class="sg-component__head">
-        <span class="sg-component__title">ProviderRedirectOverlay</span>
-        <span class="sg-component__file">src/components/ui/provider-redirect-overlay.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Full-screen fixed <code class="tok">role="status"</code> overlay (<code class="tok">.loading-screen</code>,
-          z = <code class="tok">--z-skip-nav</code>) shown during an OAuth provider redirect: a centered Brandmark plus a
-          muted "Redirecting..." line. Takes no props.
-        </p>
-        <span class="sg-block-label">Overlay (inline representation)</span>
-        <div class="sg-demo sg-demo--stack">
-          <div class="loading-screen-demo" role="status">
-            <svg class="brandmark" width="48" height="48" viewBox="0 0 40 40" fill="none" style="color:var(--fg-primary);" aria-hidden="true"><path d="M0 8C0 3.58172 3.58172 0 8 0H32C36.4183 0 40 3.58172 40 8V32C40 36.4183 36.4183 40 32 40H8C3.58172 40 0 36.4183 0 32V8Z" fill="currentColor"/><path d="M29.8965 22.5791C29.7197 23.9952 29.2851 25.2627 28.5918 26.3828C27.8974 27.5029 26.9757 28.3863 25.8262 29.0312C24.6754 29.6762 23.3451 29.9999 21.835 30C20.2149 30 18.7905 29.6896 17.5645 29.0693L19.5527 27.167C20.2356 27.404 20.995 27.5273 21.835 27.5273C23.3104 27.5273 24.5302 27.069 25.4961 26.1553C26.4621 25.2414 27.0424 24.0493 27.2354 22.5801V22.5791H29.8965ZM21.6172 22.0518L14.4609 28.8994C13.792 29.5396 12.7408 29.5057 12.1133 28.8232L11.6914 28.3643L9 25.4336L10.8262 23.6875L13.3633 26.4492L19.9062 20.1895L21.6172 22.0518ZM21.833 10C23.2554 10 24.529 10.2916 25.6533 10.874C26.7777 11.4565 27.6864 12.2634 28.3809 13.2939C29.074 14.3244 29.5349 15.4942 29.7637 16.8018H27.1025C26.8564 15.5118 26.2602 14.467 25.3115 13.6699C24.3628 12.8716 23.2381 12.4727 21.833 12.4727C20.4281 12.4727 19.2423 12.8052 18.2764 13.4678C17.3104 14.1304 16.5955 15.0321 16.1299 16.1699C15.6643 17.3089 15.4316 18.5861 15.4316 20.001C15.4317 20.4418 15.4577 20.8677 15.5039 21.2803L15.501 21.2812L13.1689 23.5137C12.8524 22.4183 12.6905 21.2482 12.6904 20.002C12.6904 18.1566 13.0379 16.4762 13.7324 14.9609C14.4257 13.4457 15.4623 12.2409 16.8408 11.3447C18.2192 10.4487 19.8839 10.0001 21.833 10Z" fill="var(--bg-canvas)"/></svg>
-            <p style="margin:0;font-size:0.875rem;letter-spacing:0.03em;color:var(--fg-muted);">Redirecting...</p>
-          </div>
-        </div>
-      </div>
-    </article>
-
-    <!-- Toast -->
-    <article class="sg-component" id="toast">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Toast / ToastProvider / useToast</span>
-        <span class="sg-component__file">src/components/ui/toast.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Portal-backed aria-live stack (bottom-right desktop / full-width mobile). Mount <code class="tok">&lt;ToastProvider&gt;</code>
-          high in the tree; call <code class="tok">useToast().toast({...})</code> to enqueue. Variants default / success / error;
-          <code class="tok">duration</code> (0/∞ = sticky), optional <code class="tok">action</code> (e.g. Undo), pause-on-hover.
-          Errors announce assertively (<code class="tok">role="alert"</code>); others politely.
-        </p>
-        <span class="sg-block-label">default (with Undo) · success · error</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack" style="gap:12px;">
-          <div class="toast" role="status">
-            <div style="flex:1;min-width:0;"><p class="toast__title">Response hidden</p><p class="toast__desc">Removed from your feed.</p></div>
-            <button class="toast__action">Undo</button>
-            <button class="toast__close" aria-label="Dismiss notification"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
-          </div>
-          <div class="toast toast--success" role="status">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--color-success-text)" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>
-            <div style="flex:1;min-width:0;"><p class="toast__title">Profile saved</p></div>
-            <button class="toast__close" aria-label="Dismiss notification"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
-          </div>
-          <div class="toast toast--error" role="alert">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--color-error)" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/></svg>
-            <div style="flex:1;min-width:0;"><p class="toast__title">Couldn't publish</p><p class="toast__desc">Try again in a moment.</p></div>
-            <button class="toast__close" aria-label="Dismiss notification"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
-          </div>
-        </div>
-        <table class="sg-api"><caption>toast(options) — ToastOptions</caption><thead><tr><th>Field</th><th>Type</th><th>Default</th></tr></thead><tbody>
-          <tr><td>title</td><td>ReactNode (required)</td><td>—</td></tr>
-          <tr><td>description</td><td>ReactNode</td><td>—</td></tr>
-          <tr><td>variant</td><td>"default" | "success" | "error"</td><td>"default"</td></tr>
-          <tr><td>duration</td><td>number (ms; 0/∞ sticky)</td><td>6000</td></tr>
-          <tr><td>action</td><td>{ label, onClick }</td><td>—</td></tr>
-        </tbody></table>
-      </div>
-    </article>
-
-    <!-- Banner -->
-    <article class="sg-component" id="banner">
-      <div class="sg-component__head">
-        <span class="sg-component__title">Banner</span>
-        <span class="sg-component__file">src/components/ui/banner.tsx</span>
-      </div>
-      <div class="sg-component__body">
-        <p class="sg-usage">
-          Inline (non-modal) callout. Four variants with a default leading icon + tint surface + ARIA role
-          (info/success → <code class="tok">status</code>; warning/error → <code class="tok">alert</code>). Optional bold
-          <code class="tok">title</code>, custom or suppressed <code class="tok">icon</code>, and a trailing dismiss button
-          (<code class="tok">onDismiss</code>; the caller owns unmounting).
-        </p>
-        <span class="sg-block-label">info · warning · success · error</span>
-        <div class="sg-demo sg-demo--col sg-demo--stack" style="gap:12px;">
-          <div class="banner banner--info">
-            <span class="banner__icon banner__icon--info" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg></span>
-            <div><p class="banner__body">Your changes are saved automatically as you edit.</p></div>
-          </div>
-          <div class="banner banner--warning" role="alert">
-            <span class="banner__icon banner__icon--warning" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><path d="M12 9v4M12 17h.01"/></svg></span>
-            <div><p class="banner__title">Custom domain not verified</p><p class="banner__body">DNS changes can take up to 24 hours to propagate.</p></div>
-          </div>
-          <div class="banner banner--success" role="status">
-            <span class="banner__icon banner__icon--success" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21.801 10A10 10 0 1 1 17 3.335"/><path d="m9 11 3 3L22 4"/></svg></span>
-            <div><p class="banner__body">Your social graph import finished successfully.</p></div>
-          </div>
-          <div class="banner banner--error" role="alert">
-            <span class="banner__icon banner__icon--error" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/></svg></span>
-            <div><p class="banner__title">Session expired</p><p class="banner__body">Sign in again to continue.</p></div>
-          </div>
-        </div>
-        <table class="sg-api"><caption>Props (extends HTMLAttributes, omits "title")</caption><thead><tr><th>Prop</th><th>Type</th><th>Default</th></tr></thead><tbody>
-          <tr><td>variant</td><td>"info" | "warning" | "success" | "error"</td><td>"info"</td></tr>
-          <tr><td>title</td><td>ReactNode</td><td>—</td></tr>
-          <tr><td>icon</td><td>ReactNode | false</td><td>per-variant default</td></tr>
-          <tr><td>onDismiss</td><td>() =&gt; void</td><td>— (renders dismiss button)</td></tr>
-          <tr><td>dismissLabel</td><td>string</td><td>"Dismiss"</td></tr>
-        </tbody></table>
-      </div>
-    </article>
-  </section>
-
-  <!-- ============================================================= -->
-  <!-- DESIGN TOKENS                                                 -->
-  <!-- ============================================================= -->
-  <section class="sg-category" id="tokens">
-    <h2 class="font-headline">Design tokens</h2>
-    <p class="sg-category-desc">Live token values from <code class="tok">src/app/styles/tokens.css</code>. Swatches render the current theme — toggle to see each token flip. Light/dark hex pairs are annotated.</p>
-
-    <!-- Surfaces -->
-    <article class="sg-component">
-      <div class="sg-component__head"><span class="sg-component__title">Surfaces &amp; foregrounds</span></div>
-      <div class="sg-component__body">
-        <div class="swatch-grid">
-          <div class="swatch"><div class="swatch__chip" style="background:var(--bg-canvas);"></div><div class="swatch__meta"><span class="swatch__name">--bg-canvas</span><span class="swatch__val">#f9f9f9 / #18181b</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--bg-sunken);"></div><div class="swatch__meta"><span class="swatch__name">--bg-sunken</span><span class="swatch__val">#eeeeee / #111114</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--bg-raised);"></div><div class="swatch__meta"><span class="swatch__name">--bg-raised</span><span class="swatch__val">#f3f3f3 / #26262b</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--bg-elevated);"></div><div class="swatch__meta"><span class="swatch__name">--bg-elevated</span><span class="swatch__val">#FFFFFF / #2d2d33</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--fg-primary);"></div><div class="swatch__meta"><span class="swatch__name">--fg-primary</span><span class="swatch__val">#111111 / #f5f5f7</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--fg-secondary);"></div><div class="swatch__meta"><span class="swatch__name">--fg-secondary</span><span class="swatch__val">#4c4546 / #c7c7cc</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--fg-muted);"></div><div class="swatch__meta"><span class="swatch__name">--fg-muted</span><span class="swatch__val">#6b6263 / #8e8e93</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--color-surface-container-high);"></div><div class="swatch__meta"><span class="swatch__name">--color-surface-container-high</span><span class="swatch__val">#e7e7e7 / #3a3a40</span></div></div>
-        </div>
-      </div>
-    </article>
-
-    <!-- Primary / accent / borders -->
-    <article class="sg-component">
-      <div class="sg-component__head"><span class="sg-component__title">Primary button, accent &amp; borders</span></div>
-      <div class="sg-component__body">
-        <div class="swatch-grid">
-          <div class="swatch"><div class="swatch__chip" style="background:var(--btn-primary-bg);"></div><div class="swatch__meta"><span class="swatch__name">--btn-primary-bg</span><span class="swatch__val">#111111 / #f5f5f7 (inverts)</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--btn-primary-fg);"></div><div class="swatch__meta"><span class="swatch__name">--btn-primary-fg</span><span class="swatch__val">#FFFFFF / #0b0b0d (inverts)</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--color-accent);"></div><div class="swatch__meta"><span class="swatch__name">--color-accent / --focus-ring</span><span class="swatch__val">#5e5e5e / #a0a0a8</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--bg-elevated);border-bottom:none;box-shadow:inset 0 0 0 8px var(--border-default);"></div><div class="swatch__meta"><span class="swatch__name">--border-default</span><span class="swatch__val">rgba(0,0,0,.08) / rgba(255,255,255,.08)</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--bg-elevated);border-bottom:none;box-shadow:inset 0 0 0 8px var(--border-hover);"></div><div class="swatch__meta"><span class="swatch__name">--border-hover</span><span class="swatch__val">rgba(0,0,0,.15) / rgba(255,255,255,.18)</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--bg-elevated);border-bottom:none;box-shadow:inset 0 0 0 8px var(--border-subtle);"></div><div class="swatch__meta"><span class="swatch__name">--border-subtle</span><span class="swatch__val">rgba(0,0,0,.04) / rgba(255,255,255,.04)</span></div></div>
-        </div>
-      </div>
-    </article>
-
-    <!-- Status & badge tokens -->
-    <article class="sg-component">
-      <div class="sg-component__head"><span class="sg-component__title">Status &amp; badge colors</span></div>
-      <div class="sg-component__body">
-        <div class="swatch-grid">
-          <div class="swatch"><div class="swatch__chip" style="background:var(--color-success);"></div><div class="swatch__meta"><span class="swatch__name">--color-success</span><span class="swatch__val">#2ECC71 (both)</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--color-warning);"></div><div class="swatch__meta"><span class="swatch__name">--color-warning</span><span class="swatch__val">#F5A623 (both)</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--color-error);"></div><div class="swatch__meta"><span class="swatch__name">--color-error</span><span class="swatch__val">#ba1a1a / #f87171</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--badge-success-bg);"></div><div class="swatch__meta"><span class="swatch__name">--badge-success-bg/fg</span><span class="swatch__val">#e8f5e9 · #1b7a3d</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--badge-warning-bg);"></div><div class="swatch__meta"><span class="swatch__name">--badge-warning-bg/fg</span><span class="swatch__val">#fff3e0 · #b37100</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--badge-neutral-bg);"></div><div class="swatch__meta"><span class="swatch__name">--badge-neutral-bg/fg</span><span class="swatch__val">#f5f5f5 · #6b6263</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--badge-count-bg);"></div><div class="swatch__meta"><span class="swatch__name">--badge-count-bg/fg</span><span class="swatch__val">#b91c1c · #fff / #dc2626</span></div></div>
-          <div class="swatch"><div class="swatch__chip" style="background:var(--color-error-bg);"></div><div class="swatch__meta"><span class="swatch__name">--color-error-bg</span><span class="swatch__val">rgba(186,26,26,.08) / rgba(248,113,113,.12)</span></div></div>
-        </div>
-      </div>
-    </article>
-
-    <!-- Type scale -->
-    <article class="sg-component">
-      <div class="sg-component__head"><span class="sg-component__title">Type scale</span><span class="sg-component__file">tailwind.config.ts fontSize · headline = font-headline</span></div>
-      <div class="sg-component__body">
-        <div class="scale-row"><span class="scale-row__tag">display · 3rem</span><span class="font-headline text-display">Certified ledger</span></div>
-        <div class="scale-row"><span class="scale-row__tag">h1 · 2.25rem</span><span class="font-headline text-h1">Certified ledger</span></div>
-        <div class="scale-row"><span class="scale-row__tag">h2 · 1.75rem</span><span class="font-headline text-h2">Certified ledger</span></div>
-        <div class="scale-row"><span class="scale-row__tag">h3 · 1.375rem</span><span class="font-headline text-h3">Certified ledger</span></div>
-        <div class="scale-row"><span class="scale-row__tag">h4 · 1.125rem</span><span class="font-headline text-h4">Certified ledger</span></div>
-        <div class="scale-row"><span class="scale-row__tag">body · 1rem</span><span class="text-body">The quick brown fox jumps over the lazy dog (Inter / system-ui).</span></div>
-        <div class="scale-row"><span class="scale-row__tag">body-sm · .875rem</span><span class="text-body-sm">The quick brown fox jumps over the lazy dog.</span></div>
-        <div class="scale-row"><span class="scale-row__tag">caption · .75rem</span><span class="text-caption" style="text-transform:uppercase;">Section label · uppercase tracking</span></div>
-        <p class="sg-note">Headline rows use Georgia, serif here (Noto Serif fallback). display/h1/h2 carry negative tracking; caption is uppercase with +0.05em tracking.</p>
-      </div>
-    </article>
-
-    <!-- Spacing & radii -->
-    <article class="sg-component">
-      <div class="sg-component__head"><span class="sg-component__title">Spacing &amp; radii</span></div>
-      <div class="sg-component__body">
-        <span class="sg-block-label">Spacing (4px grid — the documented scale)</span>
-        <div class="space-row"><span class="space-row__tag">4px</span><span class="space-bar" style="width:4px;"></span></div>
-        <div class="space-row"><span class="space-row__tag">8px</span><span class="space-bar" style="width:8px;"></span></div>
-        <div class="space-row"><span class="space-row__tag">12px</span><span class="space-bar" style="width:12px;"></span></div>
-        <div class="space-row"><span class="space-row__tag">16px</span><span class="space-bar" style="width:16px;"></span></div>
-        <div class="space-row"><span class="space-row__tag">20px</span><span class="space-bar" style="width:20px;"></span></div>
-        <div class="space-row"><span class="space-row__tag">24px</span><span class="space-bar" style="width:24px;"></span></div>
-        <div class="space-row"><span class="space-row__tag">32px</span><span class="space-bar" style="width:32px;"></span></div>
-        <div class="space-row"><span class="space-row__tag">48px</span><span class="space-bar" style="width:48px;"></span></div>
-
-        <span class="sg-block-label">Radii</span>
-        <div class="radius-row"><span class="space-row__tag">--radius (2px)</span><span class="radius-box" style="border-radius:var(--radius);"></span><span class="sg-note" style="margin:0;">All cards, buttons, inputs</span></div>
-        <div class="radius-row"><span class="space-row__tag">999px (pill)</span><span class="radius-box" style="border-radius:999px;width:80px;"></span><span class="sg-note" style="margin:0;">Badges, switches, drag handles</span></div>
-        <div class="radius-row"><span class="space-row__tag">50% (circle)</span><span class="radius-box" style="border-radius:50%;"></span><span class="sg-note" style="margin:0;">Avatars only</span></div>
-
-        <span class="sg-block-label">Shadows</span>
-        <div class="sg-demo" style="background:var(--bg-canvas);">
-          <span class="radius-box" style="box-shadow:var(--shadow-sm);background:var(--bg-elevated);border:none;"></span>
-          <span class="radius-box" style="box-shadow:var(--shadow-md);background:var(--bg-elevated);border:none;"></span>
-          <span class="radius-box" style="box-shadow:var(--shadow-lg);background:var(--bg-elevated);border:none;"></span>
-          <span class="sg-demo__caption">--shadow-sm · --shadow-md · --shadow-lg</span>
-        </div>
-      </div>
-    </article>
-  </section>
-
-  <hr class="sg-hr" />
-  <p class="sg-note" style="padding-top:24px;">
-    Hand-authored static mirror of <code class="tok">src/components/ui/</code>. Tokens copied verbatim from
-    <code class="tok">src/app/styles/tokens.css</code>; class names and props derived from each primitive's TSX source.
-    Open via <code class="tok">file://</code> — no build, no network.
-  </p>
-
-</main>
-
+<div hidden=""><!--$--><!--/$--></div><a href="#main-content" class="skip-nav">Skip to main content</a><!--$--><!--/$--><header class="desktop-top-bar" aria-label="App chrome"><div class="desktop-top-bar__row desktop-top-bar__row--chrome"><div class="desktop-top-bar__left"><button type="button" class="desktop-top-bar__menu" aria-label="Open site navigation" aria-expanded="false"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-menu" aria-hidden="true"><line x1="4" x2="20" y1="12" y2="12"></line><line x1="4" x2="20" y1="6" y2="6"></line><line x1="4" x2="20" y1="18" y2="18"></line></svg></button><a class="desktop-top-bar__brand desktop-top-bar__brand--wordmark" aria-label="Certified home" href="/welcome"><img alt="Certified" class="desktop-top-bar__wordmark" src="/brand/wordmark/certified_wordmark_black.svg"></a></div><div class="desktop-top-bar__right"><div class="desktop-top-bar__search"><div class="people-search " role="search"><div class="w-full"><div class="relative w-full"><span aria-hidden="true" class="pointer-events-none absolute top-1/2 -translate-y-1/2 left-4 flex items-center text-[var(--fg-muted)]"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-search" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg></span><input id="_r_3_" class="h-11 px-4 text-base md:text-sm  pl-11  w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " placeholder="Search Certified" aria-label="Search Certified" role="combobox" aria-autocomplete="list" aria-expanded="false" autocomplete="off" spellcheck="false" type="text" value=""></div></div><div class="sr-only" aria-live="polite" aria-atomic="true"></div></div></div><a class="desktop-top-bar__icon-btn" aria-label="Apps" title="Apps" href="/apps"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-layout-grid" aria-hidden="true"><rect width="7" height="7" x="3" y="3" rx="1"></rect><rect width="7" height="7" x="14" y="3" rx="1"></rect><rect width="7" height="7" x="14" y="14" rx="1"></rect><rect width="7" height="7" x="3" y="14" rx="1"></rect></svg></a><button type="button" class="desktop-top-bar__signin-btn" aria-label="Sign in"><img alt="" aria-hidden="true" class="desktop-top-bar__signin-img" src="/brand/signin/certified_signin_black.svg"></button></div></div></header><main id="main-content" class="flex-1"><div class="app-shell "><div class="app-shell__grid"><div class="app-shell__center"><div class="app-shell__content"><div class="min-h-screen w-full bg-[var(--bg-canvas)] px-6 py-12"><div class="mx-auto flex w-full max-w-[720px] flex-col gap-12"><header class="flex flex-col gap-2"><h1 class="font-headline text-h1 text-[var(--fg-primary)]">Component gallery</h1><p class="text-body text-[var(--fg-secondary)]">Live render of every <code>@/components/ui/*</code> primitive with its variants and states. Dev-only.</p></header><section class="flex flex-col gap-6 border-t border-[var(--border-subtle)] pt-8"><h2 class="font-headline text-h3 text-[var(--fg-primary)]">Core interactive</h2><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Button — variants</span><div class="flex flex-wrap items-center gap-3"><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--btn-primary-bg)] text-[var(--btn-primary-fg)] border-none hover:opacity-90 py-2.5 px-6 text-sm   ">Primary</button><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-2.5 px-6 text-sm   ">Secondary</button><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-muted)] hover:bg-[var(--overlay-weak)] hover:text-[var(--fg-primary)] py-2.5 px-6 text-sm   ">Ghost</button><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--color-error-bg)] text-[var(--color-error)] border border-[var(--color-error-border)] hover:opacity-90 py-2.5 px-6 text-sm   ">Destructive</button></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Button — sizes</span><div class="flex flex-wrap items-center gap-3"><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--btn-primary-bg)] text-[var(--btn-primary-fg)] border-none hover:opacity-90 py-1.5 px-4 text-xs   ">Small</button><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--btn-primary-bg)] text-[var(--btn-primary-fg)] border-none hover:opacity-90 py-2.5 px-6 text-sm   ">Medium</button><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--btn-primary-bg)] text-[var(--btn-primary-fg)] border-none hover:opacity-90 py-3 px-8 text-sm   ">Large</button><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--btn-primary-bg)] text-[var(--btn-primary-fg)] border-none hover:opacity-90 h-10 w-10 p-0 text-sm   " aria-label="Star"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-star h-4 w-4"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"></path></svg></button></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Button — loading + disabled</span><div class="flex flex-wrap items-center gap-3"><button type="button" disabled="" aria-busy="true" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--btn-primary-bg)] text-[var(--btn-primary-fg)] border-none hover:opacity-90 py-2.5 px-6 text-sm  opacity-50 cursor-not-allowed "><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-loader-circle h-4 w-4 animate-spin motion-reduce:animate-none"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>Saving</button><button type="button" disabled="" aria-busy="true" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-2.5 px-6 text-sm  opacity-50 cursor-not-allowed "><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-loader-circle h-4 w-4 animate-spin motion-reduce:animate-none"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>Loading</button><button type="button" disabled="" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--btn-primary-bg)] text-[var(--btn-primary-fg)] border-none hover:opacity-90 py-2.5 px-6 text-sm  opacity-50 cursor-not-allowed ">Disabled</button><button type="button" disabled="" aria-busy="true" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--btn-primary-bg)] text-[var(--btn-primary-fg)] border-none hover:opacity-90 h-10 w-10 p-0 text-sm  opacity-50 cursor-not-allowed " aria-label="Loading icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-loader-circle h-4 w-4 animate-spin motion-reduce:animate-none"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg></button></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Button — pressed (NEW: secondary + ghost, false vs true)</span><div class="flex flex-wrap items-center gap-3"><button type="button" aria-busy="false" aria-pressed="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-2.5 px-6 text-sm   ">Secondary off</button><button type="button" aria-busy="false" aria-pressed="true" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-2.5 px-6 text-sm bg-[var(--overlay-medium)] text-[var(--fg-primary)] border-[var(--border-hover)]  ">Secondary on</button><button type="button" aria-busy="false" aria-pressed="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-muted)] hover:bg-[var(--overlay-weak)] hover:text-[var(--fg-primary)] py-2.5 px-6 text-sm   ">Ghost off</button><button type="button" aria-busy="false" aria-pressed="true" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-muted)] hover:bg-[var(--overlay-weak)] hover:text-[var(--fg-primary)] py-2.5 px-6 text-sm bg-[var(--overlay-medium)] text-[var(--fg-primary)]  ">Ghost on</button></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Switch</span><div class="flex flex-wrap items-center gap-3"><div class="inline-flex items-center gap-2"><button id="_R_1lh35esnebmlb6lb_" type="button" role="switch" aria-checked="true" aria-labelledby="_R_1lh35esnebmlb6lb_-label" class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-[999px] border border-transparent transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 bg-[var(--btn-primary-bg)] "><span aria-hidden="true" class="pointer-events-none inline-block h-4 w-4 rounded-full bg-[var(--bg-elevated)] shadow-sm transition-transform duration-150 motion-reduce:transition-none translate-x-4"></span></button><label id="_R_1lh35esnebmlb6lb_-label" for="_R_1lh35esnebmlb6lb_" class="text-sm text-[var(--fg-primary)] cursor-pointer">Notifications</label></div><button id="_R_2lh35esnebmlb6lb_" type="button" role="switch" aria-checked="false" aria-label="Off" class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-[999px] border border-transparent transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 bg-[var(--border-hover)] "><span aria-hidden="true" class="pointer-events-none inline-block h-4 w-4 rounded-full bg-[var(--bg-elevated)] shadow-sm transition-transform duration-150 motion-reduce:transition-none translate-x-0.5"></span></button><button id="_R_3lh35esnebmlb6lb_" type="button" role="switch" aria-checked="true" aria-label="Disabled on" disabled="" class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-[999px] border border-transparent transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 bg-[var(--btn-primary-bg)] "><span aria-hidden="true" class="pointer-events-none inline-block h-4 w-4 rounded-full bg-[var(--bg-elevated)] shadow-sm transition-transform duration-150 motion-reduce:transition-none translate-x-4"></span></button></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Checkbox</span><div class="flex flex-wrap items-center gap-3"><div class="flex flex-col gap-1.5"><div class="flex items-center gap-2"><span class="relative inline-flex h-4 w-4 shrink-0"><input id="_R_1mh35esnebmlb6lb_" type="checkbox" class="peer absolute inset-0 z-[1] m-0 h-4 w-4 cursor-pointer appearance-none rounded opacity-0 disabled:cursor-not-allowed" checked=""><span aria-hidden="true" class="pointer-events-none flex h-4 w-4 items-center justify-center rounded border bg-[var(--bg-elevated)] border-[var(--border-hover)] text-transparent transition-colors duration-150 motion-reduce:transition-none peer-checked:border-[var(--btn-primary-bg)] peer-checked:bg-[var(--btn-primary-bg)] peer-checked:text-[var(--btn-primary-fg)] peer-indeterminate:border-[var(--btn-primary-bg)] peer-indeterminate:bg-[var(--btn-primary-bg)] peer-indeterminate:text-[var(--btn-primary-fg)] peer-focus-visible:outline-2 peer-focus-visible:outline-[var(--focus-ring)] peer-focus-visible:outline-offset-2 peer-disabled:opacity-50"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-check h-3 w-3"><path d="M20 6 9 17l-5-5"></path></svg></span></span><label for="_R_1mh35esnebmlb6lb_" class="text-sm text-[var(--fg-primary)] cursor-pointer">Checked</label></div></div><div class="flex flex-col gap-1.5"><div class="flex items-center gap-2"><span class="relative inline-flex h-4 w-4 shrink-0"><input id="_R_2mh35esnebmlb6lb_" type="checkbox" class="peer absolute inset-0 z-[1] m-0 h-4 w-4 cursor-pointer appearance-none rounded opacity-0 disabled:cursor-not-allowed"><span aria-hidden="true" class="pointer-events-none flex h-4 w-4 items-center justify-center rounded border bg-[var(--bg-elevated)] border-[var(--border-hover)] text-transparent transition-colors duration-150 motion-reduce:transition-none peer-checked:border-[var(--btn-primary-bg)] peer-checked:bg-[var(--btn-primary-bg)] peer-checked:text-[var(--btn-primary-fg)] peer-indeterminate:border-[var(--btn-primary-bg)] peer-indeterminate:bg-[var(--btn-primary-bg)] peer-indeterminate:text-[var(--btn-primary-fg)] peer-focus-visible:outline-2 peer-focus-visible:outline-[var(--focus-ring)] peer-focus-visible:outline-offset-2 peer-disabled:opacity-50"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-check h-3 w-3"><path d="M20 6 9 17l-5-5"></path></svg></span></span><label for="_R_2mh35esnebmlb6lb_" class="text-sm text-[var(--fg-primary)] cursor-pointer">Unchecked</label></div></div><div class="flex flex-col gap-1.5"><div class="flex items-center gap-2"><span class="relative inline-flex h-4 w-4 shrink-0"><input id="_R_3mh35esnebmlb6lb_" type="checkbox" class="peer absolute inset-0 z-[1] m-0 h-4 w-4 cursor-pointer appearance-none rounded opacity-0 disabled:cursor-not-allowed"><span aria-hidden="true" class="pointer-events-none flex h-4 w-4 items-center justify-center rounded border bg-[var(--bg-elevated)] border-[var(--border-hover)] text-transparent transition-colors duration-150 motion-reduce:transition-none peer-checked:border-[var(--btn-primary-bg)] peer-checked:bg-[var(--btn-primary-bg)] peer-checked:text-[var(--btn-primary-fg)] peer-indeterminate:border-[var(--btn-primary-bg)] peer-indeterminate:bg-[var(--btn-primary-bg)] peer-indeterminate:text-[var(--btn-primary-fg)] peer-focus-visible:outline-2 peer-focus-visible:outline-[var(--focus-ring)] peer-focus-visible:outline-offset-2 peer-disabled:opacity-50"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-minus h-3 w-3"><path d="M5 12h14"></path></svg></span></span><label for="_R_3mh35esnebmlb6lb_" class="text-sm text-[var(--fg-primary)] cursor-pointer">Indeterminate</label></div></div><div class="flex flex-col gap-1.5"><div class="flex items-center gap-2"><span class="relative inline-flex h-4 w-4 shrink-0"><input id="_R_4mh35esnebmlb6lb_" type="checkbox" disabled="" class="peer absolute inset-0 z-[1] m-0 h-4 w-4 cursor-pointer appearance-none rounded opacity-0 disabled:cursor-not-allowed"><span aria-hidden="true" class="pointer-events-none flex h-4 w-4 items-center justify-center rounded border bg-[var(--bg-elevated)] border-[var(--border-hover)] text-transparent transition-colors duration-150 motion-reduce:transition-none peer-checked:border-[var(--btn-primary-bg)] peer-checked:bg-[var(--btn-primary-bg)] peer-checked:text-[var(--btn-primary-fg)] peer-indeterminate:border-[var(--btn-primary-bg)] peer-indeterminate:bg-[var(--btn-primary-bg)] peer-indeterminate:text-[var(--btn-primary-fg)] peer-focus-visible:outline-2 peer-focus-visible:outline-[var(--focus-ring)] peer-focus-visible:outline-offset-2 peer-disabled:opacity-50"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-check h-3 w-3"><path d="M20 6 9 17l-5-5"></path></svg></span></span><label for="_R_4mh35esnebmlb6lb_" class="text-sm text-[var(--fg-primary)] cursor-not-allowed opacity-50">Disabled</label></div></div><div class="flex flex-col gap-1.5"><div class="flex items-center gap-2"><span class="relative inline-flex h-4 w-4 shrink-0"><input id="_R_5mh35esnebmlb6lb_" type="checkbox" aria-invalid="true" aria-describedby="_R_5mh35esnebmlb6lb_-error" class="peer absolute inset-0 z-[1] m-0 h-4 w-4 cursor-pointer appearance-none rounded opacity-0 disabled:cursor-not-allowed"><span aria-hidden="true" class="pointer-events-none flex h-4 w-4 items-center justify-center rounded border bg-[var(--bg-elevated)] border-[var(--color-error-border)] text-transparent transition-colors duration-150 motion-reduce:transition-none peer-checked:border-[var(--btn-primary-bg)] peer-checked:bg-[var(--btn-primary-bg)] peer-checked:text-[var(--btn-primary-fg)] peer-indeterminate:border-[var(--btn-primary-bg)] peer-indeterminate:bg-[var(--btn-primary-bg)] peer-indeterminate:text-[var(--btn-primary-fg)] peer-focus-visible:outline-2 peer-focus-visible:outline-[var(--focus-ring)] peer-focus-visible:outline-offset-2 peer-disabled:opacity-50"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-check h-3 w-3"><path d="M20 6 9 17l-5-5"></path></svg></span></span><label for="_R_5mh35esnebmlb6lb_" class="text-sm text-[var(--fg-primary)] cursor-pointer">With error</label></div><p id="_R_5mh35esnebmlb6lb_-error" role="alert" class="text-xs text-error">This field is required</p></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Radio group</span><div class="flex flex-wrap items-center gap-3"><div role="radiogroup" aria-orientation="horizontal" class="flex gap-4" aria-label="Demo radio group"><button type="button" role="radio" aria-checked="true" tabindex="0" class="inline-flex items-center gap-2 rounded text-sm text-[var(--fg-primary)] transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ">Option A</button><button type="button" role="radio" aria-checked="false" tabindex="-1" class="inline-flex items-center gap-2 rounded text-sm text-[var(--fg-primary)] transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ">Option B</button><button type="button" role="radio" aria-checked="false" aria-disabled="true" disabled="" tabindex="-1" class="inline-flex items-center gap-2 rounded text-sm text-[var(--fg-primary)] transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ">Disabled</button></div></div></div></section><section class="flex flex-col gap-6 border-t border-[var(--border-subtle)] pt-8"><h2 class="font-headline text-h3 text-[var(--fg-primary)]">Form fields</h2><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Input — variants + sizes</span><div class="flex flex-wrap items-center gap-3"><div class="flex w-full flex-col gap-3"><div class="w-full"><label for="_R_1hhj5esnebmlb6lb_" class="app-card__label block mb-1.5">Default</label><input id="_R_1hhj5esnebmlb6lb_" class="h-11 px-4 text-base md:text-sm    w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " placeholder="Default field"></div><div class="w-full"><input id="_R_2hhj5esnebmlb6lb_" class="h-11 px-4 text-base md:text-sm    w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border-0 border-b border-[var(--border-medium)] rounded-none bg-transparent focus:border-[var(--fg-primary)]  " placeholder="Underline variant" aria-label="Underline"></div><div class="w-full"><input id="_R_3hhj5esnebmlb6lb_" class="h-11 px-4 text-base md:text-sm    w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border-[1.5px] border-[var(--border-hover)] focus:border-[var(--focus-ring)] rounded  " aria-label="Inline edit" value="Inline-edit variant"></div><div class="w-full"><input id="_R_4hhj5esnebmlb6lb_" class="h-9 px-3 text-sm    w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " placeholder="Small" aria-label="Small"></div><div class="w-full"><input id="_R_5hhj5esnebmlb6lb_" class="h-14 px-5 text-base    w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " placeholder="Large" aria-label="Large"></div><div class="w-full"><label for="_R_6hhj5esnebmlb6lb_" class="app-card__label block mb-1.5">Disabled</label><input id="_R_6hhj5esnebmlb6lb_" disabled="" class="h-11 px-4 text-base md:text-sm    w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20 disabled:cursor-not-allowed disabled:opacity-60 disabled:bg-[var(--bg-sunken)] " placeholder="Disabled"></div><div class="w-full"><label for="_R_7hhj5esnebmlb6lb_" class="app-card__label block mb-1.5">With error</label><input id="_R_7hhj5esnebmlb6lb_" aria-invalid="true" aria-describedby="_R_7hhj5esnebmlb6lb_-error" class="h-11 px-4 text-base md:text-sm    w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--color-error-border)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " value="oops"><p id="_R_7hhj5esnebmlb6lb_-error" role="alert" class="mt-1.5 text-xs text-[var(--color-error)]">That doesn't look right</p></div><div class="w-full"><label for="_R_8hhj5esnebmlb6lb_" class="app-card__label block mb-1.5">With helper text</label><input id="_R_8hhj5esnebmlb6lb_" aria-describedby="_R_8hhj5esnebmlb6lb_-helper" class="h-11 px-4 text-base md:text-sm    w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " placeholder="you@example.com"><p id="_R_8hhj5esnebmlb6lb_-helper" class="mt-1.5 text-xs text-[var(--fg-muted)]">We'll never share this.</p></div><div class="w-full"><div class="relative w-full"><span aria-hidden="true" class="pointer-events-none absolute top-1/2 -translate-y-1/2 left-4 flex items-center text-[var(--fg-muted)]"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-search h-4 w-4"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg></span><input id="_R_9hhj5esnebmlb6lb_" class="h-11 px-4 text-base md:text-sm  pl-11  w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " placeholder="Search with leading icon" aria-label="Search"></div></div></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Input — trailingButton + combobox (NEW)</span><div class="flex flex-wrap items-center gap-3"><div class="flex w-full flex-col gap-3"><div class="w-full"><div class="relative w-full"><input id="_R_1ihj5esnebmlb6lb_" class="h-11 px-4 text-base md:text-sm   pr-11 w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " aria-label="Clearable input" placeholder="Type to clear" data-testid="input-trailing-button-field" value="clearable text"><span class="absolute top-1/2 -translate-y-1/2 right-4 flex items-center"><button type="button" aria-label="Clear input" data-testid="input-clear-button" class="inline-flex h-6 w-6 items-center justify-center rounded text-[var(--fg-muted)] transition-colors duration-150 hover:bg-[var(--overlay-weak)] hover:text-[var(--fg-primary)] focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 motion-reduce:transition-none"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x h-4 w-4"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg></button></span></div></div><span class="inline-flex relative"><div class="w-full" data-testid="combobox-trigger" aria-haspopup="menu" aria-expanded="false" aria-controls="_R_2ihj5esnebmlb6lb_"><div class="w-full"><div class="relative w-full"><span aria-hidden="true" class="pointer-events-none absolute top-1/2 -translate-y-1/2 left-4 flex items-center text-[var(--fg-muted)]"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-search h-4 w-4"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg></span><input id="_R_eihj5esnebmlb6lb_" class="h-11 px-4 text-base md:text-sm  pl-11 pr-11 w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " aria-label="Organization combobox" role="combobox" aria-expanded="false" placeholder="Find an organization" value="acme"><span class="absolute top-1/2 -translate-y-1/2 right-4 flex items-center"><button type="button" aria-label="Open suggestions" class="inline-flex h-6 items-center rounded px-1.5 text-caption font-semibold uppercase tracking-wider text-[var(--fg-muted)] transition-colors duration-150 hover:text-[var(--fg-primary)] focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 motion-reduce:transition-none">Go</button></span></div></div></div></span></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Textarea</span><div class="flex flex-wrap items-center gap-3"><div class="flex w-full flex-col gap-3"><div class="w-full"><label for="_R_1jhj5esnebmlb6lb_" class="app-card__label block mb-1.5">Default</label><textarea id="_R_1jhj5esnebmlb6lb_" rows="3" class="px-4 py-3 text-base md:text-sm  w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none resize-y border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " placeholder="Write something…"></textarea><div class="flex items-start justify-between gap-2"><div class="min-w-0 flex-1"></div></div></div><div class="w-full"><textarea id="_R_2jhj5esnebmlb6lb_" rows="3" class="px-4 py-3 text-base md:text-sm  w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none resize-y border-0 border-b border-[var(--border-medium)] rounded-none bg-transparent focus:border-[var(--fg-primary)]  " placeholder="Underline variant" aria-label="Underline textarea"></textarea><div class="flex items-start justify-between gap-2"><div class="min-w-0 flex-1"></div></div></div><div class="w-full"><label for="_R_3jhj5esnebmlb6lb_" class="app-card__label block mb-1.5">With counter</label><textarea id="_R_3jhj5esnebmlb6lb_" rows="3" maxlength="120" aria-describedby="_R_3jhj5esnebmlb6lb_-count" class="px-4 py-3 text-base md:text-sm  w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none resize-y border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  ">Counting characters</textarea><div class="flex items-start justify-between gap-2"><div class="min-w-0 flex-1"></div><p id="_R_3jhj5esnebmlb6lb_-count" aria-live="polite" class="mt-1.5 shrink-0 text-xs tabular-nums text-[var(--fg-muted)]">19 / 120</p></div></div><div class="w-full"><label for="_R_4jhj5esnebmlb6lb_" class="app-card__label block mb-1.5">With error</label><textarea id="_R_4jhj5esnebmlb6lb_" rows="3" aria-invalid="true" aria-describedby="_R_4jhj5esnebmlb6lb_-error" class="px-4 py-3 text-base md:text-sm  w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none resize-y border border-[var(--color-error-border)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  ">hi</textarea><div class="flex items-start justify-between gap-2"><div class="min-w-0 flex-1"><p id="_R_4jhj5esnebmlb6lb_-error" role="alert" class="mt-1.5 text-xs text-[var(--color-error)]">Too short</p></div></div></div><div class="w-full"><label for="_R_5jhj5esnebmlb6lb_" class="app-card__label block mb-1.5">Disabled</label><textarea id="_R_5jhj5esnebmlb6lb_" rows="3" disabled="" class="px-4 py-3 text-base md:text-sm  w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none resize-y border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20 disabled:cursor-not-allowed disabled:opacity-60 disabled:bg-[var(--bg-sunken)] disabled:resize-none " placeholder="Disabled"></textarea><div class="flex items-start justify-between gap-2"><div class="min-w-0 flex-1"></div></div></div></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Select</span><div class="flex flex-wrap items-center gap-3"><div class="flex w-full flex-col gap-3"><div class="w-full"><label for="_R_1khj5esnebmlb6lb_" class="app-card__label block mb-1.5">Default</label><div class="relative w-full"><select id="_R_1khj5esnebmlb6lb_" class="h-11 pl-4 pr-10 text-base md:text-sm w-full appearance-none bg-[var(--bg-elevated)] text-[var(--fg-primary)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  [&amp;&gt;option]:bg-[var(--bg-elevated)] [&amp;&gt;option]:text-[var(--fg-primary)] "><option value="a">First option</option><option value="b" selected="">Second option</option><option value="c">Third option</option></select><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down pointer-events-none absolute top-1/2 -translate-y-1/2 right-4 text-[var(--fg-muted)]" aria-hidden="true"><path d="m6 9 6 6 6-6"></path></svg></div></div><div class="w-full"><label for="_R_2khj5esnebmlb6lb_" class="app-card__label block mb-1.5">Disabled</label><div class="relative w-full"><select id="_R_2khj5esnebmlb6lb_" disabled="" class="h-11 pl-4 pr-10 text-base md:text-sm w-full appearance-none bg-[var(--bg-elevated)] text-[var(--fg-primary)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20 disabled:cursor-not-allowed disabled:opacity-60 disabled:bg-[var(--bg-sunken)] [&amp;&gt;option]:bg-[var(--bg-elevated)] [&amp;&gt;option]:text-[var(--fg-primary)] "><option value="a" selected="">Locked</option></select><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down pointer-events-none absolute top-1/2 -translate-y-1/2 right-4 text-[var(--fg-muted)]" aria-hidden="true"><path d="m6 9 6 6 6-6"></path></svg></div></div><div class="w-full"><label for="_R_3khj5esnebmlb6lb_" class="app-card__label block mb-1.5">With error</label><div class="relative w-full"><select id="_R_3khj5esnebmlb6lb_" aria-invalid="true" aria-describedby="_R_3khj5esnebmlb6lb_-error" class="h-11 pl-4 pr-10 text-base md:text-sm w-full appearance-none bg-[var(--bg-elevated)] text-[var(--fg-primary)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--color-error-border)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  [&amp;&gt;option]:bg-[var(--bg-elevated)] [&amp;&gt;option]:text-[var(--fg-primary)] "><option value="" selected="">Choose…</option><option value="a">First option</option></select><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down pointer-events-none absolute top-1/2 -translate-y-1/2 right-4 text-[var(--fg-muted)]" aria-hidden="true"><path d="m6 9 6 6 6-6"></path></svg></div><p id="_R_3khj5esnebmlb6lb_-error" role="alert" class="mt-1.5 text-xs text-[var(--color-error)]">Pick one</p></div></div></div></div></section><section class="flex flex-col gap-6 border-t border-[var(--border-subtle)] pt-8"><h2 class="font-headline text-h3 text-[var(--fg-primary)]">Surfaces</h2><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Card — variants</span><div class="flex flex-wrap items-center gap-3"><div class="flex w-full flex-col gap-3"><div class="bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded p-6  ">Elevated card</div><div class="bg-[var(--bg-canvas)] border border-[var(--border-default)] rounded p-6  ">Inset card</div><div class="bg-transparent border-0 border-b border-[var(--border-subtle)] rounded-none py-5  ">Row card (divider)</div><div class="bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded p-6 transition-all duration-150 motion-reduce:transition-none hover:border-[var(--border-hover)] hover:shadow-sm ">Elevated, hoverable</div></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Avatar — sizes + fallback</span><div class="flex flex-wrap items-center gap-3"><div class="h-8 w-8 text-body-sm rounded-full overflow-hidden flex items-center justify-center border border-[var(--border-subtle)] "><div class="w-full h-full bg-[var(--color-surface-container-high)] text-[var(--fg-primary)] font-semibold flex items-center justify-center">AB</div></div><div class="h-12 w-12 text-body rounded-full overflow-hidden flex items-center justify-center border border-[var(--border-subtle)] "><div class="w-full h-full bg-[var(--color-surface-container-high)] text-[var(--fg-primary)] font-semibold flex items-center justify-center">CD</div></div><div class="h-16 w-16 text-h4 rounded-full overflow-hidden flex items-center justify-center border border-[var(--border-subtle)] "><div class="w-full h-full bg-[var(--color-surface-container-high)] text-[var(--fg-primary)] font-semibold flex items-center justify-center">EF</div></div><div class="h-24 w-24 text-h3 rounded-full overflow-hidden flex items-center justify-center border border-[var(--border-subtle)] "><div class="w-full h-full bg-[var(--color-surface-container-high)] text-[var(--fg-primary)] font-semibold flex items-center justify-center">GH</div></div><div class="h-12 w-12 text-body rounded-full overflow-hidden flex items-center justify-center border-2 border-[var(--bg-elevated)] "><div class="w-full h-full bg-[var(--color-surface-container-high)] text-[var(--fg-primary)] font-semibold flex items-center justify-center">IJ</div></div></div></div></section><section class="flex flex-col gap-6 border-t border-[var(--border-subtle)] pt-8"><h2 class="font-headline text-h3 text-[var(--fg-primary)]">Status &amp; feedback</h2><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Badge — status</span><div class="flex flex-wrap items-center gap-3"><span class="rounded-[999px] inline-flex items-center gap-1.5 px-3 py-1 text-body-sm font-medium bg-[var(--badge-success-bg)] text-[var(--badge-success-fg)] "><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big h-4 w-4" aria-hidden="true"><path d="M21.801 10A10 10 0 1 1 17 3.335"></path><path d="m9 11 3 3L22 4"></path></svg>Verified</span><span class="rounded-[999px] inline-flex items-center gap-1.5 px-3 py-1 text-body-sm font-medium bg-[var(--badge-warning-bg)] text-[var(--badge-warning-fg)] "><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-clock h-4 w-4" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>Pending</span><span class="rounded-[999px] inline-flex items-center gap-1.5 px-3 py-1 text-body-sm font-medium bg-[var(--badge-neutral-bg)] text-[var(--badge-neutral-fg)] border border-[var(--badge-neutral-border)] ">Unverified</span></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Badge — chips + quality</span><div class="flex flex-wrap items-center gap-3"><span class="rounded-[999px] inline-flex items-center gap-1.5 px-2 py-0.5 text-caption font-semibold bg-[var(--bg-sunken)] text-[var(--fg-secondary)] uppercase tracking-wider ">Tag</span><span class="rounded-[999px] inline-flex items-center gap-1.5 px-2 py-0.5 text-caption font-semibold bg-[var(--bg-canvas)] text-[var(--fg-muted)] uppercase tracking-wider ">Admin</span><span class="rounded-[999px] inline-flex items-center gap-1.5 px-2 py-0.5 text-caption font-semibold bg-[var(--badge-success-bg)] text-[var(--badge-success-fg)] ">High quality</span><span class="rounded-[999px] inline-flex items-center gap-1.5 px-2 py-0.5 text-caption font-semibold bg-[var(--bg-sunken)] text-[var(--fg-secondary)] ">Standard</span><span class="rounded-[999px] inline-flex items-center gap-1.5 px-2 py-0.5 text-caption font-semibold bg-[var(--badge-warning-bg)] text-[var(--badge-warning-fg)] ">Draft</span><span class="rounded-[999px] inline-flex items-center gap-1.5 px-2 py-0.5 text-caption font-semibold bg-[var(--bg-raised)] text-[var(--fg-muted)] ">Test</span></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Badge — counts (NEW: tone=neutral + count-bare)</span><div class="flex flex-wrap items-center gap-3"><span class="rounded-[999px] inline-flex items-center gap-1.5 px-2 py-0.5 text-caption font-semibold bg-[var(--badge-count-bg)] text-[var(--badge-count-fg)] font-semibold ">12</span><span class="rounded-[999px] inline-flex items-center gap-1.5 px-2 py-0.5 text-caption font-semibold bg-[var(--bg-sunken)] text-[var(--fg-muted)] font-semibold ">12</span><span class="inline-flex items-center gap-1 text-body-sm text-[var(--fg-secondary)]">Members<span class="inline-flex items-center text-caption text-[var(--fg-muted)] font-semibold tabular-nums ">128</span></span></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Banner — variants</span><div class="flex flex-wrap items-center gap-3"><div class="flex w-full flex-col gap-3"><div role="status" class="flex gap-3 rounded border p-4 text-sm text-[var(--fg-primary)] bg-[var(--bg-sunken)] border-[var(--border-default)] "><span aria-hidden="true" class="flex-shrink-0 mt-px text-[var(--fg-muted)]"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-info h-5 w-5 text-[var(--fg-muted)]"><circle cx="12" cy="12" r="10"></circle><path d="M12 16v-4"></path><path d="M12 8h.01"></path></svg></span><div class="flex-1 min-w-0"><p class="font-semibold tracking-wider text-[var(--fg-primary)]">Heads up</p><div class="text-[var(--fg-secondary)] mt-1">This is an informational banner.</div></div></div><div role="status" class="flex gap-3 rounded border p-4 text-sm text-[var(--fg-primary)] bg-[var(--color-success-bg)] border-[var(--border-default)] "><span aria-hidden="true" class="flex-shrink-0 mt-px text-[var(--color-success-text)]"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check h-5 w-5 text-[var(--color-success-text)]"><circle cx="12" cy="12" r="10"></circle><path d="m9 12 2 2 4-4"></path></svg></span><div class="flex-1 min-w-0"><p class="font-semibold tracking-wider text-[var(--fg-primary)]">All set</p><div class="text-[var(--fg-secondary)] mt-1">Your changes were saved.</div></div></div><div role="alert" class="flex gap-3 rounded border p-4 text-sm text-[var(--fg-primary)] bg-[var(--color-warning-bg)] border-[var(--color-warning-border)] "><span aria-hidden="true" class="flex-shrink-0 mt-px text-[var(--color-warning-text)]"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-triangle-alert h-5 w-5 text-[var(--color-warning-text)]"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"></path><path d="M12 9v4"></path><path d="M12 17h.01"></path></svg></span><div class="flex-1 min-w-0"><p class="font-semibold tracking-wider text-[var(--fg-primary)]">Careful</p><div class="text-[var(--fg-secondary)] mt-1">This action can't be undone.</div></div></div><div role="alert" class="flex gap-3 rounded border p-4 text-sm text-[var(--fg-primary)] bg-[var(--color-error-bg)] border-[var(--color-error-border)] "><span aria-hidden="true" class="flex-shrink-0 mt-px text-[var(--color-error)]"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-alert h-5 w-5 text-[var(--color-error)]"><circle cx="12" cy="12" r="10"></circle><line x1="12" x2="12" y1="8" y2="12"></line><line x1="12" x2="12.01" y1="16" y2="16"></line></svg></span><div class="flex-1 min-w-0"><p class="font-semibold tracking-wider text-[var(--fg-primary)]">Something failed</p><div class="text-[var(--fg-secondary)] mt-1">We couldn't reach the server. Dismissable.</div></div><button type="button" aria-label="Dismiss" class="flex-shrink-0 -mr-1 -mt-1 inline-flex h-7 w-7 items-center justify-center rounded text-[var(--fg-muted)] transition-colors duration-150 motion-reduce:transition-none hover:bg-[var(--overlay-weak)] hover:text-[var(--fg-primary)] focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x h-4 w-4"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg></button></div></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">ErrorMessage</span><div class="flex flex-wrap items-center gap-3"><div class="w-full"><div role="alert" class="rounded border border-[var(--color-error-border)] bg-[var(--color-error-bg)] p-6 "><div class="flex gap-4"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-alert w-5 h-5 text-[var(--color-error)] flex-shrink-0 mt-0.5"><circle cx="12" cy="12" r="10"></circle><line x1="12" x2="12" y1="8" y2="12"></line><line x1="12" x2="12.01" y1="16" y2="16"></line></svg><div class="flex-1"><h4 class="text-sm font-semibold text-[var(--fg-primary)] tracking-wider mb-1">Something went wrong</h4><p class="text-sm text-[var(--fg-secondary)]">The request timed out. Please try again.</p><div class="mt-4"><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-1.5 px-4 text-xs   ">Try again</button></div></div></div></div></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">EmptyState — rich / inline / compact (NEW inline + compact)</span><div class="flex flex-wrap items-center gap-3"><div class="flex w-full flex-col gap-4"><div class="bg-[var(--bg-canvas)] border border-[var(--border-default)] rounded p-6  "><div class="empty-state "><div class="empty-state__icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-inbox"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"></polyline><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"></path></svg></div><h3 class="empty-state__title">No certificates yet</h3><p class="empty-state__desc">Certificates you create will show up here.</p><div class="empty-state__actions"><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--btn-primary-bg)] text-[var(--btn-primary-fg)] border-none hover:opacity-90 py-1.5 px-4 text-xs   ">Create one</button></div></div></div><p class="m-0 text-sm text-[var(--fg-muted)] ">No members in this group.<span class="ml-1"><a href="#" class="text-[var(--fg-primary)] underline underline-offset-2">Invite one</a></span></p><p class="m-0 text-sm text-[var(--fg-muted)] ">Nothing here yet.<span class="text-[var(--fg-muted)]"> <!-- -->(compact alias)</span></p></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">LoadingSpinner — sizes</span><div class="flex flex-wrap items-center gap-3"><div role="status" aria-live="polite" class="flex items-center justify-center " style="color:var(--fg-primary)"><svg width="100%" height="100%" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Loading" class="h-6 w-6 animate-pulse" style="animation-duration:1.5s;animation-timing-function:ease-in-out"><title>Loading</title><path d="M0 8C0 3.58172 3.58172 0 8 0H32C36.4183 0 40 3.58172 40 8V32C40 36.4183 36.4183 40 32 40H8C3.58172 40 0 36.4183 0 32V8Z" fill="currentColor"></path><path d="M29.8965 22.5791C29.7197 23.9952 29.2851 25.2627 28.5918 26.3828C27.8974 27.5029 26.9757 28.3863 25.8262 29.0312C24.6754 29.6762 23.3451 29.9999 21.835 30C20.2149 30 18.7905 29.6896 17.5645 29.0693L19.5527 27.167C20.2356 27.404 20.995 27.5273 21.835 27.5273C23.3104 27.5273 24.5302 27.069 25.4961 26.1553C26.4621 25.2414 27.0424 24.0493 27.2354 22.5801V22.5791H29.8965ZM21.6172 22.0518L14.4609 28.8994C13.792 29.5396 12.7408 29.5057 12.1133 28.8232L11.6914 28.3643L9 25.4336L10.8262 23.6875L13.3633 26.4492L19.9062 20.1895L21.6172 22.0518ZM21.833 10C23.2554 10 24.529 10.2916 25.6533 10.874C26.7777 11.4565 27.6864 12.2634 28.3809 13.2939C29.074 14.3244 29.5349 15.4942 29.7637 16.8018H27.1025C26.8564 15.5118 26.2602 14.467 25.3115 13.6699C24.3628 12.8716 23.2381 12.4727 21.833 12.4727C20.4281 12.4727 19.2423 12.8052 18.2764 13.4678C17.3104 14.1304 16.5955 15.0321 16.1299 16.1699C15.6643 17.3089 15.4316 18.5861 15.4316 20.001C15.4317 20.4418 15.4577 20.8677 15.5039 21.2803L15.501 21.2812L13.1689 23.5137C12.8524 22.4183 12.6905 21.2482 12.6904 20.002C12.6904 18.1566 13.0379 16.4762 13.7324 14.9609C14.4257 13.4457 15.4623 12.2409 16.8408 11.3447C18.2192 10.4487 19.8839 10.0001 21.833 10Z" fill="var(--bg-canvas)"></path></svg><span class="sr-only">Loading</span><noscript><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-loader-circle h-6 w-6 animate-spin" aria-label="Loading"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg></noscript></div><div role="status" aria-live="polite" class="flex items-center justify-center " style="color:var(--fg-primary)"><svg width="100%" height="100%" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Loading" class="h-12 w-12 animate-pulse" style="animation-duration:1.5s;animation-timing-function:ease-in-out"><title>Loading</title><path d="M0 8C0 3.58172 3.58172 0 8 0H32C36.4183 0 40 3.58172 40 8V32C40 36.4183 36.4183 40 32 40H8C3.58172 40 0 36.4183 0 32V8Z" fill="currentColor"></path><path d="M29.8965 22.5791C29.7197 23.9952 29.2851 25.2627 28.5918 26.3828C27.8974 27.5029 26.9757 28.3863 25.8262 29.0312C24.6754 29.6762 23.3451 29.9999 21.835 30C20.2149 30 18.7905 29.6896 17.5645 29.0693L19.5527 27.167C20.2356 27.404 20.995 27.5273 21.835 27.5273C23.3104 27.5273 24.5302 27.069 25.4961 26.1553C26.4621 25.2414 27.0424 24.0493 27.2354 22.5801V22.5791H29.8965ZM21.6172 22.0518L14.4609 28.8994C13.792 29.5396 12.7408 29.5057 12.1133 28.8232L11.6914 28.3643L9 25.4336L10.8262 23.6875L13.3633 26.4492L19.9062 20.1895L21.6172 22.0518ZM21.833 10C23.2554 10 24.529 10.2916 25.6533 10.874C26.7777 11.4565 27.6864 12.2634 28.3809 13.2939C29.074 14.3244 29.5349 15.4942 29.7637 16.8018H27.1025C26.8564 15.5118 26.2602 14.467 25.3115 13.6699C24.3628 12.8716 23.2381 12.4727 21.833 12.4727C20.4281 12.4727 19.2423 12.8052 18.2764 13.4678C17.3104 14.1304 16.5955 15.0321 16.1299 16.1699C15.6643 17.3089 15.4316 18.5861 15.4316 20.001C15.4317 20.4418 15.4577 20.8677 15.5039 21.2803L15.501 21.2812L13.1689 23.5137C12.8524 22.4183 12.6905 21.2482 12.6904 20.002C12.6904 18.1566 13.0379 16.4762 13.7324 14.9609C14.4257 13.4457 15.4623 12.2409 16.8408 11.3447C18.2192 10.4487 19.8839 10.0001 21.833 10Z" fill="var(--bg-canvas)"></path></svg><span class="sr-only">Loading</span><noscript><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-loader-circle h-12 w-12 animate-spin" aria-label="Loading"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg></noscript></div><div role="status" aria-live="polite" class="flex items-center justify-center " style="color:var(--fg-primary)"><svg width="100%" height="100%" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Loading" class="h-16 w-16 animate-pulse" style="animation-duration:1.5s;animation-timing-function:ease-in-out"><title>Loading</title><path d="M0 8C0 3.58172 3.58172 0 8 0H32C36.4183 0 40 3.58172 40 8V32C40 36.4183 36.4183 40 32 40H8C3.58172 40 0 36.4183 0 32V8Z" fill="currentColor"></path><path d="M29.8965 22.5791C29.7197 23.9952 29.2851 25.2627 28.5918 26.3828C27.8974 27.5029 26.9757 28.3863 25.8262 29.0312C24.6754 29.6762 23.3451 29.9999 21.835 30C20.2149 30 18.7905 29.6896 17.5645 29.0693L19.5527 27.167C20.2356 27.404 20.995 27.5273 21.835 27.5273C23.3104 27.5273 24.5302 27.069 25.4961 26.1553C26.4621 25.2414 27.0424 24.0493 27.2354 22.5801V22.5791H29.8965ZM21.6172 22.0518L14.4609 28.8994C13.792 29.5396 12.7408 29.5057 12.1133 28.8232L11.6914 28.3643L9 25.4336L10.8262 23.6875L13.3633 26.4492L19.9062 20.1895L21.6172 22.0518ZM21.833 10C23.2554 10 24.529 10.2916 25.6533 10.874C26.7777 11.4565 27.6864 12.2634 28.3809 13.2939C29.074 14.3244 29.5349 15.4942 29.7637 16.8018H27.1025C26.8564 15.5118 26.2602 14.467 25.3115 13.6699C24.3628 12.8716 23.2381 12.4727 21.833 12.4727C20.4281 12.4727 19.2423 12.8052 18.2764 13.4678C17.3104 14.1304 16.5955 15.0321 16.1299 16.1699C15.6643 17.3089 15.4316 18.5861 15.4316 20.001C15.4317 20.4418 15.4577 20.8677 15.5039 21.2803L15.501 21.2812L13.1689 23.5137C12.8524 22.4183 12.6905 21.2482 12.6904 20.002C12.6904 18.1566 13.0379 16.4762 13.7324 14.9609C14.4257 13.4457 15.4623 12.2409 16.8408 11.3447C18.2192 10.4487 19.8839 10.0001 21.833 10Z" fill="var(--bg-canvas)"></path></svg><span class="sr-only">Loading</span><noscript><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-loader-circle h-16 w-16 animate-spin" aria-label="Loading"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg></noscript></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Skeleton — variants</span><div class="flex flex-wrap items-center gap-3"><div class="flex w-full flex-col gap-3"><div aria-hidden="true" class="bg-[var(--overlay-weak)] rounded animate-pulse motion-reduce:animate-none" style="width:60%;height:12px"></div><div aria-hidden="true" class="bg-[var(--overlay-weak)] rounded animate-pulse motion-reduce:animate-none" style="width:100%;height:80px"></div><div aria-hidden="true" class="flex flex-col gap-2 "><div class="bg-[var(--overlay-weak)] rounded animate-pulse motion-reduce:animate-none " style="width:100%;height:12px"></div><div class="bg-[var(--overlay-weak)] rounded animate-pulse motion-reduce:animate-none " style="width:100%;height:12px"></div><div class="bg-[var(--overlay-weak)] rounded animate-pulse motion-reduce:animate-none " style="width:60%;height:12px"></div></div><div aria-hidden="true" class="bg-[var(--overlay-weak)] rounded animate-pulse motion-reduce:animate-none  shrink-0" style="width:40px;height:40px;border-radius:999px"></div></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Skeleton — static circle in a flex row (NEW animate=false)</span><div class="flex flex-wrap items-center gap-3"><div class="flex items-center gap-3"><div aria-hidden="true" class="bg-[var(--overlay-weak)] rounded animate-pulse motion-reduce:animate-none !animate-none shrink-0" style="width:40px;height:40px;border-radius:999px"></div><div class="flex flex-col gap-2"><div aria-hidden="true" class="bg-[var(--overlay-weak)] rounded animate-pulse motion-reduce:animate-none !animate-none" style="width:160px;height:12px"></div><div aria-hidden="true" class="bg-[var(--overlay-weak)] rounded animate-pulse motion-reduce:animate-none !animate-none" style="width:100px;height:12px"></div></div></div></div></div></section><section class="flex flex-col gap-6 border-t border-[var(--border-subtle)] pt-8"><h2 class="font-headline text-h3 text-[var(--fg-primary)]">Navigation</h2><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Tabs — underline (interactive)</span><div class="flex flex-wrap items-center gap-3"><div class="w-full" data-testid="tabs-demo"><div class=""><div role="tablist" class="inline-flex gap-4 border-b border-[var(--border-subtle)] " aria-label="Underline tabs demo"><button type="button" role="tab" id="_R_9j35esnebmlb6lb_-tab-overview" aria-controls="_R_9j35esnebmlb6lb_-panel-overview" aria-selected="true" tabindex="0" class="inline-flex items-center gap-2 px-1 py-3 text-sm border-b-2 transition-colors duration-150 motion-reduce:transition-none text-[var(--fg-primary)] border-[var(--fg-primary)] font-semibold cursor-pointer " data-testid="tabs-demo-overview">Overview</button><button type="button" role="tab" id="_R_9j35esnebmlb6lb_-tab-activity" aria-controls="_R_9j35esnebmlb6lb_-panel-activity" aria-selected="false" tabindex="-1" class="inline-flex items-center gap-2 px-1 py-3 text-sm border-b-2 transition-colors duration-150 motion-reduce:transition-none text-[var(--fg-muted)] border-transparent hover:text-[var(--fg-primary)] cursor-pointer ">Activity<span class="rounded-[999px] inline-flex items-center gap-1.5 px-2 py-0.5 text-caption font-semibold bg-[var(--badge-count-bg)] text-[var(--badge-count-fg)] font-semibold ">3</span></button><button type="button" role="tab" id="_R_9j35esnebmlb6lb_-tab-settings" aria-controls="_R_9j35esnebmlb6lb_-panel-settings" aria-selected="false" tabindex="-1" class="inline-flex items-center gap-2 px-1 py-3 text-sm border-b-2 transition-colors duration-150 motion-reduce:transition-none text-[var(--fg-muted)] border-transparent hover:text-[var(--fg-primary)] cursor-pointer " data-testid="tabs-demo-settings">Settings</button><button type="button" role="tab" id="_R_9j35esnebmlb6lb_-tab-disabled" aria-controls="_R_9j35esnebmlb6lb_-panel-disabled" aria-selected="false" aria-disabled="true" tabindex="-1" class="inline-flex items-center gap-2 px-1 py-3 text-sm border-b-2 transition-colors duration-150 motion-reduce:transition-none text-[var(--fg-muted)] border-transparent opacity-50 cursor-not-allowed ">Disabled</button></div><div role="tabpanel" id="_R_9j35esnebmlb6lb_-panel-overview" aria-labelledby="_R_9j35esnebmlb6lb_-tab-overview" class="pt-4 text-body text-[var(--fg-secondary)]">Overview panel content.</div></div></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Tabs — segmented (NEW variant)</span><div class="flex flex-wrap items-center gap-3"><div class="w-full" data-testid="tabs-segmented"><div class=""><div role="tablist" class="inline-flex gap-1 p-1 bg-[var(--bg-sunken)] rounded " aria-label="Segmented tabs demo"><button type="button" role="tab" id="_R_aj35esnebmlb6lb_-tab-day" aria-controls="_R_aj35esnebmlb6lb_-panel-day" aria-selected="true" tabindex="0" class="inline-flex items-center justify-center gap-2 px-3 py-1.5 text-sm rounded transition-colors duration-150 motion-reduce:transition-none text-[var(--fg-primary)] bg-[var(--bg-elevated)] shadow-[var(--shadow-sm)] font-semibold cursor-pointer ">Day</button><button type="button" role="tab" id="_R_aj35esnebmlb6lb_-tab-week" aria-controls="_R_aj35esnebmlb6lb_-panel-week" aria-selected="false" tabindex="-1" class="inline-flex items-center justify-center gap-2 px-3 py-1.5 text-sm rounded transition-colors duration-150 motion-reduce:transition-none text-[var(--fg-muted)] hover:text-[var(--fg-primary)] cursor-pointer ">Week</button><button type="button" role="tab" id="_R_aj35esnebmlb6lb_-tab-month" aria-controls="_R_aj35esnebmlb6lb_-panel-month" aria-selected="false" tabindex="-1" class="inline-flex items-center justify-center gap-2 px-3 py-1.5 text-sm rounded transition-colors duration-150 motion-reduce:transition-none text-[var(--fg-muted)] hover:text-[var(--fg-primary)] cursor-pointer ">Month</button></div><div role="tabpanel" id="_R_aj35esnebmlb6lb_-panel-day" aria-labelledby="_R_aj35esnebmlb6lb_-tab-day" class="pt-4 text-body text-[var(--fg-secondary)]">Day view.</div></div></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Tabs — link tabs (NEW href, rendered as anchors)</span><div class="flex flex-wrap items-center gap-3"><div class="w-full" data-testid="tabs-link"><div class=""><div role="tablist" class="inline-flex gap-4 border-b border-[var(--border-subtle)] " aria-label="Link tabs demo"><a role="tab" id="_R_bj35esnebmlb6lb_-tab-posts" aria-controls="_R_bj35esnebmlb6lb_-panel-posts" aria-selected="true" tabindex="0" class="inline-flex items-center gap-2 px-1 py-3 text-sm border-b-2 transition-colors duration-150 motion-reduce:transition-none text-[var(--fg-primary)] border-[var(--fg-primary)] font-semibold cursor-pointer " href="/dev/gallery?tab=posts">Posts</a><a role="tab" id="_R_bj35esnebmlb6lb_-tab-replies" aria-controls="_R_bj35esnebmlb6lb_-panel-replies" aria-selected="false" tabindex="-1" class="inline-flex items-center gap-2 px-1 py-3 text-sm border-b-2 transition-colors duration-150 motion-reduce:transition-none text-[var(--fg-muted)] border-transparent hover:text-[var(--fg-primary)] cursor-pointer " href="/dev/gallery?tab=replies">Replies</a><a role="tab" id="_R_bj35esnebmlb6lb_-tab-likes" aria-controls="_R_bj35esnebmlb6lb_-panel-likes" aria-selected="false" tabindex="-1" class="inline-flex items-center gap-2 px-1 py-3 text-sm border-b-2 transition-colors duration-150 motion-reduce:transition-none text-[var(--fg-muted)] border-transparent hover:text-[var(--fg-primary)] cursor-pointer " href="/dev/gallery?tab=likes">Likes<span class="rounded-[999px] inline-flex items-center gap-1.5 px-2 py-0.5 text-caption font-semibold bg-[var(--badge-count-bg)] text-[var(--badge-count-fg)] font-semibold ">9</span></a></div></div></div></div></div></section><section class="flex flex-col gap-6 border-t border-[var(--border-subtle)] pt-8"><h2 class="font-headline text-h3 text-[var(--fg-primary)]">New primitives</h2><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Combobox — working typeahead (NEW: open with results)</span><div class="flex flex-wrap items-center gap-3"><div class="w-full max-w-[360px]" data-testid="combobox-demo"><div class="" role="search"><div class="w-full"><div class="relative w-full"><span aria-hidden="true" class="pointer-events-none absolute top-1/2 -translate-y-1/2 left-4 flex items-center text-[var(--fg-muted)]"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-search h-4 w-4"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg></span><input id="_R_71jj5esnebmlb6lb_" class="h-11 px-4 text-base md:text-sm  pl-11 pr-11 w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " type="text" aria-label="Search people" placeholder="Search people" role="combobox" aria-autocomplete="list" aria-expanded="true" aria-controls="_R_11jj5esnebmlb6lb_-listbox" autocomplete="off" spellcheck="false" value="a" aria-activedescendant="_R_11jj5esnebmlb6lb_-option-0"><span class="absolute top-1/2 -translate-y-1/2 right-4 flex items-center"><button type="button" aria-label="Clear search" data-testid="combobox-clear" class="inline-flex h-6 w-6 items-center justify-center rounded text-[var(--fg-muted)] transition-colors duration-150 hover:bg-[var(--overlay-weak)] hover:text-[var(--fg-primary)] focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 motion-reduce:transition-none"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x h-4 w-4"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg></button></span></div></div><ul id="_R_11jj5esnebmlb6lb_-listbox" role="listbox" class="mt-1 max-h-64 overflow-auto rounded border border-[var(--border-default)] bg-[var(--bg-elevated)] p-1 shadow-md"><li role="option" id="_R_11jj5esnebmlb6lb_-option-0" data-combobox-option="true" aria-selected="true" data-testid="combobox-option-ada" class="flex cursor-pointer items-center justify-between rounded px-3 py-2 text-body-sm bg-[var(--overlay-weak)] text-[var(--fg-primary)]"><span class="text-[var(--fg-primary)]">Ada Lovelace</span><span class="text-[var(--fg-muted)]">@ada</span></li><li role="option" id="_R_11jj5esnebmlb6lb_-option-1" data-combobox-option="true" aria-selected="false" data-testid="combobox-option-alan" class="flex cursor-pointer items-center justify-between rounded px-3 py-2 text-body-sm text-[var(--fg-secondary)]"><span class="text-[var(--fg-primary)]">Alan Turing</span><span class="text-[var(--fg-muted)]">@alan</span></li><li role="option" id="_R_11jj5esnebmlb6lb_-option-2" data-combobox-option="true" aria-selected="false" data-testid="combobox-option-grace" class="flex cursor-pointer items-center justify-between rounded px-3 py-2 text-body-sm text-[var(--fg-secondary)]"><span class="text-[var(--fg-primary)]">Grace Hopper</span><span class="text-[var(--fg-muted)]">@grace</span></li><li role="option" id="_R_11jj5esnebmlb6lb_-option-3" data-combobox-option="true" aria-selected="false" data-testid="combobox-option-katherine" class="flex cursor-pointer items-center justify-between rounded px-3 py-2 text-body-sm text-[var(--fg-secondary)]"><span class="text-[var(--fg-primary)]">Katherine Johnson</span><span class="text-[var(--fg-muted)]">@katherine</span></li><li role="option" id="_R_11jj5esnebmlb6lb_-option-4" data-combobox-option="true" aria-selected="false" data-testid="combobox-option-linus" class="flex cursor-pointer items-center justify-between rounded px-3 py-2 text-body-sm text-[var(--fg-secondary)]"><span class="text-[var(--fg-primary)]">Linus Torvalds</span><span class="text-[var(--fg-muted)]">@linus</span></li></ul></div></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">SegmentedControl — icon-only joined square (md)</span><div class="flex flex-wrap items-center gap-3"><span style="display:contents"><div role="radiogroup" aria-orientation="horizontal" class="inline-flex items-stretch overflow-hidden border border-[var(--border-default)] bg-[var(--bg-sunken)] rounded" aria-label="View mode"><button type="button" role="radio" aria-checked="true" tabindex="0" class="inline-flex items-center gap-2 rounded text-sm text-[var(--fg-primary)] transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 relative inline-flex items-center justify-center gap-1.5 font-medium leading-none transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:-outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 h-8 text-sm w-8 px-0 border-0 bg-[var(--bg-elevated)] text-[var(--fg-primary)]" aria-label="List view"><span class="inline-flex items-center" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list"><path d="M3 12h.01"></path><path d="M3 18h.01"></path><path d="M3 6h.01"></path><path d="M8 12h13"></path><path d="M8 18h13"></path><path d="M8 6h13"></path></svg></span></button><button type="button" role="radio" aria-checked="false" tabindex="-1" class="inline-flex items-center gap-2 rounded text-sm text-[var(--fg-primary)] transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 relative inline-flex items-center justify-center gap-1.5 font-medium leading-none transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:-outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 h-8 text-sm w-8 px-0 border-0 border-l border-[var(--border-default)] bg-transparent text-[var(--fg-muted)] hover:text-[var(--fg-primary)]" aria-label="Gallery view"><span class="inline-flex items-center" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-layout-grid"><rect width="7" height="7" x="3" y="3" rx="1"></rect><rect width="7" height="7" x="14" y="3" rx="1"></rect><rect width="7" height="7" x="14" y="14" rx="1"></rect><rect width="7" height="7" x="3" y="14" rx="1"></rect></svg></span></button></div></span><span class="text-body-sm text-[var(--fg-muted)]" data-testid="segmented-icon-value">list</span></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">SegmentedControl — text pills (joined=false, shape=pill)</span><div class="flex flex-wrap items-center gap-3"><span style="display:contents"><div role="radiogroup" aria-orientation="horizontal" class="inline-flex items-stretch gap-1" aria-label="Date range"><button type="button" role="radio" aria-checked="false" tabindex="-1" class="inline-flex items-center gap-2 rounded text-sm text-[var(--fg-primary)] transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 relative inline-flex items-center justify-center gap-1.5 font-medium leading-none transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:-outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 h-8 text-sm px-3 border border-[var(--border-default)] bg-[var(--bg-elevated)] rounded-[999px] bg-transparent text-[var(--fg-muted)] hover:text-[var(--fg-primary)]"><span class="leading-none">Day</span></button><button type="button" role="radio" aria-checked="true" tabindex="0" class="inline-flex items-center gap-2 rounded text-sm text-[var(--fg-primary)] transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 relative inline-flex items-center justify-center gap-1.5 font-medium leading-none transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:-outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 h-8 text-sm px-3 border border-[var(--border-default)] bg-[var(--bg-elevated)] rounded-[999px] bg-[var(--bg-elevated)] text-[var(--fg-primary)]"><span class="leading-none">Week</span></button><button type="button" role="radio" aria-checked="false" tabindex="-1" class="inline-flex items-center gap-2 rounded text-sm text-[var(--fg-primary)] transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 relative inline-flex items-center justify-center gap-1.5 font-medium leading-none transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:-outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 h-8 text-sm px-3 border border-[var(--border-default)] bg-[var(--bg-elevated)] rounded-[999px] bg-transparent text-[var(--fg-muted)] hover:text-[var(--fg-primary)]"><span class="leading-none">Month</span></button></div></span></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">ToggleGroup — multi-select tones (neutral / success / warn)</span><div class="flex flex-wrap items-center gap-3"><div class="flex flex-wrap items-center gap-4" data-testid="toggle-group-demo"><div role="group" aria-label="Response" class="inline-flex items-stretch gap-1"><button type="button" aria-pressed="true" class="relative inline-flex items-center justify-center gap-1.5 font-medium leading-none transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:-outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 h-8 text-sm px-3 border border-[var(--border-default)] bg-[var(--bg-elevated)] rounded-[999px] bg-[var(--color-success-bg)] text-[var(--color-success-text)] border-[var(--color-success-text)]"><span class="inline-flex items-center" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-check"><path d="M20 6 9 17l-5-5"></path></svg></span><span class="leading-none">Accept</span></button><button type="button" aria-pressed="false" class="relative inline-flex items-center justify-center gap-1.5 font-medium leading-none transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:-outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 h-8 text-sm px-3 border border-[var(--border-default)] bg-[var(--bg-elevated)] rounded-[999px] bg-transparent text-[var(--fg-muted)] hover:text-[var(--fg-primary)]"><span class="inline-flex items-center" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg></span><span class="leading-none">Reject</span></button></div><div role="group" aria-label="Text formatting" class="inline-flex items-stretch overflow-hidden border border-[var(--border-default)] bg-[var(--bg-sunken)] rounded"><button type="button" aria-pressed="false" class="relative inline-flex items-center justify-center gap-1.5 font-medium leading-none transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:-outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 h-8 text-sm px-3 border-0 bg-transparent text-[var(--fg-muted)] hover:text-[var(--fg-primary)]"><span class="leading-none">Bold</span></button><button type="button" aria-pressed="false" class="relative inline-flex items-center justify-center gap-1.5 font-medium leading-none transition-colors duration-150 motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:-outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 h-8 text-sm px-3 border-0 border-l border-[var(--border-default)] bg-transparent text-[var(--fg-muted)] hover:text-[var(--fg-primary)]"><span class="leading-none">Italic</span></button></div></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Popover — portal + side/align (NEW)</span><div class="flex flex-wrap items-center gap-3"><span class="inline-flex relative"><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-2.5 px-6 text-sm   " data-testid="open-popover-portal" aria-haspopup="menu" aria-expanded="false" aria-controls="_R_15jj5esnebmlb6lb_">Open portal menu</button></span></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Input — bare (inherits heading font)</span><div class="flex flex-wrap items-center gap-3"><div class="w-full font-headline text-h2 text-[var(--fg-primary)]"><div class="w-full"><input id="_R_16jj5esnebmlb6lb_" class="px-3 font-[inherit] text-[length:inherit] leading-[inherit]    w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " aria-label="Bare heading input" data-testid="input-bare" value="Untitled certificate"></div></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Input — density=compact</span><div class="flex flex-wrap items-center gap-3"><div class="w-full max-w-[280px]"><div class="w-full"><input id="_R_17jj5esnebmlb6lb_" class="h-11 px-4 text-base md:text-sm py-0.5 px-1.5 text-[0.8125rem]   w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  " aria-label="Compact meta input" data-testid="input-compact" placeholder="Compact meta field"></div></div></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Input — flush (in a flex row)</span><div class="flex flex-wrap items-center gap-3"><div class="flex w-full max-w-[360px] items-center gap-2 rounded border border-[var(--border-default)] bg-[var(--bg-elevated)] px-3 py-2"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-search h-4 w-4 shrink-0 text-[var(--fg-muted)]"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg><input id="_R_58jj5esnebmlb6lb_" class="h-11 px-4 text-base md:text-sm    w-full bg-[var(--bg-elevated)] text-[var(--fg-primary)] placeholder:text-[var(--fg-muted)] focus:outline-none transition-all duration-150 motion-reduce:transition-none border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20  bg-transparent" aria-label="Flush row input" data-testid="input-flush" placeholder="Flush field — no wrapper"><button type="button" aria-label="Clear flush field" data-testid="input-flush-clear" class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-[var(--fg-muted)] hover:bg-[var(--overlay-weak)] hover:text-[var(--fg-primary)] focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x h-4 w-4"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg></button></div></div></div></section><section class="flex flex-col gap-6 border-t border-[var(--border-subtle)] pt-8"><h2 class="font-headline text-h3 text-[var(--fg-primary)]">Overlays (interactive triggers)</h2><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Popover</span><div class="flex flex-wrap items-center gap-3"><span class="inline-flex relative"><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-2.5 px-6 text-sm   " data-testid="open-popover" aria-haspopup="menu" aria-expanded="false" aria-controls="_R_9k35esnebmlb6lb_">Open popover</button></span></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Toast</span><div class="flex flex-wrap items-center gap-3"><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-2.5 px-6 text-sm   " data-testid="fire-toast">Fire toast (success)</button><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-2.5 px-6 text-sm   " data-testid="fire-toast-error">Fire toast (error + action)</button></div></div><div class="flex flex-col gap-2"><span class="text-caption uppercase tracking-wider text-[var(--fg-muted)]">Dialogs &amp; panels</span><div class="flex flex-wrap items-center gap-3"><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--btn-primary-bg)] text-[var(--btn-primary-fg)] border-none hover:opacity-90 py-2.5 px-6 text-sm   " data-testid="open-appdialog">Open AppDialog</button><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--color-error-bg)] text-[var(--color-error)] border border-[var(--color-error-border)] hover:opacity-90 py-2.5 px-6 text-sm   " data-testid="open-confirmdialog">Open ConfirmDialog</button><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-[var(--btn-primary-bg)] text-[var(--btn-primary-fg)] border-none hover:opacity-90 py-2.5 px-6 text-sm   " data-testid="open-formdialog">Open FormDialog</button><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-2.5 px-6 text-sm   " data-testid="open-bottomsheet">Open BottomSheet</button><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-2.5 px-6 text-sm   " data-testid="open-drawer">Open Drawer</button><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-2.5 px-6 text-sm   " data-testid="open-responsivedialog">Open ResponsiveDialog</button></div></div></section></div></div><!--$--><!--/$--></div></div></div><footer class="site-footer" aria-label="Site footer"><div class="site-footer__row"><div class="site-footer__left"><img src="/brand/wordmark/certified_wordmark_black.svg" alt="Certified" class="site-footer__wordmark"><span class="site-footer__copy">© <!-- -->2026<!-- --> Hypercerts Foundation</span></div><nav class="site-footer__nav" aria-label="Footer links"><a class="site-footer__link" href="/about">About</a><a class="site-footer__link" href="/terms">Terms</a><a class="site-footer__link" href="/privacy">Privacy</a><a class="site-footer__link" href="/imprint">Imprint</a><button type="button" class="site-footer__link site-footer__link--button">Feedback</button></nav></div></footer></div></main><!--$--><!--/$--><next-route-announcer style="position: absolute;"></next-route-announcer><div aria-hidden="true" class="fixed inset-0 z-[var(--z-portal-sheet)] bg-[var(--navy-overlay-30)] transition-opacity duration-300 ease-out motion-reduce:transition-none pointer-events-none opacity-0"></div><aside role="dialog" aria-modal="true" aria-label="Demo drawer" inert="" class="fixed top-0 bottom-0 left-0 z-[var(--z-portal-sheet)] flex w-[83.33%] max-w-[320px] flex-col overflow-y-auto bg-[var(--bg-elevated)] shadow-[var(--shadow-lg)] transition-transform duration-300 ease-out motion-reduce:transition-none -translate-x-full"><div class="flex flex-col gap-3 p-6"><span class="font-headline text-h4 text-[var(--fg-primary)]">Drawer</span><p class="text-body text-[var(--fg-secondary)]">Edge-anchored panel content.</p><button type="button" aria-busy="false" class="rounded text-sm font-medium tracking-wider transition-all duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 inline-flex items-center justify-center gap-2 press-scale bg-transparent text-[var(--fg-primary)] border border-[var(--border-default)] hover:border-[var(--border-hover)] py-2.5 px-6 text-sm   " data-testid="drawer-close">Close</button></div></aside><div class="pointer-events-none fixed inset-x-0 bottom-0 z-[var(--z-feedback)] flex flex-col items-center gap-2 p-4 max-[799px]:items-stretch min-[800px]:inset-x-auto min-[800px]:bottom-4 min-[800px]:right-4 min-[800px]:items-end"><style>
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+</style></div><div aria-hidden="true" class="fixed inset-0 z-[var(--z-portal-sheet)] bg-[var(--navy-overlay-30)] transition-opacity duration-300 ease-out motion-reduce:transition-none pointer-events-none opacity-0"></div><aside role="dialog" aria-modal="true" aria-label="Site navigation" inert="" class="fixed top-0 bottom-0 left-0 z-[var(--z-portal-sheet)] flex w-[83.33%] max-w-[320px] flex-col overflow-y-auto bg-[var(--bg-elevated)] shadow-[var(--shadow-lg)] transition-transform duration-300 ease-out motion-reduce:transition-none -translate-x-full"><header class="site-drawer__head"><a class="site-drawer__brand" aria-label="Certified home" href="/welcome"><img alt="Certified" class="site-drawer__wordmark" src="/brand/wordmark/certified_wordmark_black.svg"></a><button type="button" class="site-drawer__close" aria-label="Close navigation"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x" aria-hidden="true"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg></button></header><nav class="site-drawer__nav" aria-label="Primary"><a class="site-drawer__item" href="/home"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-house" aria-hidden="true"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"></path><path d="M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path></svg>Home</a><a class="site-drawer__item" href="/explore"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-compass" aria-hidden="true"><path d="m16.24 7.76-1.804 5.411a2 2 0 0 1-1.265 1.265L7.76 16.24l1.804-5.411a2 2 0 0 1 1.265-1.265z"></path><circle cx="12" cy="12" r="10"></circle></svg>Explore</a><button type="button" class="site-drawer__item site-drawer__item--disabled" disabled="" title="Sign in to access your profile"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-user" aria-hidden="true"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>My profile</button><a class="site-drawer__item" href="/settings"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-settings" aria-hidden="true"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path><circle cx="12" cy="12" r="3"></circle></svg>Settings</a></nav></aside>
 <script>
-/* Theme toggle — flips data-theme on <html>. The token blocks above do the
-   rest. No persistence/network; pure inline toggle per the requirements. */
 (function () {
   var root = document.documentElement;
-  var btn = document.getElementById("theme-btn");
-  var icon = document.getElementById("theme-icon");
-  var label = document.getElementById("theme-label");
+  var btn = document.getElementById("sg-theme-btn");
+  var icon = document.getElementById("sg-theme-icon");
+  var label = document.getElementById("sg-theme-label");
   function apply(theme) {
     root.setAttribute("data-theme", theme);
+    root.style.colorScheme = theme;
     var dark = theme === "dark";
     btn.setAttribute("aria-pressed", String(dark));
-    icon.textContent = dark ? "☀" : "☾";
-    label.textContent = dark ? "Light" : "Dark";
+    if (icon) icon.textContent = dark ? "\u2600" : "\u263E";
+    if (label) label.textContent = dark ? "Light" : "Dark";
   }
   btn.addEventListener("click", function () {
     apply(root.getAttribute("data-theme") === "dark" ? "light" : "dark");

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
-    "typecheck:test": "tsc --noEmit -p tsconfig.test.json"
+    "typecheck:test": "tsc --noEmit -p tsconfig.test.json",
+    "styleguide:generate": "node scripts/generate-styleguide.mjs"
   },
   "dependencies": {
     "@atproto/api": "^0.13.20",

--- a/scripts/generate-styleguide.mjs
+++ b/scripts/generate-styleguide.mjs
@@ -1,0 +1,375 @@
+// generate-styleguide.mjs
+//
+// Generates the static styleguide at docs/component-library/index.html FROM
+// the live dev gallery at /dev/gallery, so the two can't drift. This is the
+// "single source of truth" approach (D6): the gallery TSX is authored once,
+// and this script snapshots its rendered output + all the CSS the page uses
+// into one self-contained HTML file that opens over file:// with no network.
+//
+// It ASSUMES a dev server is already running at http://127.0.0.1:3000.
+// It does NOT start one. Run it like:
+//
+//   # in one terminal
+//   npm run dev
+//   # in another, once the server is up
+//   npm run styleguide:generate
+//
+// What it does:
+//   1. Launches headless chromium, navigates to /dev/gallery, waits for load
+//      plus a short settle so client components have rendered.
+//   2. Fetches every <link rel="stylesheet"> the page references and inlines
+//      its text (this is how Tailwind utilities + globals + next/font are
+//      served in dev), plus captures any inline <style> blocks.
+//   3. Captures the gallery's rendered <body> HTML, strips the Next.js runtime
+//      (<script> tags, hydration noise, dev error overlay / issue toast).
+//   4. Wraps it in a clean, self-contained document with the inlined <style>,
+//      a "GENERATED — do not edit by hand" header, and one tiny inline script
+//      that toggles data-theme="dark" on <html>.
+//
+// Uses the repo's bundled Playwright.
+
+import { chromium } from "playwright";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+const OUT_DIR = join(ROOT, "docs/component-library");
+const OUT_FILE = join(OUT_DIR, "index.html");
+
+const BASE = process.env.BASE || "http://127.0.0.1:3000";
+const GALLERY_URL = `${BASE}/dev/gallery`;
+
+// Timeouts (ms). Generous because dev compiles the route on first hit.
+const NAV_TIMEOUT = 60_000;
+const SETTLE_MS = 1_200;
+const FETCH_TIMEOUT = 20_000;
+
+function log(...args) {
+  console.log("[styleguide]", ...args);
+}
+
+/**
+ * Fetch a URL's text with a timeout. Returns null (and logs) on failure so a
+ * single unreachable stylesheet doesn't abort the whole snapshot.
+ */
+async function fetchText(url) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal });
+    if (!res.ok) {
+      log(`  WARN ${res.status} fetching ${url} — skipping`);
+      return null;
+    }
+    return await res.text();
+  } catch (e) {
+    log(`  WARN failed to fetch ${url} (${e.message.split("\n")[0]}) — skipping`);
+    return null;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+/**
+ * Rewrite relative url(...) references inside a stylesheet to absolute URLs
+ * against the dev server. next/font @font-face blocks point at /_next/... font
+ * files with root-relative paths; left untouched they'd resolve against the
+ * file:// document and fail. Pointing them at the running dev server keeps the
+ * snapshot faithful while the server is up; when it isn't, the CSS already
+ * declares system-ui / serif fallbacks so the page still renders.
+ *
+ * Skips data: URIs and anything already absolute (http:, https:, //).
+ */
+function absolutizeCssUrls(cssText, sheetUrl) {
+  return cssText.replace(
+    /url\(\s*(['"]?)([^'")]+)\1\s*\)/g,
+    (match, quote, ref) => {
+      const trimmed = ref.trim();
+      if (
+        trimmed.startsWith("data:") ||
+        trimmed.startsWith("http://") ||
+        trimmed.startsWith("https://") ||
+        trimmed.startsWith("//")
+      ) {
+        return match;
+      }
+      try {
+        const abs = new URL(trimmed, sheetUrl).toString();
+        return `url(${quote}${abs}${quote})`;
+      } catch {
+        return match;
+      }
+    },
+  );
+}
+
+async function main() {
+  log(`Source : ${GALLERY_URL}`);
+  log(`Output : ${OUT_FILE}`);
+  log("Launching headless chromium…");
+
+  const browser = await chromium.launch();
+  let html;
+
+  try {
+    const ctx = await browser.newContext({
+      viewport: { width: 1280, height: 900 },
+      colorScheme: "light",
+    });
+    const page = await ctx.newPage();
+    page.on("pageerror", (err) =>
+      log(`  [pageerror] ${err.message.split("\n")[0]}`),
+    );
+
+    log("Navigating…");
+    const resp = await page.goto(GALLERY_URL, {
+      waitUntil: "networkidle",
+      timeout: NAV_TIMEOUT,
+    });
+    if (!resp) throw new Error("navigation returned no response");
+    if (!resp.ok()) {
+      throw new Error(
+        `gallery returned HTTP ${resp.status()} — is the dev server running at ${BASE}? (note: /dev/gallery 404s under NODE_ENV=production)`,
+      );
+    }
+    log(`  HTTP ${resp.status()} — settling ${SETTLE_MS}ms…`);
+    await page.waitForTimeout(SETTLE_MS);
+
+    // ---- 1. Collect every stylesheet the page uses -----------------------
+    // Order matters for the cascade, so read links in document order.
+    const sheetHrefs = await page.$$eval(
+      'link[rel~="stylesheet"]',
+      (links) => links.map((l) => l.href).filter(Boolean),
+    );
+    const inlineStyles = await page.$$eval("style", (els) =>
+      els.map((el) => el.textContent || ""),
+    );
+    log(
+      `Captured ${sheetHrefs.length} stylesheet link(s) + ${inlineStyles.length} inline <style> block(s).`,
+    );
+
+    const cssParts = [];
+    for (const href of sheetHrefs) {
+      const css = await fetchText(href);
+      if (css == null) continue;
+      cssParts.push(
+        `/* ---- linked stylesheet: ${href} ---- */\n` +
+          absolutizeCssUrls(css, href),
+      );
+      log(`  inlined ${css.length} bytes from ${href}`);
+    }
+    for (const css of inlineStyles) {
+      if (css.trim()) {
+        cssParts.push(
+          `/* ---- inline <style> ---- */\n` + absolutizeCssUrls(css, BASE),
+        );
+      }
+    }
+    const inlinedCss = cssParts.join("\n\n");
+
+    // ---- 2. Capture + sanitize the rendered body -------------------------
+    // Run inside the page so we operate on the live DOM, then strip the
+    // Next.js runtime and dev-only chrome before serializing.
+    const capturedTheme = await page.evaluate(
+      () => document.documentElement.getAttribute("data-theme") || "light",
+    );
+
+    const bodyHtml = await page.evaluate(() => {
+      const body = document.body.cloneNode(true);
+
+      // Drop all scripts (Next.js runtime, hydration payloads, inline boot).
+      body.querySelectorAll("script").forEach((n) => n.remove());
+
+      // Drop the Next.js dev error overlay / "N Issues" toast and portals.
+      const devChromeSelectors = [
+        "nextjs-portal",
+        "[data-nextjs-toast]",
+        "[data-nextjs-dialog-overlay]",
+        "[data-nextjs-dialog]",
+        "[data-nextjs-error-overlay]",
+        "[data-next-mark]",
+        "#__next-build-watcher",
+        "[data-nextjs-dev-tools-button]",
+        "[data-nextjs-devtools]",
+      ];
+      body
+        .querySelectorAll(devChromeSelectors.join(","))
+        .forEach((n) => n.remove());
+
+      // Strip Next.js hydration noise attributes from every element.
+      const walk = (el) => {
+        for (const attr of Array.from(el.attributes || [])) {
+          const name = attr.name;
+          if (
+            name.startsWith("data-next") ||
+            name === "data-reactroot" ||
+            name === "data-react-checksum"
+          ) {
+            el.removeAttribute(name);
+          }
+        }
+        for (const child of Array.from(el.children)) walk(child);
+      };
+      walk(body);
+
+      return body.innerHTML;
+    });
+
+    log(`  body HTML: ${bodyHtml.length} bytes (theme="${capturedTheme}")`);
+
+    await ctx.close();
+
+    // ---- 3. Assemble the self-contained document -------------------------
+    const generatedAt = new Date().toISOString();
+    html = buildDocument({ inlinedCss, bodyHtml, generatedAt });
+  } finally {
+    await browser.close();
+  }
+
+  await mkdir(OUT_DIR, { recursive: true });
+  await writeFile(OUT_FILE, html, "utf8");
+
+  const bytes = Buffer.byteLength(html, "utf8");
+  log("");
+  log(`Wrote ${OUT_FILE}`);
+  log(`Size  ${bytes.toLocaleString()} bytes (${(bytes / 1024).toFixed(1)} KiB)`);
+  log("Done. Open it over file:// — light + dark via the header toggle.");
+}
+
+/**
+ * Wrap the captured CSS + body into a clean, self-contained HTML document.
+ * The header (banner + toggle) is gallery-local chrome; it carries its own
+ * scoped styles so it doesn't depend on, or pollute, the captured design
+ * system. The one inline <script> toggles data-theme="dark" on <html>.
+ */
+function buildDocument({ inlinedCss, bodyHtml, generatedAt }) {
+  // Header banner styles use only fixed values / generic fonts so the banner
+  // renders identically regardless of the captured token CSS.
+  const headerCss = `
+/* ==========================================================================
+   GENERATED-STYLEGUIDE CHROME (not part of the captured design system).
+   Scoped under .sg-gen-* so it can't collide with snapshot classes.
+   ========================================================================== */
+.sg-gen-banner {
+  position: sticky;
+  top: 0;
+  z-index: 2147483647;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 10px 16px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #f9f9f9;
+  background: #111111;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+}
+.sg-gen-banner__msg { max-width: 78ch; }
+.sg-gen-banner code {
+  background: rgba(255, 255, 255, 0.12);
+  padding: 1px 5px;
+  border-radius: 2px;
+}
+.sg-gen-banner__toggle {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font: inherit;
+  color: #111111;
+  background: #f9f9f9;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 6px 12px;
+}
+.sg-gen-banner__toggle:hover { background: #ffffff; }
+.sg-gen-banner__toggle:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+`.trim();
+
+  // Tiny, dependency-free theme toggle. Mirrors next-themes' contract: flips
+  // data-theme on <html> and keeps color-scheme in sync.
+  const toggleScript = `
+(function () {
+  var root = document.documentElement;
+  var btn = document.getElementById("sg-theme-btn");
+  var icon = document.getElementById("sg-theme-icon");
+  var label = document.getElementById("sg-theme-label");
+  function apply(theme) {
+    root.setAttribute("data-theme", theme);
+    root.style.colorScheme = theme;
+    var dark = theme === "dark";
+    btn.setAttribute("aria-pressed", String(dark));
+    if (icon) icon.textContent = dark ? "\\u2600" : "\\u263E";
+    if (label) label.textContent = dark ? "Light" : "Dark";
+  }
+  btn.addEventListener("click", function () {
+    apply(root.getAttribute("data-theme") === "dark" ? "light" : "dark");
+  });
+})();
+`.trim();
+
+  return `<!DOCTYPE html>
+<!--
+  GENERATED FILE — DO NOT EDIT BY HAND.
+  Produced from the live dev gallery at /dev/gallery by
+  scripts/generate-styleguide.mjs. To refresh: start the dev server, then run
+  \`npm run styleguide:generate\`. Editing this file directly will be lost on
+  the next regeneration and defeats the single-source-of-truth guarantee.
+  Generated: ${generatedAt}
+-->
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Certified — Component Library Styleguide (generated)</title>
+<style>
+${headerCss}
+
+/* ==========================================================================
+   CAPTURED CSS — inlined verbatim from every stylesheet the live /dev/gallery
+   page loads (Tailwind utilities, globals + token imports, next/font faces),
+   plus any inline <style> blocks. Do not hand-edit; regenerate instead.
+   ========================================================================== */
+${inlinedCss}
+</style>
+</head>
+<body>
+<header class="sg-gen-banner" role="banner">
+  <span class="sg-gen-banner__msg">
+    GENERATED from <code>/dev/gallery</code> — do not edit by hand. Refresh with
+    <code>npm run styleguide:generate</code>. Single source of truth: the
+    gallery TSX, snapshotted here.
+  </span>
+  <button
+    type="button"
+    id="sg-theme-btn"
+    class="sg-gen-banner__toggle"
+    aria-pressed="false"
+    aria-label="Toggle dark theme"
+  >
+    <span id="sg-theme-icon" aria-hidden="true">&#9790;</span>
+    <span id="sg-theme-label">Dark</span>
+  </button>
+</header>
+${bodyHtml}
+<script>
+${toggleScript}
+</script>
+</body>
+</html>
+`;
+}
+
+main().catch((e) => {
+  console.error("[styleguide] FAILED:", e.message);
+  process.exit(1);
+});

--- a/scripts/preview-screenshots.mjs
+++ b/scripts/preview-screenshots.mjs
@@ -1,0 +1,129 @@
+// Preview-harness screenshotter.
+//
+// Navigates each auth-mock preview surface at
+//   http://127.0.0.1:3000/dev/preview/<surface>
+// and captures light + dark screenshots to
+//   /tmp/preview-<surface>-<theme>.png
+//
+// The /dev/preview/* routes mount the REAL composed surfaces (profile,
+// feed, settings, workspace) wrapped in MockFetchProvider, so they render
+// fully populated with fixture data while signed-out. This script exists
+// so a visual regression of those surfaces can be captured without a live
+// backend or a real session.
+//
+// Usage:
+//   node scripts/preview-screenshots.mjs
+//   BASE=http://127.0.0.1:3000 node scripts/preview-screenshots.mjs
+//   FIXTURE=empty node scripts/preview-screenshots.mjs   (empty-state pass)
+//
+// Requires the dev server to already be running. Uses the repo's bundled
+// Playwright (node_modules/playwright).
+
+import { chromium } from "playwright";
+
+const BASE = process.env.BASE || "http://127.0.0.1:3000";
+const FIXTURE = process.env.FIXTURE || ""; // "" | "empty"
+const OUT_DIR = process.env.OUT_DIR || "/tmp";
+
+const SURFACES = ["profile", "profile-org", "feed", "settings", "workspace"];
+const THEMES = ["light", "dark"];
+
+const VIEWPORT = { width: 1440, height: 900 };
+
+function urlFor(surface) {
+  const u = new URL(`/dev/preview/${surface}`, BASE);
+  if (FIXTURE) u.searchParams.set("fixture", FIXTURE);
+  return u.toString();
+}
+
+function outFile(surface, theme) {
+  const suffix = FIXTURE ? `-${FIXTURE}` : "";
+  return `${OUT_DIR}/preview-${surface}-${theme}${suffix}.png`;
+}
+
+// Pre-warm: compile each route once so Playwright's navigation isn't
+// racing the first Next.js compile (which can blow the timeout).
+async function prewarm() {
+  console.log("Pre-warming preview routes...");
+  for (const surface of SURFACES) {
+    const url = urlFor(surface);
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), 60_000);
+    const t0 = Date.now();
+    try {
+      const r = await fetch(url, { signal: ctrl.signal });
+      console.log(`  ${r.status} ${url} (${Date.now() - t0}ms)`);
+    } catch {
+      console.log(`  TIMEOUT ${url}`);
+    } finally {
+      clearTimeout(t);
+    }
+  }
+}
+
+async function main() {
+  await prewarm();
+
+  const browser = await chromium.launch();
+  let ok = 0;
+  let failed = 0;
+
+  try {
+    for (const theme of THEMES) {
+      const ctx = await browser.newContext({
+        viewport: VIEWPORT,
+        colorScheme: theme,
+        deviceScaleFactor: 2,
+      });
+      // next-themes persists to localStorage under "theme" and flips the
+      // `data-theme` attribute on <html>. Seed both the storage key and
+      // the attribute so the first paint is already in the target theme
+      // (no flash, no system-pref dependence).
+      await ctx.addInitScript((t) => {
+        try {
+          localStorage.setItem("theme", t);
+          document.documentElement.setAttribute("data-theme", t);
+          document.documentElement.style.colorScheme = t;
+        } catch {
+          /* ignore */
+        }
+      }, theme);
+
+      const page = await ctx.newPage();
+      page.on("pageerror", (err) => {
+        console.error(`  [pageerror] ${err.message.split("\n")[0]}`);
+      });
+
+      for (const surface of SURFACES) {
+        const url = urlFor(surface);
+        const file = outFile(surface, theme);
+        try {
+          await page.goto(url, {
+            waitUntil: "networkidle",
+            timeout: 30_000,
+          });
+          // Settle: let the fixture-driven fetches resolve + render.
+          await page.waitForTimeout(800);
+          await page.screenshot({ path: file, fullPage: true, timeout: 20_000 });
+          ok++;
+          console.log(`✓ ${surface} (${theme}) → ${file}`);
+        } catch (e) {
+          failed++;
+          console.error(`✗ ${surface} (${theme}): ${e.message.split("\n")[0]}`);
+        }
+      }
+
+      await ctx.close();
+    }
+  } finally {
+    await browser.close();
+  }
+
+  console.log(`\nDone. ok=${ok} failed=${failed}`);
+  if (failed > 0) process.exitCode = 1;
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -17,6 +17,7 @@ import { useOrg } from "@/lib/groups/org-context"
 import { authFetch } from "@/lib/auth/fetch"
 import EmptyState from "@/components/ui/empty-state"
 import Button from "@/components/ui/button"
+import Input from "@/components/ui/input"
 import LeafletEditor from "@/components/leaflet/leaflet-editor"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import ImageEditOverlay from "@/components/feed/image-edit-overlay"
@@ -661,21 +662,37 @@ export default function CreatePage() {
                       either way. The displayed text format is
                       controlled by the browser/OS locale and can't
                       be overridden without dropping the picker UI. */}
-                  <input
+                  {/* flex-[1_1_0] + min-w-0 reproduce the legacy
+                      `.create-cert__date-row .cert-detail__meta-input`
+                      rule so the two date fields split the row evenly
+                      (the bare input is otherwise content-width). */}
+                  <Input
+                    flush
+                    density="compact"
+                    borderWeight="hover"
                     type="date"
                     aria-label="Start date"
-                    className="cert-detail__meta-input"
+                    className="flex-[1_1_0] min-w-0"
                     value={startDate}
                     onChange={(e) => setStartDate(e.target.value)}
                   />
                   <span aria-hidden>→</span>
-                  <input
+                  <Input
+                    flush
+                    density="compact"
+                    borderWeight="hover"
                     type="date"
                     aria-label="End date"
+                    // Preserve the exact legacy invalid treatment from
+                    // `.create-cert__contrib-id-input--invalid` (solid
+                    // --color-error border + red focus ring), which is a
+                    // heavier cue than the primitive's translucent
+                    // `error` border. Applied via className so it wins
+                    // over the borderWeight="hover" resting border.
                     className={
                       datesValid
-                        ? "cert-detail__meta-input"
-                        : "cert-detail__meta-input create-cert__contrib-id-input--invalid"
+                        ? "flex-[1_1_0] min-w-0"
+                        : "flex-[1_1_0] min-w-0 !border-[var(--color-error)] focus:!border-[var(--color-error)] focus:!ring-2 focus:!ring-[var(--color-error)]/15"
                     }
                     aria-invalid={!datesValid}
                     value={endDate}
@@ -699,10 +716,13 @@ export default function CreatePage() {
                 Work scope
               </dt>
               <dd className="cert-detail__meta-value">
-                <input
+                <Input
+                  flush
+                  density="compact"
+                  borderWeight="hover"
                   type="text"
                   aria-label="Work scope"
-                  className="cert-detail__meta-input create-cert__field--full"
+                  className="create-cert__field--full"
                   placeholder="e.g. mentorship, code review…"
                   value={workScope}
                   maxLength={256}
@@ -777,6 +797,15 @@ export default function CreatePage() {
                     None available
                   </span>
                 ) : (
+                  // NOTE: left as a native <select> with the compact
+                  // `cert-detail__meta-input` chrome. The <Select>
+                  // primitive only exposes a sm/md/lg size axis (no
+                  // `density="compact"`), and its smallest size (sm =
+                  // h-9, 1px --border-default) is taller and lighter
+                  // than this 0.8125rem / 1.5px --border-hover meta
+                  // field — adopting it would change the inline meta-row
+                  // rhythm. Migrate once <Select> grows a compact
+                  // density that matches the meta-input scale.
                   <select
                     className="cert-detail__meta-input"
                     aria-label="Rights"
@@ -799,11 +828,22 @@ export default function CreatePage() {
         <div className="page-layout__main cert-detail__main">
           <header className="cert-detail__headline">
             <div className="create-cert__input-with-counter">
-              <input
+              {/* Bare/flush <Input> so the title typography cascades.
+                  The serif headline scale, weight, tracking, and the
+                  1.375rem create-form size are carried inline here
+                  (the legacy `.cert-detail__title-input` +
+                  `.create-cert .cert-detail__title-input` rules that
+                  used to supply them are now dead). borderWeight="hover"
+                  reproduces the 1.5px --border-hover / --fg-primary
+                  focus chrome the legacy class painted. */}
+              <Input
+                flush
+                size="bare"
+                borderWeight="hover"
                 type="text"
-                className="cert-detail__title-input"
                 aria-label="Title"
                 placeholder="Title for your activity"
+                className="flex-[1_1_auto] min-w-0 font-headline !text-[1.375rem] font-bold !leading-[1.15] tracking-[-0.015em] text-[var(--fg-primary)] !px-2.5 py-1"
                 value={title}
                 maxLength={TITLE_MAX}
                 onChange={(e) => setTitle(e.target.value)}
@@ -958,9 +998,11 @@ export default function CreatePage() {
                         excludeIdentities={otherIdentities}
                       />
                     )}
-                    <input
+                    <Input
+                      flush
+                      density="compact"
+                      borderWeight="hover"
                       type="text"
-                      className="cert-detail__meta-input"
                       aria-label={`Contributor ${idx + 1} role (optional)`}
                       placeholder="Role (optional)"
                       value={c.role}
@@ -975,13 +1017,21 @@ export default function CreatePage() {
                         )
                       }
                     />
-                    <input
+                    <Input
+                      flush
+                      density="compact"
+                      borderWeight="hover"
                       type="text"
                       inputMode="decimal"
+                      // `create-cert__contrib-weight` keeps the row's
+                      // text-align:left layout. Invalid border matches
+                      // the legacy `--invalid` (solid --color-error +
+                      // red focus ring), applied via className so it
+                      // wins over borderWeight="hover".
                       className={
                         weightValid
-                          ? "cert-detail__meta-input create-cert__contrib-weight"
-                          : "cert-detail__meta-input create-cert__contrib-weight create-cert__contrib-id-input--invalid"
+                          ? "create-cert__contrib-weight"
+                          : "create-cert__contrib-weight !border-[var(--color-error)] focus:!border-[var(--color-error)] focus:!ring-2 focus:!ring-[var(--color-error)]/15"
                       }
                       aria-label={`Contributor ${idx + 1} weight (optional)`}
                       aria-invalid={!weightValid}

--- a/src/app/dev/gallery/page.tsx
+++ b/src/app/dev/gallery/page.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { notFound } from "next/navigation";
-import { Search, X, Inbox, Star } from "lucide-react";
+import {
+  Search,
+  X,
+  Inbox,
+  Star,
+  List,
+  LayoutGrid,
+  Check,
+} from "lucide-react";
 
 import Badge from "@/components/ui/badge";
 import Button from "@/components/ui/button";
@@ -20,6 +28,8 @@ import Skeleton from "@/components/ui/skeleton";
 import LoadingSpinner from "@/components/ui/loading-spinner";
 import ErrorMessage from "@/components/ui/error-message";
 import { Tabs, TabList, Tab, TabPanel } from "@/components/ui/tabs";
+import Combobox from "@/components/ui/combobox";
+import SegmentedControl, { ToggleGroup } from "@/components/ui/segmented-control";
 import {
   Popover,
   PopoverTrigger,
@@ -91,6 +101,13 @@ export default function GalleryPage() {
   const [comboValue, setComboValue] = useState("acme");
   const [trailingValue, setTrailingValue] = useState("clearable text");
 
+  // NEW primitives — local-only state for the live demos below.
+  const [typeahead, setTypeahead] = useState("a");
+  const [typeaheadOpen, setTypeaheadOpen] = useState(true);
+  const [iconView, setIconView] = useState("list");
+  const [pillView, setPillView] = useState("week");
+  const [responses, setResponses] = useState<string[]>(["accept"]);
+
   // Overlay open-flags.
   const [appDialogOpen, setAppDialogOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -100,6 +117,28 @@ export default function GalleryPage() {
   const [responsiveOpen, setResponsiveOpen] = useState(false);
 
   const { toast } = useToast();
+
+  // Static mock list for the working Combobox typeahead; filtered by the
+  // typed value (case-insensitive substring). Local-only — no fetch.
+  const TYPEAHEAD_ITEMS = useMemo(
+    () => [
+      { id: "ada", name: "Ada Lovelace", handle: "@ada" },
+      { id: "alan", name: "Alan Turing", handle: "@alan" },
+      { id: "grace", name: "Grace Hopper", handle: "@grace" },
+      { id: "katherine", name: "Katherine Johnson", handle: "@katherine" },
+      { id: "linus", name: "Linus Torvalds", handle: "@linus" },
+    ],
+    [],
+  );
+  const typeaheadResults = useMemo(() => {
+    const q = typeahead.trim().toLowerCase();
+    if (!q) return TYPEAHEAD_ITEMS;
+    return TYPEAHEAD_ITEMS.filter(
+      (it) =>
+        it.name.toLowerCase().includes(q) ||
+        it.handle.toLowerCase().includes(q),
+    );
+  }, [typeahead, TYPEAHEAD_ITEMS]);
 
   return (
     <div className="min-h-screen w-full bg-[var(--bg-canvas)] px-6 py-12">
@@ -564,6 +603,250 @@ export default function GalleryPage() {
                   </Tab>
                 </TabList>
               </Tabs>
+            </div>
+          </Row>
+        </Section>
+
+        {/* ================================================================ */}
+        {/* NEW PRIMITIVES                                                   */}
+        {/* ================================================================ */}
+        <Section title="New primitives">
+          {/* ----- Combobox: working typeahead -------------------------- */}
+          <Row label="Combobox — working typeahead (NEW: open with results)">
+            <div className="w-full max-w-[360px]" data-testid="combobox-demo">
+              <Combobox
+                value={typeahead}
+                onValueChange={(next) => {
+                  setTypeahead(next);
+                  setTypeaheadOpen(true);
+                }}
+                items={typeaheadResults}
+                getItemKey={(item) => item.id}
+                open={typeaheadOpen}
+                onOpenChange={setTypeaheadOpen}
+                onSelect={(item) => {
+                  setTypeahead(item.name);
+                  setTypeaheadOpen(false);
+                }}
+                role="search"
+                inputProps={{
+                  "aria-label": "Search people",
+                  placeholder: "Search people",
+                  leadingIcon: <Search className="h-4 w-4" />,
+                }}
+                trailingButton={
+                  typeahead ? (
+                    <button
+                      type="button"
+                      aria-label="Clear search"
+                      data-testid="combobox-clear"
+                      onClick={() => {
+                        setTypeahead("");
+                        setTypeaheadOpen(true);
+                      }}
+                      className="inline-flex h-6 w-6 items-center justify-center rounded text-[var(--fg-muted)] transition-colors duration-150 hover:bg-[var(--overlay-weak)] hover:text-[var(--fg-primary)] focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 motion-reduce:transition-none"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  ) : null
+                }
+                listboxClassName="mt-1 max-h-64 overflow-auto rounded border border-[var(--border-default)] bg-[var(--bg-elevated)] p-1 shadow-md"
+                renderEmpty={() => (
+                  <li
+                    role="presentation"
+                    className="px-3 py-2 text-body-sm text-[var(--fg-muted)]"
+                  >
+                    No matches.
+                  </li>
+                )}
+                renderOption={({
+                  item,
+                  highlighted,
+                  optionId,
+                  onHover,
+                  onSelect,
+                }) => (
+                  <li
+                    role="option"
+                    id={optionId}
+                    data-combobox-option
+                    aria-selected={highlighted}
+                    data-testid={`combobox-option-${item.id}`}
+                    onMouseEnter={onHover}
+                    onMouseDown={onSelect}
+                    className={`flex cursor-pointer items-center justify-between rounded px-3 py-2 text-body-sm ${
+                      highlighted
+                        ? "bg-[var(--overlay-weak)] text-[var(--fg-primary)]"
+                        : "text-[var(--fg-secondary)]"
+                    }`}
+                  >
+                    <span className="text-[var(--fg-primary)]">{item.name}</span>
+                    <span className="text-[var(--fg-muted)]">{item.handle}</span>
+                  </li>
+                )}
+              />
+            </div>
+          </Row>
+
+          {/* ----- SegmentedControl: single-select --------------------- */}
+          <Row label="SegmentedControl — icon-only joined square (md)">
+            <SegmentedControl
+              aria-label="View mode"
+              value={iconView}
+              onValueChange={setIconView}
+              size="md"
+              joined
+              shape="square"
+              iconOnly
+              options={[
+                {
+                  value: "list",
+                  icon: <List size={16} />,
+                  ariaLabel: "List view",
+                },
+                {
+                  value: "gallery",
+                  icon: <LayoutGrid size={16} />,
+                  ariaLabel: "Gallery view",
+                },
+              ]}
+            />
+            <span
+              className="text-body-sm text-[var(--fg-muted)]"
+              data-testid="segmented-icon-value"
+            >
+              {iconView}
+            </span>
+          </Row>
+
+          <Row label="SegmentedControl — text pills (joined=false, shape=pill)">
+            <SegmentedControl
+              aria-label="Date range"
+              value={pillView}
+              onValueChange={setPillView}
+              joined={false}
+              shape="pill"
+              options={[
+                { value: "day", label: "Day" },
+                { value: "week", label: "Week" },
+                { value: "month", label: "Month" },
+              ]}
+            />
+          </Row>
+
+          {/* ----- ToggleGroup: multi-select with tone variants -------- */}
+          <Row label="ToggleGroup — multi-select tones (neutral / success / warn)">
+            <div
+              className="flex flex-wrap items-center gap-4"
+              data-testid="toggle-group-demo"
+            >
+              {/* Color-coded accept (green) / reject (amber) pair — both
+                  togglable, multi-select (either, both, or neither). */}
+              <ToggleGroup
+                aria-label="Response"
+                value={responses}
+                onValueChange={setResponses}
+                shape="pill"
+                joined={false}
+                options={[
+                  {
+                    value: "accept",
+                    label: "Accept",
+                    tone: "success",
+                    icon: <Check size={14} />,
+                  },
+                  {
+                    value: "reject",
+                    label: "Reject",
+                    tone: "warn",
+                    icon: <X size={14} />,
+                  },
+                ]}
+              />
+              {/* A joined neutral-tone multi-select for contrast. */}
+              <ToggleGroup
+                aria-label="Text formatting"
+                value={responses.filter((v) => v === "bold" || v === "italic")}
+                onValueChange={(next) =>
+                  setResponses((prev) => [
+                    ...prev.filter((v) => v !== "bold" && v !== "italic"),
+                    ...next,
+                  ])
+                }
+                tone="neutral"
+                joined
+                shape="square"
+                options={[
+                  { value: "bold", label: "Bold" },
+                  { value: "italic", label: "Italic" },
+                ]}
+              />
+            </div>
+          </Row>
+
+          {/* ----- Popover portal -------------------------------------- */}
+          <Row label="Popover — portal + side/align (NEW)">
+            <Popover>
+              <PopoverTrigger>
+                <Button
+                  variant="secondary"
+                  data-testid="open-popover-portal"
+                >
+                  Open portal menu
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent portal side="bottom" align="start" minWidth={220}>
+                <PopoverItem data-testid="popover-portal-item-rename">
+                  Rename
+                </PopoverItem>
+                <PopoverItem>Move to…</PopoverItem>
+                <PopoverItem>Export</PopoverItem>
+                <PopoverItem disabled>Delete (disabled)</PopoverItem>
+              </PopoverContent>
+            </Popover>
+          </Row>
+
+          {/* ----- Input variants -------------------------------------- */}
+          <Row label="Input — bare (inherits heading font)">
+            <div className="w-full font-headline text-h2 text-[var(--fg-primary)]">
+              <Input
+                size="bare"
+                aria-label="Bare heading input"
+                data-testid="input-bare"
+                defaultValue="Untitled certificate"
+              />
+            </div>
+          </Row>
+
+          <Row label="Input — density=compact">
+            <div className="w-full max-w-[280px]">
+              <Input
+                density="compact"
+                aria-label="Compact meta input"
+                data-testid="input-compact"
+                placeholder="Compact meta field"
+              />
+            </div>
+          </Row>
+
+          <Row label="Input — flush (in a flex row)">
+            <div className="flex w-full max-w-[360px] items-center gap-2 rounded border border-[var(--border-default)] bg-[var(--bg-elevated)] px-3 py-2">
+              <Search className="h-4 w-4 shrink-0 text-[var(--fg-muted)]" />
+              <Input
+                flush
+                aria-label="Flush row input"
+                data-testid="input-flush"
+                placeholder="Flush field — no wrapper"
+                className="bg-transparent"
+              />
+              <button
+                type="button"
+                aria-label="Clear flush field"
+                data-testid="input-flush-clear"
+                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-[var(--fg-muted)] hover:bg-[var(--overlay-weak)] hover:text-[var(--fg-primary)] focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2"
+              >
+                <X className="h-4 w-4" />
+              </button>
             </div>
           </Row>
         </Section>

--- a/src/app/dev/preview/[surface]/page.tsx
+++ b/src/app/dev/preview/[surface]/page.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+/**
+ * Dev-only auth-mock PREVIEW HARNESS.
+ *
+ * Renders an auth-gated composed surface (profile / feed / settings /
+ * workspace) against fixture data so Playwright can screenshot it
+ * logged-out. The surface components are the REAL production ones — the
+ * only thing swapped is the network layer (`MockFetchProvider` patches
+ * `window.fetch`) and a NESTED copy of the real provider stack so the
+ * fixture session is the one the subtree reads.
+ *
+ * Why a nested stack: the global providers in `app/layout.tsx` mount at
+ * app boot, before this page (and its `MockFetchProvider`) exist, so
+ * their `/api/auth/session` call already resolved to "signed out". We
+ * re-instantiate the SAME real providers here, nested under
+ * `MockFetchProvider`; React context resolves to the nearest provider,
+ * so the composed surface reads the fixture-backed auth/org state. The
+ * providers are imported, never faked — the surfaces stay byte-identical
+ * to production.
+ *
+ * Gated to non-production via `notFound()`.
+ *
+ * Routes:
+ *   /dev/preview/profile        — own individual profile
+ *   /dev/preview/profile-org    — own organization profile
+ *   /dev/preview/feed           — signed-in home feed
+ *   /dev/preview/settings       — settings panel
+ *   /dev/preview/workspace      — workspace explorer
+ *
+ * `?fixture=empty` switches every list/connection to its empty variant.
+ */
+
+import { Suspense, useMemo } from "react"
+import { notFound, useParams, useSearchParams } from "next/navigation"
+
+// Real providers — same imports app/layout.tsx uses.
+import { Providers } from "@/lib/providers"
+import { AuthProvider } from "@/lib/auth/auth-context"
+import { OrgProvider } from "@/lib/groups/org-context"
+import { OnboardingProvider } from "@/lib/onboarding/onboarding-context"
+import { NotificationsProvider } from "@/lib/notifications-context"
+import { NavbarProvider } from "@/lib/navbar-context"
+import { FeedbackProvider } from "@/lib/feedback-context"
+import { ToastProvider } from "@/components/ui/toast"
+
+import MockFetchProvider, {
+  type MockScenario,
+} from "@/components/dev/mock-fetch-provider"
+import type { ProfileScenario } from "@/lib/dev/fixtures/profile"
+
+// Real composed surfaces.
+import UserProfilePage from "@/app/profile/[handle]/page"
+import Home from "@/components/home/home"
+import SettingsPanel from "@/components/settings/settings-panel"
+import Workspace from "@/components/workspace/workspace"
+
+const SURFACES = [
+  "profile",
+  "profile-org",
+  "feed",
+  "settings",
+  "workspace",
+] as const
+type Surface = (typeof SURFACES)[number]
+
+function isSurface(v: string | undefined): v is Surface {
+  return !!v && (SURFACES as readonly string[]).includes(v)
+}
+
+/** The real composed surface for a given preview slug. */
+function SurfaceBody({ surface }: { surface: Surface }) {
+  switch (surface) {
+    case "profile":
+    case "profile-org":
+      // UserProfilePage reads the handle from useParams(); in this route
+      // the param is `surface`, but the page only uses it to seed the
+      // resolve-did call, which the mock ignores (it always returns the
+      // viewer's own profile). isOwnProfile resolves true because the
+      // resolved DID equals the fixture session DID.
+      return <UserProfilePage />
+    case "feed":
+      return <Home />
+    case "settings":
+      return <SettingsPanel />
+    case "workspace":
+      return (
+        <div className="workspace-page">
+          <Suspense fallback={null}>
+            <Workspace />
+          </Suspense>
+        </div>
+      )
+  }
+}
+
+export default function PreviewPage() {
+  if (process.env.NODE_ENV === "production") notFound()
+
+  const params = useParams()
+  const searchParams = useSearchParams()
+  const rawSurface =
+    typeof params.surface === "string" ? params.surface : undefined
+
+  const fixture = searchParams?.get("fixture")
+  const scenario: MockScenario = fixture === "empty" ? "empty" : "populated"
+
+  const profileScenario: ProfileScenario = useMemo(
+    () => (rawSurface === "profile-org" ? "org" : "individual"),
+    [rawSurface],
+  )
+
+  if (!isSurface(rawSurface)) notFound()
+
+  return (
+    <MockFetchProvider profileScenario={profileScenario} scenario={scenario}>
+      {/* SAME provider order as app/layout.tsx, re-instantiated under the
+          fetch mock so the fixture session is the one this subtree reads. */}
+      <Providers>
+        <ToastProvider>
+          <AuthProvider>
+            <OrgProvider>
+              <OnboardingProvider>
+                <NotificationsProvider>
+                  <NavbarProvider>
+                    <FeedbackProvider>
+                      <main
+                        id="preview-main"
+                        data-preview-surface={rawSurface}
+                        className="flex-1"
+                      >
+                        <SurfaceBody surface={rawSurface} />
+                      </main>
+                    </FeedbackProvider>
+                  </NavbarProvider>
+                </NotificationsProvider>
+              </OnboardingProvider>
+            </OrgProvider>
+          </AuthProvider>
+        </ToastProvider>
+      </Providers>
+    </MockFetchProvider>
+  )
+}

--- a/src/app/dev/preview/[surface]/page.tsx
+++ b/src/app/dev/preview/[surface]/page.tsx
@@ -33,6 +33,19 @@
 
 import { Suspense, useMemo } from "react"
 import { notFound, useParams, useSearchParams } from "next/navigation"
+// Next resolves `useParams()` from this client context. The /dev/preview
+// route's own param is `{ surface }`, so inside the profile surface
+// `useParams().handle` is undefined — which makes `useUserProfile(null)`
+// short-circuit (no resolve-did call) and the page render "Profile not
+// found". We re-provide the param context with the fixture handle around
+// the profile surface ONLY, so the real page resolves the own-profile
+// identity through the unchanged mocked /api/resolve-did path. This is the
+// single handle/identity entry point — the surface internals stay
+// byte-identical to production.
+import {
+  PathParamsContext,
+  NavigationPromisesContext,
+} from "next/dist/shared/lib/hooks-client-context.shared-runtime"
 
 // Real providers — same imports app/layout.tsx uses.
 import { Providers } from "@/lib/providers"
@@ -48,6 +61,7 @@ import MockFetchProvider, {
   type MockScenario,
 } from "@/components/dev/mock-fetch-provider"
 import type { ProfileScenario } from "@/lib/dev/fixtures/profile"
+import { MOCK_HANDLE } from "@/lib/dev/fixtures/session"
 
 // Real composed surfaces.
 import UserProfilePage from "@/app/profile/[handle]/page"
@@ -73,12 +87,31 @@ function SurfaceBody({ surface }: { surface: Surface }) {
   switch (surface) {
     case "profile":
     case "profile-org":
-      // UserProfilePage reads the handle from useParams(); in this route
-      // the param is `surface`, but the page only uses it to seed the
-      // resolve-did call, which the mock ignores (it always returns the
-      // viewer's own profile). isOwnProfile resolves true because the
-      // resolved DID equals the fixture session DID.
-      return <UserProfilePage />
+      // UserProfilePage reads the viewed handle from `useParams().handle`.
+      // This route's real param is `{ surface }`, so without an override the
+      // handle is undefined → `useUserProfile(null)` short-circuits (no
+      // resolve-did fetch) → `!did` → "Profile not found". We re-provide the
+      // param context with the fixture handle so the page resolves the
+      // own-profile identity through the mocked /api/resolve-did. The mock
+      // resolves both profile + profile-org to the SESSION DID, so
+      // `isOwnProfile` (and `canEditInline`) hold and the owner-only
+      // affordances render; `profileScenario` controls the org marker.
+      // In dev, Next's `useParams`/`useSearchParams`/`usePathname` first
+      // read `NavigationPromisesContext`; when it's non-null they return
+      // ITS promise-backed values, ignoring the plain `PathParamsContext`.
+      // So we null that context out (the hooks then fall through to the
+      // plain contexts) AND supply `PathParamsContext` with the fixture
+      // handle. `useSearchParams`/`usePathname` fall back to the plain
+      // SearchParams/Pathname contexts the app-router still mounts above,
+      // so the real ?tab= + pathname keep working — only `handle` is
+      // synthesized.
+      return (
+        <NavigationPromisesContext.Provider value={null}>
+          <PathParamsContext.Provider value={{ handle: MOCK_HANDLE }}>
+            <UserProfilePage />
+          </PathParamsContext.Provider>
+        </NavigationPromisesContext.Provider>
+      )
     case "feed":
       return <Home />
     case "settings":

--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -394,49 +394,6 @@
   color: var(--fg-primary);
 }
 
-/* ---------- View toggle (certs + projects) ---------- */
-
-.explore__view-toggle {
-  display: inline-flex;
-  align-items: stretch;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius);
-  overflow: hidden;
-  background: var(--bg-elevated);
-}
-
-.explore__view-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border: 0;
-  background: transparent;
-  color: var(--fg-secondary);
-  cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast);
-}
-
-.explore__view-btn:hover {
-  background: var(--bg-sunken);
-  color: var(--fg-primary);
-}
-
-.explore__view-btn--active {
-  background: var(--fg-primary);
-  color: var(--bg-canvas);
-}
-
-.explore__view-btn--active:hover {
-  background: var(--fg-primary);
-  color: var(--bg-canvas);
-}
-
-.explore__view-btn + .explore__view-btn {
-  border-left: 1px solid var(--border-subtle);
-}
-
 /* ---------- List view (certs + projects) ---------- */
 
 .explore__list {
@@ -897,29 +854,6 @@
 .explore__degree-pills {
   display: inline-flex;
   gap: 4px;
-}
-
-.explore__degree-pill {
-  border: 1px solid var(--border-default);
-  background: var(--bg-sunken);
-  color: var(--fg-secondary);
-  padding: 4px 12px;
-  border-radius: 999px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
-}
-
-.explore__degree-pill:hover {
-  background: var(--bg-raised);
-  color: var(--fg-primary);
-}
-
-.explore__degree-pill--active {
-  background: var(--fg-primary);
-  color: var(--bg-canvas);
-  border-color: var(--fg-primary);
 }
 
 .explore__degree-truncated {

--- a/src/app/styles/feed.css
+++ b/src/app/styles/feed.css
@@ -1859,7 +1859,6 @@
    and in the right rail; ensure that and the create-form inputs hit
    the threshold. */
 @media (max-width: 799px) {
-  .people-search__input,
   .create-form__input,
   .create-form__textarea {
     font-size: 16px;

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -1250,17 +1250,6 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   .left-rail__switcher svg { display: block; }
 }
 
-/* Portaled to <body>; positioned via inline style (fixed + computed
-   bottom/left). This rule only carries appearance, not layout. */
-.account-switcher__menu--rail {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow-md);
-  padding: 8px;
-  z-index: var(--z-popover);
-}
-
 /* Primary "New activity" button. Full-width pill at >=1300; 44px
    square at 800-1299. NEVER a circular FAB (2px radius matches
    the rest of the brand's primary buttons per DESIGN.md). */
@@ -1645,45 +1634,6 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   width: 100%;
 }
 
-.people-search__field {
-  position: relative;
-  display: flex;
-  align-items: center;
-  height: 44px;
-  padding: 0 12px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius);
-  transition: border-color var(--transition-fast);
-}
-
-.people-search__field:focus-within {
-  border-color: var(--border-hover);
-}
-
-.people-search__icon {
-  flex: 0 0 auto;
-  color: var(--fg-muted);
-  margin-right: 8px;
-}
-
-.people-search__input {
-  flex: 1 1 auto;
-  min-width: 0;
-  height: 100%;
-  border: none;
-  background: transparent;
-  outline: none;
-  font: inherit;
-  font-size: 0.875rem;
-  color: var(--fg-primary);
-  padding: 0;
-}
-
-.people-search__input::placeholder {
-  color: var(--fg-muted);
-}
-
 .people-search__clear {
   flex: 0 0 auto;
   display: inline-flex;
@@ -1996,32 +1946,6 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   border-bottom: 1px solid var(--border-medium);
 }
 
-/* Align the first tab's TEXT with the hamburger icon above (not
-   just the button left-edges). The hamburger button sits at the
-   row's 12px padding-left and is 36px wide with an 18px icon
-   centered inside, so the icon's left edge lands at x=21 (= 12 +
-   9). With a 12px padding-left the tab text starts at x=24 — a
-   touch right of the icon's left edge, which reads cleaner than
-   pixel-matching the icon. Skipped when the row carries a back
-   button (cert / project detail pages) — the back button already
-   owns the left gutter there. */
-.desktop-top-bar__row--tabs:not(:has(.desktop-top-bar__back))
-  .desktop-top-bar__tab:first-of-type {
-  padding-left: 12px;
-}
-
-/* The active-tab underline reserves 18px of gutter at each end of
-   the button via `left: 18px; right: 18px` (see the .--active::after
-   rule below). When we shrink the first tab's left padding to 12px
-   the default 18px underline-left leaves the underline 6px short on
-   the left — so it doesn't extend under the start of "Certs".
-   Match the underline-left to the new padding so the bar tracks the
-   text width. */
-.desktop-top-bar__row--tabs:not(:has(.desktop-top-bar__back))
-  .desktop-top-bar__tab:first-of-type.desktop-top-bar__tab--active::after {
-  left: 12px;
-}
-
 .desktop-top-bar__left {
   display: flex;
   align-items: center;
@@ -2119,21 +2043,6 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   .desktop-top-bar__search {
     width: 300px;
   }
-}
-
-/* Shrink the PeopleSearch field when it lives in the top bar — the
-   44px default is too tall for a navbar control and made row 1
-   feel cramped. Drop to 32px (still keyboard-accessible, matches
-   the chrome buttons on /explore). Focus border matches the
-   explore-page search input (--fg-primary) so the affordance reads
-   the same across the two search surfaces. */
-.desktop-top-bar__search .people-search__field {
-  height: 32px;
-  border-radius: var(--radius);
-}
-
-.desktop-top-bar__search .people-search__field:focus-within {
-  border-color: var(--fg-primary);
 }
 
 .desktop-top-bar__icon-btn {
@@ -2260,16 +2169,6 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   display: block;
 }
 
-/* Profile tabs strip (row 2). Underline-active style mirrors the
-   in-page tabs used on mobile (.profile-tabs__tab) — keep them visually
-   identical so switching between viewports doesn't surprise users. */
-.desktop-top-bar__tabs {
-  display: flex;
-  align-items: stretch;
-  gap: 0;
-  height: 100%;
-}
-
 /* Back affordance rendered in the row-2 slot on cert / project detail
    pages. Left-aligned, sits at the same height as the tab strip. */
 .desktop-top-bar__back {
@@ -2297,57 +2196,6 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   outline-offset: 2px;
 }
 
-.desktop-top-bar__tab {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  padding: 0 18px;
-  font-family: var(--font-inter), system-ui, sans-serif;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--fg-muted);
-  text-decoration: none;
-  white-space: nowrap;
-  transition: color var(--transition-fast);
-}
-
-.desktop-top-bar__tab:hover {
-  color: var(--fg-primary);
-}
-
-.desktop-top-bar__tab--active {
-  color: var(--fg-primary);
-  font-weight: 600;
-}
-
-.desktop-top-bar__tab--active::after {
-  content: "";
-  position: absolute;
-  left: 18px;
-  right: 18px;
-  bottom: 0;
-  height: 2px;
-  background: var(--fg-primary);
-  border-radius: var(--radius);
-}
-
-.desktop-top-bar__tab:focus-visible {
-  outline: 2px solid var(--focus-ring);
-  outline-offset: -2px;
-  border-radius: 2px;
-}
-
-/* Top-bar variant of the account switcher menu — sits below the trigger
-   instead of above it. Position is supplied inline. */
-.account-switcher__menu--top-bar {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow-md);
-  padding: 8px;
-  z-index: var(--z-popover);
-}
-
 /* "+" create-menu trigger wrapper — kept as a wrapper so the
    open/close effects can anchor against a stable DOM node even
    when the button itself re-renders. */
@@ -2355,9 +2203,9 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   display: inline-flex;
 }
 
-/* Dropdown panel rendered via createPortal — same surface
-   treatment as `.account-switcher__menu--top-bar` so the three
-   shortcuts visually read as the same "menu" family. */
+/* Dropdown panel rendered via createPortal — elevated surface
+   treatment (border + --shadow-md) so the three shortcuts visually
+   read as the same "menu" family as the other portaled menus. */
 .desktop-top-bar__create-menu {
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);

--- a/src/app/styles/pages.css
+++ b/src/app/styles/pages.css
@@ -538,30 +538,6 @@
   background: var(--bg-canvas);
 }
 
-.account-switcher__menu {
-  display: none;
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  min-width: 260px;
-  max-height: 70vh;
-  overflow-y: auto;
-  /* Reserve scrollbar space so a long org list doesn't crowd item
-     content into the avatar when the scrollbar appears. */
-  scrollbar-gutter: stable;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow-md);
-  z-index: 60;
-}
-
-@media (min-width: 800px) {
-  .account-switcher__menu {
-    display: block;
-  }
-}
-
 .account-switcher__section-label {
   font-size: 0.6875rem;
   font-weight: 600;

--- a/src/app/styles/profile-edit.css
+++ b/src/app/styles/profile-edit.css
@@ -192,44 +192,6 @@
   font-variant-numeric: tabular-nums;
 }
 
-.pe__input {
-  width: 100%;
-  /* Belt-and-braces against any inherited box-sizing surprises — without
-     this, an extra-wide URL placeholder can push the row sideways and
-     cause horizontal scroll inside the 600px column. */
-  box-sizing: border-box;
-  min-width: 0;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius);
-  padding: 8px 12px;
-  font-family: var(--font-inter), system-ui, sans-serif;
-  font-size: 0.875rem;
-  font-weight: 450;
-  color: var(--fg-primary);
-  transition:
-    border-color var(--transition-fast),
-    background var(--transition-fast);
-}
-
-.pe__input::placeholder {
-  color: var(--fg-muted);
-  font-weight: 400;
-}
-
-.pe__input:hover {
-  border-color: var(--border-hover, var(--fg-muted));
-}
-
-.pe__input:focus {
-  outline: none;
-  border-color: var(--fg-primary);
-}
-
-.pe__input--invalid {
-  border-color: var(--color-error);
-}
-
 .pe__field-error {
   font-size: 0.75rem;
   color: var(--color-error);

--- a/src/components/badges/response-buttons.tsx
+++ b/src/components/badges/response-buttons.tsx
@@ -5,6 +5,7 @@ import {
   createResponse,
   type ResponseState,
 } from "@/lib/atproto/badges"
+import { ToggleGroup } from "@/components/ui/segmented-control"
 
 interface ResponseButtonsProps {
   /** The award being responded to — passed through to createResponse
@@ -38,11 +39,11 @@ interface ResponseButtonsProps {
  * Loud inline Show / Hide buttons rendered next to an incoming
  * endorsement on the /notifications surface.
  *
- * Why two buttons, not a toggle: per WAI-ARIA toggle-group pattern,
- * users with screen readers benefit from both options being visible
- * even when one is the current state. `aria-pressed` carries the
- * binary state; the parent `role="group"` element gives per-row
- * context.
+ * Why two buttons, not a single toggle: per WAI-ARIA toggle-group
+ * pattern, users with screen readers benefit from both options being
+ * visible even when one is the current state. Each option carries its
+ * own `aria-pressed` (rendered by <ToggleGroup>); the group's
+ * `role="group"` element gives per-row context.
  *
  * Why no separate "default" affordance: in default state both
  * buttons are unpressed; clicking Show writes an `accepted` record,
@@ -96,42 +97,72 @@ export default function ResponseButtons({
   const isRejected = state === "rejected"
   const isUnknown = state === "unknown"
 
+  // The set of currently-pressed values for the ToggleGroup. At most one
+  // of accept/reject is pressed at a time (accepted XOR rejected); an
+  // unknown/default state presses neither.
+  const pressedValues = isAccepted
+    ? ["accepted"]
+    : isRejected
+      ? ["rejected"]
+      : []
+
+  // Translate a toggle into a write. Clicking either button always
+  // writes its response (matching the original "no reset here" intent),
+  // so we diff the emitted set against the current one to learn which
+  // option the user actuated, then write that response.
+  const onValueChange = useCallback(
+    (next: string[]) => {
+      const prev = new Set(pressedValues)
+      const added = next.find((v) => !prev.has(v))
+      // `added` is set when the user pressed a currently-unpressed button.
+      // When they click the already-pressed button it's removed from the
+      // set instead; the original buttons re-wrote the same response on
+      // that click, so resolve to whichever option is no longer in `next`.
+      const toggled =
+        added ?? ["accepted", "rejected"].find((v) => prev.has(v) && !next.includes(v))
+      if (toggled === "accepted") void write("accepted")
+      else if (toggled === "rejected") void write("rejected")
+    },
+    [pressedValues, write],
+  )
+
+  const writing = isWriting !== null
+  const disabled = !ownerDid || writing
+
   return (
     <div
       role="group"
       aria-label={`Response to endorsement from ${issuerDisplayName}`}
-      aria-busy={isWriting !== null}
-      className="response-buttons"
+      aria-busy={writing}
+      className="inline-flex items-center gap-1.5 flex-shrink-0"
     >
       {isUnknown ? (
         <span className="sr-only">
           The current response state is not recognised by this app.
         </span>
       ) : null}
-      <button
-        type="button"
-        aria-pressed={isAccepted}
-        disabled={!ownerDid || isWriting !== null}
-        onClick={() => write("accepted")}
-        className={`response-buttons__btn response-buttons__btn--show ${
-          isAccepted ? "response-buttons__btn--pressed" : ""
-        }`}
-      >
-        {isWriting === "show" ? "Saving…" : labels.accept}
-      </button>
-      <button
-        type="button"
-        aria-pressed={isRejected}
-        disabled={!ownerDid || isWriting !== null}
-        onClick={() => write("rejected")}
-        className={`response-buttons__btn response-buttons__btn--hide ${
-          isRejected ? "response-buttons__btn--pressed" : ""
-        }`}
-      >
-        {isWriting === "hide" ? "Saving…" : labels.reject}
-      </button>
+      <ToggleGroup
+        aria-label={`Response to endorsement from ${issuerDisplayName}`}
+        value={pressedValues}
+        onValueChange={onValueChange}
+        joined={false}
+        tone="neutral"
+        size="sm"
+        options={[
+          {
+            value: "accepted",
+            label: isWriting === "show" ? "Saving…" : labels.accept,
+            disabled,
+          },
+          {
+            value: "rejected",
+            label: isWriting === "hide" ? "Saving…" : labels.reject,
+            disabled,
+          },
+        ]}
+      />
       {error ? (
-        <span className="response-buttons__error" role="alert">
+        <span className="text-[0.6875rem] text-[var(--color-error)] ml-1.5" role="alert">
           {error}
         </span>
       ) : null}

--- a/src/components/badges/response-menu.tsx
+++ b/src/components/badges/response-menu.tsx
@@ -8,6 +8,7 @@ import {
   type BadgeResponseRecord,
   type ResponseState,
 } from "@/lib/atproto/badges"
+import { ToggleGroup } from "@/components/ui/segmented-control"
 
 interface ResponseMenuProps {
   readonly awardUri: string
@@ -28,36 +29,18 @@ interface ResponseMenuProps {
 }
 
 /**
- * Quiet kebab-menu control rendered on profile / endorsements
- * audit-surface rows (the row's owner is viewing their own wall).
+ * Quiet color-coded quick-actions control rendered on profile /
+ * endorsements audit-surface rows (the row's owner is viewing their
+ * own wall).
  *
- * Owner-only state indicator at the top of the menu, then the
- * actions:
+ * Two joined icon buttons — Accept (Check, green/success) and Reject
+ * (X, amber/warning). Both buttons are always shown; the active one
+ * carries `aria-pressed` and the tone-tinted active state so the
+ * rendered decision is unambiguous. No menu, no kebab.
  *
- *   - default  → "Showing on your profile (default)" +
- *                "Hide from profile"
- *   - accepted → "Showing on your profile"           +
- *                "Hide from profile" + "Reset to default"
- *   - rejected → "Hidden from your profile"          +
- *                "Show on profile" + "Reset to default"
- *   - unknown  → "Unrecognised response state"       +
- *                "Hide from profile" + "Reset to default"
- *
- * The kebab is only rendered on the profile owner's view (see the
- * ProfileEndorsements + /endorsements page gating) — non-owner
- * viewers never see the indicator, matching the plan §"Accept-state
- * visibility" owner-only contract.
- *
- * Keyboard contract (WAI-ARIA menu pattern):
- *   - Trigger: Enter/Space opens; first menuitem auto-focuses.
- *   - In menu: ArrowUp/ArrowDown moves between items; Home/End jump
- *     to first/last. Esc closes + returns focus to trigger.
- *     Outside-click closes.
- *
- * After Hide on a row, the row removes from its list. Focus moves
- * to the next sibling's kebab via `findNextFocusTarget`. Plan
- * AC#7. AC#8 shows a 6-second `aria-live="polite"` undo toast
- * anchored to the menu column.
+ * Single-click toggle:
+ *   - clicking the currently-active state → reset to default
+ *   - clicking the other state → write that response
  */
 export default function ResponseMenu({
   awardUri,
@@ -114,67 +97,79 @@ export default function ResponseMenu({
    *    - clicking the currently-active state → reset to default
    *    - clicking the other state → write that response
    * Both buttons are always shown; the active one carries the
-   * `--active` class so the rendered state is unambiguous. No
-   * menu, no kebab, no reset-to-default menuitem (clicking the
-   * active button serves that role). */
-  const onAcceptClick = useCallback(() => {
-    if (state === "accepted") resetToDefault()
-    else writeResponse("accepted")
+   * tone-tinted active state so the rendered state is unambiguous.
+   * Clicking the active button serves the "reset to default" role. */
+  const onAccept = useCallback(() => {
+    if (state === "accepted") void resetToDefault()
+    else void writeResponse("accepted")
   }, [state, resetToDefault, writeResponse])
 
-  const onRejectClick = useCallback(() => {
-    if (state === "rejected") resetToDefault()
-    else writeResponse("rejected")
+  const onReject = useCallback(() => {
+    if (state === "rejected") void resetToDefault()
+    else void writeResponse("rejected")
   }, [state, resetToDefault, writeResponse])
+
+  // The pressed set: exactly the currently-active state (accept XOR
+  // reject), empty for default/unknown. A toggle of "accepted" routes
+  // to onAccept and "rejected" to onReject regardless of direction —
+  // both pressing and un-pressing a value emit it in the diff below.
+  const pressedValues =
+    state === "accepted"
+      ? ["accepted"]
+      : state === "rejected"
+        ? ["rejected"]
+        : []
+
+  const onValueChange = useCallback(
+    (next: string[]) => {
+      const prev = new Set(pressedValues)
+      // Whichever value changed membership (added when un-pressed → pressed,
+      // removed when the active button is clicked to reset) is the one the
+      // user actuated.
+      const toggled =
+        next.find((v) => !prev.has(v)) ??
+        ["accepted", "rejected"].find((v) => prev.has(v) && !next.includes(v))
+      if (toggled === "accepted") onAccept()
+      else if (toggled === "rejected") onReject()
+    },
+    [pressedValues, onAccept, onReject],
+  )
+
+  const disabled = !ownerDid || isWriting
 
   return (
-    <div className="response-menu" aria-busy={isWriting}>
-      <div
-        className="response-menu__quick-actions"
-        role="group"
+    <div className="relative flex-shrink-0" aria-busy={isWriting}>
+      <ToggleGroup
         aria-label={`Respond to endorsement from ${issuerDisplayName}`}
-      >
-        <button
-          type="button"
-          className={`response-menu__quick-btn response-menu__quick-btn--accept ${
-            state === "accepted"
-              ? "response-menu__quick-btn--active"
-              : ""
-          }`}
-          aria-label={
-            state === "accepted"
-              ? `Reset accepted endorsement from ${issuerDisplayName} to default`
-              : `Accept endorsement from ${issuerDisplayName}`
-          }
-          aria-pressed={state === "accepted"}
-          title={state === "accepted" ? "Accepted — click to reset" : "Accept"}
-          onClick={onAcceptClick}
-          disabled={!ownerDid || isWriting}
-        >
-          <Check size={14} strokeWidth={2.25} aria-hidden="true" />
-        </button>
-        <button
-          type="button"
-          className={`response-menu__quick-btn response-menu__quick-btn--reject ${
-            state === "rejected"
-              ? "response-menu__quick-btn--active"
-              : ""
-          }`}
-          aria-label={
-            state === "rejected"
-              ? `Reset rejected endorsement from ${issuerDisplayName} to default`
-              : `Reject endorsement from ${issuerDisplayName}`
-          }
-          aria-pressed={state === "rejected"}
-          title={state === "rejected" ? "Rejected — click to reset" : "Reject"}
-          onClick={onRejectClick}
-          disabled={!ownerDid || isWriting}
-        >
-          <X size={14} strokeWidth={2.25} aria-hidden="true" />
-        </button>
-      </div>
+        value={pressedValues}
+        onValueChange={onValueChange}
+        size="sm"
+        iconOnly
+        options={[
+          {
+            value: "accepted",
+            tone: "success",
+            icon: <Check size={14} strokeWidth={2.25} aria-hidden="true" />,
+            ariaLabel:
+              state === "accepted"
+                ? `Reset accepted endorsement from ${issuerDisplayName} to default`
+                : `Accept endorsement from ${issuerDisplayName}`,
+            disabled,
+          },
+          {
+            value: "rejected",
+            tone: "warn",
+            icon: <X size={14} strokeWidth={2.25} aria-hidden="true" />,
+            ariaLabel:
+              state === "rejected"
+                ? `Reset rejected endorsement from ${issuerDisplayName} to default`
+                : `Reject endorsement from ${issuerDisplayName}`,
+            disabled,
+          },
+        ]}
+      />
       {error ? (
-        <p className="response-menu__error" role="alert">
+        <p className="text-[0.6875rem] text-[var(--color-error)] mt-1" role="alert">
           {error}
         </p>
       ) : null}

--- a/src/components/create/contributor-identity-field.tsx
+++ b/src/components/create/contributor-identity-field.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import Combobox from "@/components/ui/combobox"
 import { isAtprotoIdentity } from "@/hooks/use-contributor-info"
 
 /**
@@ -11,7 +12,11 @@ import { isAtprotoIdentity } from "@/hooks/use-contributor-info"
  *     `/api/search-actors`, the same endpoint that powers the
  *     HandleSearch component in groups + endorsements. Renders as
  *     a `cert-detail__meta-input` so it sits flush in a row
- *     alongside Role + Weight inputs.
+ *     alongside Role + Weight inputs. The input + dropdown +
+ *     keyboard + ARIA machinery is the shared `Combobox` primitive
+ *     (via its bare-input `renderInput` escape hatch); this surface
+ *     keeps its own fetch / exclude filtering / commit-on-Enter /
+ *     blur-commit behaviour.
  *   - `normalizeIdentity` — strips the leading `@` and trims.
  *   - `isContributorIdentityAcceptable` — empty OR a recognisable
  *     atproto handle / DID.
@@ -87,8 +92,6 @@ export function ContributorIdentityField({
   const [results, setResults] = useState<Actor[]>([])
   const [isOpen, setIsOpen] = useState(false)
   const [isSearching, setIsSearching] = useState(false)
-  const [focusedIndex, setFocusedIndex] = useState(-1)
-  const containerRef = useRef<HTMLDivElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastSelectedRef = useRef<string>("")
 
@@ -133,42 +136,30 @@ export function ContributorIdentityField({
     }
   }, [value])
 
-  useEffect(() => {
-    if (!isOpen) return
-    const handleClick = (e: MouseEvent) => {
-      const target = e.target
-      if (!(target instanceof Node)) return
-      if (containerRef.current && !containerRef.current.contains(target)) {
+  const handleSelect = useCallback(
+    (actor: Actor) => {
+      const h = actor.handle?.toLowerCase() ?? ""
+      const d = actor.did?.toLowerCase() ?? ""
+      if (
+        (h && excludeIdentities.has(h)) ||
+        (d && excludeIdentities.has(d))
+      ) {
         setIsOpen(false)
+        setResults([])
+        return
       }
-    }
-    document.addEventListener("mousedown", handleClick)
-    return () => document.removeEventListener("mousedown", handleClick)
-  }, [isOpen])
-
-  const handleSelect = (actor: Actor) => {
-    const h = actor.handle?.toLowerCase() ?? ""
-    const d = actor.did?.toLowerCase() ?? ""
-    if (
-      (h && excludeIdentities.has(h)) ||
-      (d && excludeIdentities.has(d))
-    ) {
+      const picked =
+        actor.handle && actor.handle !== actor.did
+          ? `@${actor.handle}`
+          : actor.did
+      lastSelectedRef.current = picked
+      onChange(picked)
       setIsOpen(false)
       setResults([])
-      setFocusedIndex(-1)
-      return
-    }
-    const picked =
-      actor.handle && actor.handle !== actor.did
-        ? `@${actor.handle}`
-        : actor.did
-    lastSelectedRef.current = picked
-    onChange(picked)
-    setIsOpen(false)
-    setResults([])
-    setFocusedIndex(-1)
-    onCommit?.(picked)
-  }
+      onCommit?.(picked)
+    },
+    [excludeIdentities, onChange, onCommit],
+  )
 
   const visibleResults = results.filter((a) => {
     const h = a.handle?.toLowerCase() ?? ""
@@ -178,38 +169,30 @@ export function ContributorIdentityField({
     return true
   })
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "ArrowDown") {
-      e.preventDefault()
-      if (!isOpen || visibleResults.length === 0) return
-      setFocusedIndex((prev) => (prev + 1) % visibleResults.length)
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault()
-      if (!isOpen || visibleResults.length === 0) return
-      setFocusedIndex((prev) =>
-        prev <= 0 ? visibleResults.length - 1 : prev - 1,
-      )
-    } else if (e.key === "Escape") {
-      setIsOpen(false)
-      setFocusedIndex(-1)
-    } else if (e.key === "Enter") {
-      if (focusedIndex >= 0 && focusedIndex < visibleResults.length) {
-        e.preventDefault()
-        handleSelect(visibleResults[focusedIndex])
-      } else if (visibleResults.length === 1) {
-        e.preventDefault()
-        handleSelect(visibleResults[0])
-      } else if (isContributorIdentityAcceptable(value) && value.trim().length > 0) {
-        // No dropdown match — but the typed value is a recognisable
-        // DID or handle. Treat Enter as "I'm done typing"; the
-        // parent swaps the input out for the contributor card.
-        e.preventDefault()
-        onCommit?.(value.trim())
+  const handleValueChange = useCallback(
+    (next: string) => {
+      if (next !== lastSelectedRef.current) {
+        lastSelectedRef.current = ""
       }
-    }
-  }
+      onChange(next)
+    },
+    [onChange],
+  )
 
-  const handleBlur = () => {
+  // Bare Enter with no dropdown match — but the typed value is a
+  // recognisable DID or handle. Treat Enter as "I'm done typing"; the
+  // parent swaps the input out for the contributor card.
+  const handleSubmitNoMatch = useCallback(
+    (raw: string) => {
+      const v = raw.trim()
+      if (isContributorIdentityAcceptable(raw) && v.length > 0) {
+        onCommit?.(v)
+      }
+    },
+    [onCommit],
+  )
+
+  const handleBlur = useCallback(() => {
     // Blur acts as an implicit commit when the typed value is a
     // recognisable identity — same effect as picking from the
     // typeahead, just without the dropdown round-trip. Empty / not-
@@ -220,85 +203,70 @@ export function ContributorIdentityField({
     if (!v) return
     if (!isContributorIdentityAcceptable(v)) return
     onCommit?.(v)
-  }
+  }, [value, onCommit])
 
   return (
-    <div className="create-cert__contrib-id" ref={containerRef}>
-      <input
-        type="text"
-        className={
-          invalid
-            ? "cert-detail__meta-input create-cert__contrib-id-input--invalid"
-            : "cert-detail__meta-input"
-        }
-        aria-label={ariaLabel}
-        aria-invalid={invalid}
-        placeholder="@handle or did:plc:…"
-        value={value}
-        maxLength={1000}
-        autoComplete="off"
-        onBlur={handleBlur}
-        role="combobox"
-        aria-expanded={isOpen}
-        aria-controls={`create-cert-contrib-listbox-${idx}`}
-        aria-autocomplete="list"
-        aria-activedescendant={
-          focusedIndex >= 0
-            ? `create-cert-contrib-opt-${idx}-${focusedIndex}`
-            : undefined
-        }
-        onChange={(e) => {
-          if (e.target.value !== lastSelectedRef.current) {
-            lastSelectedRef.current = ""
+    <Combobox<Actor>
+      className="create-cert__contrib-id"
+      value={value}
+      onValueChange={handleValueChange}
+      items={visibleResults}
+      getItemKey={(actor) => actor.did}
+      isLoading={isSearching}
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      onSelect={handleSelect}
+      onSubmitNoMatch={handleSubmitNoMatch}
+      enableHomeEnd={false}
+      escapeStage="close-only"
+      liveStatus={null}
+      listboxClassName="create-cert__contrib-id-dropdown"
+      renderInput={({ ref, onKeyDown, ...rest }) => (
+        <>
+          <input
+            ref={ref}
+            type="text"
+            id={`create-cert-contrib-input-${idx}`}
+            className={
+              invalid
+                ? "cert-detail__meta-input create-cert__contrib-id-input--invalid"
+                : "cert-detail__meta-input"
+            }
+            aria-label={ariaLabel}
+            aria-invalid={invalid}
+            placeholder="@handle or did:plc:…"
+            maxLength={1000}
+            onKeyDown={onKeyDown}
+            onBlur={handleBlur}
+            {...rest}
+          />
+          {isSearching ? (
+            <span className="create-cert__contrib-id-spinner" aria-hidden />
+          ) : null}
+        </>
+      )}
+      renderOption={({ item: actor, highlighted, optionId, onHover, onSelect }) => (
+        <li
+          id={optionId}
+          role="option"
+          aria-selected={highlighted}
+          data-combobox-option
+          className={
+            highlighted
+              ? "create-cert__contrib-id-option create-cert__contrib-id-option--active"
+              : "create-cert__contrib-id-option"
           }
-          onChange(e.target.value)
-        }}
-        onKeyDown={handleKeyDown}
-        onFocus={() => {
-          if (visibleResults.length > 0) setIsOpen(true)
-        }}
-      />
-      {isSearching ? (
-        <span className="create-cert__contrib-id-spinner" aria-hidden />
-      ) : null}
-      {isOpen && visibleResults.length > 0 ? (
-        <ul
-          id={`create-cert-contrib-listbox-${idx}`}
-          role="listbox"
-          className="create-cert__contrib-id-dropdown"
+          onMouseEnter={onHover}
+          onMouseDown={onSelect}
         >
-          {visibleResults.map((actor, i) => {
-            const isActive = i === focusedIndex
-            return (
-              <li
-                key={actor.did}
-                id={`create-cert-contrib-opt-${idx}-${i}`}
-                role="option"
-                aria-selected={isActive}
-                className={
-                  isActive
-                    ? "create-cert__contrib-id-option create-cert__contrib-id-option--active"
-                    : "create-cert__contrib-id-option"
-                }
-                onMouseEnter={() => setFocusedIndex(i)}
-                onMouseDown={(e) => {
-                  e.preventDefault()
-                  handleSelect(actor)
-                }}
-              >
-                <span className="create-cert__contrib-id-name">
-                  {actor.displayName || actor.handle}
-                </span>
-                <span className="create-cert__contrib-id-handle">
-                  {actor.handle !== actor.did
-                    ? `@${actor.handle}`
-                    : actor.did}
-                </span>
-              </li>
-            )
-          })}
-        </ul>
-      ) : null}
-    </div>
+          <span className="create-cert__contrib-id-name">
+            {actor.displayName || actor.handle}
+          </span>
+          <span className="create-cert__contrib-id-handle">
+            {actor.handle !== actor.did ? `@${actor.handle}` : actor.did}
+          </span>
+        </li>
+      )}
+    />
   )
 }

--- a/src/components/dev/mock-fetch-provider.tsx
+++ b/src/components/dev/mock-fetch-provider.tsx
@@ -358,7 +358,40 @@ function installMockFetch(
         return json(groupsMembershipsResponse())
       }
       if (path === "/api/notifications") {
-        return json({ data: { notifications: [] } })
+        // The notifications client (`lib/atproto/notifications.ts`) POSTs
+        // a GraphQL-shaped `{ operationName, variables }` and dispatches
+        // the response by op. `unreadNotificationCount` in particular
+        // throws "Unread count unavailable" if the field is missing, so
+        // every op the provider polls needs a valid envelope here.
+        let op: string | undefined
+        try {
+          const text =
+            typeof init?.body === "string"
+              ? init.body
+              : init?.body
+                ? String(init.body)
+                : "{}"
+          op = (JSON.parse(text) as { operationName?: string }).operationName
+        } catch {
+          /* fall through → default empty notifications page */
+        }
+        if (op === "unreadNotificationCount") {
+          return json({
+            data: { unreadNotificationCount: { count: 0, more: false } },
+          })
+        }
+        if (op === "updateNotificationsSeen") {
+          return json({ data: { updateNotificationsSeen: { seenAt: null } } })
+        }
+        // `notifications` (list) and anything else → empty, valid page.
+        return json({
+          data: {
+            notifications: {
+              edges: [],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        })
       }
     }
 

--- a/src/components/dev/mock-fetch-provider.tsx
+++ b/src/components/dev/mock-fetch-provider.tsx
@@ -1,0 +1,401 @@
+"use client"
+
+/**
+ * Dev-only auth-mock fetch provider.
+ *
+ * Patches `window.fetch` BEFORE its children mount so the real provider
+ * stack (`AuthProvider` → `OrgProvider` → …) and the real composed
+ * surfaces resolve against fixture data instead of the live backend.
+ * This lets Playwright screenshot the auth-gated surfaces (profile,
+ * feed, settings, workspace) logged-out, byte-identically to production.
+ *
+ * Routing:
+ *   - `/api/auth/session`              → fixture session `{ did }`
+ *   - `/api/indexer` (POST)            → dispatched by `operationName`
+ *   - `/api/resolve-did`  (GET)        → single resolved profile
+ *   - `/api/resolve-dids` (POST)       → batched resolved profiles
+ *   - `/api/xrpc/...`                  → getSession / getRecord / listRecords
+ *                                        (incl. the org-marker getRecord variant)
+ *   - `/api/search-actors`             → filtered actor directory
+ *   - `/api/groups/memberships`        → empty (personal identity stays active)
+ *   - `https://plc.directory/<did>`    → fixture DID document (resolvePdsUrl)
+ *   - everything else                  → passthrough to the real fetch
+ *
+ * NOT shipped to production: the only mount site is the dev preview page,
+ * which `notFound()`s in production. The patch is installed once (guarded
+ * by a module flag against React StrictMode double-invocation) and
+ * removed on unmount.
+ */
+
+import { useState, useEffect } from "react"
+import {
+  sessionResponse,
+  getSessionResponse,
+  plcDidDocument,
+  MOCK_DID,
+} from "@/lib/dev/fixtures/session"
+import {
+  resolvedProfile,
+  certsProfileRecord,
+  orgMarkerRecord,
+  MOCK_ORG_DID,
+  type ProfileScenario,
+} from "@/lib/dev/fixtures/profile"
+import { resolveDidsResults } from "@/lib/dev/fixtures/authors"
+import {
+  followerEventsConnection,
+  hydrateFeedPageData,
+  activitiesConnection,
+} from "@/lib/dev/fixtures/feed"
+import {
+  networkActorsConnection,
+  actorWorkspaceCounts,
+  followersConnection,
+  receivedEndorsementsConnection,
+  userProjectsConnection,
+  evaluatorEndorsementsConnection,
+  followRecords,
+  groupsMembershipsResponse,
+} from "@/lib/dev/fixtures/groups"
+import { searchActorsResponse } from "@/lib/dev/fixtures/search"
+
+export type MockScenario = "populated" | "empty"
+
+interface MockFetchProviderProps {
+  children: React.ReactNode
+  /** Which profile identity to resolve own-profile to. */
+  profileScenario?: ProfileScenario
+  /** Fixture density. `empty` makes every list/connection empty so
+   *  empty-state surfaces can be screenshotted too. */
+  scenario?: MockScenario
+}
+
+const JSON_HEADERS = { "Content-Type": "application/json" } as const
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS })
+}
+
+/** Marker on the patched function so we never double-wrap (StrictMode). */
+const PATCHED = Symbol.for("certified.dev.mockFetch")
+
+type IndexerBody = { operationName?: string; variables?: Record<string, unknown> }
+
+/** Dispatch an `/api/indexer` POST by GraphQL `operationName`. Returns a
+ *  GraphQL-shaped `{ data }` envelope matching the upstream the proxy
+ *  forwards verbatim. Unknown ops return `{ data: {} }` (the client
+ *  fetchers treat a missing root field as an empty result). */
+function indexerResponse(
+  body: IndexerBody,
+  opts: { empty: boolean },
+): Response {
+  const op = body.operationName
+  const vars = body.variables ?? {}
+  const did = typeof vars.did === "string" ? vars.did : MOCK_DID
+
+  const emptyConn = {
+    totalCount: 0,
+    edges: [],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }
+
+  switch (op) {
+    case "FollowerEvents":
+      return json({
+        data: {
+          followerEvents: opts.empty
+            ? { edges: [], pageInfo: { hasNextPage: false, endCursor: null } }
+            : followerEventsConnection(),
+        },
+      })
+    case "HydrateFeedPage":
+      return json({
+        data: opts.empty
+          ? {
+              activities: { edges: [] },
+              collections: { edges: [] },
+              badgeAwards: { edges: [] },
+              evaluations: { edges: [] },
+              measurements: { edges: [] },
+              hyperboards: { edges: [] },
+              attachments: { edges: [] },
+            }
+          : hydrateFeedPageData(),
+      })
+    case "EvaluatorEndorsements":
+      return json({
+        data: { appCertifiedBadgeAward: evaluatorEndorsementsConnection() },
+      })
+    case "NetworkActors":
+    case "NetworkActorsByKind":
+    case "NetworkActorsByDids":
+      return json({
+        data: {
+          appCertifiedActorProfile: opts.empty
+            ? emptyConn
+            : networkActorsConnection(),
+        },
+      })
+    case "ActorWorkspaceCounts":
+      return json({
+        data: opts.empty
+          ? {
+              certs: { totalCount: 0 },
+              projects: { totalCount: 0 },
+              lists: { totalCount: 0 },
+              endorsementsReceived: { totalCount: 0 },
+              followers: { totalCount: 0 },
+            }
+          : actorWorkspaceCounts(did),
+      })
+    case "Followers":
+      return json({
+        data: {
+          appCertifiedGraphFollow: opts.empty
+            ? emptyConn
+            : followersConnection(did),
+        },
+      })
+    case "ReceivedEndorsements":
+      return json({
+        data: {
+          appCertifiedBadgeAward: opts.empty
+            ? { edges: [], pageInfo: { hasNextPage: false, endCursor: null } }
+            : receivedEndorsementsConnection(did),
+        },
+      })
+    case "UserProjects":
+    case "Projects":
+      return json({
+        data: {
+          orgHypercertsCollection: opts.empty
+            ? emptyConn
+            : userProjectsConnection(did),
+        },
+      })
+    case "Activities":
+    case "AuthoredActivities":
+    case "ContributedActivities":
+      return json({
+        data: {
+          orgHypercertsClaimActivity: opts.empty
+            ? emptyConn
+            : activitiesConnection(),
+        },
+      })
+    case "ProfileCount":
+    case "OrganizationCount":
+    case "ActivityCount":
+    case "ProjectCount":
+    case "AwardCount": {
+      // Welcome-strip counts — single aggregate connections.
+      const root =
+        op === "ProfileCount"
+          ? "appCertifiedActorProfile"
+          : op === "OrganizationCount"
+            ? "appCertifiedActorOrganization"
+            : op === "ActivityCount"
+              ? "orgHypercertsClaimActivity"
+              : op === "ProjectCount"
+                ? "orgHypercertsCollection"
+                : "appCertifiedBadgeAward"
+      return json({
+        data: {
+          [root]: {
+            totalCount: opts.empty ? 0 : 128,
+            edges: [],
+            pageInfo: { hasNextPage: false },
+          },
+        },
+      })
+    }
+    default:
+      // Unknown / unused op — return an empty GraphQL envelope. The
+      // client fetchers all guard on a missing root field and degrade
+      // to an empty result rather than throwing.
+      return json({ data: {} })
+  }
+}
+
+/** Handle an `/api/xrpc/...` request. Path segments after `/api/xrpc/`
+ *  join into the method name; query params carry repo/collection/rkey. */
+function xrpcResponse(
+  url: URL,
+  scenario: ProfileScenario,
+  empty: boolean,
+): Response {
+  const method = url.pathname.replace(/^\/api\/xrpc\//, "").replace(/\//g, ".")
+  const params = url.searchParams
+  const collection = params.get("collection") ?? ""
+
+  if (method === "com.atproto.server.getSession") {
+    return json(getSessionResponse())
+  }
+
+  if (method === "com.atproto.repo.getRecord") {
+    if (collection === "app.certified.actor.profile") {
+      return json(certsProfileRecord(scenario))
+    }
+    if (collection === "app.certified.actor.organization") {
+      // ORG-MARKER variant: present for the org scenario, a
+      // RecordNotFound-shaped 400 otherwise (matches the real proxy,
+      // which surfaces the agent error as 400 `{ error: "RecordNotFound" }`).
+      if (scenario === "org") return json(orgMarkerRecord())
+      return json({ error: "RecordNotFound" }, 400)
+    }
+    // Any other single record (bsky profile, etc.) — treat as missing.
+    return json({ error: "RecordNotFound" }, 400)
+  }
+
+  if (method === "com.atproto.repo.listRecords") {
+    if (collection === "app.certified.graph.follow") {
+      return json(empty ? { records: [] } : followRecords())
+    }
+    // Memberships, activities-by-PDS, and anything else → empty list.
+    return json({ records: [] })
+  }
+
+  // getBlob and any other XRPC read — empty 404; avatars fall back to
+  // initials in the preview.
+  return json({ error: "NotFound" }, 404)
+}
+
+function installMockFetch(
+  profileScenario: ProfileScenario,
+  scenario: MockScenario,
+): () => void {
+  if (typeof window === "undefined") return () => {}
+  const realFetch = window.fetch
+  // Already patched (StrictMode re-mount or nested provider) — no-op.
+  if ((realFetch as unknown as Record<symbol, unknown>)[PATCHED]) {
+    return () => {}
+  }
+
+  const empty = scenario === "empty"
+
+  const mockFetch: typeof window.fetch = async (input, init) => {
+    let url: URL
+    try {
+      const raw =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url
+      url = new URL(raw, window.location.origin)
+    } catch {
+      return realFetch(input as RequestInfo, init)
+    }
+
+    const path = url.pathname
+
+    // --- PLC directory (resolvePdsUrl / resolveHandle fetch it directly) ---
+    if (url.hostname === "plc.directory") {
+      return json(plcDidDocument())
+    }
+
+    // --- public Bluesky AppView (the home "Our news" rail fetches it
+    //     directly, bypassing our /api/* routes). Return an empty feed so
+    //     the preview stays fully offline and deterministic. ---
+    if (url.hostname === "public.api.bsky.app") {
+      if (path.includes("getAuthorFeed")) return json({ feed: [] })
+      if (path.includes("getProfile")) {
+        return json({ did: MOCK_DID, handle: "preview", displayName: "Preview" })
+      }
+      if (path.includes("searchActors")) return json({ actors: [] })
+      if (path.includes("resolveHandle")) return json({ did: MOCK_DID })
+      return json({})
+    }
+
+    // --- same-origin API routes ---
+    if (url.origin === window.location.origin) {
+      if (path === "/api/auth/session") {
+        return json(sessionResponse())
+      }
+      if (path === "/api/auth/logout" || path === "/api/auth/login") {
+        return json({ ok: true })
+      }
+      if (path === "/api/indexer") {
+        let parsed: IndexerBody = {}
+        try {
+          const text =
+            typeof init?.body === "string"
+              ? init.body
+              : init?.body
+                ? String(init.body)
+                : "{}"
+          parsed = JSON.parse(text) as IndexerBody
+        } catch {
+          /* fall through with empty body → default op */
+        }
+        return indexerResponse(parsed, { empty })
+      }
+      if (path === "/api/resolve-did") {
+        // Single resolve — the viewer's own profile (or org variant).
+        return json(resolvedProfile(profileScenario))
+      }
+      if (path === "/api/resolve-dids") {
+        let identities: string[] = []
+        try {
+          const text =
+            typeof init?.body === "string" ? init.body : String(init?.body)
+          const b = JSON.parse(text) as { identities?: unknown }
+          identities = Array.isArray(b.identities)
+            ? b.identities.filter((v): v is string => typeof v === "string")
+            : []
+        } catch {
+          /* empty */
+        }
+        return json({ results: resolveDidsResults(identities) })
+      }
+      if (path.startsWith("/api/xrpc/")) {
+        return xrpcResponse(url, profileScenario, empty)
+      }
+      if (path === "/api/search-actors") {
+        return json(searchActorsResponse(url.searchParams.get("q") ?? ""))
+      }
+      if (path === "/api/groups/memberships") {
+        return json(groupsMembershipsResponse())
+      }
+      if (path === "/api/notifications") {
+        return json({ data: { notifications: [] } })
+      }
+    }
+
+    // Everything else (fonts, _next assets, analytics, etc.) → real fetch.
+    return realFetch(input as RequestInfo, init)
+  }
+
+  ;(mockFetch as unknown as Record<symbol, unknown>)[PATCHED] = true
+  window.fetch = mockFetch
+
+  return () => {
+    // Only restore if we're still the installed patch.
+    if (window.fetch === mockFetch) window.fetch = realFetch
+  }
+}
+
+export default function MockFetchProvider({
+  children,
+  profileScenario = "individual",
+  scenario = "populated",
+}: MockFetchProviderProps) {
+  // Install synchronously during the FIRST render (via the useState lazy
+  // initializer) so the patch is in place before any child provider's
+  // effect fires its first fetch. The initializer returns the teardown
+  // fn, which is held in state and called on unmount. Storing it in
+  // state (not a ref) keeps render side-effect-free per react-hooks/refs.
+  const [teardown] = useState<() => void>(() =>
+    installMockFetch(profileScenario, scenario),
+  )
+
+  useEffect(() => {
+    return () => {
+      teardown()
+    }
+  }, [teardown])
+
+  return <>{children}</>
+}
+
+export { MOCK_DID, MOCK_ORG_DID }

--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -32,6 +32,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 import LoadingSpinner from "@/components/ui/loading-spinner"
+import SegmentedControl, { ToggleGroup } from "@/components/ui/segmented-control"
 import EmptyState from "@/components/ui/empty-state"
 import SharedLoadMoreSentinel from "@/components/ui/load-more-sentinel"
 import ActivityCard from "@/components/feed/activity-card"
@@ -505,26 +506,18 @@ export default function Explore() {
         : undefined,
   })
 
-  const onDegreeButtonClick = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
-      const raw = e.currentTarget.dataset.degreeKey
-      const key =
-        raw === "1" ? 1 : raw === "2" ? 2 : raw === "3" ? 3 : null
-      if (!key) return
-      // Toggle: deselect if already active, select otherwise.
-      // Deselecting the last ring is allowed — the result list
-      // renders empty until the user re-adds a ring. serializeDegrees
-      // encodes the empty set as the explicit sentinel so the round-
-      // trip through the URL doesn't collapse it back to the default.
-      const next = new Set<Degree>(degrees)
-      if (next.has(key)) next.delete(key)
-      else next.add(key)
-      // Clear the legacy `degree=` param while we're patching so it
-      // doesn't outlive a multi-select edit and re-take precedence
-      // on the next read.
+  const onDegreesChange = useCallback(
+    (next: Set<Degree>) => {
+      // Each ring toggles independently; deselecting the last ring is
+      // allowed — the result list renders empty until the user re-adds a
+      // ring. serializeDegrees encodes the empty set as the explicit
+      // sentinel so the round-trip through the URL doesn't collapse it
+      // back to the default. Clear the legacy `degree=` param while we're
+      // patching so it doesn't outlive a multi-select edit and re-take
+      // precedence on the next read.
       setUrl({ degrees: serializeDegrees(next), degree: null })
     },
-    [degrees, setUrl],
+    [setUrl],
   )
 
   // Local search debounce: keep typing snappy, hit indexer once typing stops.
@@ -647,30 +640,34 @@ export default function Explore() {
             </div>
 
             <div className="explore__chrome-actions">
-              <div
-                className="explore__view-toggle"
-                role="group"
+              <SegmentedControl
                 aria-label={`${kind === "activities" ? "Activity" : kind === "projects" ? "Project" : "Account"} view`}
-              >
-                <button
-                  type="button"
-                  aria-label="List view"
-                  aria-pressed={view === "list"}
-                  className={`explore__view-btn${view === "list" ? " explore__view-btn--active" : ""}`}
-                  onClick={() => setUrl({ view: null })}
-                >
-                  <ListIcon size={14} strokeWidth={1.75} aria-hidden />
-                </button>
-                <button
-                  type="button"
-                  aria-label="Gallery view"
-                  aria-pressed={view === "gallery"}
-                  className={`explore__view-btn${view === "gallery" ? " explore__view-btn--active" : ""}`}
-                  onClick={() => setUrl({ view: "gallery" })}
-                >
-                  <LayoutGrid size={14} strokeWidth={1.75} aria-hidden />
-                </button>
-              </div>
+                value={view}
+                // List is the default view, so selecting it clears the
+                // `?view=` param (keeps the URL clean); Gallery writes
+                // `?view=gallery`. Same mapping the two buttons had.
+                onValueChange={(next) =>
+                  setUrl({ view: next === "gallery" ? "gallery" : null })
+                }
+                options={[
+                  {
+                    value: "list",
+                    icon: <ListIcon size={14} strokeWidth={1.75} aria-hidden />,
+                    ariaLabel: "List view",
+                  },
+                  {
+                    value: "gallery",
+                    icon: (
+                      <LayoutGrid size={14} strokeWidth={1.75} aria-hidden />
+                    ),
+                    ariaLabel: "Gallery view",
+                  },
+                ]}
+                size="md"
+                joined
+                shape="square"
+                iconOnly
+              />
               <UiPopover open={sortOpen} onOpenChange={setSortOpen}>
                 <PopoverTrigger>
                   <button type="button" className="explore__chrome-btn">
@@ -811,7 +808,7 @@ export default function Explore() {
           {showsDegreeControl ? (
             <EndorsementDegreeBar
               degrees={degrees}
-              onSelect={onDegreeButtonClick}
+              onChange={onDegreesChange}
               onReset={onResetDegrees}
               meta={data.endorsementClosure}
             />
@@ -848,14 +845,6 @@ const DEGREE_LABEL: Record<Degree, string> = {
   3: "3rd",
 }
 
-/** Hover tooltip per degree pill. Explains the ring in plain language
- *  so the abbreviated "1st / 2nd / 3rd" labels don't have to. */
-const DEGREE_TITLE: Record<Degree, string> = {
-  1: "1st-degree — accounts you endorse directly.",
-  2: "2nd-degree — accounts endorsed by the people you endorse.",
-  3: "3rd-degree — accounts endorsed by your 2nd-degree connections.",
-}
-
 /**
  * Multi-select pill row above the result list when the active filter
  * is endorsement-based (Accounts/"endorsed", Projects|Certs/"by-endorsed").
@@ -865,18 +854,21 @@ const DEGREE_TITLE: Record<Degree, string> = {
  * endorsements, or only 3rd-degree connections, or skip the 2nd ring
  * entirely). The caption tracks the current selection.
  *
- * Implementation note: data-degree-key on each button + a captured
- * onSelect avoids the same SWC-minifier closure-capture hazard the
- * filter / sub-option buttons solve via `data-filter-key` / `data-sub-key`.
+ * Rendered with the canonical <ToggleGroup> primitive (gapped pills,
+ * neutral tone): it owns the aria-pressed buttons + role="group" and
+ * emits the full next subset, which we convert back into the
+ * `Set<Degree>` the URL serialiser expects. (This also sidesteps the
+ * old SWC-minifier closure-capture hazard the data-degree-key hand-roll
+ * was working around — the primitive carries no per-button closure.)
  */
 function EndorsementDegreeBar({
   degrees,
-  onSelect,
+  onChange,
   onReset,
   meta,
 }: {
   degrees: Set<Degree>
-  onSelect: (e: React.MouseEvent<HTMLButtonElement>) => void
+  onChange: (next: Set<Degree>) => void
   onReset: () => void
   meta: ReturnType<typeof useExploreData>["endorsementClosure"]
 }) {
@@ -885,29 +877,26 @@ function EndorsementDegreeBar({
   // visit.
   const isDefault = degrees.size === 1 && degrees.has(1)
   return (
-    <div
-      className="explore__degree-bar"
-      role="group"
-      aria-label="Endorsement rings — mark one or more"
-    >
+    <div className="explore__degree-bar">
       <div className="explore__degree-pills">
-        {ALL_DEGREES.map((d) => {
-          const active = degrees.has(d)
-          return (
-            <button
-              key={d}
-              type="button"
-              data-degree-key={String(d)}
-              onClick={onSelect}
-              className={`explore__degree-pill${active ? " explore__degree-pill--active" : ""}`}
-              aria-pressed={active}
-              title={DEGREE_TITLE[d]}
-              aria-label={DEGREE_TITLE[d]}
-            >
-              {DEGREE_LABEL[d]}
-            </button>
-          )
-        })}
+        <ToggleGroup
+          aria-label="Endorsement rings — mark one or more"
+          value={ALL_DEGREES.filter((d) => degrees.has(d)).map(String)}
+          onValueChange={(values) =>
+            onChange(
+              new Set<Degree>(
+                ALL_DEGREES.filter((d) => values.includes(String(d))),
+              ),
+            )
+          }
+          options={ALL_DEGREES.map((d) => ({
+            value: String(d),
+            label: DEGREE_LABEL[d],
+          }))}
+          tone="neutral"
+          shape="pill"
+          joined={false}
+        />
         {!isDefault ? (
           <button
             type="button"

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -32,6 +32,7 @@ import { useRights } from "@/hooks/use-rights"
 import { getInitials } from "@/lib/utils/initials"
 import { formatShortDate } from "@/lib/utils/format-date"
 import Avatar from "@/components/ui/avatar"
+import Input from "@/components/ui/input"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import EditBanner from "@/components/ui/edit-banner"
 import { useCertProjects } from "@/hooks/use-cert-projects"
@@ -700,9 +701,18 @@ export default function ActivityDetail({
     <header className="cert-detail__headline">
       <div className="cert-detail__title-row">
         {editing ? (
-          <input
+          // Bare/flush <Input> for the inline title edit. The detail
+          // page keeps the full 1.875rem serif headline scale (the
+          // create form shrinks it to 1.375rem); carried inline here
+          // since the legacy `.cert-detail__title-input` rule is now
+          // dead. borderWeight="hover" reproduces its 1.5px
+          // --border-hover / --fg-primary focus chrome.
+          <Input
+            flush
+            size="bare"
+            borderWeight="hover"
             type="text"
-            className="cert-detail__title-input"
+            className="flex-[1_1_auto] min-w-0 font-headline !text-[1.875rem] font-bold !leading-[1.15] tracking-[-0.015em] text-[var(--fg-primary)] !px-2.5 py-1"
             value={drafts.title}
             maxLength={256}
             placeholder="Activity title"
@@ -886,20 +896,31 @@ export default function ActivityDetail({
                 /* Two date inputs in place of the rendered label.
                    Empty input drops the field on save (#75). */
                 <span className="cert-detail__meta-edit">
-                  <input
+                  {/* `!w-auto max-w-full min-w-0` reproduces the legacy
+                      `.cert-detail__meta-input` sizing (no fixed width,
+                      max-width:100%, min-width:0) — the primitive's
+                      flush `w-full` would otherwise stretch each date
+                      field inside this inline-flex meta-edit row. */}
+                  <Input
+                    flush
+                    density="compact"
+                    borderWeight="hover"
                     type="date"
                     aria-label="Start date"
-                    className="cert-detail__meta-input"
+                    className="!w-auto max-w-full min-w-0"
                     value={drafts.startDate}
                     onChange={(e) =>
                       setDrafts((d) => ({ ...d, startDate: e.target.value }))
                     }
                   />
                   <span aria-hidden="true">–</span>
-                  <input
+                  <Input
+                    flush
+                    density="compact"
+                    borderWeight="hover"
                     type="date"
                     aria-label="End date"
-                    className="cert-detail__meta-input"
+                    className="!w-auto max-w-full min-w-0"
                     value={drafts.endDate}
                     onChange={(e) =>
                       setDrafts((d) => ({ ...d, endDate: e.target.value }))
@@ -923,11 +944,17 @@ export default function ActivityDetail({
                   /* Plain text input. Serialised as the
                      `WorkScopeString` lexicon variant on save;
                      complex CEL workscope authoring lives
-                     elsewhere (#75 trade-off). */
-                  <input
+                     elsewhere (#75 trade-off).
+                     `!w-auto max-w-full min-w-0` reproduces the legacy
+                     `.cert-detail__meta-input` sizing (intrinsic width,
+                     not the primitive's flush `w-full`). */
+                  <Input
+                    flush
+                    density="compact"
+                    borderWeight="hover"
                     type="text"
                     aria-label="Work scope"
-                    className="cert-detail__meta-input"
+                    className="!w-auto max-w-full min-w-0"
                     placeholder="e.g. mentorship, code review…"
                     value={drafts.workScope}
                     maxLength={256}

--- a/src/components/groups/handle-search.tsx
+++ b/src/components/groups/handle-search.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import React, { useState, useEffect, useRef, useCallback } from "react"
+import { useState, useEffect, useRef, useCallback } from "react"
 import { Loader2, Search, X } from "lucide-react"
 import { authFetch } from "@/lib/auth/fetch"
 import Avatar from "@/components/ui/avatar"
-import Input from "@/components/ui/input"
+import Combobox from "@/components/ui/combobox"
 
 interface Actor {
   did: string
@@ -36,16 +36,9 @@ export default function HandleSearch({
   const [isSearching, setIsSearching] = useState(false)
   // Holds a resolved DID result shown in the dropdown, waiting for user confirmation
   const [resolvedDid, setResolvedDid] = useState<Actor | null>(null)
-  const [focusedIndex, setFocusedIndex] = useState(-1)
   const [searchError, setSearchError] = useState<string | null>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null)
-
-  // Reset focused index when results change
-  useEffect(() => {
-    setFocusedIndex(-1)
-  }, [results, resolvedDid])
 
   const search = useCallback(async (q: string) => {
     const trimmed = q.trim()
@@ -137,147 +130,108 @@ export default function HandleSearch({
     }
   }, [query, search])
 
-  // Close on outside click
-  useEffect(() => {
-    if (!isOpen) return
-    const handleClick = (e: MouseEvent) => {
-      const target = e.target
-      if (!(target instanceof Node)) return
-      if (containerRef.current && !containerRef.current.contains(target)) {
-        setIsOpen(false)
-      }
-    }
-    document.addEventListener("mousedown", handleClick)
-    return () => document.removeEventListener("mousedown", handleClick)
-  }, [isOpen])
-
-  const handleSelectActor = (actor: Actor) => {
-    setQuery("")
-    setIsOpen(false)
-    setResults([])
-    setResolvedDid(null)
-    onSelect(actor.did, actor.handle)
-  }
-
-  const allResults = resolvedDid ? [resolvedDid] : results
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "ArrowDown") {
-      e.preventDefault()
-      if (!isOpen || allResults.length === 0) return
-      setFocusedIndex((prev) => (prev + 1) % allResults.length)
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault()
-      if (!isOpen || allResults.length === 0) return
-      setFocusedIndex((prev) => (prev <= 0 ? allResults.length - 1 : prev - 1))
-    } else if (e.key === "Escape") {
+  const handleSelectActor = useCallback(
+    (actor: Actor) => {
+      setQuery("")
       setIsOpen(false)
-      setFocusedIndex(-1)
-    } else if (e.key === "Enter") {
-      e.preventDefault()
-      if (focusedIndex >= 0 && focusedIndex < allResults.length) {
-        handleSelectActor(allResults[focusedIndex])
-        return
-      }
-      // If there's a resolved DID waiting, select it
-      if (resolvedDid) {
-        handleSelectActor(resolvedDid)
-        return
-      }
-      // If there's exactly one search result, select it
-      if (results.length === 1) {
-        handleSelectActor(results[0])
-        return
-      }
-    }
-  }
+      setResults([])
+      setResolvedDid(null)
+      onSelect(actor.did, actor.handle)
+    },
+    [onSelect],
+  )
+
+  // Items in render order: a single resolved-DID confirmation row when
+  // present, otherwise the handle search results. While the error banner
+  // is showing the original surfaced the error in place of any results,
+  // so we hand the combobox an empty list (the banner renders via
+  // renderListHeader).
+  const allResults = searchError ? [] : resolvedDid ? [resolvedDid] : results
 
   return (
-    <div className="handle-search" ref={containerRef}>
-      <Input
-        ref={inputRef}
-        type="text"
-        size="sm"
-        variant="underline"
-        label={label || undefined}
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        autoComplete="off"
-        spellCheck={false}
-        aria-label={label ? undefined : "Search for user"}
-        role="combobox"
-        aria-expanded={isOpen}
-        aria-controls="handle-search-listbox"
-        aria-autocomplete="list"
-        aria-activedescendant={
-          focusedIndex >= 0 ? `handle-option-${focusedIndex}` : undefined
-        }
-        leadingIcon={<Search size={16} strokeWidth={1.75} aria-hidden />}
-        trailingIcon={
-          isSearching ? (
-            <Loader2
-              size={14}
-              strokeWidth={2}
-              className="animate-spin motion-reduce:animate-none"
-              aria-hidden
-            />
-          ) : undefined
-        }
-        trailingButton={
-          !isSearching && query ? (
-            <button
-              type="button"
-              className="handle-search__clear"
-              aria-label="Clear search"
-              onClick={() => {
-                setQuery("")
-                setResults([])
-                setResolvedDid(null)
-                setIsOpen(false)
-                inputRef.current?.focus()
-              }}
-            >
-              <X size={14} strokeWidth={2} aria-hidden />
-            </button>
-          ) : undefined
-        }
-      />
-      {isOpen && searchError && (
-        <div className="handle-search__dropdown" role="status">
-          <p className="handle-search__error">{searchError}</p>
-        </div>
+    <Combobox<Actor>
+      className="handle-search"
+      value={query}
+      onValueChange={setQuery}
+      items={allResults}
+      getItemKey={(actor) => actor.did}
+      isLoading={isSearching}
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      onSelect={handleSelectActor}
+      inputRef={inputRef}
+      listboxClassName="handle-search__dropdown"
+      enableHomeEnd={false}
+      escapeStage="close-only"
+      liveStatus={null}
+      inputProps={{
+        size: "sm",
+        variant: "underline",
+        label: label || undefined,
+        placeholder,
+        "aria-label": label ? undefined : "Search for user",
+        leadingIcon: <Search size={16} strokeWidth={1.75} aria-hidden />,
+        trailingIcon: isSearching ? (
+          <Loader2
+            size={14}
+            strokeWidth={2}
+            className="animate-spin motion-reduce:animate-none"
+            aria-hidden
+          />
+        ) : undefined,
+      }}
+      trailingButton={
+        !isSearching && query ? (
+          <button
+            type="button"
+            className="handle-search__clear"
+            aria-label="Clear search"
+            onClick={() => {
+              setQuery("")
+              setResults([])
+              setResolvedDid(null)
+              setIsOpen(false)
+              inputRef.current?.focus()
+            }}
+          >
+            <X size={14} strokeWidth={2} aria-hidden />
+          </button>
+        ) : undefined
+      }
+      renderListHeader={
+        searchError
+          ? () => (
+              <li className="handle-search__error" role="status">
+                {searchError}
+              </li>
+            )
+          : undefined
+      }
+      renderOption={({ item: actor, highlighted, optionId, onHover, onSelect }) => (
+        <li
+          id={optionId}
+          role="option"
+          aria-selected={highlighted}
+          data-combobox-option
+          className={`handle-search__item${highlighted ? " handle-search__item--focused" : ""}`}
+          onMouseEnter={onHover}
+          onMouseDown={onSelect}
+        >
+          <Avatar
+            size="sm"
+            src={actor.avatar || undefined}
+            fallbackInitials={(actor.displayName || actor.handle).slice(0, 2).toUpperCase()}
+          />
+          <div className="handle-search__item-info">
+            <span className="handle-search__item-name">
+              {actor.displayName || actor.handle}
+            </span>
+            <span className="handle-search__item-handle">
+              {actor.handle !== actor.did ? `@${actor.handle}` : actor.did}
+            </span>
+          </div>
+        </li>
       )}
-      {isOpen && !searchError && allResults.length > 0 && (
-        <div className="handle-search__dropdown" role="listbox" id="handle-search-listbox">
-          {allResults.map((actor, index) => (
-            <button
-              key={actor.did}
-              className={`handle-search__item${index === focusedIndex ? " handle-search__item--focused" : ""}`}
-              onClick={() => handleSelectActor(actor)}
-              type="button"
-              role="option"
-              id={`handle-option-${index}`}
-              aria-selected={index === focusedIndex}
-            >
-              <Avatar
-                size="sm"
-                src={actor.avatar || undefined}
-                fallbackInitials={(actor.displayName || actor.handle).slice(0, 2).toUpperCase()}
-              />
-              <div className="handle-search__item-info">
-                <span className="handle-search__item-name">
-                  {actor.displayName || actor.handle}
-                </span>
-                <span className="handle-search__item-handle">
-                  {actor.handle !== actor.did ? `@${actor.handle}` : actor.did}
-                </span>
-              </div>
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
+    />
   )
 }

--- a/src/components/layout/desktop-left-rail.tsx
+++ b/src/components/layout/desktop-left-rail.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import React, { useMemo, useRef, useState, useEffect } from "react";
-import { createPortal } from "react-dom";
+import React, { useMemo, useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
@@ -29,11 +28,11 @@ import { routeForActorSwitch } from "@/lib/groups/navigation";
 import { useOrgProfile } from "@/hooks/use-org-profile";
 import { usePendingAwardsCount } from "@/hooks/use-pending-awards-count";
 import { useNotifications } from "@/lib/notifications-context";
-import { useMounted } from "@/hooks/use-mounted";
 import Avatar from "@/components/ui/avatar";
 import { getInitials } from "@/lib/utils/initials";
 import AccountSwitcherList from "./account-switcher-list";
 import Brandmark from "@/components/ui/brandmark";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 
 const ROLE_ORDER: Record<string, number> = { owner: 0, admin: 1, member: 2 };
 
@@ -90,69 +89,14 @@ export default function DesktopLeftRail() {
   const pendingCount = usePendingAwardsCount();
   const pendingBadge = formatPendingBadge(pendingCount);
 
-  // Account-switcher dropdown state. The dropdown is portaled to <body>
-  // because the .left-rail's overflow-y: auto would otherwise clip it —
-  // especially at the 86px icon-only width where the dropdown needs to
-  // extend rightward beyond the rail into the center column.
+  // Account-switcher dropdown state. The menu is portaled to <body> via the
+  // canonical <Popover> (portal + side="top" + align="start") because the
+  // .left-rail's overflow-y: auto would otherwise clip it — especially at the
+  // 86px icon-only width where the dropdown needs to extend rightward beyond
+  // the rail into the center column. The Popover primitive owns positioning,
+  // click-outside, Esc-to-close (with focus-return to the trigger) and
+  // re-measurement on scroll/resize.
   const [switcherOpen, setSwitcherOpen] = useState(false);
-  const switcherRef = useRef<HTMLDivElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const mounted = useMounted();
-
-  // Anchor position for the portaled menu, recomputed when it opens and
-  // on window resize while open.
-  const [anchor, setAnchor] = useState<{ left: number; bottom: number } | null>(null);
-  useEffect(() => {
-    if (!switcherOpen || !switcherRef.current) {
-      setAnchor(null);
-      return;
-    }
-    const computeAnchor = () => {
-      const rect = switcherRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      setAnchor({
-        left: rect.left,
-        bottom: globalThis.innerHeight - rect.top + 8, // 8px gap above the trigger
-      });
-    };
-    computeAnchor();
-    globalThis.addEventListener("resize", computeAnchor);
-    globalThis.addEventListener("scroll", computeAnchor, true);
-    return () => {
-      globalThis.removeEventListener("resize", computeAnchor);
-      globalThis.removeEventListener("scroll", computeAnchor, true);
-    };
-  }, [switcherOpen]);
-
-  useEffect(() => {
-    if (!switcherOpen) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      const target = e.target;
-      if (!(target instanceof Node)) return;
-      const inTrigger = switcherRef.current?.contains(target) ?? false;
-      const inMenu = menuRef.current?.contains(target) ?? false;
-      if (!inTrigger && !inMenu) setSwitcherOpen(false);
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [switcherOpen]);
-
-  // Esc-to-close — WAI-ARIA menu requirement. Returns focus to the
-  // trigger button so the keyboard user lands somewhere predictable.
-  useEffect(() => {
-    if (!switcherOpen) return;
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key !== "Escape") return;
-      e.preventDefault();
-      setSwitcherOpen(false);
-      const trigger = switcherRef.current?.querySelector<HTMLButtonElement>(
-        "button.left-rail__switcher"
-      );
-      trigger?.focus();
-    };
-    document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
-  }, [switcherOpen]);
 
   // Close on navigation
   useEffect(() => {
@@ -288,31 +232,69 @@ export default function DesktopLeftRail() {
       <div className="left-rail__bottom">
         {isAuthenticated ? (
           <>
-            {/* Account-switcher trigger — minimal avatar + handle + chevron.
-                Reads useOrg().activeOrg so identity reflects the acting role. */}
-            <div className="account-switcher" ref={switcherRef}>
-              <button
-                type="button"
-                className="left-rail__switcher"
-                onClick={() => setSwitcherOpen((v) => !v)}
-                aria-haspopup="menu"
-                aria-expanded={switcherOpen}
-                aria-label={`Switch account (currently ${identity.name || "anonymous"})`}
-              >
-                <Avatar
-                  size="sm"
-                  src={identity.avatarUrl}
-                  fallbackInitials={identity.initials}
-                />
-                <span className="left-rail__switcher-meta">
-                  <span className="left-rail__switcher-name">{identity.name || "Anonymous"}</span>
-                  {identity.handle ? (
-                    <span className="left-rail__switcher-handle">@{identity.handle}</span>
-                  ) : null}
-                </span>
-                <ChevronDown size={16} strokeWidth={1.5} aria-hidden />
-              </button>
-              {/* Dropdown is portaled below; nothing rendered inline here. */}
+            {/* Account-switcher — minimal avatar + handle + chevron trigger.
+                Reads useOrg().activeOrg so identity reflects the acting role.
+                The menu portals to <body> via the canonical <Popover> so it
+                escapes the rail's overflow-y: auto clip and opens upward
+                (side="top") aligned to the trigger's left edge (align="start"). */}
+            <div className="account-switcher">
+              <Popover open={switcherOpen} onOpenChange={setSwitcherOpen}>
+                <PopoverTrigger>
+                  <button
+                    type="button"
+                    className="left-rail__switcher"
+                    aria-label={`Switch account (currently ${identity.name || "anonymous"})`}
+                  >
+                    <Avatar
+                      size="sm"
+                      src={identity.avatarUrl}
+                      fallbackInitials={identity.initials}
+                    />
+                    <span className="left-rail__switcher-meta">
+                      <span className="left-rail__switcher-name">{identity.name || "Anonymous"}</span>
+                      {identity.handle ? (
+                        <span className="left-rail__switcher-handle">@{identity.handle}</span>
+                      ) : null}
+                    </span>
+                    <ChevronDown size={16} strokeWidth={1.5} aria-hidden />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent
+                  portal
+                  side="top"
+                  align="start"
+                  offset={8}
+                  // Wider than the rail-bottom box so the vertical scrollbar
+                  // (when the org list is long) doesn't crowd the content
+                  // into a horizontal scroll. max-height + overflow preserve
+                  // the base `.account-switcher__menu` scroll behaviour for a
+                  // long org list (70vh cap, stable scrollbar gutter).
+                  minWidth={260}
+                  style={{ width: 300 }}
+                  className="max-h-[70vh] overflow-y-auto [scrollbar-gutter:stable]"
+                >
+                  <AccountSwitcherList
+                    session={{ handle: handle ?? null }}
+                    profile={profile ? { displayName: profile.displayName ?? undefined } : null}
+                    avatarUrl={avatarUrl ?? undefined}
+                    sortedOrgs={sortedOrgs}
+                    activeOrg={activeOrg}
+                    switchOrg={switchOrg}
+                    onAfterSwitch={(next) => {
+                      setSwitcherOpen(false);
+                      router.push(routeForActorSwitch(pathname, next));
+                    }}
+                    onSignOut={() => {
+                      setSwitcherOpen(false);
+                      signOut();
+                    }}
+                    onSwitchAccount={() => {
+                      setSwitcherOpen(false);
+                      openSignIn();
+                    }}
+                  />
+                </PopoverContent>
+              </Popover>
             </div>
           </>
         ) : (
@@ -334,55 +316,6 @@ export default function DesktopLeftRail() {
         )}
       </div>
 
-      {/* Portaled account-switcher menu — sits outside .left-rail so it
-          escapes the rail's overflow-y: auto clip. Positioned to sit
-          immediately above the trigger row. */}
-      {mounted && switcherOpen && isAuthenticated && anchor
-        ? createPortal(
-            <div
-              ref={menuRef}
-              className="account-switcher__menu account-switcher__menu--rail"
-              role="menu"
-              style={{
-                position: "fixed",
-                // Base `.account-switcher__menu` has top: calc(100%+8px)
-                // and right: 0 inherited from the navbar variant — with
-                // position:fixed those resolve viewport-relative and push
-                // the menu off-screen. Reset them so left+bottom govern.
-                top: "auto",
-                right: "auto",
-                left: anchor.left,
-                bottom: anchor.bottom,
-                // Wider than the rail-bottom box so the vertical scrollbar
-                // (when the org list is long) doesn't crowd the content
-                // into a horizontal scroll.
-                width: 300,
-              }}
-            >
-              <AccountSwitcherList
-                session={{ handle: handle ?? null }}
-                profile={profile ? { displayName: profile.displayName ?? undefined } : null}
-                avatarUrl={avatarUrl ?? undefined}
-                sortedOrgs={sortedOrgs}
-                activeOrg={activeOrg}
-                switchOrg={switchOrg}
-                onAfterSwitch={(next) => {
-                  setSwitcherOpen(false);
-                  router.push(routeForActorSwitch(pathname, next));
-                }}
-                onSignOut={() => {
-                  setSwitcherOpen(false);
-                  signOut();
-                }}
-                onSwitchAccount={() => {
-                  setSwitcherOpen(false);
-                  openSignIn();
-                }}
-              />
-            </div>,
-            document.body
-          )
-        : null}
     </nav>
   );
 }

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -30,6 +30,8 @@ import { getInitials } from "@/lib/utils/initials";
 import AccountSwitcherList from "./account-switcher-list";
 import Brandmark from "@/components/ui/brandmark";
 import GlobalSearch from "@/components/search/global-search";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { Tabs, TabList, Tab } from "@/components/ui/tabs";
 
 const ROLE_ORDER: Record<string, number> = { owner: 0, admin: 1, member: 2 };
 
@@ -222,12 +224,26 @@ export default function DesktopTopBar() {
     return "overview";
   }, [searchParams, visibleProfileTabs]);
 
-  // Switcher dropdown — portaled to <body> so it escapes the bar's
-  // overflow/transform context. Anchor recomputed on resize/scroll.
+  // Active /explore kind — reads ?kind= with the same migration shim
+  // <Explore> uses (users / profiles legacy → accounts; certs → activities).
+  // Drives the explore tab strip's selected state.
+  const exploreKind = useMemo(() => {
+    const raw = searchParams?.get("kind") ?? null;
+    return raw === "accounts" || raw === "projects" || raw === "activities"
+      ? raw
+      : raw === "users" || raw === "profiles"
+        ? "accounts"
+        : raw === "certs"
+          ? "activities"
+          : "activities";
+  }, [searchParams]);
+
+  // Switcher dropdown — now the canonical <Popover> (portal + side="bottom"
+  // + align="end"), which escapes the bar's overflow/transform context and
+  // owns positioning, click-outside, Esc-to-close (focus-return to trigger)
+  // and re-measurement on resize/scroll.
   const [switcherOpen, setSwitcherOpen] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const switcherRef = useRef<HTMLDivElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
   const mounted = useMounted();
 
   // "+" create dropdown — same pattern as the account switcher
@@ -243,54 +259,8 @@ export default function DesktopTopBar() {
     top: number;
   } | null>(null);
 
-  const [anchor, setAnchor] = useState<{ right: number; top: number } | null>(null);
-  useEffect(() => {
-    if (!switcherOpen || !switcherRef.current) {
-      setAnchor(null);
-      return;
-    }
-    const compute = () => {
-      const rect = switcherRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      setAnchor({
-        right: globalThis.innerWidth - rect.right,
-        top: rect.bottom + 8,
-      });
-    };
-    compute();
-    globalThis.addEventListener("resize", compute);
-    globalThis.addEventListener("scroll", compute, true);
-    return () => {
-      globalThis.removeEventListener("resize", compute);
-      globalThis.removeEventListener("scroll", compute, true);
-    };
-  }, [switcherOpen]);
-
-  useEffect(() => {
-    if (!switcherOpen) return;
-    const onMouseDown = (e: MouseEvent) => {
-      const t = e.target;
-      if (!(t instanceof Node)) return;
-      const inTrigger = switcherRef.current?.contains(t) ?? false;
-      const inMenu = menuRef.current?.contains(t) ?? false;
-      if (!inTrigger && !inMenu) setSwitcherOpen(false);
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    return () => document.removeEventListener("mousedown", onMouseDown);
-  }, [switcherOpen]);
-
-  useEffect(() => {
-    if (!switcherOpen) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "Escape") return;
-      e.preventDefault();
-      setSwitcherOpen(false);
-      switcherRef.current?.querySelector<HTMLButtonElement>("button")?.focus();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [switcherOpen]);
-
+  // Close the switcher on navigation. Positioning, click-outside and
+  // Esc-to-close are owned by the <Popover> primitive.
   useEffect(() => {
     setSwitcherOpen(false);
   }, [pathname]);
@@ -464,30 +434,64 @@ export default function DesktopTopBar() {
           ) : null}
 
           {isAuthenticated ? (
-            <div className="desktop-top-bar__switcher-wrap" ref={switcherRef}>
-              <button
-                type="button"
-                className="desktop-top-bar__switcher"
-                onClick={() => setSwitcherOpen((v) => !v)}
-                aria-haspopup="menu"
-                aria-expanded={switcherOpen}
-                aria-label={`Switch account (currently ${identity.name || "anonymous"})`}
-              >
-                <Avatar
-                  size="sm"
-                  src={identity.avatarUrl}
-                  fallbackInitials={identity.initials}
-                />
-                <span className="desktop-top-bar__switcher-meta">
-                  {identity.name ? (
-                    <span className="desktop-top-bar__switcher-name">{identity.name}</span>
-                  ) : null}
-                  {identity.handle ? (
-                    <span className="desktop-top-bar__switcher-handle">@{identity.handle}</span>
-                  ) : null}
-                </span>
-                <ChevronDown size={14} strokeWidth={1.75} aria-hidden />
-              </button>
+            <div className="desktop-top-bar__switcher-wrap">
+              <Popover open={switcherOpen} onOpenChange={setSwitcherOpen}>
+                <PopoverTrigger>
+                  <button
+                    type="button"
+                    className="desktop-top-bar__switcher"
+                    aria-label={`Switch account (currently ${identity.name || "anonymous"})`}
+                  >
+                    <Avatar
+                      size="sm"
+                      src={identity.avatarUrl}
+                      fallbackInitials={identity.initials}
+                    />
+                    <span className="desktop-top-bar__switcher-meta">
+                      {identity.name ? (
+                        <span className="desktop-top-bar__switcher-name">{identity.name}</span>
+                      ) : null}
+                      {identity.handle ? (
+                        <span className="desktop-top-bar__switcher-handle">@{identity.handle}</span>
+                      ) : null}
+                    </span>
+                    <ChevronDown size={14} strokeWidth={1.75} aria-hidden />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent
+                  portal
+                  side="bottom"
+                  align="end"
+                  minWidth={260}
+                  style={{ width: 300 }}
+                  className="max-h-[70vh] overflow-y-auto [scrollbar-gutter:stable]"
+                >
+                  <AccountSwitcherList
+                    session={{ handle: handle ?? null }}
+                    profile={profile ? { displayName: profile.displayName ?? undefined } : null}
+                    avatarUrl={avatarUrl ?? undefined}
+                    sortedOrgs={sortedOrgs}
+                    activeOrg={activeOrg}
+                    switchOrg={switchOrg}
+                    onAfterSwitch={(next) => {
+                      setSwitcherOpen(false);
+                      // Stay on the current page after the swap unless
+                      // it's a personal-only surface the new actor can't
+                      // visit (e.g. /create when switching personal →
+                      // group); the helper returns /home in that case.
+                      router.push(routeForActorSwitch(pathname, next));
+                    }}
+                    onSignOut={() => {
+                      setSwitcherOpen(false);
+                      signOut();
+                    }}
+                    onSwitchAccount={() => {
+                      setSwitcherOpen(false);
+                      openSignIn();
+                    }}
+                  />
+                </PopoverContent>
+              </Popover>
             </div>
           ) : (
             <button
@@ -509,74 +513,48 @@ export default function DesktopTopBar() {
 
       {isOnExplore ? (
         <div className="desktop-top-bar__row desktop-top-bar__row--tabs">
-          <nav
-            className="desktop-top-bar__tabs"
-            role="tablist"
-            aria-label="Explore sections"
-          >
-            {EXPLORE_TABS.map((t) => {
-              // Active kind: read ?kind= with the same migration shim
-              // <Explore> uses (users / profiles legacy → accounts).
-              const raw = searchParams?.get("kind") ?? null;
-              const currentKind =
-                raw === "accounts" || raw === "projects" || raw === "activities"
-                  ? raw
-                  : raw === "users" || raw === "profiles"
-                  ? "accounts"
-                  : raw === "certs"
-                  ? "activities"
-                  : "activities";
-              const isActive = currentKind === t.key;
+          {/* Explore kind strip — canonical <Tabs> (underline). The row
+              wrapper owns the bottom border, so TabList drops its own
+              (border-0). onChange replaces ?kind= in place with
+              scroll:false to match the on-page kind switcher (which resets
+              filter/sub/q/sort/view/attrs). */}
+          <Tabs
+            value={exploreKind}
+            onChange={(next) => {
               const params = new URLSearchParams();
-              // Reset other state (filter/sub/q/sort/view/attrs) when
-              // switching kind — matches the on-page kind switcher.
-              params.set("kind", t.key);
-              const href = `/explore?${params.toString()}`;
-              return (
-                <Link
-                  key={t.key}
-                  href={href}
-                  role="tab"
-                  aria-selected={isActive}
-                  aria-current={isActive ? "page" : undefined}
-                  scroll={false}
-                  replace
-                  className={`desktop-top-bar__tab ${
-                    isActive ? "desktop-top-bar__tab--active" : ""
-                  }`}
-                >
+              params.set("kind", next);
+              router.replace(`/explore?${params.toString()}`, { scroll: false });
+            }}
+          >
+            <TabList aria-label="Explore sections" className="border-0">
+              {EXPLORE_TABS.map((t) => (
+                <Tab key={t.key} value={t.key}>
                   {t.label}
-                </Link>
-              );
-            })}
-          </nav>
+                </Tab>
+              ))}
+            </TabList>
+          </Tabs>
         </div>
       ) : showTabsRow ? (
         <div className="desktop-top-bar__row desktop-top-bar__row--tabs">
-          <nav
-            className="desktop-top-bar__tabs"
-            role="tablist"
-            aria-label="Profile sections"
+          {/* Profile ?tab= strip — canonical <Tabs> (underline). onChange
+              pushes the ?tab= URL (scroll:false) so the page mirrors it,
+              matching the prior <Link scroll={false}> default-push. */}
+          <Tabs
+            value={activeTab}
+            onChange={(next) => {
+              const tab = visibleProfileTabs.find((t) => t.key === next);
+              if (tab) router.push(tabHref(tab), { scroll: false });
+            }}
           >
-            {visibleProfileTabs.map((tab) => {
-              const isActive = activeTab === tab.key;
-              return (
-                <Link
-                  key={tab.key}
-                  href={tabHref(tab)}
-                  role="tab"
-                  aria-selected={isActive}
-                  aria-current={isActive ? "page" : undefined}
-                  scroll={false}
-                  className={`desktop-top-bar__tab ${
-                    isActive ? "desktop-top-bar__tab--active" : ""
-                  }`}
-                >
+            <TabList aria-label="Profile sections" className="border-0">
+              {visibleProfileTabs.map((tab) => (
+                <Tab key={tab.key} value={tab.key}>
                   {tab.label}
-                </Link>
-              );
-            })}
-          </nav>
+                </Tab>
+              ))}
+            </TabList>
+          </Tabs>
         </div>
       ) : showBackRow ? (
         <div className="desktop-top-bar__row desktop-top-bar__row--tabs">
@@ -589,62 +567,57 @@ export default function DesktopTopBar() {
             <ArrowLeft size={16} strokeWidth={1.75} aria-hidden />
             Back
           </button>
-          {pathname && (isOnCertDetail || isOnProjectDetail) ? (
-            <nav
-              className="desktop-top-bar__tabs"
-              role="tablist"
-              aria-label={isOnCertDetail ? "Activity sections" : "Project sections"}
-            >
-              {(isOnCertDetail
-                ? CERT_DETAIL_TABS
-                : PROJECT_DETAIL_TABS
-              ).map((t) => {
-                // Two flavors: query-param tabs (overview/description/…)
-                // and sub-route tabs (explore). Sub-route tabs leave
-                // the same pathname behind so the user can navigate
-                // back to the parent detail page with the Back button.
-                let href: string
-                let isActive: boolean
-                const isOnSubRoute = pathname?.endsWith("/explore")
-                if (t.subRoute) {
-                  // Strip any trailing /<subRoute> to avoid /explore/explore.
-                  const base = pathname?.replace(/\/explore$/, "") ?? ""
-                  href = `${base}/${t.subRoute}`
-                  isActive = !!isOnSubRoute && t.key === "explore"
-                } else {
-                  const params = new URLSearchParams(
-                    searchParams?.toString() ?? "",
-                  )
-                  if (t.key === "overview") params.delete("tab")
-                  else params.set("tab", t.key)
-                  const qs = params.toString()
-                  const base = pathname?.replace(/\/explore$/, "") ?? ""
-                  href = qs ? `${base}?${qs}` : base
-                  const currentTab = searchParams?.get("tab") ?? "overview"
-                  isActive = !isOnSubRoute && currentTab === t.key
-                }
-                return (
-                  <Link
-                    key={t.key}
-                    href={href}
-                    scroll={false}
-                    // Replace (not push) so switching between tabs on
-                    // the same cert / project doesn't pollute browser
-                    // history. The Back button then skips tab states
-                    // and goes back to wherever the user came from.
-                    replace
-                    role="tab"
-                    aria-selected={isActive}
-                    className={`desktop-top-bar__tab ${
-                      isActive ? "desktop-top-bar__tab--active" : ""
-                    }`}
-                  >
-                    {t.label}
-                  </Link>
-                )
-              })}
-            </nav>
-          ) : null}
+          {pathname && (isOnCertDetail || isOnProjectDetail) ? (() => {
+            const detailTabs = isOnCertDetail ? CERT_DETAIL_TABS : PROJECT_DETAIL_TABS
+            const isOnSubRoute = pathname?.endsWith("/explore")
+            // Compute the navigation target for a detail tab. Two flavors:
+            // query-param tabs (overview/description/…) and sub-route tabs
+            // (explore) which leave the same pathname behind so the Back
+            // button returns to the parent detail page.
+            const hrefFor = (t: DetailTab): string => {
+              if (t.subRoute) {
+                // Strip any trailing /<subRoute> to avoid /explore/explore.
+                const base = pathname?.replace(/\/explore$/, "") ?? ""
+                return `${base}/${t.subRoute}`
+              }
+              const params = new URLSearchParams(searchParams?.toString() ?? "")
+              if (t.key === "overview") params.delete("tab")
+              else params.set("tab", t.key)
+              const qs = params.toString()
+              const base = pathname?.replace(/\/explore$/, "") ?? ""
+              return qs ? `${base}?${qs}` : base
+            }
+            // Active tab: sub-route "explore" when on the /explore child,
+            // else the ?tab= value (overview default).
+            const activeDetailTab = isOnSubRoute
+              ? (detailTabs.find((t) => t.subRoute && t.key === "explore")?.key ??
+                 (searchParams?.get("tab") ?? "overview"))
+              : (searchParams?.get("tab") ?? "overview")
+            return (
+              // Detail strip — canonical <Tabs> (underline). onChange
+              // REPLACES (not pushes) so switching tabs on the same cert /
+              // project doesn't pollute history; scroll:false keeps the
+              // scroll position. The row wrapper owns the bottom border.
+              <Tabs
+                value={activeDetailTab}
+                onChange={(next) => {
+                  const t = detailTabs.find((tab) => tab.key === next)
+                  if (t) router.replace(hrefFor(t), { scroll: false })
+                }}
+              >
+                <TabList
+                  aria-label={isOnCertDetail ? "Activity sections" : "Project sections"}
+                  className="border-0"
+                >
+                  {detailTabs.map((t) => (
+                    <Tab key={t.key} value={t.key}>
+                      {t.label}
+                    </Tab>
+                  ))}
+                </TabList>
+              </Tabs>
+            )
+          })() : null}
         </div>
       ) : null}
 
@@ -688,48 +661,6 @@ export default function DesktopTopBar() {
                 <Building2 size={16} strokeWidth={1.75} aria-hidden />
                 <span>New group</span>
               </Link>
-            </div>,
-            document.body
-          )
-        : null}
-
-      {mounted && switcherOpen && isAuthenticated && anchor
-        ? createPortal(
-            <div
-              ref={menuRef}
-              className="account-switcher__menu account-switcher__menu--top-bar"
-              role="menu"
-              style={{
-                position: "fixed",
-                top: anchor.top,
-                right: anchor.right,
-                width: 300,
-              }}
-            >
-              <AccountSwitcherList
-                session={{ handle: handle ?? null }}
-                profile={profile ? { displayName: profile.displayName ?? undefined } : null}
-                avatarUrl={avatarUrl ?? undefined}
-                sortedOrgs={sortedOrgs}
-                activeOrg={activeOrg}
-                switchOrg={switchOrg}
-                onAfterSwitch={(next) => {
-                  setSwitcherOpen(false);
-                  // Stay on the current page after the swap unless
-                  // it's a personal-only surface the new actor can't
-                  // visit (e.g. /create when switching personal →
-                  // group); the helper returns /home in that case.
-                  router.push(routeForActorSwitch(pathname, next));
-                }}
-                onSignOut={() => {
-                  setSwitcherOpen(false);
-                  signOut();
-                }}
-                onSwitchAccount={() => {
-                  setSwitcherOpen(false);
-                  openSignIn();
-                }}
-              />
             </div>,
             document.body
           )

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -19,6 +19,7 @@ import AccountSwitcherList from "./account-switcher-list";
 import Brandmark from "@/components/ui/brandmark";
 import ThemeToggle from "@/components/ui/theme-toggle";
 import BottomSheet from "@/components/ui/bottom-sheet";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { useLayoutBreakpoints } from "@/hooks/use-layout-breakpoints";
 
 const ROLE_ORDER: Record<string, number> = { owner: 0, admin: 1, member: 2 };
@@ -65,11 +66,13 @@ const Navbar: React.FC = () => {
     setSwitcherOpen(false);
   }, [isDesktop]);
 
-  // Close account switcher on outside click. Governs the inline
-  // `.account-switcher__menu` dropdown. The mobile <BottomSheet> portals
-  // its content (and backdrop) to document.body — outside `switcherRef`
-  // — so we skip mousedowns landing inside the sheet here and let the
-  // sheet own its own dismissal (backdrop tap / Esc / drag).
+  // Close account switcher on outside click. The desktop inline menu now
+  // lives in a portal <Popover> (which owns its own click-outside), so at
+  // ≥800px this is redundant; below 800px the <BottomSheet> portals its
+  // content (and backdrop) to document.body — outside `switcherRef` — so we
+  // skip mousedowns landing inside the sheet and let the sheet own its own
+  // dismissal (backdrop tap / Esc / drag). Kept as a harmless guard for the
+  // trigger so the mobile switcher state can't get stuck open.
   useEffect(() => {
     if (!switcherOpen) return;
     const handleClickOutside = (e: MouseEvent) => {
@@ -274,21 +277,42 @@ const Navbar: React.FC = () => {
         <div className="navbar__right">
         {isAuthenticated ? (
           <>
-            {/* Account switcher — hidden at desktop widths; left rail
-                hosts its own trigger (see desktop-left-rail.tsx). */}
+            {/* Account switcher — the desktop inline menu now portals via
+                the canonical <Popover> (side=bottom, align=end). It is gated
+                to desktop widths to match the old CSS, which hid
+                `.account-switcher__menu` below 800px; the mobile range uses
+                the <BottomSheet> below. Since this navbar early-returns null
+                at ≥800px, the desktop Popover never actually mounts here —
+                the left rail / top bar host the desktop switcher — but the
+                gate keeps the contract explicit and the two paths disjoint. */}
             <div className="account-switcher" ref={switcherRef}>
-              <button
-                className="account-switcher__trigger"
-                onClick={() => { setSwitcherOpen(!switcherOpen); setDropdownOpen(false); }}
-                aria-label="Switch account"
-                aria-haspopup="menu"
-                aria-expanded={switcherOpen}
-              >
-                <Avatar size="sm" src={displayAvatarUrl} fallbackInitials={avatarInitials} />
-                <ChevronDown size={14} className="navbar__chevron-desktop" />
-              </button>
-                {switcherOpen && (
-                  <div className="account-switcher__menu" role="menu">
+              {isDesktop ? (
+                // Desktop inline menu, migrated to the canonical portal
+                // <Popover> (side=bottom, align=end). The old
+                // `.account-switcher__menu` was CSS-hidden below 800px, so
+                // gating the whole Popover to `isDesktop` reproduces that
+                // exactly. NOTE: this navbar early-returns null at ≥800px,
+                // so in practice this branch never mounts here — the left
+                // rail / top bar host the desktop switcher — but it keeps
+                // the migration faithful and the BEM removable.
+                <Popover open={switcherOpen} onOpenChange={setSwitcherOpen}>
+                  <PopoverTrigger>
+                    <button
+                      className="account-switcher__trigger"
+                      onClick={() => { setDropdownOpen(false); }}
+                      aria-label="Switch account"
+                    >
+                      <Avatar size="sm" src={displayAvatarUrl} fallbackInitials={avatarInitials} />
+                      <ChevronDown size={14} className="navbar__chevron-desktop" />
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    portal
+                    side="bottom"
+                    align="end"
+                    minWidth={260}
+                    className="max-h-[70vh] overflow-y-auto [scrollbar-gutter:stable]"
+                  >
                     <AccountSwitcherList
                       session={{ handle }}
                       profile={profile}
@@ -306,8 +330,23 @@ const Navbar: React.FC = () => {
                         openSignIn();
                       }}
                     />
-                  </div>
-                )}
+                  </PopoverContent>
+                </Popover>
+              ) : (
+                // Mobile trigger — opens the <BottomSheet> switcher below.
+                // Kept as a plain button so its aria-expanded reflects the
+                // sheet state exactly as before (the sanctioned sheet path).
+                <button
+                  className="account-switcher__trigger"
+                  onClick={() => { setSwitcherOpen(!switcherOpen); setDropdownOpen(false); }}
+                  aria-label="Switch account"
+                  aria-haspopup="menu"
+                  aria-expanded={switcherOpen}
+                >
+                  <Avatar size="sm" src={displayAvatarUrl} fallbackInitials={avatarInitials} />
+                  <ChevronDown size={14} className="navbar__chevron-desktop" />
+                </button>
+              )}
               </div>
 
             {/* Mobile bottom sheet for account switcher — the canonical

--- a/src/components/profile/profile-edit-form.tsx
+++ b/src/components/profile/profile-edit-form.tsx
@@ -500,16 +500,19 @@ const ProfileEditForm: React.FC<ProfileEditFormProps> = ({
                   {urlRows.map((row) => (
                     <div key={row.id} className="pe__url-item">
                       <div className="pe__url-row">
-                        <input
+                        {/* flush Input as a direct grid child. `error` drives
+                            the error border + aria-invalid; the row keeps its
+                            own `.pe__field-error` <p> below (flush mode renders
+                            no error block), so aria-describedby is wired by
+                            hand to point at it. */}
+                        <Input
+                          flush
                           type="url"
                           inputMode="url"
-                          className={`pe__input${
-                            row.error ? " pe__input--invalid" : ""
-                          }`}
                           value={row.url}
                           placeholder="https://example.com"
                           aria-label="URL"
-                          aria-invalid={row.error ? true : undefined}
+                          error={row.error}
                           aria-describedby={
                             row.error ? `${row.id}-error` : undefined
                           }
@@ -517,9 +520,9 @@ const ProfileEditForm: React.FC<ProfileEditFormProps> = ({
                             updateUrlRow(row.id, { url: e.target.value })
                           }
                         />
-                        <input
+                        <Input
+                          flush
                           type="text"
-                          className="pe__input"
                           value={row.label}
                           maxLength={48}
                           placeholder="Label"

--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -20,6 +20,7 @@ import {
 import Avatar from "@/components/ui/avatar"
 import Button from "@/components/ui/button"
 import ConfirmDialog from "@/components/ui/confirm-dialog"
+import Input from "@/components/ui/input"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import SmartLink from "@/components/ui/smart-link"
 import { getInitials } from "@/lib/utils/initials"
@@ -235,15 +236,25 @@ export default function ProfileSidebar({
 
       <div className="profile-sidebar__name-block">
         {isEditing && hasInline ? (
-          <input
-            type="text"
-            className="profile-sidebar__name-input"
-            value={drafts?.displayName ?? ""}
-            maxLength={64}
-            placeholder="Display name"
-            aria-label="Display name"
-            onChange={(e) => onDraftChange?.("displayName", e.target.value)}
-          />
+          // Bare Input inside the H1 context so it inherits the serif H1
+          // scale (font/size/weight/leading cascade from
+          // `.profile-sidebar__name`). `borderWeight="hover"` reproduces the
+          // 1.5px --border-hover resting / --fg-primary + --overlay-weak focus
+          // chrome the legacy `.profile-sidebar__name-input` used.
+          <h1 className="profile-sidebar__name">
+            <Input
+              size="bare"
+              flush
+              borderWeight="hover"
+              type="text"
+              className="py-1.5 px-2.5"
+              value={drafts?.displayName ?? ""}
+              maxLength={64}
+              placeholder="Display name"
+              aria-label="Display name"
+              onChange={(e) => onDraftChange?.("displayName", e.target.value)}
+            />
+          </h1>
         ) : (
           <h1 className="profile-sidebar__name">{displayName}</h1>
         )}
@@ -391,10 +402,18 @@ export default function ProfileSidebar({
             <li className="profile-sidebar__details-header">Main website</li>
             <li className="profile-sidebar__website-edit">
               <LinkIcon size={16} strokeWidth={1.75} aria-hidden />
-              <input
+              {/* flex:1 bare Input beside the icon. `borderWeight="hover"`
+                  matches the legacy `.profile-sidebar__website-input`
+                  1.5px --border-hover resting / --fg-primary focus chrome;
+                  font-size cascades from `.profile-sidebar__details li`
+                  (0.875rem). */}
+              <Input
+                size="bare"
+                flush
+                borderWeight="hover"
                 type="url"
                 inputMode="url"
-                className="profile-sidebar__website-input"
+                className="flex-1 min-w-0 py-1.5 px-2.5"
                 value={drafts?.website ?? ""}
                 maxLength={256}
                 placeholder="https://example.com"
@@ -437,9 +456,15 @@ export default function ProfileSidebar({
           <li className="profile-sidebar__org-field-edit">
             <Calendar size={16} strokeWidth={1.75} aria-hidden />
             <span className="profile-sidebar__org-field-label">Founded</span>
-            <input
+            {/* flex:1 bare Input. `borderWeight="default"` matches the legacy
+                `.profile-sidebar__org-input` 1px --border-default resting
+                border; font-size cascades from the details-list row. */}
+            <Input
+              size="bare"
+              flush
+              borderWeight="default"
               type="date"
-              className="profile-sidebar__org-input"
+              className="flex-1 min-w-0 py-1.5 px-2.5"
               value={drafts?.foundedDate ?? ""}
               aria-label="Founded date"
               onChange={(e) => onDraftChange?.("foundedDate", e.target.value)}
@@ -544,10 +569,16 @@ function OrgUrlListEditor({ rows, onChange }: OrgUrlListEditorProps) {
         return (
           <li key={row.id} className="profile-sidebar__org-url-edit">
             <LinkIcon size={16} strokeWidth={1.75} aria-hidden />
-            <input
+            {/* flex:1 bare Input beside the icon. `borderWeight="default"`
+                matches the legacy `.profile-sidebar__org-input` 1px
+                --border-default resting border. */}
+            <Input
+              size="bare"
+              flush
+              borderWeight="default"
               type="url"
               inputMode="url"
-              className="profile-sidebar__org-input"
+              className="flex-1 min-w-0 py-1.5 px-2.5"
               value={row.url}
               placeholder="https://example.com"
               aria-label="URL"

--- a/src/components/search/cert-search.tsx
+++ b/src/components/search/cert-search.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Search as SearchIcon, X } from "lucide-react"
 import CertIcon from "@/components/ui/cert-icon"
-import Input from "@/components/ui/input"
+import Combobox from "@/components/ui/combobox"
 import {
   fetchIndexerActivities,
   fetchUserIndexerActivities,
@@ -54,6 +54,10 @@ const OWN_SEARCH_PAGE_SIZE = 4
  *  pattern (keyboard nav, debounce, a11y), but renders cert rows
  *  and optionally surfaces the editor's own certs at the top.
  *
+ *  The input + dropdown + keyboard + ARIA machinery is the shared
+ *  `Combobox` primitive; this surface keeps its own fetch / merge /
+ *  dedupe / Your-vs-Other partition + clearOnSelect behaviour.
+ *
  *  Reusable: the project edit page uses it to add certs to a
  *  project's items[]; the top-bar global search composes it
  *  alongside people results. Doesn't navigate on its own — the
@@ -72,11 +76,8 @@ export default function CertSearch({
   const [results, setResults] = useState<CertSearchResult[]>([])
   const [isOpen, setIsOpen] = useState(false)
   const [isSearching, setIsSearching] = useState(false)
-  const [highlight, setHighlight] = useState(-1)
 
   const inputRef = useRef<HTMLInputElement>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
-  const listRef = useRef<HTMLUListElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Drop stale responses when the user keeps typing.
   const requestSeq = useRef(0)
@@ -143,7 +144,6 @@ export default function CertSearch({
         pushFrom(globalPage?.records, globalPage?.dids, false)
 
         setResults(merged)
-        setHighlight(merged.length > 0 ? 0 : -1)
         setIsOpen(true)
       } finally {
         if (seq === requestSeq.current) setIsSearching(false)
@@ -159,7 +159,6 @@ export default function CertSearch({
       setResults([])
       setIsOpen(false)
       setIsSearching(false)
-      setHighlight(-1)
       return
     }
     const seq = ++requestSeq.current
@@ -172,29 +171,6 @@ export default function CertSearch({
     }
   }, [query, search])
 
-  // Close on outside click.
-  useEffect(() => {
-    if (!isOpen) return
-    const handleClick = (e: MouseEvent) => {
-      const target = e.target
-      if (!(target instanceof Node)) return
-      if (containerRef.current && !containerRef.current.contains(target)) {
-        setIsOpen(false)
-      }
-    }
-    document.addEventListener("mousedown", handleClick)
-    return () => document.removeEventListener("mousedown", handleClick)
-  }, [isOpen])
-
-  // Keep the highlighted row visible when arrowing through results.
-  useEffect(() => {
-    if (highlight < 0 || !listRef.current) return
-    const rows = listRef.current.querySelectorAll<HTMLLIElement>(
-      "[data-result-row]",
-    )
-    rows[highlight]?.scrollIntoView({ block: "nearest" })
-  }, [highlight])
-
   const handleSelect = useCallback(
     (result: CertSearchResult) => {
       if (clearOnSelect) {
@@ -203,204 +179,117 @@ export default function CertSearch({
       }
       setIsOpen(false)
       setIsSearching(false)
-      setHighlight(-1)
       onSelect(result)
     },
     [clearOnSelect, onSelect],
   )
 
-  const moveHighlight = useCallback(
-    (delta: 1 | -1) => {
-      setIsOpen(true)
-      setHighlight((h) => {
-        if (results.length === 0) return -1
-        if (delta === 1) return (h + 1) % results.length
-        return h <= 0 ? results.length - 1 : h - 1
-      })
-    },
-    [results.length],
-  )
-
-  const onEnter = useCallback(() => {
-    if (results.length === 0) return
-    const target = highlight >= 0 ? results[highlight] : results[0]
-    if (target) handleSelect(target)
-  }, [results, highlight, handleSelect])
-
-  const onEscape = useCallback(() => {
-    if (isOpen) {
-      setIsOpen(false)
-      return
-    }
-    if (query) setQuery("")
-    else inputRef.current?.blur()
-  }, [isOpen, query])
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    switch (e.key) {
-      case "ArrowDown":
-        if (results.length === 0) return
-        e.preventDefault()
-        moveHighlight(1)
-        return
-      case "ArrowUp":
-        if (results.length === 0) return
-        e.preventDefault()
-        moveHighlight(-1)
-        return
-      case "Enter":
-        if (results.length === 0) return
-        e.preventDefault()
-        onEnter()
-        return
-      case "Escape":
-        e.preventDefault()
-        onEscape()
-        return
-      case "Home":
-        if (results.length === 0) return
-        e.preventDefault()
-        setHighlight(0)
-        return
-      case "End":
-        if (results.length === 0) return
-        e.preventDefault()
-        setHighlight(results.length - 1)
-    }
-  }
-
   const handleClear = () => {
     setQuery("")
     setResults([])
     setIsOpen(false)
-    setHighlight(-1)
     inputRef.current?.focus()
   }
-
-  const showDropdown =
-    isOpen && (isSearching || results.length > 0 || query.trim().length > 0)
-
-  const listboxId = "cert-search-listbox"
-  const activeId =
-    highlight >= 0 ? `cert-search-option-${highlight}` : undefined
-
-  let liveStatus = ""
-  if (isSearching) liveStatus = "Searching"
-  else if (results.length > 0)
-    liveStatus = `${results.length} result${results.length === 1 ? "" : "s"}`
-  else if (query.trim()) liveStatus = "No activities found"
 
   // Partition for the rendered listbox — own certs first if any.
   // We render a divider between groups (only when both groups have
   // members) so the "Your certs" framing is visible.
   const ownIdxEnd = results.findIndex((r) => !r.isOwn)
   const dividerAt = ownIdxEnd > 0 ? ownIdxEnd : -1
+  const hasOwn = Boolean(prioritizeAuthorDid) && results.some((r) => r.isOwn)
 
   return (
-    <div
-      ref={containerRef}
+    <Combobox<CertSearchResult>
       className={`cert-search ${className}`}
       role="search"
-    >
-      <Input
-        ref={inputRef}
-        type="text"
-        size="md"
-        value={query}
-        placeholder={placeholder}
-        onChange={(e) => setQuery(e.target.value)}
-        onKeyDown={handleKeyDown}
-        onFocus={() => {
-          if (results.length > 0) setIsOpen(true)
-        }}
-        role="combobox"
-        aria-label={placeholder}
-        aria-autocomplete="list"
-        aria-expanded={showDropdown}
-        aria-controls={showDropdown ? listboxId : undefined}
-        aria-activedescendant={activeId}
-        autoComplete="off"
-        autoFocus={autoFocus}
-        spellCheck={false}
-        leadingIcon={<SearchIcon size={16} aria-hidden="true" />}
-        trailingButton={
-          query ? (
-            <button
-              type="button"
-              className="cert-search__clear"
-              onClick={handleClear}
-              aria-label="Clear search"
-            >
-              <X size={14} aria-hidden="true" />
-            </button>
-          ) : undefined
+      value={query}
+      onValueChange={setQuery}
+      items={results}
+      getItemKey={(result) => result.record.uri}
+      isLoading={isSearching}
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      onSelect={handleSelect}
+      inputRef={inputRef}
+      listboxClassName="cert-search__dropdown"
+      liveStatus={{
+        searching: "Searching",
+        results: (n) => `${n} result${n === 1 ? "" : "s"}`,
+        empty: "No activities found",
+      }}
+      inputProps={{
+        size: "md",
+        placeholder,
+        autoFocus,
+        "aria-label": placeholder,
+        leadingIcon: <SearchIcon size={16} aria-hidden="true" />,
+      }}
+      trailingButton={
+        query ? (
+          <button
+            type="button"
+            className="cert-search__clear"
+            onClick={handleClear}
+            aria-label="Clear search"
+          >
+            <X size={14} aria-hidden="true" />
+          </button>
+        ) : undefined
+      }
+      renderEmpty={() => {
+        if (isSearching) {
+          return <li className="cert-search__empty">Searching…</li>
         }
-      />
-
-      <div className="sr-only" aria-live="polite" aria-atomic="true">
-        {liveStatus}
-      </div>
-
-      {showDropdown && (
-        <ul
-          ref={listRef}
-          id={listboxId}
-          role="listbox"
-          aria-busy={isSearching}
-          className="cert-search__dropdown"
-        >
-          {isSearching && results.length === 0 && (
-            <li className="cert-search__empty">Searching…</li>
-          )}
-          {!isSearching && results.length === 0 && query.trim() && (
+        if (query.trim()) {
+          return (
             <li className="cert-search__empty">
               No activities found for &ldquo;{query.trim()}&rdquo;.
             </li>
-          )}
-
-          {/* "Your certs" header — only when we're prioritizing a DID
-              AND we got at least one own result back. */}
-          {prioritizeAuthorDid && results.some((r) => r.isOwn) ? (
-            <li
-              className="cert-search__group-header"
-              role="presentation"
-              aria-hidden="true"
-            >
-              Your activities
-            </li>
-          ) : null}
-
-          {results.map((result, i) => (
-            <CertSearchRow
-              key={result.record.uri}
-              result={result}
-              index={i}
-              highlighted={i === highlight}
-              showOtherHeader={i === dividerAt}
-              onHover={() => setHighlight(i)}
-              onSelect={() => handleSelect(result)}
-            />
-          ))}
-        </ul>
+          )
+        }
+        return null
+      }}
+      renderListHeader={
+        hasOwn
+          ? () => (
+              <li
+                className="cert-search__group-header"
+                role="presentation"
+                aria-hidden="true"
+              >
+                Your activities
+              </li>
+            )
+          : undefined
+      }
+      renderOption={({ item: result, index, highlighted, optionId, onHover, onSelect }) => (
+        <CertSearchRow
+          result={result}
+          optionId={optionId}
+          highlighted={highlighted}
+          showOtherHeader={index === dividerAt}
+          onHover={onHover}
+          onSelect={onSelect}
+        />
       )}
-    </div>
+    />
   )
 }
 
 interface CertSearchRowProps {
   result: CertSearchResult
-  index: number
+  optionId: string
   highlighted: boolean
   /** Render the "Other certs" group header above this row (the
    *  first non-own result after a run of own results). */
   showOtherHeader: boolean
   onHover: () => void
-  onSelect: () => void
+  onSelect: (e: React.MouseEvent) => void
 }
 
 function CertSearchRow({
   result,
-  index,
+  optionId,
   highlighted,
   showOtherHeader,
   onHover,
@@ -426,20 +315,15 @@ function CertSearchRow({
         </li>
       ) : null}
       <li
-        id={`cert-search-option-${index}`}
+        id={optionId}
         role="option"
         aria-selected={highlighted}
-        data-result-row
+        data-combobox-option
         className={`cert-search__item ${
           highlighted ? "cert-search__item--highlighted" : ""
         }`}
         onMouseEnter={onHover}
-        onMouseDown={(e) => {
-          // mouseDown (not click) — fires before input blur so the
-          // dropdown doesn't close before our handler runs.
-          e.preventDefault()
-          onSelect()
-        }}
+        onMouseDown={onSelect}
       >
         {imageUrl ? (
           // eslint-disable-next-line @next/next/no-img-element

--- a/src/components/search/global-search.tsx
+++ b/src/components/search/global-search.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import { Search as SearchIcon, X } from "lucide-react"
 import CertIcon from "@/components/ui/cert-icon"
 import Avatar from "@/components/ui/avatar"
+import Combobox from "@/components/ui/combobox"
 import { getInitials } from "@/lib/utils/initials"
 import { fetchIndexerActivities } from "@/lib/atproto/indexer"
 import { resolveActivityImageUrl } from "@/lib/atproto/activity"
@@ -51,8 +52,13 @@ const CERTS_LIMIT = 6
  *     full-text matches
  *
  * Results render in two grouped sections in one dropdown
- * ("People" / "Certs"). Arrow keys walk the combined list; Enter
+ * ("People" / "Activities"). Arrow keys walk the combined list; Enter
  * activates the highlighted row.
+ *
+ * The input + dropdown + keyboard + ARIA machinery is the shared
+ * `Combobox` primitive; this surface keeps its own two-source fetch,
+ * the flat People-then-Activities row order, the interleaved group
+ * headers, and the Cmd/Ctrl+K focus shortcut.
  *
  * Selecting a person navigates to /profile/<did>; selecting a cert
  * navigates to its detail page (/activity/<did>/<rkey>).
@@ -68,18 +74,15 @@ export default function GlobalSearch({
   const [certs, setCerts] = useState<CertRow[]>([])
   const [isOpen, setIsOpen] = useState(false)
   const [isSearching, setIsSearching] = useState(false)
-  const [highlight, setHighlight] = useState(-1)
 
   const inputRef = useRef<HTMLInputElement>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
-  const listRef = useRef<HTMLUListElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const requestSeq = useRef(0)
   const suppressNextSearchRef = useRef(false)
 
   // Flat row list used for keyboard nav. Order matches render
   // order: People section first, then Certs. Memoised so the
-  // `onEnter` useCallback below isn't invalidated on every render —
+  // `select` useCallback below isn't invalidated on every render —
   // its `[rows, ...]` dep array would otherwise spawn a new identity
   // each render, breaking downstream memoization.
   const rows: Row[] = useMemo(
@@ -134,9 +137,6 @@ export default function GlobalSearch({
         }
       }
       setCerts(certRows)
-
-      const total = (peopleRes.actors?.length ?? 0) + certRows.length
-      setHighlight(total > 0 ? 0 : -1)
       setIsOpen(true)
     } finally {
       if (seq === requestSeq.current) setIsSearching(false)
@@ -155,7 +155,6 @@ export default function GlobalSearch({
       setCerts([])
       setIsOpen(false)
       setIsSearching(false)
-      setHighlight(-1)
       return
     }
     const seq = ++requestSeq.current
@@ -167,20 +166,6 @@ export default function GlobalSearch({
       if (debounceRef.current) clearTimeout(debounceRef.current)
     }
   }, [query, search])
-
-  // Close on outside click.
-  useEffect(() => {
-    if (!isOpen) return
-    const handleClick = (e: MouseEvent) => {
-      const target = e.target
-      if (!(target instanceof Node)) return
-      if (containerRef.current && !containerRef.current.contains(target)) {
-        setIsOpen(false)
-      }
-    }
-    document.addEventListener("mousedown", handleClick)
-    return () => document.removeEventListener("mousedown", handleClick)
-  }, [isOpen])
 
   // Cmd/Ctrl+K focus shortcut — same gesture as the old PeopleSearch.
   useEffect(() => {
@@ -204,15 +189,6 @@ export default function GlobalSearch({
     return () => globalThis.removeEventListener("keydown", onKey)
   }, [])
 
-  // Keep the highlighted row visible during arrow navigation.
-  useEffect(() => {
-    if (highlight < 0 || !listRef.current) return
-    const els = listRef.current.querySelectorAll<HTMLLIElement>(
-      "[data-result-row]",
-    )
-    els[highlight]?.scrollIntoView({ block: "nearest" })
-  }, [highlight])
-
   const select = useCallback(
     (row: Row) => {
       suppressNextSearchRef.current = true
@@ -228,128 +204,51 @@ export default function GlobalSearch({
       setCerts([])
       setIsOpen(false)
       setIsSearching(false)
-      setHighlight(-1)
       inputRef.current?.blur()
     },
     [router],
   )
-
-  const moveHighlight = useCallback(
-    (delta: 1 | -1) => {
-      setIsOpen(true)
-      setHighlight((h) => {
-        if (rows.length === 0) return -1
-        if (delta === 1) return (h + 1) % rows.length
-        return h <= 0 ? rows.length - 1 : h - 1
-      })
-    },
-    [rows.length],
-  )
-
-  const onEnter = useCallback(() => {
-    if (rows.length === 0) return
-    const target = highlight >= 0 ? rows[highlight] : rows[0]
-    if (target) select(target)
-  }, [rows, highlight, select])
-
-  const onEscape = useCallback(() => {
-    if (isOpen) {
-      setIsOpen(false)
-      return
-    }
-    if (query) setQuery("")
-    else inputRef.current?.blur()
-  }, [isOpen, query])
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    switch (e.key) {
-      case "ArrowDown":
-        if (rows.length === 0) return
-        e.preventDefault()
-        moveHighlight(1)
-        return
-      case "ArrowUp":
-        if (rows.length === 0) return
-        e.preventDefault()
-        moveHighlight(-1)
-        return
-      case "Enter":
-        if (rows.length === 0) return
-        e.preventDefault()
-        onEnter()
-        return
-      case "Escape":
-        e.preventDefault()
-        onEscape()
-        return
-      case "Home":
-        if (rows.length === 0) return
-        e.preventDefault()
-        setHighlight(0)
-        return
-      case "End":
-        if (rows.length === 0) return
-        e.preventDefault()
-        setHighlight(rows.length - 1)
-    }
-  }
 
   const handleClear = () => {
     setQuery("")
     setPeople([])
     setCerts([])
     setIsOpen(false)
-    setHighlight(-1)
     inputRef.current?.focus()
   }
 
-  const showDropdown =
-    isOpen && (isSearching || rows.length > 0 || query.trim().length > 0)
-
-  const listboxId = "global-search-listbox"
-  const activeId =
-    highlight >= 0 ? `global-search-option-${highlight}` : undefined
-
-  let liveStatus = ""
-  if (isSearching) liveStatus = "Searching"
-  else if (rows.length > 0)
-    liveStatus = `${rows.length} result${rows.length === 1 ? "" : "s"}`
-  else if (query.trim()) liveStatus = "No results"
+  const peopleCount = people.length
 
   return (
-    <div
-      ref={containerRef}
+    <Combobox<Row>
       className={`people-search ${className}`}
       role="search"
-    >
-      <div className="people-search__field">
-        <SearchIcon
-          size={16}
-          className="people-search__icon"
-          aria-hidden="true"
-        />
-        <input
-          ref={inputRef}
-          type="text"
-          className="people-search__input"
-          value={query}
-          placeholder={placeholder}
-          onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onFocus={() => {
-            if (rows.length > 0) setIsOpen(true)
-          }}
-          role="combobox"
-          aria-label={placeholder}
-          aria-autocomplete="list"
-          aria-expanded={showDropdown}
-          aria-controls={showDropdown ? listboxId : undefined}
-          aria-activedescendant={activeId}
-          autoComplete="off"
-          autoFocus={autoFocus}
-          spellCheck={false}
-        />
-        {query ? (
+      value={query}
+      onValueChange={setQuery}
+      items={rows}
+      getItemKey={(row) =>
+        row.kind === "person" ? `p-${row.actor.did}` : `c-${row.record.uri}`
+      }
+      isLoading={isSearching}
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      onSelect={select}
+      inputRef={inputRef}
+      listboxClassName="people-search__dropdown"
+      liveStatus={{
+        searching: "Searching",
+        results: (n) => `${n} result${n === 1 ? "" : "s"}`,
+        empty: "No results",
+      }}
+      inputProps={{
+        size: "md",
+        placeholder,
+        autoFocus,
+        "aria-label": placeholder,
+        leadingIcon: <SearchIcon size={16} aria-hidden="true" />,
+      }}
+      trailingButton={
+        query ? (
           <button
             type="button"
             className="people-search__clear"
@@ -358,85 +257,72 @@ export default function GlobalSearch({
           >
             <X size={14} aria-hidden="true" />
           </button>
-        ) : null}
-      </div>
-
-      <div className="sr-only" aria-live="polite" aria-atomic="true">
-        {liveStatus}
-      </div>
-
-      {showDropdown && (
-        <ul
-          ref={listRef}
-          id={listboxId}
-          role="listbox"
-          aria-busy={isSearching}
-          className="people-search__dropdown"
-        >
-          {isSearching && rows.length === 0 && (
-            <li className="people-search__empty">Searching…</li>
-          )}
-          {!isSearching && rows.length === 0 && query.trim() && (
+        ) : undefined
+      }
+      renderEmpty={() => {
+        if (isSearching) {
+          return <li className="people-search__empty">Searching…</li>
+        }
+        if (query.trim()) {
+          return (
             <li className="people-search__empty">
               No results for &ldquo;{query.trim()}&rdquo;.
             </li>
-          )}
-
-          {/* People section — header + person rows. Both the header
-              and the rows are conditional on people.length so we
-              don't render an empty "People" header when only certs
-              came back. */}
-          {people.length > 0 ? (
-            <li
-              className="cert-search__group-header"
-              role="presentation"
-              aria-hidden="true"
-            >
-              People
-            </li>
-          ) : null}
-          {people.map((actor, i) => (
-            <PersonRowItem
-              key={`p-${actor.did}`}
-              actor={actor}
-              index={i}
-              highlighted={i === highlight}
-              onHover={() => setHighlight(i)}
-              onSelect={() => select({ kind: "person", actor })}
-            />
-          ))}
-
-          {/* Certs section — same shape. Header + cert rows, both
-              conditional on certs.length. */}
-          {certs.length > 0 ? (
-            <li
-              className="cert-search__group-header"
-              role="presentation"
-              aria-hidden="true"
-            >
-              Activities
-            </li>
-          ) : null}
-          {certs.map((row, i) => {
-            // Continue the flat-list highlight index past the
-            // people section so arrow-key nav matches the visual
-            // row order.
-            const flatIndex = people.length + i
-            return (
-              <CertRowItem
-                key={`c-${row.record.uri}`}
-                record={row.record}
-                did={row.did}
-                index={flatIndex}
-                highlighted={flatIndex === highlight}
-                onHover={() => setHighlight(flatIndex)}
-                onSelect={() => select(row)}
+          )
+        }
+        return null
+      }}
+      renderOption={({ item: row, index, highlighted, optionId, onHover, onSelect }) => {
+        if (row.kind === "person") {
+          return (
+            <>
+              {/* People header — interleaved above the first person row.
+                  Only rendered when people came back (index 0 is a person
+                  iff people.length > 0). */}
+              {index === 0 ? (
+                <li
+                  className="cert-search__group-header"
+                  role="presentation"
+                  aria-hidden="true"
+                >
+                  People
+                </li>
+              ) : null}
+              <PersonRowItem
+                actor={row.actor}
+                optionId={optionId}
+                highlighted={highlighted}
+                onHover={onHover}
+                onSelect={onSelect}
               />
-            )
-          })}
-        </ul>
-      )}
-    </div>
+            </>
+          )
+        }
+        return (
+          <>
+            {/* Activities header — interleaved above the first cert row
+                (the row at flat index === people.length). */}
+            {index === peopleCount ? (
+              <li
+                className="cert-search__group-header"
+                role="presentation"
+                aria-hidden="true"
+              >
+                Activities
+              </li>
+            ) : null}
+            <CertRowItem
+              record={row.record}
+              did={row.did}
+              optionId={optionId}
+              highlighted={highlighted}
+              onHover={onHover}
+              onSelect={onSelect}
+            />
+          </>
+        )
+      }}
+    />
   )
 }
 
@@ -448,15 +334,15 @@ function activityDetailHrefFromRecord(uri: string): string | null {
 
 interface PersonRowProps {
   actor: Actor
-  index: number
+  optionId: string
   highlighted: boolean
   onHover: () => void
-  onSelect: () => void
+  onSelect: (e: React.MouseEvent) => void
 }
 
 function PersonRowItem({
   actor,
-  index,
+  optionId,
   highlighted,
   onHover,
   onSelect,
@@ -464,18 +350,15 @@ function PersonRowItem({
   const name = actor.displayName || actor.handle
   return (
     <li
-      id={`global-search-option-${index}`}
+      id={optionId}
       role="option"
       aria-selected={highlighted}
-      data-result-row
+      data-combobox-option
       className={`people-search__item ${
         highlighted ? "people-search__item--highlighted" : ""
       }`}
       onMouseEnter={onHover}
-      onMouseDown={(e) => {
-        e.preventDefault()
-        onSelect()
-      }}
+      onMouseDown={onSelect}
     >
       <Avatar
         size="sm"
@@ -494,16 +377,16 @@ function PersonRowItem({
 interface CertRowProps {
   record: ActivityRecord
   did: string
-  index: number
+  optionId: string
   highlighted: boolean
   onHover: () => void
-  onSelect: () => void
+  onSelect: (e: React.MouseEvent) => void
 }
 
 function CertRowItem({
   record,
   did,
-  index,
+  optionId,
   highlighted,
   onHover,
   onSelect,
@@ -516,42 +399,39 @@ function CertRowItem({
   const handle = info?.handle ?? null
 
   return (
-      <li
-        id={`global-search-option-${index}`}
-        role="option"
-        aria-selected={highlighted}
-        data-result-row
-        className={`cert-search__item ${
-          highlighted ? "cert-search__item--highlighted" : ""
-        }`}
-        onMouseEnter={onHover}
-        onMouseDown={(e) => {
-          e.preventDefault()
-          onSelect()
-        }}
-      >
-        {imageUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            className="cert-search__thumb"
-            src={imageUrl}
-            alt=""
-            loading="lazy"
-          />
-        ) : (
-          <div
-            className="cert-search__thumb cert-search__thumb--placeholder"
-            aria-hidden="true"
-          >
-            <CertIcon size={16} strokeWidth={1.5} />
-          </div>
-        )}
-        <div className="cert-search__item-info">
-          <span className="cert-search__item-title">{title}</span>
-          {handle ? (
-            <span className="cert-search__item-handle">@{handle}</span>
-          ) : null}
+    <li
+      id={optionId}
+      role="option"
+      aria-selected={highlighted}
+      data-combobox-option
+      className={`cert-search__item ${
+        highlighted ? "cert-search__item--highlighted" : ""
+      }`}
+      onMouseEnter={onHover}
+      onMouseDown={onSelect}
+    >
+      {imageUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          className="cert-search__thumb"
+          src={imageUrl}
+          alt=""
+          loading="lazy"
+        />
+      ) : (
+        <div
+          className="cert-search__thumb cert-search__thumb--placeholder"
+          aria-hidden="true"
+        >
+          <CertIcon size={16} strokeWidth={1.5} />
         </div>
-      </li>
+      )}
+      <div className="cert-search__item-info">
+        <span className="cert-search__item-title">{title}</span>
+        {handle ? (
+          <span className="cert-search__item-handle">@{handle}</span>
+        ) : null}
+      </div>
+    </li>
   )
 }

--- a/src/components/search/people-search.tsx
+++ b/src/components/search/people-search.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Search as SearchIcon, X } from "lucide-react";
 import Avatar from "@/components/ui/avatar";
-import Input from "@/components/ui/input";
+import Combobox from "@/components/ui/combobox";
 import { getInitials } from "@/lib/utils/initials";
 
 interface Actor {
@@ -58,6 +58,10 @@ function isEditableTarget(target: EventTarget | null): boolean {
  * announces "Searching…" / "N results" / "No results" so screen readers
  * are notified when the dropdown state changes.
  *
+ * The input + dropdown + keyboard + ARIA machinery is the shared
+ * `Combobox` primitive; this surface keeps its own fetch / debounce /
+ * navigate-on-select / suppress-next-search behaviour.
+ *
  * Mirrors hypercerts-org/certified-app#51.
  */
 export default function PeopleSearch({
@@ -71,11 +75,8 @@ export default function PeopleSearch({
   const [results, setResults] = useState<Actor[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
-  const [highlight, setHighlight] = useState<number>(-1);
 
   const inputRef = useRef<HTMLInputElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const listRef = useRef<HTMLUListElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Drop stale responses when the user keeps typing.
   const requestSeq = useRef(0);
@@ -105,11 +106,9 @@ export default function PeopleSearch({
         const data = (await res.json()) as { actors?: Actor[] };
         const next = data.actors ?? [];
         setResults(next);
-        setHighlight(next.length > 0 ? 0 : -1);
         setIsOpen(true);
       } else {
         setResults([]);
-        setHighlight(-1);
         setIsOpen(true);
       }
     } catch (err) {
@@ -135,7 +134,6 @@ export default function PeopleSearch({
       setResults([]);
       setIsOpen(false);
       setIsSearching(false);
-      setHighlight(-1);
       return;
     }
     const seq = ++requestSeq.current;
@@ -144,20 +142,6 @@ export default function PeopleSearch({
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
   }, [query, search]);
-
-  // Close on outside click.
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleClick = (e: MouseEvent) => {
-      const target = e.target;
-      if (!(target instanceof Node)) return;
-      if (containerRef.current && !containerRef.current.contains(target)) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [isOpen]);
 
   // Cmd/Ctrl+K focus shortcut. Only fires when the user isn't already
   // typing in another editable element — yanking focus from a post
@@ -174,13 +158,6 @@ export default function PeopleSearch({
     return () => globalThis.removeEventListener("keydown", onKey);
   }, []);
 
-  // Keep the highlighted row visible when navigating with the keyboard.
-  useEffect(() => {
-    if (highlight < 0 || !listRef.current) return;
-    const el = listRef.current.querySelectorAll<HTMLLIElement>("[data-result-row]")[highlight];
-    el?.scrollIntoView({ block: "nearest" });
-  }, [highlight]);
-
   const select = useCallback(
     (actor: Actor) => {
       suppressNextSearchRef.current = true;
@@ -188,195 +165,96 @@ export default function PeopleSearch({
       setResults([]);
       setIsOpen(false);
       setIsSearching(false);
-      setHighlight(-1);
       inputRef.current?.blur();
       router.push(`/profile/${encodeURIComponent(actor.did)}`);
     },
     [router]
   );
 
-  // Per-key handlers — keeps handleKeyDown trivially below Sonar's
-  // cognitive-complexity ceiling and easier to scan.
-  const moveHighlight = useCallback((delta: 1 | -1) => {
-    setIsOpen(true);
-    setHighlight((h) => {
-      if (results.length === 0) return -1;
-      if (delta === 1) return (h + 1) % results.length;
-      return h <= 0 ? results.length - 1 : h - 1;
-    });
-  }, [results.length]);
-
-  const onEnter = useCallback(() => {
-    if (results.length === 0) return;
-    const target = highlight >= 0 ? results[highlight] : results[0];
-    if (target) select(target);
-  }, [results, highlight, select]);
-
-  // Esc: WAI-ARIA combobox pattern. First press closes the listbox; if it's
-  // already closed (or the input is empty), clear the input.
-  const onEscape = useCallback(() => {
-    if (isOpen) {
-      setIsOpen(false);
-      return;
-    }
-    if (query) setQuery("");
-    else inputRef.current?.blur();
-  }, [isOpen, query]);
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    switch (e.key) {
-      case "ArrowDown":
-        if (results.length === 0) return;
-        e.preventDefault();
-        moveHighlight(1);
-        return;
-      case "ArrowUp":
-        if (results.length === 0) return;
-        e.preventDefault();
-        moveHighlight(-1);
-        return;
-      case "Enter":
-        if (results.length === 0) return;
-        e.preventDefault();
-        onEnter();
-        return;
-      case "Escape":
-        e.preventDefault();
-        onEscape();
-        return;
-      case "Home":
-        if (results.length === 0) return;
-        e.preventDefault();
-        setHighlight(0);
-        return;
-      case "End":
-        if (results.length === 0) return;
-        e.preventDefault();
-        setHighlight(results.length - 1);
-    }
-  };
-
   const handleClear = () => {
     setQuery("");
     setResults([]);
     setIsOpen(false);
-    setHighlight(-1);
     inputRef.current?.focus();
   };
 
-  const showDropdown =
-    isOpen && (isSearching || results.length > 0 || query.trim().length > 0);
-
-  const listboxId = "people-search-listbox";
-  const activeId = highlight >= 0 ? `people-search-option-${highlight}` : undefined;
-
-  // Live-region message. Empty string when nothing to announce so
-  // screen readers don't say "blank".
-  let liveStatus = "";
-  if (isSearching) liveStatus = "Searching";
-  else if (results.length > 0) liveStatus = `${results.length} result${results.length === 1 ? "" : "s"}`;
-  else if (query.trim()) liveStatus = "No people found";
-
   return (
-    <div
-      ref={containerRef}
+    <Combobox<Actor>
       className={`people-search ${className}`}
       role="search"
-    >
-      <Input
-        ref={inputRef}
-        type="text"
-        size="md"
-        value={query}
-        placeholder={placeholder}
-        onChange={(e) => setQuery(e.target.value)}
-        onKeyDown={handleKeyDown}
-        onFocus={() => {
-          if (results.length > 0) setIsOpen(true);
-        }}
-        role="combobox"
-        aria-label="Search people on atproto"
-        aria-autocomplete="list"
-        aria-expanded={showDropdown}
-        aria-controls={showDropdown ? listboxId : undefined}
-        aria-activedescendant={activeId}
-        autoComplete="off"
-        autoFocus={autoFocus}
-        spellCheck={false}
-        leadingIcon={<SearchIcon size={16} aria-hidden="true" />}
-        trailingButton={
-          query ? (
-            <button
-              type="button"
-              className="people-search__clear"
-              onClick={handleClear}
-              aria-label="Clear search"
-            >
-              <X size={14} aria-hidden="true" />
-            </button>
-          ) : undefined
+      value={query}
+      onValueChange={setQuery}
+      items={results}
+      getItemKey={(actor) => actor.did}
+      isLoading={isSearching}
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      onSelect={select}
+      inputRef={inputRef}
+      listboxClassName="people-search__dropdown"
+      liveStatus={{
+        searching: "Searching",
+        results: (n) => `${n} result${n === 1 ? "" : "s"}`,
+        empty: "No people found",
+      }}
+      inputProps={{
+        size: "md",
+        placeholder,
+        autoFocus,
+        "aria-label": "Search people on atproto",
+        leadingIcon: <SearchIcon size={16} aria-hidden="true" />,
+      }}
+      trailingButton={
+        query ? (
+          <button
+            type="button"
+            className="people-search__clear"
+            onClick={handleClear}
+            aria-label="Clear search"
+          >
+            <X size={14} aria-hidden="true" />
+          </button>
+        ) : undefined
+      }
+      renderEmpty={() => {
+        if (isSearching) {
+          return <li className="people-search__empty">Searching…</li>;
         }
-      />
-
-      {/* Visually-hidden live region — announces search state to SR users.
-          Polite so it doesn't interrupt mid-utterance. */}
-      <div className="sr-only" aria-live="polite" aria-atomic="true">
-        {liveStatus}
-      </div>
-
-      {showDropdown && (
-        <ul
-          ref={listRef}
-          id={listboxId}
-          role="listbox"
-          aria-busy={isSearching}
-          className="people-search__dropdown"
-        >
-          {isSearching && results.length === 0 && (
-            <li className="people-search__empty">
-              Searching…
-            </li>
-          )}
-          {!isSearching && results.length === 0 && query.trim() && (
+        if (query.trim()) {
+          return (
             <li className="people-search__empty">
               No people found for &ldquo;{query.trim()}&rdquo;.
             </li>
-          )}
-          {results.map((actor, i) => {
-            const name = actor.displayName || actor.handle;
-            const isHighlighted = i === highlight;
-            return (
-              <li
-                key={actor.did}
-                id={`people-search-option-${i}`}
-                role="option"
-                aria-selected={isHighlighted}
-                data-result-row
-                className={`people-search__item ${
-                  isHighlighted ? "people-search__item--highlighted" : ""
-                }`}
-                onMouseEnter={() => setHighlight(i)}
-                onMouseDown={(e) => {
-                  // mouseDown (not click) — fires before the input's blur so
-                  // the dropdown doesn't disappear before navigation.
-                  e.preventDefault();
-                  select(actor);
-                }}
-              >
-                <Avatar
-                  size="sm"
-                  src={actor.avatar || undefined}
-                  fallbackInitials={getInitials(name, actor.did)}
-                />
-                <div className="people-search__item-info">
-                  <span className="people-search__item-name">{name}</span>
-                  <span className="people-search__item-handle">@{actor.handle}</span>
-                </div>
-              </li>
-            );
-          })}
-        </ul>
-      )}
-    </div>
+          );
+        }
+        return null;
+      }}
+      renderOption={({ item: actor, highlighted, optionId, onHover, onSelect }) => {
+        const name = actor.displayName || actor.handle;
+        return (
+          <li
+            id={optionId}
+            role="option"
+            aria-selected={highlighted}
+            data-combobox-option
+            className={`people-search__item ${
+              highlighted ? "people-search__item--highlighted" : ""
+            }`}
+            onMouseEnter={onHover}
+            onMouseDown={onSelect}
+          >
+            <Avatar
+              size="sm"
+              src={actor.avatar || undefined}
+              fallbackInitials={getInitials(name, actor.did)}
+            />
+            <div className="people-search__item-info">
+              <span className="people-search__item-name">{name}</span>
+              <span className="people-search__item-handle">@{actor.handle}</span>
+            </div>
+          </li>
+        );
+      }}
+    />
   );
 }

--- a/src/components/ui/__tests__/combobox.test.tsx
+++ b/src/components/ui/__tests__/combobox.test.tsx
@@ -1,0 +1,287 @@
+import React, { useState } from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import Combobox, { type ComboboxOptionRenderProps } from "../combobox";
+
+afterEach(() => {
+  cleanup();
+});
+
+/**
+ * jsdom doesn't implement scrollIntoView; the combobox calls it on the
+ * highlighted row during keyboard nav. Stub it so those code paths run.
+ */
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => undefined;
+}
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+const ITEMS: Item[] = [
+  { id: "a", label: "Alpha" },
+  { id: "b", label: "Bravo" },
+  { id: "c", label: "Charlie" },
+];
+
+interface HarnessProps {
+  items?: Item[];
+  isLoading?: boolean;
+  onSelect?: (item: Item, index: number) => void;
+  onSubmitNoMatch?: (raw: string) => void;
+  escapeStage?: "two-stage" | "close-only";
+  enableHomeEnd?: boolean;
+  withLiveStatus?: boolean;
+}
+
+/**
+ * Thin controlled wrapper — the combobox is controlled-items, so the
+ * harness owns `value` / `open` and feeds a fixed list. Lets the tests
+ * drive the keyboard + assert ARIA without a real data layer.
+ */
+function Harness({
+  items = ITEMS,
+  isLoading = false,
+  onSelect = () => undefined,
+  onSubmitNoMatch,
+  escapeStage = "two-stage",
+  enableHomeEnd = true,
+  withLiveStatus = false,
+}: HarnessProps) {
+  const [value, setValue] = useState("a");
+  const [open, setOpen] = useState(true);
+  return (
+    <Combobox<Item>
+      value={value}
+      onValueChange={setValue}
+      items={items}
+      getItemKey={(it) => it.id}
+      isLoading={isLoading}
+      open={open}
+      onOpenChange={setOpen}
+      onSelect={onSelect}
+      onSubmitNoMatch={onSubmitNoMatch}
+      escapeStage={escapeStage}
+      enableHomeEnd={enableHomeEnd}
+      inputProps={{ "aria-label": "Search", placeholder: "Search" }}
+      liveStatus={
+        withLiveStatus
+          ? {
+              searching: "Searching",
+              results: (n) => `${n} results`,
+              empty: "No results",
+            }
+          : undefined
+      }
+      renderEmpty={() => <li className="empty">No results.</li>}
+      renderOption={({
+        item,
+        highlighted,
+        optionId,
+        onHover,
+        onSelect: selectRow,
+      }: ComboboxOptionRenderProps<Item>) => (
+        <li
+          id={optionId}
+          role="option"
+          aria-selected={highlighted}
+          data-combobox-option
+          data-highlighted={highlighted}
+          onMouseEnter={onHover}
+          onMouseDown={selectRow}
+        >
+          {item.label}
+        </li>
+      )}
+    />
+  );
+}
+
+function getInput() {
+  return screen.getByRole("combobox") as HTMLInputElement;
+}
+
+function highlightedLabel(): string | null {
+  const el = document.querySelector('[data-combobox-option][data-highlighted="true"]');
+  return el ? el.textContent : null;
+}
+
+describe("Combobox — ARIA", () => {
+  it("wires the combobox/listbox ARIA contract", () => {
+    render(<Harness />);
+    const input = getInput();
+    expect(input.getAttribute("aria-autocomplete")).toBe("list");
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+
+    const listbox = screen.getByRole("listbox");
+    const controls = input.getAttribute("aria-controls");
+    expect(controls).toBeTruthy();
+    expect(listbox.getAttribute("id")).toBe(controls);
+  });
+
+  it("points aria-activedescendant at the highlighted option's id", () => {
+    render(<Harness />);
+    const input = getInput();
+    // First row is highlighted on mount (items non-empty → index 0).
+    const active = input.getAttribute("aria-activedescendant");
+    expect(active).toBeTruthy();
+    const firstOption = screen.getAllByRole("option")[0];
+    expect(firstOption.getAttribute("id")).toBe(active);
+  });
+
+  it("sets aria-busy on the listbox while loading", () => {
+    render(<Harness isLoading />);
+    expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("announces the live status from liveStatus", () => {
+    render(<Harness withLiveStatus />);
+    // Not loading, 3 items → "3 results".
+    const region = document.querySelector('[aria-live="polite"]');
+    expect(region?.textContent).toBe("3 results");
+  });
+});
+
+describe("Combobox — keyboard", () => {
+  it("highlights the first item when items are non-empty", () => {
+    render(<Harness />);
+    expect(highlightedLabel()).toBe("Alpha");
+  });
+
+  it("ArrowDown moves the highlight and wraps at the end", () => {
+    render(<Harness />);
+    const input = getInput();
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(highlightedLabel()).toBe("Bravo");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(highlightedLabel()).toBe("Charlie");
+    // Wrap back to the first item.
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(highlightedLabel()).toBe("Alpha");
+  });
+
+  it("ArrowUp wraps to the last item from the first", () => {
+    render(<Harness />);
+    const input = getInput();
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(highlightedLabel()).toBe("Charlie");
+  });
+
+  it("Home/End jump to the first/last item", () => {
+    render(<Harness />);
+    const input = getInput();
+    fireEvent.keyDown(input, { key: "End" });
+    expect(highlightedLabel()).toBe("Charlie");
+    fireEvent.keyDown(input, { key: "Home" });
+    expect(highlightedLabel()).toBe("Alpha");
+  });
+
+  it("does not move on Home/End when enableHomeEnd is false", () => {
+    render(<Harness enableHomeEnd={false} />);
+    const input = getInput();
+    fireEvent.keyDown(input, { key: "End" });
+    expect(highlightedLabel()).toBe("Alpha");
+  });
+
+  it("Enter selects the highlighted item", () => {
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} />);
+    const input = getInput();
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // highlight Bravo
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0]).toEqual({ id: "b", label: "Bravo" });
+    expect(onSelect.mock.calls[0][1]).toBe(1);
+  });
+
+  it("Enter falls back to the first item when nothing is explicitly highlighted but items exist", () => {
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} />);
+    // Highlight defaults to 0 on mount, so Enter selects the first item.
+    fireEvent.keyDown(getInput(), { key: "Enter" });
+    expect(onSelect.mock.calls[0][1]).toBe(0);
+  });
+
+  it("Enter calls onSubmitNoMatch with the raw value when the list is empty", () => {
+    const onSelect = vi.fn();
+    const onSubmitNoMatch = vi.fn();
+    render(
+      <Harness items={[]} onSelect={onSelect} onSubmitNoMatch={onSubmitNoMatch} />,
+    );
+    // Empty list → no listbox options. Type into the input then Enter.
+    const input = getInput();
+    fireEvent.change(input, { target: { value: "alice.social" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onSubmitNoMatch).toHaveBeenCalledWith("alice.social");
+  });
+
+  it("mouse selecting a row fires onSelect with that item + index", () => {
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} />);
+    const charlie = screen.getByText("Charlie");
+    fireEvent.mouseDown(charlie);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0]).toEqual({ id: "c", label: "Charlie" });
+    expect(onSelect.mock.calls[0][1]).toBe(2);
+  });
+
+  it("hovering a row moves the highlight to it", () => {
+    render(<Harness />);
+    fireEvent.mouseEnter(screen.getByText("Charlie"));
+    expect(highlightedLabel()).toBe("Charlie");
+  });
+});
+
+describe("Combobox — Escape", () => {
+  it("two-stage: first Escape closes the listbox, second clears the value", () => {
+    render(<Harness escapeStage="two-stage" />);
+    const input = getInput();
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+
+    // First Escape — close.
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(input.getAttribute("aria-expanded")).toBe("false");
+    expect((getInput() as HTMLInputElement).value).toBe("a");
+
+    // Second Escape (already closed) — clear the value.
+    fireEvent.keyDown(getInput(), { key: "Escape" });
+    expect((getInput() as HTMLInputElement).value).toBe("");
+  });
+
+  it("close-only: Escape closes but never clears the value", () => {
+    render(<Harness escapeStage="close-only" />);
+    const input = getInput();
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(getInput().getAttribute("aria-expanded")).toBe("false");
+    // Second Escape must be a no-op for the value.
+    fireEvent.keyDown(getInput(), { key: "Escape" });
+    expect((getInput() as HTMLInputElement).value).toBe("a");
+  });
+});
+
+describe("Combobox — empty state", () => {
+  it("renders the empty node inside the listbox when open with no items but a typed value", () => {
+    function EmptyHarness() {
+      const [open] = useState(true);
+      return (
+        <Combobox<Item>
+          value="zzz"
+          onValueChange={() => undefined}
+          items={[]}
+          getItemKey={(it) => it.id}
+          open={open}
+          onOpenChange={() => undefined}
+          onSelect={() => undefined}
+          inputProps={{ "aria-label": "Search" }}
+          renderEmpty={() => <li className="empty">No results.</li>}
+          renderOption={() => null}
+        />
+      );
+    }
+    render(<EmptyHarness />);
+    expect(screen.getByRole("listbox").textContent).toContain("No results.");
+  });
+});

--- a/src/components/ui/__tests__/segmented-control.test.tsx
+++ b/src/components/ui/__tests__/segmented-control.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { render, cleanup, fireEvent } from "@testing-library/react"
+import SegmentedControl, { ToggleGroup } from "../segmented-control"
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("SegmentedControl (single-select)", () => {
+  it("renders a radiogroup with one radio per option and marks the selected one", () => {
+    const { container, getByRole } = render(
+      <SegmentedControl
+        aria-label="View"
+        value="list"
+        options={[
+          { value: "list", label: "List" },
+          { value: "gallery", label: "Gallery" },
+        ]}
+      />,
+    )
+    expect(getByRole("radiogroup").getAttribute("aria-label")).toBe("View")
+    const radios = container.querySelectorAll('[role="radio"]')
+    expect(radios.length).toBe(2)
+    expect(radios[0].getAttribute("aria-checked")).toBe("true")
+    expect(radios[1].getAttribute("aria-checked")).toBe("false")
+  })
+
+  it("fires onValueChange with the clicked value (and not when re-clicking the active one)", () => {
+    const onValueChange = vi.fn()
+    const { container } = render(
+      <SegmentedControl
+        aria-label="View"
+        value="list"
+        onValueChange={onValueChange}
+        options={[
+          { value: "list", label: "List" },
+          { value: "gallery", label: "Gallery" },
+        ]}
+      />,
+    )
+    const radios = container.querySelectorAll('[role="radio"]')
+    fireEvent.click(radios[1])
+    expect(onValueChange).toHaveBeenCalledWith("gallery")
+    onValueChange.mockClear()
+    // Re-clicking the already-selected option is a no-op (RadioGroup guards it).
+    fireEvent.click(radios[0])
+    expect(onValueChange).not.toHaveBeenCalled()
+  })
+
+  it("uses ariaLabel for icon-only segments (no visible label)", () => {
+    const { container } = render(
+      <SegmentedControl
+        aria-label="View"
+        value="list"
+        iconOnly
+        options={[
+          { value: "list", ariaLabel: "List view", icon: <svg /> },
+          { value: "gallery", ariaLabel: "Gallery view", icon: <svg /> },
+        ]}
+      />,
+    )
+    const radios = container.querySelectorAll('[role="radio"]')
+    expect(radios[0].getAttribute("aria-label")).toBe("List view")
+    expect(radios[1].getAttribute("aria-label")).toBe("Gallery view")
+  })
+
+  it("applies the joined container border + overflow-hidden and an inset focus offset", () => {
+    const { getByRole, container } = render(
+      <SegmentedControl
+        aria-label="View"
+        value="a"
+        joined
+        options={[
+          { value: "a", label: "A" },
+          { value: "b", label: "B" },
+        ]}
+      />,
+    )
+    const group = getByRole("radiogroup")
+    expect(group.className).toContain("overflow-hidden")
+    expect(group.className).toContain("border-[var(--border-default)]")
+    const radios = container.querySelectorAll('[role="radio"]')
+    // Inset (negative) offset so the focus ring isn't clipped by overflow-hidden.
+    expect(radios[0].className).toContain("focus-visible:-outline-offset-2")
+    // First segment has no left divider; the second does.
+    expect(radios[0].className).not.toContain("border-l")
+    expect(radios[1].className).toContain("border-l")
+  })
+
+  it("resolves the forwarded ref to the radiogroup root node", () => {
+    const ref = { current: null as HTMLDivElement | null }
+    render(
+      <SegmentedControl
+        ref={ref}
+        aria-label="View"
+        value="a"
+        options={[
+          { value: "a", label: "A" },
+          { value: "b", label: "B" },
+        ]}
+      />,
+    )
+    expect(ref.current).not.toBeNull()
+    expect(ref.current?.getAttribute("role")).toBe("radiogroup")
+  })
+
+  it("disables a segment when the option is disabled", () => {
+    const { container } = render(
+      <SegmentedControl
+        aria-label="View"
+        value="a"
+        options={[
+          { value: "a", label: "A" },
+          { value: "b", label: "B", disabled: true },
+        ]}
+      />,
+    )
+    const radios = container.querySelectorAll('[role="radio"]')
+    expect((radios[1] as HTMLButtonElement).disabled).toBe(true)
+  })
+})
+
+describe("ToggleGroup (multi-select)", () => {
+  it("renders role=group with aria-pressed buttons reflecting the value set", () => {
+    const { getByRole, container } = render(
+      <ToggleGroup
+        aria-label="Rings"
+        value={["1", "3"]}
+        options={[
+          { value: "1", label: "1st" },
+          { value: "2", label: "2nd" },
+          { value: "3", label: "3rd" },
+        ]}
+      />,
+    )
+    expect(getByRole("group").getAttribute("aria-label")).toBe("Rings")
+    const btns = container.querySelectorAll("button")
+    expect(btns[0].getAttribute("aria-pressed")).toBe("true")
+    expect(btns[1].getAttribute("aria-pressed")).toBe("false")
+    expect(btns[2].getAttribute("aria-pressed")).toBe("true")
+  })
+
+  it("adds a value when toggling an unpressed option, preserving option order", () => {
+    const onValueChange = vi.fn()
+    const { container } = render(
+      <ToggleGroup
+        aria-label="Rings"
+        value={["1"]}
+        onValueChange={onValueChange}
+        options={[
+          { value: "1", label: "1st" },
+          { value: "2", label: "2nd" },
+          { value: "3", label: "3rd" },
+        ]}
+      />,
+    )
+    const btns = container.querySelectorAll("button")
+    fireEvent.click(btns[2])
+    expect(onValueChange).toHaveBeenCalledWith(["1", "3"])
+  })
+
+  it("removes a value when toggling a pressed option (allowing the empty set)", () => {
+    const onValueChange = vi.fn()
+    const { container } = render(
+      <ToggleGroup
+        aria-label="Rings"
+        value={["2"]}
+        onValueChange={onValueChange}
+        options={[
+          { value: "1", label: "1st" },
+          { value: "2", label: "2nd" },
+        ]}
+      />,
+    )
+    const btns = container.querySelectorAll("button")
+    fireEvent.click(btns[1])
+    expect(onValueChange).toHaveBeenCalledWith([])
+  })
+
+  it("applies semantic tone classes per-option for the active state", () => {
+    const { container } = render(
+      <ToggleGroup
+        aria-label="Response"
+        value={["accept", "reject"]}
+        iconOnly
+        options={[
+          { value: "accept", tone: "success", ariaLabel: "Accept", icon: <svg /> },
+          { value: "reject", tone: "warn", ariaLabel: "Reject", icon: <svg /> },
+        ]}
+      />,
+    )
+    const btns = container.querySelectorAll("button")
+    // Success uses the green success tokens; reject uses the AMBER warning
+    // tokens (NOT error/red).
+    expect(btns[0].className).toContain("bg-[var(--color-success-bg)]")
+    expect(btns[0].className).toContain("text-[var(--color-success-text)]")
+    expect(btns[1].className).toContain("bg-[var(--color-warning-bg)]")
+    expect(btns[1].className).toContain("text-[var(--color-warning-text)]")
+  })
+
+  it("does not apply tone classes to an unpressed toned option", () => {
+    const { container } = render(
+      <ToggleGroup
+        aria-label="Response"
+        value={[]}
+        iconOnly
+        options={[
+          { value: "accept", tone: "success", ariaLabel: "Accept", icon: <svg /> },
+        ]}
+      />,
+    )
+    const btn = container.querySelector("button") as HTMLButtonElement
+    expect(btn.className).not.toContain("bg-[var(--color-success-bg)]")
+    expect(btn.getAttribute("aria-pressed")).toBe("false")
+  })
+
+  it("supports gapped (un-joined) layout where each segment is self-bordered", () => {
+    const { getByRole, container } = render(
+      <ToggleGroup
+        aria-label="Rings"
+        value={[]}
+        joined={false}
+        shape="pill"
+        options={[
+          { value: "1", label: "1st" },
+          { value: "2", label: "2nd" },
+        ]}
+      />,
+    )
+    const group = getByRole("group")
+    expect(group.className).toContain("gap-1")
+    expect(group.className).not.toContain("overflow-hidden")
+    const btns = container.querySelectorAll("button")
+    expect(btns[0].className).toContain("border")
+    expect(btns[0].className).toContain("rounded-[999px]")
+  })
+})

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -1,0 +1,471 @@
+"use client";
+
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+} from "react";
+import Input, { type InputProps } from "@/components/ui/input";
+
+/**
+ * Generic typeahead Combobox primitive.
+ *
+ * This owns the *state machine* and *ARIA wiring* shared by every
+ * typeahead surface in the app (global search, cert search, people
+ * search, group handle search, the inline contributor identity
+ * field). It does NOT fetch, merge, dedupe, group, or know anything
+ * about row shape — each surface keeps its own data layer and renders
+ * its own rows through the `renderOption` render prop.
+ *
+ * The model is CONTROLLED-ITEMS: the caller passes `items` already
+ * merged/filtered into final render order, plus the typed `value` and
+ * `open` state. The combobox derives the highlight index, handles the
+ * keyboard (Arrow / Home / End / Enter / Escape), closes on outside
+ * click, keeps the highlighted row scrolled into view, and emits the
+ * full ARIA contract so screen readers see a conformant combobox +
+ * listbox pair.
+ *
+ * Chrome: by default the editable control is the shared <Input> (so
+ * leadingIcon / trailingButton / size / variant all compose for free).
+ * Surfaces that need their own flush chrome (e.g. the inline
+ * `cert-detail__meta-input`) can pass `renderInput` to render a bare
+ * styled <input>; the combobox still owns its props and ARIA.
+ */
+
+export type ComboboxEscapeStage = "two-stage" | "close-only";
+
+/**
+ * Live-region copy. The combobox renders an sr-only polite region and
+ * picks one of these strings based on `isLoading` / item count / typed
+ * value. Pass `null` (or omit) to suppress announcements entirely.
+ */
+export interface ComboboxLiveStatus {
+  /** Announced while `isLoading` is true. e.g. "Searching". */
+  searching: string;
+  /** Given the item count, return the announcement. e.g. (n) => `${n} results`. */
+  results: (count: number) => string;
+  /** Announced when not loading, zero items, and the user has typed. */
+  empty: string;
+}
+
+/**
+ * Props handed to the `renderOption` render prop for each item. The
+ * surface returns the `<li role="option">` (or a fragment that
+ * includes a group header above it). The combobox supplies the
+ * stable option id (for `aria-activedescendant`), the highlight flag,
+ * and pre-bound hover/select handlers so every surface wires its rows
+ * the same way.
+ */
+export interface ComboboxOptionRenderProps<T> {
+  item: T;
+  index: number;
+  highlighted: boolean;
+  /** The id this row MUST set on its `<li id>` so activedescendant matches. */
+  optionId: string;
+  /** Bind to `onMouseEnter` — moves the highlight to this row. */
+  onHover: () => void;
+  /**
+   * Bind to `onMouseDown` (not click). The combobox calls
+   * `e.preventDefault()` for you and then `onSelect(item, index)` so
+   * the input doesn't blur-close the listbox before selection runs.
+   */
+  onSelect: (e: React.MouseEvent) => void;
+}
+
+export interface ComboboxProps<T> {
+  /** Current typed text (controlled). */
+  value: string;
+  /** Fired on every keystroke with the new input value. */
+  onValueChange: (next: string) => void;
+
+  /**
+   * Items in final render order — already fetched, merged, deduped,
+   * filtered, and (visually) grouped by the surface. The combobox
+   * treats this as an opaque flat list for keyboard navigation; group
+   * headers are the surface's concern (render them inside
+   * `renderListHeader` or interleaved in `renderOption`).
+   */
+  items: readonly T[];
+  /** Stable key for an item — used for the React list key only. */
+  getItemKey: (item: T, index: number) => React.Key;
+
+  /** True while the surface is fetching. Drives `aria-busy` + live status. */
+  isLoading?: boolean;
+
+  /** Open state of the listbox (controlled). */
+  open: boolean;
+  /** Requests an open-state change (outside click, Escape, selection). */
+  onOpenChange: (open: boolean) => void;
+
+  /**
+   * Fired when the user commits an item (Enter on the highlighted row,
+   * or a row's mouse-select). Receives the item and its index.
+   */
+  onSelect: (item: T, index: number) => void;
+  /**
+   * Optional: fired on Enter when there is no highlighted item (empty
+   * list, or highlight === -1). Receives the raw typed value. Used by
+   * the contributor field to "commit" a typed-but-unmatched handle.
+   * Return value is ignored.
+   */
+  onSubmitNoMatch?: (raw: string) => void;
+
+  /** Render one option row. See {@link ComboboxOptionRenderProps}. */
+  renderOption: (props: ComboboxOptionRenderProps<T>) => React.ReactNode;
+  /**
+   * Optional empty-state node, rendered inside the listbox when there
+   * are no items. The combobox decides *whether* the listbox renders
+   * (open + has-content); the surface decides what "empty" looks like.
+   */
+  renderEmpty?: () => React.ReactNode;
+  /**
+   * Optional content rendered at the TOP of the listbox, before the
+   * options: group headers, an error banner, a resolved-DID hint, etc.
+   */
+  renderListHeader?: () => React.ReactNode;
+
+  /** Ref to the underlying <input>, forwarded to the caller. */
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+  /**
+   * Props merged onto the composed <Input> (or bare input via
+   * `renderInput`): placeholder, size, variant, leadingIcon,
+   * trailingIcon, label, aria-label, etc. The combobox owns the ARIA
+   * combobox attributes and the value/keyboard handlers — those are
+   * spread AFTER these, so they win.
+   */
+  inputProps?: Partial<InputProps>;
+  /**
+   * Interactive trailing control (e.g. a clear button) forwarded to
+   * the <Input>'s trailing slot. Ignored when `renderInput` is used.
+   */
+  trailingButton?: React.ReactNode;
+
+  /**
+   * Escape hatch: render a bare <input> instead of the shared <Input>.
+   * Receives the fully-wired props (value, onChange, onKeyDown, ARIA,
+   * ref) — spread them onto your own `<input className="…">`. Use this
+   * when a surface needs flush chrome the <Input> wrapper can't give.
+   */
+  renderInput?: (
+    props: React.InputHTMLAttributes<HTMLInputElement> & {
+      ref: React.RefObject<HTMLInputElement | null>;
+    },
+  ) => React.ReactNode;
+
+  /** Class on the outer wrapper. */
+  className?: string;
+  /** Class on the <ul role="listbox">. */
+  listboxClassName?: string;
+  /** When 'search', the wrapper gets `role="search"`. */
+  role?: "search";
+
+  /** Enable Home/End jump-to-edge keys. Default true. */
+  enableHomeEnd?: boolean;
+  /**
+   * Escape behaviour:
+   *  - 'two-stage' (default, WAI-ARIA): first Escape closes the
+   *    listbox; a second Escape (already closed) clears the input,
+   *    then blurs.
+   *  - 'close-only': Escape only closes the listbox.
+   */
+  escapeStage?: ComboboxEscapeStage;
+
+  /** Live-region copy. Omit to suppress sr-only announcements. */
+  liveStatus?: ComboboxLiveStatus | null;
+}
+
+/**
+ * Internal: derive the next highlight index for an arrow press,
+ * wrapping at both ends. Returns -1 when the list is empty.
+ */
+function wrapHighlight(current: number, delta: 1 | -1, length: number): number {
+  if (length === 0) return -1;
+  if (delta === 1) return (current + 1) % length;
+  return current <= 0 ? length - 1 : current - 1;
+}
+
+function Combobox<T>({
+  value,
+  onValueChange,
+  items,
+  getItemKey,
+  isLoading = false,
+  open,
+  onOpenChange,
+  onSelect,
+  onSubmitNoMatch,
+  renderOption,
+  renderEmpty,
+  renderListHeader,
+  inputRef: inputRefProp,
+  inputProps,
+  trailingButton,
+  renderInput,
+  className = "",
+  listboxClassName = "",
+  role,
+  enableHomeEnd = true,
+  escapeStage = "two-stage",
+  liveStatus,
+}: ComboboxProps<T>) {
+  const reactId = useId();
+  const listboxId = `${reactId}-listbox`;
+  const optionIdPrefix = `${reactId}-option`;
+
+  const [highlight, setHighlight] = React.useState(-1);
+
+  const internalInputRef = useRef<HTMLInputElement | null>(null);
+  const inputRef = inputRefProp ?? internalInputRef;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const count = items.length;
+
+  // Reset the highlight whenever the item set changes: first row when
+  // the list is non-empty, -1 when it's empty. Keying off `count` (not
+  // the array identity) keeps this stable when a parent passes a fresh
+  // array each render with the same contents.
+  useEffect(() => {
+    setHighlight(count > 0 ? 0 : -1);
+  }, [count]);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target;
+      if (!(target instanceof Node)) return;
+      if (containerRef.current && !containerRef.current.contains(target)) {
+        onOpenChange(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open, onOpenChange]);
+
+  // Keep the highlighted row visible during keyboard navigation.
+  useEffect(() => {
+    if (highlight < 0 || !listRef.current) return;
+    const rows = listRef.current.querySelectorAll<HTMLElement>(
+      "[data-combobox-option]",
+    );
+    rows[highlight]?.scrollIntoView({ block: "nearest" });
+  }, [highlight]);
+
+  const optionIdFor = useCallback(
+    (index: number) => `${optionIdPrefix}-${index}`,
+    [optionIdPrefix],
+  );
+
+  const moveHighlight = useCallback(
+    (delta: 1 | -1) => {
+      onOpenChange(true);
+      setHighlight((h) => wrapHighlight(h, delta, count));
+    },
+    [count, onOpenChange],
+  );
+
+  const commitHighlighted = useCallback(() => {
+    // Enter: select the highlighted row, falling back to the first row
+    // when the list has items but nothing is highlighted yet. If there
+    // are no items, hand control to `onSubmitNoMatch` (typed-but-
+    // unmatched commit). When highlight is -1 *with* items present we
+    // also treat that as "no highlighted match" for onSubmitNoMatch
+    // semantics — but only if the caller opted in AND the list is
+    // empty; with items we default to the first row to preserve the
+    // existing surfaces' "Enter picks first result" behaviour.
+    if (count > 0) {
+      const index = highlight >= 0 ? highlight : 0;
+      const item = items[index];
+      if (item !== undefined) onSelect(item, index);
+      return;
+    }
+    onSubmitNoMatch?.(value);
+  }, [count, highlight, items, onSelect, onSubmitNoMatch, value]);
+
+  const handleEscape = useCallback(() => {
+    if (open) {
+      onOpenChange(false);
+      return;
+    }
+    if (escapeStage === "close-only") return;
+    // two-stage: already closed → clear, else blur.
+    if (value) {
+      onValueChange("");
+    } else {
+      inputRef.current?.blur();
+    }
+  }, [open, escapeStage, value, onValueChange, onOpenChange, inputRef]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      switch (e.key) {
+        case "ArrowDown":
+          if (count === 0) return;
+          e.preventDefault();
+          moveHighlight(1);
+          return;
+        case "ArrowUp":
+          if (count === 0) return;
+          e.preventDefault();
+          moveHighlight(-1);
+          return;
+        case "Enter": {
+          // Enter commits. Always preventDefault when there's anything
+          // to commit (a row, or a no-match handler with a typed value)
+          // so the surrounding form doesn't submit out from under us.
+          const hasNoMatchTarget =
+            count === 0 && onSubmitNoMatch && value.trim().length > 0;
+          if (count === 0 && !hasNoMatchTarget) return;
+          e.preventDefault();
+          commitHighlighted();
+          return;
+        }
+        case "Escape":
+          e.preventDefault();
+          handleEscape();
+          return;
+        case "Home":
+          if (!enableHomeEnd || count === 0) return;
+          e.preventDefault();
+          setHighlight(0);
+          return;
+        case "End":
+          if (!enableHomeEnd || count === 0) return;
+          e.preventDefault();
+          setHighlight(count - 1);
+          return;
+        default:
+          return;
+      }
+    },
+    [
+      count,
+      enableHomeEnd,
+      moveHighlight,
+      commitHighlighted,
+      handleEscape,
+      onSubmitNoMatch,
+      value,
+    ],
+  );
+
+  const activeDescendant =
+    open && highlight >= 0 ? optionIdFor(highlight) : undefined;
+
+  // The listbox renders only when open AND there's something to show:
+  // options, an empty-state, or a header (error banner / resolved hint).
+  const hasListContent =
+    count > 0 || Boolean(renderEmpty) || Boolean(renderListHeader);
+  const showListbox = open && hasListContent;
+
+  // ARIA attributes shared by both the composed <Input> and the bare
+  // escape-hatch input. The caller's `inputProps` are spread BEFORE
+  // these in the <Input> path so these always win. Typed as a precise
+  // literal (not the broad InputHTMLAttributes) so it stays assignable
+  // to both InputProps and a bare <input>'s props.
+  const ariaProps = {
+    role: "combobox" as const,
+    "aria-autocomplete": "list" as const,
+    "aria-expanded": showListbox,
+    "aria-controls": showListbox ? listboxId : undefined,
+    "aria-activedescendant": activeDescendant,
+    autoComplete: "off" as const,
+    spellCheck: false,
+  };
+
+  const onChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onValueChange(e.target.value);
+    },
+    [onValueChange],
+  );
+
+  const onFocus = useCallback(() => {
+    if (count > 0) onOpenChange(true);
+  }, [count, onOpenChange]);
+
+  // Resolve the live-region message. Empty string → SR says nothing.
+  let liveMessage = "";
+  if (liveStatus) {
+    if (isLoading) liveMessage = liveStatus.searching;
+    else if (count > 0) liveMessage = liveStatus.results(count);
+    else if (value.trim()) liveMessage = liveStatus.empty;
+  }
+
+  const inputElement = renderInput ? (
+    // The ref object is handed to the consumer's render-prop purely so it can
+    // attach it (e.g. ref={props.ref} on a bare <input>); it is never
+    // dereferenced during render here.
+    // eslint-disable-next-line react-hooks/refs
+    renderInput({
+      ref: inputRef,
+      value,
+      onChange,
+      onKeyDown: handleKeyDown,
+      onFocus,
+      ...ariaProps,
+    })
+  ) : (
+    <Input
+      ref={inputRef}
+      type="text"
+      value={value}
+      onChange={onChange}
+      onKeyDown={handleKeyDown}
+      onFocus={onFocus}
+      trailingButton={trailingButton}
+      {...inputProps}
+      {...ariaProps}
+    />
+  );
+
+  return (
+    <div ref={containerRef} className={className} role={role}>
+      {inputElement}
+
+      {liveStatus ? (
+        <div className="sr-only" aria-live="polite" aria-atomic="true">
+          {liveMessage}
+        </div>
+      ) : null}
+
+      {showListbox ? (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          aria-busy={isLoading || undefined}
+          className={listboxClassName}
+        >
+          {renderListHeader ? renderListHeader() : null}
+          {count === 0 && renderEmpty ? renderEmpty() : null}
+          {items.map((item, index) => {
+            const optionId = optionIdFor(index);
+            return (
+              <React.Fragment key={getItemKey(item, index)}>
+                {renderOption({
+                  item,
+                  index,
+                  highlighted: index === highlight,
+                  optionId,
+                  onHover: () => setHighlight(index),
+                  onSelect: (e: React.MouseEvent) => {
+                    // mouseDown fires before the input blur — preventing
+                    // default keeps the listbox open until selection runs.
+                    e.preventDefault();
+                    onSelect(item, index);
+                  },
+                })}
+              </React.Fragment>
+            );
+          })}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+export default Combobox;

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,30 @@
 import React, { useId } from "react";
 
-export type InputSize = "sm" | "md" | "lg";
+export type InputSize = "sm" | "md" | "lg" | "bare";
 export type InputVariant = "default" | "underline" | "inline-edit";
+/**
+ * Resting + focus border treatment for the `default` variant. Two
+ * holdout-driven families coexist:
+ *   - `default` (1 px `--border-default`) — the app's standard field
+ *     weight; also what the sidebar org-URL / founded-date inputs use.
+ *   - `hover`   (1.5 px `--border-hover`) — the slightly heavier
+ *     "currently editable" weight the inline-edit holdouts use (profile
+ *     name / website, cert title / meta / short-description). Focus on
+ *     this family resolves the border to `--fg-primary` with a 2 px
+ *     `--overlay-weak` ring, matching the legacy `*-input:focus` CSS
+ *     rather than the accent focus-ring the standard field uses.
+ * Only consulted for the `default` variant — `underline` / `inline-edit`
+ * own their own border treatment and ignore this.
+ */
+export type InputBorderWeight = "default" | "hover";
+/**
+ * Typographic density. `default` keeps today's per-size padding + text
+ * scale; `compact` is the cert-detail "meta" scale (0.8125rem text,
+ * 2px/6px padding) shared by the activity meta-input holdouts. Compact
+ * only changes padding + text-size, so it composes with any size; with
+ * `size="bare"` it sets just the padding (text-size cascades).
+ */
+export type InputDensity = "default" | "compact";
 
 export interface InputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size"> {
@@ -10,6 +33,33 @@ export interface InputProps
   helperText?: string;
   size?: InputSize;
   variant?: InputVariant;
+  /**
+   * Border treatment for the `default` variant — see
+   * {@link InputBorderWeight}. Defaults to `default` (1 px). Pass
+   * `"hover"` for the heavier 1.5 px "editable" weight the profile /
+   * cert inline-edit holdouts use. Ignored by the `underline` and
+   * `inline-edit` variants.
+   */
+  borderWeight?: InputBorderWeight;
+  /**
+   * Typographic density — see {@link InputDensity}. Defaults to
+   * `default`. `compact` is the cert-detail meta scale.
+   */
+  density?: InputDensity;
+  /**
+   * Unwrapped / "flush" mode. When true the component renders the bare
+   * `<input>` (plus the relative icon wrapper only if icons are used)
+   * with NO outer `w-full` wrapper `<div>` and NO label / error /
+   * helper block — so the field can sit directly as a flex or grid
+   * child (the inline icon+input rows, the cert meta inputs). `label`,
+   * `error`, and `helperText` are ignored in this mode (a flush field
+   * is labelled by its parent row). `aria-invalid` still reflects
+   * `error` so assistive tech and styling hooks keep working.
+   * Alias: `unwrapped`.
+   */
+  flush?: boolean;
+  /** Alias for {@link flush}. */
+  unwrapped?: boolean;
   /**
    * Optional addon glyph rendered inside the field, before the text. The
    * wrapper positions it and the input is padded so text never overlaps it.
@@ -36,7 +86,21 @@ const sizeClasses: Record<InputSize, string> = {
   sm: "h-9 px-3 text-sm",
   md: "h-11 px-4 text-base md:text-sm",
   lg: "h-14 px-5 text-base",
+  // No fixed height, no text-size — typography cascades from the parent
+  // (e.g. an H1 serif scale via `font:inherit`, or the create-form's
+  // 1.375rem title rule). We still set the horizontal padding the
+  // wrapped sizes carry so a bare field isn't edge-to-edge; the
+  // `font-[inherit]` trio makes size/leading inherit the cascade.
+  bare: "px-3 font-[inherit] text-[length:inherit] leading-[inherit]",
 };
+
+// Compact density: the cert-detail "meta" scale (0.8125rem text,
+// 2px vertical / 6px horizontal padding). Overrides the size's own
+// padding + text scale. With `size="bare"` the text-size half is a
+// no-op because bare already inherits length — the padding still
+// applies, which is what the meta inputs want (2px/6px on inherited
+// typography).
+const compactClasses = "py-0.5 px-1.5 text-[0.8125rem]";
 
 // Horizontal padding the input picks up when an icon occupies that side, so
 // the caret/text clears the glyph. Mirrors sizeClasses' base px per size.
@@ -44,11 +108,13 @@ const leadingPadClasses: Record<InputSize, string> = {
   sm: "pl-9",
   md: "pl-11",
   lg: "pl-12",
+  bare: "pl-9",
 };
 const trailingPadClasses: Record<InputSize, string> = {
   sm: "pr-9",
   md: "pr-11",
   lg: "pr-12",
+  bare: "pr-9",
 };
 
 // Where the absolutely-positioned icon sits, per side and size.
@@ -56,11 +122,13 @@ const leadingIconPos: Record<InputSize, string> = {
   sm: "left-3",
   md: "left-4",
   lg: "left-5",
+  bare: "left-3",
 };
 const trailingIconPos: Record<InputSize, string> = {
   sm: "right-3",
   md: "right-4",
   lg: "right-5",
+  bare: "right-3",
 };
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
@@ -71,6 +139,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       helperText,
       size = "md",
       variant = "default",
+      borderWeight = "default",
+      density = "default",
+      flush = false,
+      unwrapped = false,
       className = "",
       leadingIcon,
       trailingIcon,
@@ -83,8 +155,14 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ) => {
     const autoId = useId();
     const inputId = id || autoId;
-    const errorId = error ? `${inputId}-error` : undefined;
-    const helperId = !error && helperText ? `${inputId}-helper` : undefined;
+    const isFlush = flush || unwrapped;
+    // Label / error / helper only render in the wrapped layout. In flush
+    // mode the parent row owns the labelling, so we skip generating the
+    // describedby ids entirely (nothing renders them) — but keep
+    // aria-invalid wired to `error` so AT + invalid styling still work.
+    const errorId = !isFlush && error ? `${inputId}-error` : undefined;
+    const helperId =
+      !isFlush && !error && helperText ? `${inputId}-helper` : undefined;
     const describedBy = [errorId, helperId].filter(Boolean).join(" ") || undefined;
 
     const baseChrome =
@@ -117,11 +195,23 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           } rounded`;
         case "default":
         default:
-          return `border ${
-            error
-              ? "border-[var(--color-error-border)]"
-              : "border-[var(--border-default)]"
-          } rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20`;
+          // Two resting/focus families, chosen by `borderWeight`. The
+          // `hover` family reproduces the inline-edit holdout chrome:
+          // 1.5px --border-hover at rest, resolving to --fg-primary + a
+          // 2px --overlay-weak ring on focus (NOT the accent focus-ring
+          // the standard field uses). The `default` family is today's
+          // 1px standard field, unchanged.
+          if (error) {
+            // `border` (1px) for default weight — byte-identical to the
+            // pre-enhancement string; `border-[1.5px]` for hover weight.
+            return borderWeight === "hover"
+              ? "border-[1.5px] border-[var(--color-error-border)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20"
+              : "border border-[var(--color-error-border)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20";
+          }
+          if (borderWeight === "hover") {
+            return "border-[1.5px] border-[var(--border-hover)] rounded focus:border-[var(--fg-primary)] focus:ring-2 focus:ring-[var(--overlay-weak)]";
+          }
+          return "border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20";
       }
     })();
 
@@ -135,6 +225,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       hasTrailingAddon ? trailingPadClasses[size] : ""
     }`;
 
+    // Density overrides the size's own padding/text scale. It's appended
+    // AFTER sizeClasses so its `px-*` / `py-*` / `text-*` win the cascade.
+    const densityClasses = density === "compact" ? compactClasses : "";
+
     const inputEl = (
       <input
         ref={ref}
@@ -142,12 +236,14 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         disabled={disabled}
         aria-invalid={error ? true : undefined}
         aria-describedby={describedBy}
-        className={`${sizeClasses[size]} ${iconPad} ${baseChrome} ${variantChrome} ${disabledChrome} ${className}`}
+        className={`${sizeClasses[size]} ${densityClasses} ${iconPad} ${baseChrome} ${variantChrome} ${disabledChrome} ${className}`}
         {...props}
       />
     );
 
     // Only pay for the relative wrapper + absolute addons when one exists.
+    // This wrapper is the ONLY structural cost even in flush mode — the
+    // outer `w-full` div + label/error block below is what flush drops.
     const field =
       leadingIcon || hasTrailingAddon ? (
         <div className="relative w-full">
@@ -183,6 +279,12 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       ) : (
         inputEl
       );
+
+    // Flush mode: return the field directly with no wrapper / label /
+    // helper / error block, so it composes as a plain flex/grid child.
+    if (isFlush) {
+      return field;
+    }
 
     return (
       <div className="w-full">

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -7,9 +7,12 @@ import React, {
   useContext,
   useEffect,
   useId,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
+import { useMounted } from "@/hooks/use-mounted";
 
 /**
  * Canonical popover primitive.
@@ -46,6 +49,29 @@ import React, {
  * Intentionally minimal — no Floating UI / popper. The token-driven
  * card chrome lives in a single utility class so the four call sites
  * all look identical.
+ *
+ * Portal mode (opt-in, `<PopoverContent portal>`):
+ *  - Renders the SAME `<div role="menu">` (same class string, same ref,
+ *    same keyboard handling) through `createPortal(node, document.body)`
+ *    with `position: fixed`, so it escapes ancestor `overflow`/`transform`
+ *    clipping contexts (e.g. a scrollable rail or a sticky top bar). This
+ *    is what the account-switcher / create menus in the layout chrome need.
+ *  - Position is computed from the trigger's `getBoundingClientRect()` for
+ *    the chosen `side` ('top' | 'bottom') and `align` (reused as the
+ *    horizontal edge: 'start' | 'center' | 'end'), then FLIP/clamped to
+ *    stay within the viewport by `collisionPadding`. It re-measures on
+ *    scroll/resize (passive, capture, cleaned up).
+ *  - `matchTriggerWidth` sets the menu width to the trigger's width.
+ *  - The portaled node still wires `contentRef`, so the existing two-ref
+ *    (`triggerRef` + `contentRef`) click-outside in <Popover> keeps working
+ *    across the portal boundary, and Esc-to-close / focus-return are
+ *    unchanged.
+ *  - SSR-guarded: the portal only mounts after the client hydrates
+ *    (`useMounted`), so the server render stays portal-free.
+ *
+ * The default (non-portal) path is BYTE-IDENTICAL to the pre-portal
+ * primitive — same DOM, same class string, same inline style — so every
+ * existing in-flow consumer renders exactly as before.
  */
 
 interface PopoverContextValue {
@@ -149,13 +175,62 @@ export function PopoverTrigger({ children }: PopoverTriggerProps) {
 
 export type PopoverAlign = "start" | "center" | "end";
 
+/** Vertical side the portaled menu opens toward (portal mode only). */
+export type PopoverSide = "top" | "bottom";
+
 export interface PopoverContentProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** Horizontal alignment relative to the trigger. */
+  /**
+   * Horizontal alignment relative to the trigger.
+   *
+   * In the default (in-flow) path this maps to the absolute-position
+   * utility class (`left-0` / centered / `right-0`). In portal mode it is
+   * reused as the horizontal *edge* the menu aligns to: 'start' = left
+   * edges aligned, 'center' = centered on the trigger, 'end' = right edges
+   * aligned.
+   */
   align?: PopoverAlign;
-  /** Pixel offset below the trigger. Defaults to 4 px. */
+  /**
+   * Pixel offset below the trigger. Defaults to 4 px. In the in-flow path
+   * this becomes the content's `margin-top`. In portal mode it is the
+   * default for `sideOffset` (the gap between trigger and menu on the
+   * chosen `side`).
+   */
   offset?: number;
   /** Optional min-width. */
   minWidth?: number | string;
+  /**
+   * Opt into a portal + fixed-position + collision layer. Default `false`
+   * keeps the original absolute, in-flow rendering BYTE-IDENTICAL. When
+   * `true`, the same menu node is portaled to `document.body` with
+   * `position: fixed` and positioned against the trigger (see the
+   * `side` / `align` / `sideOffset` / `collisionPadding` / `matchTriggerWidth`
+   * props below). Use this when an ancestor's `overflow`/`transform` would
+   * otherwise clip the menu.
+   */
+  portal?: boolean;
+  /**
+   * Portal mode only: which side of the trigger the menu opens toward.
+   * Defaults to 'bottom'. The menu FLIPs to the opposite side if there
+   * isn't room within the viewport (respecting `collisionPadding`).
+   */
+  side?: PopoverSide;
+  /**
+   * Portal mode only: gap in px between the trigger and the menu along
+   * `side`. Defaults to `offset` (so a single `offset` controls the gap
+   * in both modes).
+   */
+  sideOffset?: number;
+  /**
+   * Portal mode only: minimum distance in px the menu keeps from each
+   * viewport edge while clamping. Defaults to 8.
+   */
+  collisionPadding?: number;
+  /**
+   * Portal mode only: when `true`, the menu's width is pinned to the
+   * trigger's measured width (handy for a select-style menu that should
+   * line up with its trigger).
+   */
+  matchTriggerWidth?: boolean;
   children: React.ReactNode;
 }
 
@@ -189,6 +264,74 @@ function getMenuItems(content: HTMLElement | null): HTMLElement[] {
   );
 }
 
+/**
+ * Fixed-position coordinates for the portaled menu. `left`/`top` are
+ * viewport-relative (px) and feed straight into `position: fixed`.
+ * `width` is only set when `matchTriggerWidth` is on.
+ */
+interface PortalCoords {
+  left: number;
+  top: number;
+  width?: number;
+}
+
+/**
+ * Compute viewport-relative `position: fixed` coords for the portaled
+ * menu, given the trigger rect and the measured menu size, then
+ * FLIP/clamp so the menu stays within the viewport minus `collisionPadding`.
+ *
+ *  - `side` picks the preferred vertical side; we FLIP to the opposite
+ *    side when the preferred side lacks room but the opposite has more.
+ *  - `align` is the horizontal edge: 'start' aligns left edges, 'end'
+ *    aligns right edges, 'center' centers on the trigger. The result is
+ *    then clamped horizontally within the viewport.
+ */
+function computePortalCoords(
+  triggerRect: DOMRect,
+  menuW: number,
+  menuH: number,
+  side: PopoverSide,
+  align: PopoverAlign,
+  sideOffset: number,
+  collisionPadding: number,
+): { left: number; top: number } {
+  const vw = globalThis.innerWidth;
+  const vh = globalThis.innerHeight;
+
+  // --- vertical (side) with FLIP ---
+  const spaceBelow = vh - triggerRect.bottom;
+  const spaceAbove = triggerRect.top;
+  let resolvedSide = side;
+  if (side === "bottom" && spaceBelow < menuH + sideOffset + collisionPadding && spaceAbove > spaceBelow) {
+    resolvedSide = "top";
+  } else if (side === "top" && spaceAbove < menuH + sideOffset + collisionPadding && spaceBelow > spaceAbove) {
+    resolvedSide = "bottom";
+  }
+  let top =
+    resolvedSide === "bottom"
+      ? triggerRect.bottom + sideOffset
+      : triggerRect.top - sideOffset - menuH;
+  // Clamp vertically within the viewport.
+  const maxTop = vh - collisionPadding - menuH;
+  const minTop = collisionPadding;
+  top = Math.min(Math.max(top, minTop), Math.max(minTop, maxTop));
+
+  // --- horizontal (align) with clamp ---
+  let left: number;
+  if (align === "start") {
+    left = triggerRect.left;
+  } else if (align === "end") {
+    left = triggerRect.right - menuW;
+  } else {
+    left = triggerRect.left + triggerRect.width / 2 - menuW / 2;
+  }
+  const maxLeft = vw - collisionPadding - menuW;
+  const minLeft = collisionPadding;
+  left = Math.min(Math.max(left, minLeft), Math.max(minLeft, maxLeft));
+
+  return { left, top };
+}
+
 export function PopoverContent({
   align = "start",
   offset = 4,
@@ -197,20 +340,90 @@ export function PopoverContent({
   style,
   children,
   onKeyDown,
+  portal = false,
+  side = "bottom",
+  sideOffset,
+  collisionPadding = 8,
+  matchTriggerWidth = false,
   ...props
 }: PopoverContentProps) {
   // Pull ref + id out of the context locally — the React 19 strict-refs
   // lint rule is overly cautious about accessing context-held refs in JSX.
-  const { open, contentRef, contentId } = usePopover("PopoverContent");
+  const { open, triggerRef, contentRef, contentId } = usePopover("PopoverContent");
+
+  // Portal mode only: SSR-guard (portal can't run on the server) and the
+  // computed fixed-position coords. Both hooks run unconditionally so the
+  // hook order is stable whether or not `portal` is set.
+  const mounted = useMounted();
+  const [coords, setCoords] = useState<PortalCoords | null>(null);
+  // Effective gap on the chosen side — a single `offset` controls both
+  // modes unless the caller passes an explicit `sideOffset`.
+  const resolvedSideOffset = sideOffset ?? offset;
 
   // Focus the first menu item when the menu opens, so keyboard users land
   // inside the menu (matching native <select>/menu semantics). Esc-to-close
-  // and focus-return-to-trigger live in <Popover>.
+  // and focus-return-to-trigger live in <Popover>. In portal mode we focus
+  // with { preventScroll: true } so the browser doesn't scroll the page to
+  // bring the freshly-portaled (off-flow) node into view — the menu is
+  // already positioned next to the trigger.
   useEffect(() => {
     if (!open) return;
     const items = getMenuItems(contentRef.current);
-    items[0]?.focus();
-  }, [open, contentRef]);
+    if (portal) items[0]?.focus({ preventScroll: true });
+    else items[0]?.focus();
+  }, [open, contentRef, portal]);
+
+  // Portal mode only: measure the trigger + menu and compute fixed coords
+  // in a layout effect (before paint, so there's no first-frame flash at
+  // 0,0), then keep them in sync on scroll/resize. The listeners are
+  // passive + capture (scroll events from nested scrollers don't bubble,
+  // so capture is required to catch them) and are cleaned up on close.
+  // No-op unless we're open, in portal mode, and mounted on the client.
+  useLayoutEffect(() => {
+    if (!portal || !open || !mounted) return;
+    const reposition = () => {
+      const trigger = triggerRef.current;
+      const menu = contentRef.current;
+      if (!trigger || !menu) return;
+      const triggerRect = trigger.getBoundingClientRect();
+      const menuRect = menu.getBoundingClientRect();
+      const menuW = matchTriggerWidth ? triggerRect.width : menuRect.width;
+      const { left, top } = computePortalCoords(
+        triggerRect,
+        menuW,
+        menuRect.height,
+        side,
+        align,
+        resolvedSideOffset,
+        collisionPadding,
+      );
+      setCoords({
+        left,
+        top,
+        width: matchTriggerWidth ? triggerRect.width : undefined,
+      });
+    };
+    reposition();
+    globalThis.addEventListener("scroll", reposition, { passive: true, capture: true });
+    globalThis.addEventListener("resize", reposition, { passive: true });
+    return () => {
+      globalThis.removeEventListener("scroll", reposition, { capture: true } as EventListenerOptions);
+      globalThis.removeEventListener("resize", reposition);
+    };
+    // align/side/offset/padding/width are primitives; contentRef/triggerRef
+    // are stable refs. Re-run when any positioning input changes.
+  }, [
+    portal,
+    open,
+    mounted,
+    side,
+    align,
+    resolvedSideOffset,
+    collisionPadding,
+    matchTriggerWidth,
+    triggerRef,
+    contentRef,
+  ]);
 
   if (!open) return null;
 
@@ -252,6 +465,46 @@ export function PopoverContent({
     onKeyDown?.(e);
   };
 
+  // --- Portal path (opt-in) ---------------------------------------------
+  // Same <div role="menu"> as below, but position: fixed at the computed
+  // viewport coords and rendered into document.body via createPortal. The
+  // SAME contentRef is wired, so <Popover>'s two-ref click-outside still
+  // recognises clicks inside the portaled menu. We mount the node even
+  // before the first measurement (coords === null) so the layout effect
+  // has something to measure; it's parked off-screen + invisible for that
+  // single pre-measure frame to avoid a flash at (0,0).
+  if (portal) {
+    // SSR / pre-hydration: render nothing into the portal target. The
+    // post-mount commit (useMounted -> true) renders the real menu.
+    if (!mounted) return null;
+    const positioned = coords !== null;
+    return createPortal(
+      <div
+        ref={contentRef}
+        id={contentId}
+        role="menu"
+        onKeyDown={handleKeyDown}
+        className={`z-[var(--z-popover)] bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded shadow-md p-1 ${className}`}
+        style={{
+          position: "fixed",
+          top: coords?.top ?? 0,
+          left: coords?.left ?? 0,
+          minWidth,
+          width: coords?.width,
+          // Park the node off-flow + invisible for the single frame before
+          // the layout effect measures it; reveal once positioned.
+          visibility: positioned ? undefined : "hidden",
+          ...style,
+        }}
+        {...props}
+      >
+        {children}
+      </div>,
+      document.body,
+    );
+  }
+
+  // --- Default in-flow path (BYTE-IDENTICAL to the pre-portal primitive) -
   return (
     <div
       ref={contentRef}

--- a/src/components/ui/segmented-control.tsx
+++ b/src/components/ui/segmented-control.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import React from "react";
+import { RadioGroup, Radio } from "@/components/ui/radio";
+
+/**
+ * SegmentedControl + ToggleGroup — two related "segmented" primitives that
+ * share one styling vocabulary.
+ *
+ * SegmentedControl (default export)
+ * ---------------------------------
+ *   Single-select. A THIN wrapper over the repo's RadioGroup (role=radiogroup,
+ *   roving tabindex, arrow-key selection — all inherited, not reimplemented).
+ *   Exactly one option is active at a time.
+ *
+ *     <SegmentedControl
+ *       value={view}
+ *       onValueChange={setView}
+ *       aria-label="View"
+ *       options={[
+ *         { value: "list",    icon: <List size={14} />,       ariaLabel: "List view" },
+ *         { value: "gallery", icon: <LayoutGrid size={14} />, ariaLabel: "Gallery view" },
+ *       ]}
+ *       size="md"
+ *       joined
+ *       shape="square"
+ *       iconOnly
+ *     />
+ *
+ * ToggleGroup (named export)
+ * --------------------------
+ *   Multi / independent select. role=group of buttons each carrying
+ *   `aria-pressed`. Any non-empty subset (including the empty set) is valid;
+ *   each option toggles on its own. Supports per-option semantic color tone
+ *   (neutral / success / warn) for the active state — used by the
+ *   accept (green) / reject (amber) response control.
+ *
+ *     <ToggleGroup
+ *       value={selected}            // string[]
+ *       onValueChange={setSelected}
+ *       aria-label="Endorsement rings"
+ *       options={[
+ *         { value: "1", label: "1st" },
+ *         { value: "2", label: "2nd" },
+ *         { value: "3", label: "3rd" },
+ *       ]}
+ *       shape="pill"
+ *       joined={false}
+ *     />
+ *
+ * Shared geometry
+ * ---------------
+ *   - `joined` (default true): one shared outer border with `overflow-hidden`;
+ *     each segment drops its own border (border:0) and a left divider separates
+ *     adjacent segments. `joined={false}` gaps the segments and gives each its
+ *     own border.
+ *   - `shape`: "square" → rounded (= var(--radius), 2px); "pill" →
+ *     rounded-[999px].
+ *   - `size`: "sm" (h-7 / 28px) | "md" (h-8 / 32px).
+ *   - Focus ring: drawn with a NEGATIVE outline-offset so it renders INSIDE the
+ *     segment and is never clipped by the joined container's overflow-hidden.
+ *     (A positive offset, as used elsewhere in the repo, would be clipped.)
+ */
+
+export interface SegmentOption {
+  value: string;
+  label?: React.ReactNode;
+  icon?: React.ReactNode;
+  disabled?: boolean;
+  /** Accessible name for icon-only segments (no visible text). */
+  ariaLabel?: string;
+}
+
+type Size = "sm" | "md";
+type Shape = "square" | "pill";
+type Tone = "neutral" | "success" | "warn";
+
+/** Outer container geometry shared by both primitives. */
+function containerClass(joined: boolean, shape: Shape): string {
+  const radius = shape === "pill" ? "rounded-[999px]" : "rounded";
+  if (joined) {
+    // One border for the whole strip; overflow-hidden clips segment corners to
+    // the container radius. Inline-flex so it hugs its content.
+    return `inline-flex items-stretch overflow-hidden border border-[var(--border-default)] bg-[var(--bg-sunken)] ${radius}`;
+  }
+  // Gapped: no shared border/background; each segment is bordered on its own.
+  return "inline-flex items-stretch gap-1";
+}
+
+/** Per-segment geometry shared by both primitives. */
+function segmentClass({
+  joined,
+  shape,
+  size,
+  iconOnly,
+  isFirst,
+}: {
+  joined: boolean;
+  shape: Shape;
+  size: Size;
+  iconOnly: boolean;
+  isFirst: boolean;
+}): string {
+  const parts: string[] = [
+    "relative inline-flex items-center justify-center gap-1.5 font-medium leading-none transition-colors duration-150 motion-reduce:transition-none",
+    // Focus ring drawn INSIDE the box so the joined overflow-hidden can't clip
+    // it. outline-offset is negative → the 2px outline sits within the segment.
+    "focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:-outline-offset-2",
+    "disabled:cursor-not-allowed disabled:opacity-50",
+    size === "sm" ? "h-7 text-[13px]" : "h-8 text-sm",
+    iconOnly
+      ? size === "sm"
+        ? "w-7 px-0"
+        : "w-8 px-0"
+      : size === "sm"
+        ? "px-2.5"
+        : "px-3",
+  ];
+
+  if (joined) {
+    // No per-segment border; a left divider separates adjacent segments. The
+    // container owns the outer border + radius.
+    parts.push("border-0");
+    if (!isFirst) parts.push("border-l border-[var(--border-default)]");
+  } else {
+    // Standalone bordered chip.
+    parts.push("border border-[var(--border-default)] bg-[var(--bg-elevated)]");
+    parts.push(shape === "pill" ? "rounded-[999px]" : "rounded");
+  }
+
+  return parts.join(" ");
+}
+
+// --------------------------------------------------------------------------
+// SegmentedControl — single-select, role=radiogroup (wraps RadioGroup)
+// --------------------------------------------------------------------------
+
+export interface SegmentedControlProps {
+  /** Currently-selected value. */
+  value?: string;
+  /** Fired with the new value on click or arrow-key selection. */
+  onValueChange?: (value: string) => void;
+  options: SegmentOption[];
+  size?: Size;
+  /** true (default) → shared border + dividers; false → gapped chips. */
+  joined?: boolean;
+  shape?: Shape;
+  /** Hide labels and size segments as squares/circles for icon-only strips. */
+  iconOnly?: boolean;
+  /** Required: names the group for assistive tech. */
+  "aria-label": string;
+  className?: string;
+}
+
+const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>(
+  (
+    {
+      value,
+      onValueChange,
+      options,
+      size = "md",
+      joined = true,
+      shape = "square",
+      iconOnly = false,
+      "aria-label": ariaLabel,
+      className = "",
+    },
+    ref
+  ) => {
+    // RadioGroup is a plain function component (not forwardRef), so a `ref` can't
+    // be threaded through it. To honor the SegmentedControl `ref` contract
+    // (consumers measuring/scrolling the strip) we resolve the ref to the
+    // radiogroup's root node after mount via a callback ref on a
+    // `display:contents` wrapper — the wrapper produces no box of its own, so the
+    // strip's layout/geometry is unchanged.
+    const setWrapperRef = React.useCallback(
+      (node: HTMLSpanElement | null) => {
+        const target =
+          (node?.querySelector('[role="radiogroup"]') as HTMLDivElement | null) ??
+          null;
+        if (typeof ref === "function") ref(target);
+        else if (ref) ref.current = target;
+      },
+      [ref]
+    );
+    return (
+      <span ref={setWrapperRef} style={{ display: "contents" }}>
+      <RadioGroup
+        value={value}
+        onValueChange={onValueChange}
+        aria-label={ariaLabel}
+        className={`${containerClass(joined, shape)} ${className}`.trim()}
+      >
+        {options.map((opt, i) => {
+          const selected = value === opt.value;
+          const stateClass = selected
+            ? "bg-[var(--bg-elevated)] text-[var(--fg-primary)]"
+            : "bg-transparent text-[var(--fg-muted)] hover:text-[var(--fg-primary)]";
+          return (
+            <Radio
+              key={opt.value}
+              value={opt.value}
+              disabled={opt.disabled}
+              aria-label={iconOnly || !opt.label ? opt.ariaLabel : undefined}
+              className={`${segmentClass({
+                joined,
+                shape,
+                size,
+                iconOnly,
+                isFirst: i === 0,
+              })} ${stateClass}`}
+            >
+              {opt.icon ? (
+                <span className="inline-flex items-center" aria-hidden="true">
+                  {opt.icon}
+                </span>
+              ) : null}
+              {!iconOnly && opt.label ? (
+                <span className="leading-none">{opt.label}</span>
+              ) : null}
+            </Radio>
+          );
+        })}
+      </RadioGroup>
+      </span>
+    );
+  }
+);
+
+SegmentedControl.displayName = "SegmentedControl";
+
+// --------------------------------------------------------------------------
+// ToggleGroup — multi-select, role=group of aria-pressed buttons
+// --------------------------------------------------------------------------
+
+/** Active-state classes per semantic tone. Tints flip in dark via the tokens. */
+const TONE_ACTIVE: Record<Tone, string> = {
+  neutral: "bg-[var(--bg-elevated)] text-[var(--fg-primary)]",
+  success:
+    "bg-[var(--color-success-bg)] text-[var(--color-success-text)] border-[var(--color-success-text)]",
+  warn:
+    "bg-[var(--color-warning-bg)] text-[var(--color-warning-text)] border-[var(--color-warning-border)]",
+};
+
+export interface ToggleGroupOption extends SegmentOption {
+  /** Per-option override of the active-state color tone. Falls back to the
+   *  group's `tone`. */
+  tone?: Tone;
+}
+
+export interface ToggleGroupProps {
+  /** The set of currently-pressed values. */
+  value: string[];
+  /** Fired with the full next set after a toggle. */
+  onValueChange?: (value: string[]) => void;
+  options: ToggleGroupOption[];
+  /** Default active-state tone for all options (per-option `tone` overrides). */
+  tone?: Tone;
+  size?: Size;
+  /** true (default) → shared border + dividers; false → gapped chips. */
+  joined?: boolean;
+  shape?: Shape;
+  /** Hide labels and size segments as squares/circles for icon-only strips. */
+  iconOnly?: boolean;
+  /** Required: names the group for assistive tech. */
+  "aria-label": string;
+  className?: string;
+}
+
+export const ToggleGroup = React.forwardRef<HTMLDivElement, ToggleGroupProps>(
+  (
+    {
+      value,
+      onValueChange,
+      options,
+      tone = "neutral",
+      size = "md",
+      joined = true,
+      shape = "square",
+      iconOnly = false,
+      "aria-label": ariaLabel,
+      className = "",
+    },
+    ref
+  ) => {
+    const toggle = (optValue: string) => {
+      const set = new Set(value);
+      if (set.has(optValue)) set.delete(optValue);
+      else set.add(optValue);
+      // Preserve option order rather than insertion order so the emitted set is
+      // stable regardless of click sequence.
+      onValueChange?.(options.map((o) => o.value).filter((v) => set.has(v)));
+    };
+
+    return (
+      <div
+        ref={ref}
+        role="group"
+        aria-label={ariaLabel}
+        className={`${containerClass(joined, shape)} ${className}`.trim()}
+      >
+        {options.map((opt, i) => {
+          const pressed = value.includes(opt.value);
+          const optTone = opt.tone ?? tone;
+          const stateClass = pressed
+            ? TONE_ACTIVE[optTone]
+            : "bg-transparent text-[var(--fg-muted)] hover:text-[var(--fg-primary)]";
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              aria-pressed={pressed}
+              aria-label={iconOnly || !opt.label ? opt.ariaLabel : undefined}
+              disabled={opt.disabled}
+              onClick={() => toggle(opt.value)}
+              className={`${segmentClass({
+                joined,
+                shape,
+                size,
+                iconOnly,
+                isFirst: i === 0,
+              })} ${stateClass}`}
+            >
+              {opt.icon ? (
+                <span className="inline-flex items-center" aria-hidden="true">
+                  {opt.icon}
+                </span>
+              ) : null}
+              {!iconOnly && opt.label ? (
+                <span className="leading-none">{opt.label}</span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+);
+
+ToggleGroup.displayName = "ToggleGroup";
+
+export default SegmentedControl;

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,7 +1,21 @@
 import React, { useId, useState } from "react";
 
-export type TextareaSize = "sm" | "md" | "lg";
+export type TextareaSize = "sm" | "md" | "lg" | "bare";
 export type TextareaVariant = "default" | "underline";
+/**
+ * Resting + focus border treatment for the `default` variant — mirrors
+ * Input's axis. `default` = 1 px `--border-default` with the accent
+ * focus-ring (today's behaviour). `hover` = 1.5 px `--border-hover`
+ * resolving to `--fg-primary` + a 2 px `--overlay-weak` ring on focus,
+ * matching the cert-detail short-description holdout chrome. Ignored by
+ * the `underline` variant.
+ */
+export type TextareaBorderWeight = "default" | "hover";
+/**
+ * Typographic density — mirrors Input. `default` keeps today's per-size
+ * padding + text scale; `compact` is the 0.8125rem / 2px-6px meta scale.
+ */
+export type TextareaDensity = "default" | "compact";
 
 export interface TextareaProps
   extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "size"> {
@@ -11,6 +25,30 @@ export interface TextareaProps
   rows?: number;
   size?: TextareaSize;
   variant?: TextareaVariant;
+  /**
+   * Border treatment for the `default` variant — see
+   * {@link TextareaBorderWeight}. Defaults to `default`. Pass `"hover"`
+   * for the 1.5 px "editable" weight the cert short-description holdout
+   * uses. Ignored by the `underline` variant.
+   */
+  borderWeight?: TextareaBorderWeight;
+  /**
+   * Typographic density — see {@link TextareaDensity}. Defaults to
+   * `default`.
+   */
+  density?: TextareaDensity;
+  /**
+   * Unwrapped / "flush" mode. When true, renders the bare `<textarea>`
+   * with NO outer `w-full` wrapper `<div>` and NO label / error /
+   * helper / counter block — so it composes directly as a flex / grid
+   * child. `label`, `error`, `helperText`, and the `showCount` counter
+   * are not rendered in this mode (the parent owns the surrounding
+   * chrome). `aria-invalid` still reflects `error`. `maxLength` is still
+   * forwarded so the browser cap holds. Alias: `unwrapped`.
+   */
+  flush?: boolean;
+  /** Alias for {@link flush}. */
+  unwrapped?: boolean;
   /**
    * When set alongside `showCount`, renders a live "n / max" affordance under
    * the field. `maxLength` is also forwarded to the native element so the
@@ -24,7 +62,18 @@ const sizeClasses: Record<TextareaSize, string> = {
   sm: "px-3 py-2 text-sm",
   md: "px-4 py-3 text-base md:text-sm",
   lg: "px-5 py-4 text-base",
+  // No text-size / leading of its own — typography cascades from the
+  // parent (e.g. the short-desc holdout's `font:inherit; font-size:1rem;
+  // line-height:1.6`). Keep a default-ish padding so a bare textarea
+  // isn't edge-to-edge; callers that need bespoke padding pass it via
+  // `className`, which wins the cascade.
+  bare: "px-3 py-2 font-[inherit] text-[length:inherit] leading-[inherit]",
 };
+
+// Compact density — the 0.8125rem / 2px-6px meta scale. Appended after
+// sizeClasses so it wins. With `size="bare"` the text-size half is a
+// no-op (length already inherits); the padding still applies.
+const compactClasses = "py-0.5 px-1.5 text-[0.8125rem]";
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   (
@@ -35,6 +84,10 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       rows = 3,
       size = "md",
       variant = "default",
+      borderWeight = "default",
+      density = "default",
+      flush = false,
+      unwrapped = false,
       className = "",
       showCount = false,
       maxLength,
@@ -49,9 +102,14 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ) => {
     const autoId = useId();
     const textareaId = id || autoId;
-    const errorId = error ? `${textareaId}-error` : undefined;
-    const helperId = !error && helperText ? `${textareaId}-helper` : undefined;
-    const counterId = showCount ? `${textareaId}-count` : undefined;
+    const isFlush = flush || unwrapped;
+    // Counter only exists in the wrapped layout — flush mode drops the
+    // whole footer block, so don't even compute the affordance there.
+    const showCounter = showCount && !isFlush;
+    const errorId = !isFlush && error ? `${textareaId}-error` : undefined;
+    const helperId =
+      !isFlush && !error && helperText ? `${textareaId}-helper` : undefined;
+    const counterId = showCounter ? `${textareaId}-count` : undefined;
     const describedBy =
       [errorId, helperId, counterId].filter(Boolean).join(" ") || undefined;
 
@@ -78,18 +136,53 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       ? "disabled:cursor-not-allowed disabled:opacity-60 disabled:bg-[var(--bg-sunken)] disabled:resize-none"
       : "";
 
-    const variantChrome =
-      variant === "underline"
-        ? `border-0 border-b ${
-            error
-              ? "border-[var(--color-error-border)]"
-              : "border-[var(--border-medium)]"
-          } rounded-none bg-transparent focus:border-[var(--fg-primary)]`
-        : `border ${
-            error
-              ? "border-[var(--color-error-border)]"
-              : "border-[var(--border-default)]"
-          } rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20`;
+    const variantChrome = (() => {
+      if (variant === "underline") {
+        return `border-0 border-b ${
+          error
+            ? "border-[var(--color-error-border)]"
+            : "border-[var(--border-medium)]"
+        } rounded-none bg-transparent focus:border-[var(--fg-primary)]`;
+      }
+      // default variant — two border families, chosen by `borderWeight`.
+      // `hover` reproduces the short-desc holdout chrome (1.5px
+      // --border-hover → --fg-primary + 2px --overlay-weak on focus).
+      if (error) {
+        // `border` (1px) for default weight is byte-identical to the
+        // pre-enhancement string; `border-[1.5px]` for hover weight.
+        return borderWeight === "hover"
+          ? "border-[1.5px] border-[var(--color-error-border)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20"
+          : "border border-[var(--color-error-border)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20";
+      }
+      if (borderWeight === "hover") {
+        return "border-[1.5px] border-[var(--border-hover)] rounded focus:border-[var(--fg-primary)] focus:ring-2 focus:ring-[var(--overlay-weak)]";
+      }
+      return "border border-[var(--border-default)] rounded focus:border-[var(--focus-ring)] focus:ring-1 focus:ring-[var(--focus-ring)]/20";
+    })();
+
+    const densityClasses = density === "compact" ? compactClasses : "";
+
+    const textareaEl = (
+      <textarea
+        ref={ref}
+        id={textareaId}
+        rows={rows}
+        disabled={disabled}
+        maxLength={maxLength}
+        value={value}
+        defaultValue={defaultValue}
+        onChange={handleChange}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={describedBy}
+        className={`${sizeClasses[size]} ${densityClasses} ${baseChrome} ${variantChrome} ${disabledChrome} ${className}`}
+        {...props}
+      />
+    );
+
+    // Flush mode: bare element, no wrapper / label / footer block.
+    if (isFlush) {
+      return textareaEl;
+    }
 
     return (
       <div className="w-full">
@@ -98,20 +191,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
             {label}
           </label>
         )}
-        <textarea
-          ref={ref}
-          id={textareaId}
-          rows={rows}
-          disabled={disabled}
-          maxLength={maxLength}
-          value={value}
-          defaultValue={defaultValue}
-          onChange={handleChange}
-          aria-invalid={error ? true : undefined}
-          aria-describedby={describedBy}
-          className={`${sizeClasses[size]} ${baseChrome} ${variantChrome} ${disabledChrome} ${className}`}
-          {...props}
-        />
+        {textareaEl}
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
             {error && (
@@ -132,7 +212,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
               </p>
             )}
           </div>
-          {showCount && (
+          {showCounter && (
             <p
               id={counterId}
               aria-live="polite"

--- a/src/lib/dev/fixtures/authors.ts
+++ b/src/lib/dev/fixtures/authors.ts
@@ -1,0 +1,128 @@
+/**
+ * Dev-only preview fixtures — authors / actors.
+ *
+ * A small directory of synthetic actors that the feed, workspace, and
+ * byline-resolution paths share. Keeping them in one place means a feed
+ * event authored by `did:plc:author1…` resolves to the same name/avatar
+ * everywhere it appears (feed actor block, `/api/resolve-dids` byline,
+ * workspace actor switcher).
+ *
+ * The {@link MOCK_DID} viewer is intentionally the FIRST author so the
+ * feed's follow-union includes the viewer's own activity, and so the
+ * workspace actor list opens on the viewer.
+ */
+
+import type { ResolvedProfilePayload } from "@/app/api/resolve-did/resolve-core"
+import { MOCK_DID, MOCK_HANDLE } from "./session"
+
+export interface MockActor {
+  did: string
+  handle: string
+  displayName: string
+  description: string
+  /** Bare CID — feed/workspace nodes carry this and the client builds
+   *  a `/api/xrpc/com/atproto/sync/getBlob` URL from it. `null` renders
+   *  an initials avatar (no extra blob fetch needed in the preview). */
+  avatarCid: string | null
+  /** ISO join date surfaced on workspace actor rows. */
+  createdAt: string
+}
+
+/** Ordered actor directory. Index 0 is the signed-in viewer. */
+export const MOCK_ACTORS: MockActor[] = [
+  {
+    did: MOCK_DID,
+    handle: MOCK_HANDLE,
+    displayName: "Ada Pollen",
+    description:
+      "Restoration ecologist. Building soil-carbon measurement tooling.",
+    avatarCid: null,
+    createdAt: "2024-01-15T09:30:00.000Z",
+  },
+  {
+    did: "did:plc:author10000000000000000000000",
+    handle: "mangrove.certified.app",
+    displayName: "Mangrove Collective",
+    description: "Coastal reforestation, 12 sites across three estuaries.",
+    avatarCid: null,
+    createdAt: "2024-02-02T12:00:00.000Z",
+  },
+  {
+    did: "did:plc:author20000000000000000000000",
+    handle: "rosa.certified.app",
+    displayName: "Rosa Linden",
+    description: "Independent evaluator. I verify drawdown claims.",
+    avatarCid: null,
+    createdAt: "2024-03-19T08:10:00.000Z",
+  },
+  {
+    did: "did:plc:author30000000000000000000000",
+    handle: "kelp.certified.app",
+    displayName: "Kelp Forest Trust",
+    description: "Restoring kelp canopy along temperate coastlines.",
+    avatarCid: null,
+    createdAt: "2024-04-07T16:45:00.000Z",
+  },
+  {
+    did: "did:plc:author40000000000000000000000",
+    handle: "soil.certified.app",
+    displayName: "Soil Carbon Lab",
+    description: "Open measurement protocols for regenerative agriculture.",
+    avatarCid: null,
+    createdAt: "2024-05-11T11:20:00.000Z",
+  },
+]
+
+/** Lookup by DID. */
+export function actorByDid(did: string): MockActor | undefined {
+  return MOCK_ACTORS.find((a) => a.did === did)
+}
+
+/** Build a {@link ResolvedProfilePayload} for one actor — the shape
+ *  `/api/resolve-dids` returns per identity. */
+export function actorToResolvedProfile(actor: MockActor): ResolvedProfilePayload {
+  return {
+    did: actor.did,
+    handle: actor.handle,
+    displayName: actor.displayName,
+    description: actor.description,
+    avatar: null,
+    banner: null,
+    createdAt: actor.createdAt,
+    hasCertifiedProfile: true,
+    hasBlueskyProfile: false,
+    blueskyProfile: null,
+  }
+}
+
+/**
+ * Resolve a batch of inputs (DIDs or handles) to the `{ [input]: payload }`
+ * map `/api/resolve-dids` returns. Unknown inputs map to a generic
+ * placeholder payload keyed to the input itself (a valid-looking DID) so
+ * the byline still renders rather than going null.
+ */
+export function resolveDidsResults(
+  identities: string[],
+): Record<string, ResolvedProfilePayload | null> {
+  const out: Record<string, ResolvedProfilePayload | null> = {}
+  for (const input of identities) {
+    const actor =
+      MOCK_ACTORS.find((a) => a.did === input || a.handle === input) ?? null
+    if (actor) {
+      out[input] = actorToResolvedProfile(actor)
+      continue
+    }
+    // Fall back to a minimal payload so contributor / author rows for
+    // unknown identities still render a handle instead of a broken row.
+    out[input] = {
+      did: input.startsWith("did:") ? input : MOCK_DID,
+      handle: input.startsWith("did:") ? input.slice(0, 24) : input,
+      avatar: null,
+      banner: null,
+      hasCertifiedProfile: false,
+      hasBlueskyProfile: false,
+      blueskyProfile: null,
+    }
+  }
+  return out
+}

--- a/src/lib/dev/fixtures/feed.ts
+++ b/src/lib/dev/fixtures/feed.ts
@@ -1,0 +1,249 @@
+/**
+ * Dev-only preview fixtures — home feed.
+ *
+ * The home feed fans out through three indexer ops behind `/api/indexer`:
+ *
+ *   1. `FollowerEvents`  → a page of `{ id, kind, subjectUri, sortAt, actor }`
+ *      events authored by the viewer's follow union. (`fetchFollowerEvents`)
+ *   2. `HydrateFeedPage` → the headline records for those subject URIs,
+ *      bucketed by kind into `activities` / `collections` / `badgeAwards`
+ *      / … connections. (`hydrateFeedEvents`)
+ *   3. The follow union itself comes from a PDS read —
+ *      `listRecords(app.certified.graph.follow)` on the viewer's repo —
+ *      NOT the indexer. That fixture lives in `groups.ts` (followRecords).
+ *
+ * This module builds an internally-consistent set: every event's
+ * `subjectUri` has a matching node in the hydrate response, so the feed
+ * renders real preview cards rather than fallback rows.
+ *
+ * Dispatch by `operationName` happens in the MockFetchProvider via
+ * {@link indexerResponse}; this file owns the per-op payloads.
+ */
+
+import {
+  MOCK_ACTORS,
+  actorByDid,
+  type MockActor,
+} from "./authors"
+import { MOCK_DID } from "./session"
+
+type FeedKind = "cert.create" | "collection.create" | "endorsement.award"
+
+interface FeedSpec {
+  /** Authoring actor DID — must be in MOCK_ACTORS. */
+  authorDid: string
+  kind: FeedKind
+  title: string
+  shortDescription: string
+  /** For endorsement.award: the DID of the endorsed subject. */
+  subjectDid?: string
+}
+
+/** Ordered newest-first. Each entry becomes one FollowerEvents edge plus
+ *  one matching HydrateFeedPage node. */
+const FEED_SPECS: FeedSpec[] = [
+  {
+    authorDid: "did:plc:author10000000000000000000000",
+    kind: "cert.create",
+    title: "Mangrove restoration — Tagus estuary, Q1",
+    shortDescription:
+      "Planted 8,400 propagules across three intertidal zones; survival audited at 91%.",
+  },
+  {
+    authorDid: "did:plc:author20000000000000000000000",
+    kind: "endorsement.award",
+    title: "Endorsement",
+    shortDescription: "",
+    subjectDid: "did:plc:author10000000000000000000000",
+  },
+  {
+    authorDid: "did:plc:author30000000000000000000000",
+    kind: "collection.create",
+    title: "Temperate kelp canopy program",
+    shortDescription:
+      "A curated portfolio of canopy-restoration sites with shared measurement methodology.",
+  },
+  {
+    authorDid: MOCK_DID,
+    kind: "cert.create",
+    title: "Soil-carbon measurement protocol v2",
+    shortDescription:
+      "Open methodology for drawdown verification on regenerative cropland.",
+  },
+  {
+    authorDid: "did:plc:author40000000000000000000000",
+    kind: "cert.create",
+    title: "Cover-crop trial — 14 farms",
+    shortDescription:
+      "Season-over-season soil organic carbon deltas published with raw samples.",
+  },
+]
+
+/** Stable per-index timestamp, newest first (index 0 = most recent). */
+function sortAtFor(index: number): string {
+  const base = Date.UTC(2026, 4, 20, 12, 0, 0)
+  return new Date(base - index * 3_600_000).toISOString()
+}
+
+function uriFor(spec: FeedSpec, index: number): string {
+  const collection =
+    spec.kind === "cert.create"
+      ? "org.hypercerts.claim.activity"
+      : spec.kind === "collection.create"
+        ? "org.hypercerts.collection"
+        : "app.certified.badge.award"
+  return `at://${spec.authorDid}/${collection}/preview${index}`
+}
+
+function feedActorBlock(actor: MockActor) {
+  return {
+    did: actor.did,
+    handle: actor.handle,
+    displayName: actor.displayName,
+    avatarCid: actor.avatarCid,
+  }
+}
+
+/** `FollowerEvents` connection payload (the `data.followerEvents` value). */
+export function followerEventsConnection(): {
+  edges: {
+    cursor: string
+    node: {
+      id: string
+      kind: string
+      subjectUri: string
+      sortAt: string
+      actor: ReturnType<typeof feedActorBlock>
+    }
+  }[]
+  pageInfo: { hasNextPage: boolean; endCursor: string | null }
+} {
+  const edges = FEED_SPECS.map((spec, index) => {
+    const actor = actorByDid(spec.authorDid) ?? MOCK_ACTORS[0]
+    const uri = uriFor(spec, index)
+    return {
+      cursor: `cursor-${index}`,
+      node: {
+        id: uri,
+        kind: spec.kind,
+        subjectUri: uri,
+        sortAt: sortAtFor(index),
+        actor: feedActorBlock(actor),
+      },
+    }
+  })
+  return {
+    edges,
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }
+}
+
+/** `HydrateFeedPage` payload — one connection per kind, keyed by the
+ *  same subject URIs the FollowerEvents page emitted. */
+export function hydrateFeedPageData(): {
+  activities: { edges: { node: Record<string, unknown> }[] }
+  collections: { edges: { node: Record<string, unknown> }[] }
+  badgeAwards: { edges: { node: Record<string, unknown> }[] }
+  evaluations: { edges: { node: Record<string, unknown> }[] }
+  measurements: { edges: { node: Record<string, unknown> }[] }
+  hyperboards: { edges: { node: Record<string, unknown> }[] }
+  attachments: { edges: { node: Record<string, unknown> }[] }
+} {
+  const activities: { node: Record<string, unknown> }[] = []
+  const collections: { node: Record<string, unknown> }[] = []
+  const badgeAwards: { node: Record<string, unknown> }[] = []
+
+  FEED_SPECS.forEach((spec, index) => {
+    const uri = uriFor(spec, index)
+    const createdAt = sortAtFor(index)
+    if (spec.kind === "cert.create") {
+      activities.push({
+        node: {
+          uri,
+          cid: `bafyactivity${index}00000000000000000000000000000000000000`,
+          did: spec.authorDid,
+          title: spec.title,
+          shortDescription: spec.shortDescription,
+          createdAt,
+          startDate: null,
+          endDate: null,
+          labels: [],
+          image: null,
+          workScope: { scope: "ecological-restoration" },
+        },
+      })
+    } else if (spec.kind === "collection.create") {
+      collections.push({
+        node: {
+          uri,
+          cid: `bafycollection${index}0000000000000000000000000000000000`,
+          did: spec.authorDid,
+          createdAt,
+          title: spec.title,
+          shortDescription: spec.shortDescription,
+          type: "project",
+          items: [],
+          avatar: null,
+          banner: null,
+        },
+      })
+    } else {
+      badgeAwards.push({
+        node: {
+          uri,
+          cid: `bafyaward${index}000000000000000000000000000000000000000000`,
+          did: spec.authorDid,
+          createdAt,
+          note: "Verified the restoration claim end-to-end.",
+          subject: {
+            __typename: "AppCertifiedDefsDid",
+            did: spec.subjectDid ?? MOCK_DID,
+          },
+        },
+      })
+    }
+  })
+
+  return {
+    activities: { edges: activities },
+    collections: { edges: collections },
+    badgeAwards: { edges: badgeAwards },
+    evaluations: { edges: [] },
+    measurements: { edges: [] },
+    hyperboards: { edges: [] },
+    attachments: { edges: [] },
+  }
+}
+
+/** Empty-but-valid `Activities` connection (profile Activities tab via
+ *  indexer paths / explore). Profile own-activities go through PDS
+ *  listRecords, but the generic `Activities` op is also reachable. */
+export function activitiesConnection(): {
+  totalCount: number
+  edges: { cursor: string; node: Record<string, unknown> }[]
+  pageInfo: { hasNextPage: boolean; endCursor: string | null }
+} {
+  const edges = FEED_SPECS.filter((s) => s.kind === "cert.create").map(
+    (spec, i) => ({
+      cursor: `act-${i}`,
+      node: {
+        uri: `at://${spec.authorDid}/org.hypercerts.claim.activity/act${i}`,
+        cid: `bafyact${i}0000000000000000000000000000000000000000000000000`,
+        did: spec.authorDid,
+        title: spec.title,
+        shortDescription: spec.shortDescription,
+        createdAt: sortAtFor(i),
+        startDate: null,
+        endDate: null,
+        labels: [],
+        image: null,
+        workScope: { scope: "ecological-restoration" },
+      },
+    }),
+  )
+  return {
+    totalCount: edges.length,
+    edges,
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }
+}

--- a/src/lib/dev/fixtures/groups.ts
+++ b/src/lib/dev/fixtures/groups.ts
@@ -1,0 +1,210 @@
+/**
+ * Dev-only preview fixtures — groups, workspace, and the per-DID
+ * indexer connections used across profile + workspace.
+ *
+ * Covers the remaining indexer operations and the PDS reads that the
+ * composed surfaces need:
+ *
+ *   - `NetworkActors`        → workspace actor switcher list.
+ *   - `ActorWorkspaceCounts` → per-actor lexicon count headers.
+ *   - `Followers`            → profile Followers tab.
+ *   - `ReceivedEndorsements` → profile Endorsements tab.
+ *   - `UserProjects`         → profile Projects tab.
+ *   - `EvaluatorEndorsements`→ home feed "trusted evaluators" expansion.
+ *   - PDS `listRecords(app.certified.graph.follow)` → the follow union
+ *     that seeds `FollowerEvents` (the feed's `authors` arg).
+ *   - `/api/groups/memberships` → empty list (keeps the OrgProvider on
+ *     the personal identity so `isOwnProfile` stays true).
+ *
+ * "Groups" here is deliberately empty: the preview viewer belongs to no
+ * groups, so the org switcher stays on the personal account and every
+ * own-vs-foreign gate resolves to own.
+ */
+
+import { MOCK_ACTORS, actorByDid } from "./authors"
+import { MOCK_DID } from "./session"
+
+/** ---- workspace: NetworkActors ------------------------------------- */
+
+export function networkActorsConnection(): {
+  totalCount: number
+  edges: {
+    cursor: string
+    node: {
+      uri: string
+      did: string
+      displayName: string
+      description: string
+      createdAt: string
+      avatar: null
+    }
+  }[]
+  pageInfo: { hasNextPage: boolean; endCursor: string | null }
+} {
+  const edges = MOCK_ACTORS.map((actor, i) => ({
+    cursor: `actor-${i}`,
+    node: {
+      uri: `at://${actor.did}/app.certified.actor.profile/self`,
+      did: actor.did,
+      displayName: actor.displayName,
+      description: actor.description,
+      createdAt: actor.createdAt,
+      avatar: null,
+    },
+  }))
+  return {
+    totalCount: edges.length,
+    edges,
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }
+}
+
+/** ---- workspace: ActorWorkspaceCounts ------------------------------ */
+
+/** Aliased connections — each returns just `{ totalCount }`. Keyed to
+ *  the requested DID so the viewer's own counts look populated. */
+export function actorWorkspaceCounts(did: string): Record<
+  string,
+  { totalCount: number }
+> {
+  const isViewer = did === MOCK_DID
+  return {
+    certs: { totalCount: isViewer ? 6 : 3 },
+    projects: { totalCount: isViewer ? 2 : 1 },
+    lists: { totalCount: isViewer ? 1 : 0 },
+    endorsementsReceived: { totalCount: isViewer ? 4 : 2 },
+    followers: { totalCount: isViewer ? 12 : 5 },
+  }
+}
+
+/** ---- profile: Followers ------------------------------------------- */
+
+export function followersConnection(did: string): {
+  totalCount: number
+  edges: { node: { uri: string; cid: string; did: string; createdAt: string } }[]
+  pageInfo: { hasNextPage: boolean; endCursor: string | null }
+} {
+  // Everyone except the subject follows the subject.
+  const followers = MOCK_ACTORS.filter((a) => a.did !== did)
+  const edges = followers.map((a, i) => ({
+    node: {
+      uri: `at://${a.did}/app.certified.graph.follow/f${i}`,
+      cid: `bafyfollow${i}00000000000000000000000000000000000000000000000`,
+      did: a.did,
+      createdAt: a.createdAt,
+    },
+  }))
+  return {
+    totalCount: edges.length,
+    edges,
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }
+}
+
+/** ---- profile: ReceivedEndorsements -------------------------------- */
+
+export function receivedEndorsementsConnection(did: string): {
+  edges: { node: Record<string, unknown> }[]
+  pageInfo: { hasNextPage: boolean; endCursor: string | null }
+} {
+  const issuers = MOCK_ACTORS.filter((a) => a.did !== did).slice(0, 2)
+  const edges = issuers.map((issuer, i) => ({
+    node: {
+      uri: `at://${issuer.did}/app.certified.badge.award/e${i}`,
+      cid: `bafyendorse${i}0000000000000000000000000000000000000000000000`,
+      did: issuer.did,
+      createdAt: issuer.createdAt,
+      note: "Independently verified the underlying restoration work.",
+      badge: `at://${issuer.did}/app.certified.badge.definition/self`,
+      issuer: {
+        did: issuer.did,
+        handle: issuer.handle,
+        displayName: issuer.displayName,
+        description: issuer.description,
+        avatarCid: issuer.avatarCid,
+        pds: null,
+      },
+      response: { state: "accepted", weight: null, createdAt: issuer.createdAt },
+    },
+  }))
+  return {
+    edges,
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }
+}
+
+/** ---- profile: UserProjects ---------------------------------------- */
+
+export function userProjectsConnection(did: string): {
+  totalCount: number
+  edges: { cursor: string; node: Record<string, unknown> }[]
+  pageInfo: { hasNextPage: boolean; endCursor: string | null }
+} {
+  const actor = actorByDid(did)
+  const titles = [
+    "Estuary restoration portfolio",
+    "Open drawdown measurement toolkit",
+  ]
+  const edges = titles.map((title, i) => ({
+    cursor: `proj-${i}`,
+    node: {
+      uri: `at://${did}/org.hypercerts.collection/p${i}`,
+      cid: `bafyproject${i}0000000000000000000000000000000000000000000000`,
+      did,
+      createdAt: actor?.createdAt ?? "2024-06-01T00:00:00.000Z",
+      title,
+      shortDescription:
+        "A curated set of verified restoration claims grouped for funders.",
+      items: [],
+      banner: null,
+    },
+  }))
+  return {
+    totalCount: edges.length,
+    edges,
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }
+}
+
+/** ---- home feed: EvaluatorEndorsements ------------------------------ */
+
+/** Empty-but-valid connection. The home feed unions these subject DIDs
+ *  into the feed author set; empty keeps the feed scoped to the follow
+ *  union, which is enough for a populated screenshot. */
+export function evaluatorEndorsementsConnection(): {
+  edges: { cursor: string; node: Record<string, unknown> }[]
+  pageInfo: { hasNextPage: boolean; endCursor: string | null }
+} {
+  return { edges: [], pageInfo: { hasNextPage: false, endCursor: null } }
+}
+
+/** ---- PDS: app.certified.graph.follow listRecords ------------------ */
+
+/** The viewer's "following" set, read from their PDS. Drives the feed's
+ *  `authors` filter. Everyone in the directory except the viewer. */
+export function followRecords(): {
+  records: { uri: string; cid: string; value: Record<string, unknown> }[]
+} {
+  const subjects = MOCK_ACTORS.filter((a) => a.did !== MOCK_DID)
+  return {
+    records: subjects.map((a, i) => ({
+      uri: `at://${MOCK_DID}/app.certified.graph.follow/follow${i}`,
+      cid: `bafyfollowing${i}000000000000000000000000000000000000000000000`,
+      value: {
+        $type: "app.certified.graph.follow",
+        subject: a.did,
+        createdAt: a.createdAt,
+      },
+    })),
+  }
+}
+
+/** ---- /api/groups/memberships -------------------------------------- */
+
+/** No remote group memberships — keeps the personal identity active. */
+export function groupsMembershipsResponse(): {
+  groups: never[]
+  cursor: null
+} {
+  return { groups: [], cursor: null }
+}

--- a/src/lib/dev/fixtures/profile.ts
+++ b/src/lib/dev/fixtures/profile.ts
@@ -27,8 +27,12 @@ import {
   MOCK_HANDLE,
 } from "./session"
 
-/** Org identity variant — a second consistent identity used by the
- *  `profile-org` surface. Same `did:plc:` shape as MOCK_DID. */
+/** A second consistent org identity. Same `did:plc:` shape as MOCK_DID.
+ *  NOTE: the `profile-org` PREVIEW no longer resolves to this DID — it
+ *  renders the org as the viewer's OWN identity (MOCK_DID + an org marker)
+ *  so `isOwnProfile`/`canEditInline` hold. These constants remain for any
+ *  byline/contributor fixture that wants a distinct foreign org actor and
+ *  are re-exported by the mock-fetch provider. */
 export const MOCK_ORG_DID = "did:plc:previeworg0000000000000000000"
 export const MOCK_ORG_HANDLE = "earthfund.certified.app"
 
@@ -44,14 +48,24 @@ const ORG_DESCRIPTION =
 
 /** Resolved-profile payload for `/api/resolve-did` and the per-identity
  *  entries of `/api/resolve-dids`. `hasCertifiedProfile: true` so the
- *  own-profile view does NOT suppress the values as a bsky fallback. */
+ *  own-profile view does NOT suppress the values as a bsky fallback.
+ *
+ *  Both scenarios resolve to the SESSION identity ({@link MOCK_DID} /
+ *  {@link MOCK_HANDLE}) — only the display content (and, for `org`, the
+ *  org marker fetched separately) differs. Keying the org preview to the
+ *  viewer's own DID is what makes `isOwnProfile === true` (and therefore
+ *  `canEditInline === true`, so the owner-only inline-edit + response
+ *  affordances render). The dedicated MOCK_ORG_* identity is retained for
+ *  byline/contributor fixtures but is intentionally NOT the viewed DID:
+ *  a distinct org DID would make `isOwnProfile` false and, with no group
+ *  membership in the fixtures, leave the org preview read-only. */
 export function resolvedProfile(
   scenario: ProfileScenario = "individual",
 ): ResolvedProfilePayload {
   const isOrg = scenario === "org"
   return {
-    did: isOrg ? MOCK_ORG_DID : MOCK_DID,
-    handle: isOrg ? MOCK_ORG_HANDLE : MOCK_HANDLE,
+    did: MOCK_DID,
+    handle: MOCK_HANDLE,
     displayName: isOrg ? ORG_DISPLAY_NAME : INDIVIDUAL_DISPLAY_NAME,
     description: isOrg ? ORG_DESCRIPTION : INDIVIDUAL_DESCRIPTION,
     pronouns: isOrg ? undefined : "she/her",
@@ -75,7 +89,10 @@ export function certsProfileRecord(scenario: ProfileScenario = "individual"): {
   value: CertifiedProfile
 } {
   const isOrg = scenario === "org"
-  const did = isOrg ? MOCK_ORG_DID : MOCK_DID
+  // Keyed to the session DID for both scenarios — the inline-edit base
+  // (`getProfileWithCid`) fetches getRecord(repo=did) where `did` is the
+  // resolved (own) DID, which is now MOCK_DID in both cases.
+  const did = MOCK_DID
   const value: CertifiedProfile = {
     $type: "app.certified.actor.profile",
     displayName: isOrg ? ORG_DISPLAY_NAME : INDIVIDUAL_DISPLAY_NAME,
@@ -113,7 +130,9 @@ export function orgMarkerRecord(): {
     createdAt: "2022-03-01T00:00:00.000Z",
   }
   return {
-    uri: `at://${MOCK_ORG_DID}/app.certified.actor.organization/self`,
+    // Marker lives on the viewed (session) DID so `useOrgMarker(did)`
+    // resolves it for the own-profile org preview.
+    uri: `at://${MOCK_DID}/app.certified.actor.organization/self`,
     cid: "bafyreiorgmarker00000000000000000000000000000000000000000000",
     value,
   }

--- a/src/lib/dev/fixtures/profile.ts
+++ b/src/lib/dev/fixtures/profile.ts
@@ -1,0 +1,120 @@
+/**
+ * Dev-only preview fixtures — profile.
+ *
+ * Satisfies the contracts the profile surface fans out to:
+ *   - `GET  /api/resolve-did?did=…|handle=…`  → {@link ResolvedProfilePayload}
+ *     (see app/api/resolve-did/resolve-core.ts). `useUserProfile` reads
+ *     this; the DID equals {@link MOCK_DID} so `isOwnProfile === true`.
+ *   - `POST /api/resolve-dids`                → `{ results: { [input]: payload } }`
+ *     (batched byline / contributor resolution).
+ *   - `com.atproto.repo.getRecord` for `app.certified.actor.profile`
+ *     (rkey `self`) → `{ uri, cid, value }` — the RAW certs record the
+ *     own-profile inline-edit base (`getProfileWithCid`) reads.
+ *   - `com.atproto.repo.getRecord` for `app.certified.actor.organization`
+ *     (the ORG-MARKER variant) → 404-style miss for the individual
+ *     `profile` scenario, present for `profile-org`.
+ *
+ * The scenario flag flips the resolved identity between an individual and
+ * an organization so `/dev/preview/profile` and `/dev/preview/profile-org`
+ * exercise both sidebar modes.
+ */
+
+import type { ResolvedProfilePayload } from "@/app/api/resolve-did/resolve-core"
+import type { CertifiedProfile } from "@/lib/atproto/types"
+import type { GroupMetadata } from "@/lib/groups/types"
+import {
+  MOCK_DID,
+  MOCK_HANDLE,
+} from "./session"
+
+/** Org identity variant — a second consistent identity used by the
+ *  `profile-org` surface. Same `did:plc:` shape as MOCK_DID. */
+export const MOCK_ORG_DID = "did:plc:previeworg0000000000000000000"
+export const MOCK_ORG_HANDLE = "earthfund.certified.app"
+
+export type ProfileScenario = "individual" | "org"
+
+const INDIVIDUAL_DISPLAY_NAME = "Ada Pollen"
+const INDIVIDUAL_DESCRIPTION =
+  "Restoration ecologist. Building soil-carbon measurement tooling and verifying drawdown claims in the open."
+
+const ORG_DISPLAY_NAME = "Earth Fund"
+const ORG_DESCRIPTION =
+  "A pooled-funding collective backing measurable ecological-restoration work. We endorse the people and projects we have verified."
+
+/** Resolved-profile payload for `/api/resolve-did` and the per-identity
+ *  entries of `/api/resolve-dids`. `hasCertifiedProfile: true` so the
+ *  own-profile view does NOT suppress the values as a bsky fallback. */
+export function resolvedProfile(
+  scenario: ProfileScenario = "individual",
+): ResolvedProfilePayload {
+  const isOrg = scenario === "org"
+  return {
+    did: isOrg ? MOCK_ORG_DID : MOCK_DID,
+    handle: isOrg ? MOCK_ORG_HANDLE : MOCK_HANDLE,
+    displayName: isOrg ? ORG_DISPLAY_NAME : INDIVIDUAL_DISPLAY_NAME,
+    description: isOrg ? ORG_DESCRIPTION : INDIVIDUAL_DESCRIPTION,
+    pronouns: isOrg ? undefined : "she/her",
+    website: isOrg ? "https://earthfund.example" : "https://ada.example",
+    avatar: null,
+    banner: null,
+    createdAt: "2024-01-15T09:30:00.000Z",
+    hasCertifiedProfile: true,
+    hasBlueskyProfile: false,
+    blueskyProfile: null,
+  }
+}
+
+/** The RAW `app.certified.actor.profile` record `getProfileWithCid`
+ *  reads for the inline-edit base. Carries no blob refs (avatar/banner
+ *  cleared) so a text-only save wouldn't delete anything — fine for a
+ *  read-only preview. */
+export function certsProfileRecord(scenario: ProfileScenario = "individual"): {
+  uri: string
+  cid: string
+  value: CertifiedProfile
+} {
+  const isOrg = scenario === "org"
+  const did = isOrg ? MOCK_ORG_DID : MOCK_DID
+  const value: CertifiedProfile = {
+    $type: "app.certified.actor.profile",
+    displayName: isOrg ? ORG_DISPLAY_NAME : INDIVIDUAL_DISPLAY_NAME,
+    description: isOrg ? ORG_DESCRIPTION : INDIVIDUAL_DESCRIPTION,
+    pronouns: isOrg ? undefined : "she/her",
+    website: isOrg ? "https://earthfund.example" : "https://ada.example",
+    createdAt: "2024-01-15T09:30:00.000Z",
+  }
+  return {
+    uri: `at://${did}/app.certified.actor.profile/self`,
+    cid: "bafyreigh2akiscaildc000000000000000000000000000000000000000",
+    value,
+  }
+}
+
+/** The `app.certified.actor.organization` marker record — present only
+ *  for the org scenario. `useOrgMarker` reads `value` (and its `urls`)
+ *  off the getRecord `{ value }`. */
+export function orgMarkerRecord(): {
+  uri: string
+  cid: string
+  value: GroupMetadata
+} {
+  const value: GroupMetadata = {
+    $type: "app.certified.actor.organization",
+    organizationType: "Foundation",
+    urls: [
+      { url: "https://earthfund.example", label: "Website" },
+      { url: "https://bsky.app/profile/earthfund.certified.app", label: "Bluesky" },
+    ],
+    location: { name: "Lisbon, Portugal", lat: 38.7223, lng: -9.1393 },
+    foundedDate: "2022-03-01",
+    longDescription:
+      "Earth Fund pools philanthropic capital and routes it to ecological-restoration teams whose impact we have independently measured and endorsed.",
+    createdAt: "2022-03-01T00:00:00.000Z",
+  }
+  return {
+    uri: `at://${MOCK_ORG_DID}/app.certified.actor.organization/self`,
+    cid: "bafyreiorgmarker00000000000000000000000000000000000000000000",
+    value,
+  }
+}

--- a/src/lib/dev/fixtures/search.ts
+++ b/src/lib/dev/fixtures/search.ts
@@ -1,0 +1,32 @@
+/**
+ * Dev-only preview fixtures — actor search.
+ *
+ * Backs `GET /api/search-actors?q=…` (the typeahead used by the navbar
+ * search / explore). The real route returns
+ * `{ actors: [{ did, handle, displayName, avatar }] }`; we filter the
+ * shared actor directory by the query so the preview typeahead returns
+ * something plausible without hitting the public Bluesky AppView.
+ */
+
+import { MOCK_ACTORS } from "./authors"
+
+export function searchActorsResponse(query: string): {
+  actors: { did: string; handle: string; displayName: string; avatar: string | null }[]
+} {
+  const q = query.trim().toLowerCase()
+  const matches = q
+    ? MOCK_ACTORS.filter(
+        (a) =>
+          a.handle.toLowerCase().includes(q) ||
+          a.displayName.toLowerCase().includes(q),
+      )
+    : MOCK_ACTORS
+  return {
+    actors: matches.map((a) => ({
+      did: a.did,
+      handle: a.handle,
+      displayName: a.displayName,
+      avatar: null,
+    })),
+  }
+}

--- a/src/lib/dev/fixtures/session.ts
+++ b/src/lib/dev/fixtures/session.ts
@@ -1,0 +1,94 @@
+/**
+ * Dev-only preview fixtures — session.
+ *
+ * Backs the auth-mock preview harness (`/dev/preview/[surface]`) so the
+ * auth-gated composed surfaces (profile, feed, settings, workspace) can
+ * be screenshotted logged-out by Playwright. NONE of this ships to a
+ * production code path — the only importers are the dev preview page and
+ * its `MockFetchProvider`, both gated behind `notFound()` in production.
+ *
+ * ONE consistent identity is shared across every fixture so the real
+ * `useUserProfile` / `useAuth` plumbing resolves `isOwnProfile === true`:
+ * the session DID, the resolved profile DID, the workspace actor DID, and
+ * the feed-author DIDs all key off {@link MOCK_DID} / {@link MOCK_HANDLE}.
+ *
+ * The fixtures satisfy the real wire contracts:
+ *   - `/api/auth/session`            → `{ did }` (see app/api/auth/session)
+ *   - `https://plc.directory/<did>`  → a DID document carrying an
+ *                                      `#atproto_pds` service, because
+ *                                      `auth-context` resolves the PDS
+ *                                      URL via `resolvePdsUrl(did)` which
+ *                                      fetches the PLC directory directly.
+ *   - `/api/xrpc/com.atproto.server.getSession` → `{ handle, email }`
+ */
+
+/** The single identity every preview fixture is keyed to. A real-looking
+ *  `did:plc:` value so `isValidDid` and the PLC-directory URL builder in
+ *  `lib/atproto/did.ts` accept it. */
+export const MOCK_DID = "did:plc:preview000000000000000000000"
+
+/** Handle for {@link MOCK_DID}. Used by the session getSession response
+ *  and the resolved-profile / feed-actor fixtures. */
+export const MOCK_HANDLE = "ada.certified.app"
+
+/** Email surfaced on the Settings → Email card (own-session getSession). */
+export const MOCK_EMAIL = "ada@certified.app"
+
+/** A synthetic PDS endpoint for {@link MOCK_DID}. The harness intercepts
+ *  every same-origin `/api/*` call plus the PLC-directory fetch, so this
+ *  host is never actually contacted — it only has to look like a valid
+ *  https PDS URL so `resolvePdsUrl` returns non-null and downstream code
+ *  that builds `${pds}/xrpc/...` URLs produces a well-formed string. */
+export const MOCK_PDS_URL = "https://preview-pds.certified.app"
+
+/** Response body for `GET /api/auth/session` — mirrors the real route's
+ *  `{ did }` shape (no `transient` flag; the restore "succeeds"). */
+export function sessionResponse(): { did: string } {
+  return { did: MOCK_DID }
+}
+
+/** Response body for `com.atproto.server.getSession` (proxied through
+ *  `/api/xrpc/...`). `useSession` reads `handle` + `email` off this. */
+export function getSessionResponse(): {
+  did: string
+  handle: string
+  email: string
+  emailConfirmed: boolean
+  active: boolean
+} {
+  return {
+    did: MOCK_DID,
+    handle: MOCK_HANDLE,
+    email: MOCK_EMAIL,
+    emailConfirmed: true,
+    active: true,
+  }
+}
+
+/**
+ * A minimal PLC DID document for {@link MOCK_DID}. Returned by the
+ * harness for the `https://plc.directory/<did>` fetch that
+ * `resolvePdsUrl` / `resolveHandle` make directly (these bypass our
+ * `/api/*` routes, so the mock provider matches the PLC host too).
+ *
+ * Carries:
+ *   - `alsoKnownAs: [at://<handle>]` so `resolveHandle` yields MOCK_HANDLE.
+ *   - an `#atproto_pds` service so `resolvePdsUrl` yields MOCK_PDS_URL.
+ */
+export function plcDidDocument(): {
+  id: string
+  alsoKnownAs: string[]
+  service: { id: string; type: string; serviceEndpoint: string }[]
+} {
+  return {
+    id: MOCK_DID,
+    alsoKnownAs: [`at://${MOCK_HANDLE}`],
+    service: [
+      {
+        id: "#atproto_pds",
+        type: "AtprotoPersonalDataServer",
+        serviceEndpoint: MOCK_PDS_URL,
+      },
+    ],
+  }
+}


### PR DESCRIPTION
## Component library — "cost-no-object" completion pass

Follow-up to the merged consolidation (#129). This implements the decisions from `docs/component-library/decisions.html` under the *ignore-effort* assumption: build the missing primitives, migrate the last bespoke chrome, and stand up a real browser-verification harness for the auth-gated surfaces.

### New / enhanced primitives (`src/components/ui/`)
- **`Combobox<T>`** — a generic controlled-items typeahead that owns the state machine + full WAI-ARIA (debounce-agnostic, requestSeq-safe highlight, keyboard, scroll, live region) with render-prop rows; replaces **5** hand-rolled combobox state machines (~2k LOC). +17 tests.
- **`SegmentedControl`** (single-select, wraps `RadioGroup`) + **`ToggleGroup`** (multi, color-coded `tone`) — one toggle vocabulary. +tests.
- **`Popover` portal** — opt-in `portal`/`side`/`align`/`collision` so the core-nav account-switcher menus adopt the primitive; default path byte-identical.
- **`Input`/`Textarea`** — `size="bare"` (font inherits), `density="compact"`, `flush` (unwrapped) so inline/compact chrome adopts the primitive without visual regression.

### Migrations
- 5 search/typeahead fields → `Combobox` (each keeps its own fetch/rows).
- explore view-toggle/degree filters + response toggles → `SegmentedControl`/`ToggleGroup` (accept=green / reject=amber).
- account-switcher + create menus → portal `Popover` (mobile bottom-sheet left as sanctioned).
- profile-sidebar inline + cert-detail compact fields + org-URL grid → `Input` `bare`/`compact`/`flush`.
- **D3 reversed:** the top-bar/explore/detail strips are *in-page view tabs* (not page nav), so they migrate to `<Tabs>` (button-tabs + `router.replace(scroll:false)`).

### Verification harness (`/dev/preview` + Playwright)
A dev-only `/dev/preview/[surface]` route mounts the **real** composed surfaces (profile, profile-org, feed, settings, workspace) inside the **real** provider stack, with `MockFetchProvider` serving fixture JSON — so the logged-in surfaces can be screenshotted. `/dev/gallery` renders every primitive + new states. `docs/component-library/index.html` is now **generated** from the gallery (`npm run styleguide:generate`) so it can't drift.

### Browser verification (Playwright + Chromium, light + dark)
- All 5 auth-gated preview surfaces render with mock data (HTTP 200, no errors) — profile/feed/workspace verified rich; profile read-view unchanged vs. baseline.
- Portaled account/create menu positions correctly; Combobox chrome + dropdown; SegmentedControl/ToggleGroup (color-coded) + Input bare/compact/flush all verified in the gallery; `/explore` + `/search` render clean.

### Gate
| | baseline | this PR |
|---|---|---|
| `tsc` | 0 | **0** |
| `eslint` | 0 err / 66 warn | **0 err / 66 warn** |
| `vitest` | 536 | **565** (+Combobox/SegmentedControl tests) |
| `next build` | OK | **OK** |

Draft; do not merge. (Dev-only `/dev/gallery` + `/dev/preview` are `notFound()` in production.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Tracked follow-ups (filed)
- #131 — extend the preview harness to the auth-gated create/edit forms (so the compact-Input + Combobox forms are visually verified, not just gate-checked)
- #132 — prune dead inline-edit / page-tabs CSS left after the input-chrome migrations (good first issue)
- #133 — let `<Tab href>` link tabs carry Next nav props (scroll/replace) so router query-tabs can be real anchors
- #134 — review the Combobox auto-highlight (row 0) / Enter normalization for handle-search & contributor-identity
- #135 — make the generated styleguide leaner + fully offline (purge CSS, inline fonts)

_Deliberately not filed (won't-fix by design): decorative `<pattern>` SVGs, `map.tsx`'s JS-painted Leaflet color, and the brand sign-in image buttons — genuine one-offs no primitive should absorb._
