### PR TITLE
chore(pwa): disable the install prompt for now (manifest display: browser)

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -6,7 +6,10 @@ export default function manifest(): MetadataRoute.Manifest {
     short_name: "Certified",
     description: "Your identity, everywhere.",
     start_url: "/welcome",
-    display: "standalone",
+    // "browser" makes the app non-installable, so the browser stops showing the
+    // PWA "install" prompt in the address bar (it would confuse users during the
+    // redesign). Set back to "standalone" to re-enable installability.
+    display: "browser",
     theme_color: "#f9f9f6",
     background_color: "#f9f9f6",
     icons: [


### PR DESCRIPTION
## Disable the PWA install prompt (for now)

Visiting the app over HTTPS shows Chrome/Edge's **"install" affordance in the address bar** (and an Install option in the ⋮ menu). That's the browser offering to install Certified as a standalone PWA — which can confuse users during the redesign.

### Change
One line in `src/app/manifest.ts`: `display: "standalone"` → `display: "browser"`.

The desktop install prompt is gated on the manifest's `display` being `standalone` / `fullscreen` / `minimal-ui`. Setting it to `"browser"` makes the app **non-installable**, so the prompt disappears. Everything else in the manifest (name, `theme_color`, icons, `start_url`) is unchanged.

### Why this approach
- Minimal and **trivially reversible** — change `"browser"` back to `"standalone"` to re-enable installability. A comment in the file says so.
- Keeps the manifest (and its tab/theme metadata) rather than deleting it.

### Scope note
This is the **desktop Chromium** install prompt only. iOS Safari's "Add to Home Screen" is a manual Share-sheet action (not an auto-prompt) driven by `appleWebApp` in `layout.tsx`; it's left as-is since it isn't the URL-bar prompt in question. Happy to disable that too if wanted. There's no service worker, so no offline/caching behavior is affected.

### Verification
- `tsc --noEmit`: 0 errors (`"browser"` is a valid `MetadataRoute.Manifest` display value).

Not merged — over to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
