### PR TITLE
feat: org-identity aggregation — surface group-owned work, per-action write identity, flag-gated notifications

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -49,6 +49,14 @@ INDEXER_DID=
 # targeted indexer. Leave unset (or "false") to keep today's behaviour.
 # RESOLVE_DID_USE_INDEXER=false
 
+# Optional: aggregate notifications across the groups a user owns/admins
+# (not just their personal account). Default false. Requires the
+# magic-indexer `recipients` change in
+# docs/org-identity/indexer-notifications-aggregation.md FIRST — with the
+# flag on, the client sends a `recipients` arg the current indexer would
+# reject. Flip it on a preview env once the indexer supports it.
+# NEXT_PUBLIC_NOTIFICATIONS_AGGREGATION=false
+
 # Optional rate-limit bypass key for the app's server-side indexer traffic.
 # Sent as `X-RateLimit-Bypass` by the /api/indexer, /api/notifications, and
 # resolve-did upstream fetches so the app's own proxied requests aren't

--- a/docs/org-identity/indexer-notifications-aggregation.md
+++ b/docs/org-identity/indexer-notifications-aggregation.md
@@ -1,0 +1,211 @@
+# magic-indexer spec — notifications aggregation for managed identities
+
+**Status:** proposed (client built against this contract, flag-gated OFF)
+**Owner (client side):** certified-app `feat/org-identity-aggregation`
+**Blocks:** the "Notifications" slice of the org-identity aggregation model
+**Client flag:** `NEXT_PUBLIC_NOTIFICATIONS_AGGREGATION` (default `false`)
+
+---
+
+## 1. Why
+
+certified-app now aggregates records *owned by groups a user owns/admins*
+onto that user's work surfaces (Home, the `/managed` hub, the own-profile
+bridge). Projects and activities already aggregate, because their indexer
+ops (`fetchProjects`, `fetchIndexerActivities`) accept a multi-author
+`authors: [String!]` filter.
+
+**Notifications are the one surface that cannot aggregate from the client
+alone.** The notifications op is scoped *entirely* by the service-auth JWT
+`iss` claim minted server-side (`src/app/api/notifications/route.ts`):
+
+```
+iss  = user's DID            (from the OAuth agent / PDS signature)
+aud  = INDEXER_DID
+lxm  = "com.hypergoat.notification.query"
+```
+
+The `notifications` and `unreadNotificationCount` queries take **no
+recipient/subject parameter** — the indexer derives "whose notifications"
+from `iss`. So a user who owns *Estuary Alliance* has no way to see "your
+group was endorsed" notifications without acting as the group DID.
+
+We deliberately do **not** want to mint a separate `iss = groupDID` JWT per
+group and fan out (N round-trips, and it requires group signing authority
+the app proxy doesn't cleanly expose for read ops). Instead we ask the
+indexer to authorize *one* call — `iss = user` — to read notifications for a
+set of **recipients** the indexer's own role index confirms the user
+owns/admins.
+
+## 2. What changes (summary)
+
+1. Add an optional `recipients: [String!]` argument to **`notifications`**
+   and **`unreadNotificationCount`**.
+2. Add a non-null `recipient: String!` field to the **notification node**.
+3. Authorize each requested recipient against the indexer's role index:
+   the `iss` may read a recipient's notifications iff
+   `recipient == iss` **or** `iss` is an `owner`/`admin` of `recipient`.
+   Silently drop unauthorized recipients (see §5).
+
+All three are **additive and backward-compatible**: when `recipients` is
+omitted or empty, behaviour is byte-identical to today (iss-only). The
+client only sends `recipients` when its feature flag is on, so production
+traffic is unchanged until the indexer ships this.
+
+## 3. GraphQL schema (exact)
+
+### 3.1 `notifications`
+
+```graphql
+type Query {
+  notifications(
+    first: Int!
+    after: String
+    "Optional. DIDs whose notifications to include. Omitted/empty = the
+     authenticated DID only (current behaviour). Every DID is authorized
+     against the caller's owner/admin role; unauthorized DIDs are dropped."
+    recipients: [String!]
+  ): NotificationConnection!
+}
+```
+
+### 3.2 `unreadNotificationCount`
+
+```graphql
+type Query {
+  unreadNotificationCount(
+    "Same semantics + authorization as notifications.recipients."
+    recipients: [String!]
+  ): UnreadCount!
+}
+```
+
+### 3.3 Notification node — add `recipient`
+
+```graphql
+type Notification {
+  id: ID!
+  reason: String!              # "endorsement" | "activity-contributor"
+  reasonSubject: String
+  sortAt: String!
+  count: Int!
+  latestRecordUri: String!
+  latestRecordCid: String!
+  latestAuthor: String!
+  isRead: Boolean!
+  "NEW: the DID whose notification this is (== iss when recipients omitted).
+   The client uses this to tag aggregated rows 'via {group}'. Always present."
+  recipient: String!
+}
+```
+
+`recipient` is what lets the client label a row without re-parsing
+`reasonSubject` URIs. In the non-aggregated path it simply equals `iss`.
+
+## 4. Server-side query strings the client will send
+
+The Next.js route holds the query strings (the client sends only
+`operationName` + `variables`). When the flag is on **and** `recipients` is
+non-empty, the route sends these **variant** queries (note the new arg +
+`recipient` selection). When the flag is off, it sends today's queries
+unchanged.
+
+```graphql
+query notifications($first: Int!, $after: String, $recipients: [String!]) {
+  notifications(first: $first, after: $after, recipients: $recipients) {
+    edges { cursor node {
+      id reason reasonSubject sortAt count
+      latestRecordUri latestRecordCid latestAuthor isRead recipient
+    } }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+
+query unreadNotificationCount($recipients: [String!]) {
+  unreadNotificationCount(recipients: $recipients) { count more }
+}
+```
+
+## 5. Authorization model
+
+The indexer already ingests group membership / role records (it powers
+`resolveGroups` and the org role badges). Reuse that index — **do not**
+trust a client-supplied role.
+
+For a request with `iss = U` and `recipients = [R1, R2, …]`:
+
+- Always allow `Ri == U`.
+- Allow `Ri != U` iff the role index says `U` is `owner` or `admin` of
+  `Ri`. `member` is **not** sufficient (mirrors the client's
+  `ownedOrAdminGroups` filter — member-role records are excluded from
+  aggregation everywhere).
+- **Drop** unauthorized `Ri` from the result set silently rather than
+  erroring the whole request. Rationale: membership is eventually
+  consistent; a just-revoked admin shouldn't get a 4xx that blanks their
+  entire notification feed — they should just stop seeing that group's
+  rows. (The client re-derives the authorized author set from the same
+  role data on every poll, so the two converge.)
+- If, after dropping, the effective recipient set is empty, fall back to
+  `[U]` (never return a foreign-only or empty-authorized set as "all").
+
+> Optional, nice-to-have for observability: a top-level
+> `unauthorizedRecipients: [String!]` on the connection so the client can
+> warn in dev. Not required for v1.
+
+## 6. Read-state / "seen" boundary (phase 1)
+
+`updateNotificationsSeen(seenAt)` stays **iss-scoped (personal only)** in
+this phase. It is intentionally *not* extended with `recipients`:
+
+- "Seen" for a group is **shared team state** — if one admin marks the
+  group's notifications seen, it clears the badge for every other admin.
+  That is a real product decision (per-user vs per-group read state) we are
+  not making under a flag.
+- Therefore the aggregated **unread count** may include group
+  notifications that no per-group "seen" action can currently clear. The
+  client accounts for this: the aggregated badge is informational; marking
+  seen only ever affects the user's personal notifications.
+
+Phase 2 (future, out of scope here): per-(user, recipient) seen cursors so
+each admin has independent group read-state. Flagged separately when we get
+there.
+
+## 7. JWT / transport — unchanged
+
+- Same endpoint: `POST {INDEXER_URL_BASE}/notifications/graphql`.
+- Same `lxm = "com.hypergoat.notification.query"`, same `aud = INDEXER_DID`,
+  same ~60s `exp`, same `jti` replay cache.
+- `iss` is still the **user** DID. The recipients authorization is the only
+  new server-side logic. No new lexicon method, no group-issued JWTs.
+
+## 8. Client integration points (already built, flag-gated)
+
+When `NEXT_PUBLIC_NOTIFICATIONS_AGGREGATION=true`:
+
+| Concern | File | Behaviour |
+| --- | --- | --- |
+| Flag | `src/lib/utils/config.ts` | `NOTIFICATIONS_AGGREGATION_ENABLED` |
+| Client op | `src/lib/atproto/notifications.ts` | `fetchNotifications`/`fetchUnreadCount` send `recipients`, parse `recipient` |
+| Route | `src/app/api/notifications/route.ts` | validates `recipients` (DID-shaped, ≤ `MAX_RECIPIENTS`), selects the variant query only when flag on + recipients present |
+| Feed hook | `src/hooks/use-managed-notifications.ts` | fans out via `useManagedAuthors().authors`, tags each row with `ownerTagForDid(recipient, …)` |
+| Count | `src/lib/notifications-context.tsx` | aggregated unread badge across managed recipients |
+| UI | `src/app/notifications/page.tsx` | identity focus filter + "via {group}" byline, exactly like the `/managed` hub |
+
+Recommended rollout: ship the indexer change to dev → set the flag on the
+certified-app **preview** env only → verify against real data → set on
+staging → production.
+
+## 9. Acceptance checklist (indexer side)
+
+- [ ] `notifications(recipients: [])` and `notifications` (no arg) return
+      byte-identical results to today for the same `iss`.
+- [ ] `notifications(recipients: [iss])` == today.
+- [ ] `notifications(recipients: [iss, ownedGroup])` returns the union,
+      each node carrying the correct `recipient`.
+- [ ] `notifications(recipients: [groupUserOnlyMemberOf])` drops that DID
+      (returns iss-only), no error.
+- [ ] `notifications(recipients: [strangerDid])` drops it, no error, no
+      leak of the stranger's notifications.
+- [ ] `unreadNotificationCount(recipients: …)` mirrors the same authz.
+- [ ] `recipient` is present and correct on every node in all paths.
+- [ ] `updateNotificationsSeen` unchanged (iss-only).

--- a/docs/org-identity/plan.md
+++ b/docs/org-identity/plan.md
@@ -1,0 +1,86 @@
+# Org-identity aggregation — plan & decision log
+
+**Branch:** `feat/org-identity-aggregation` → Draft PR into `staging`
+**Bug that motivated it:** a user didn't see the projects he manages, because
+he manages them only *via groups he belongs to*. Records authored by a group
+live in the group's repo (its own DID), so they never appeared on his
+personal surfaces.
+
+## The model (decisions)
+
+The core question was: *treat a group as a separate actor, or fold it into
+the individual's UX?* We chose a **hybrid** — read-aggregate, write-explicit:
+
+1. **Read-aggregation is the spine.** Aggregate records owned by the groups a
+   user **owns or admins** onto their work surfaces, each tagged "via
+   {group}". Built in three places: a dedicated **`/managed` hub** (focus
+   filter), **inline on Home** (My projects / My activities), and a
+   dismissible **bridge banner** on the user's own profile. (GitHub/Linear
+   pattern: your work + the orgs you run, in one place.)
+   - **Member-role groups are excluded.** Membership alone doesn't grant the
+     responsibility that owner/admin do. Enforced in `ownedOrAdminGroups`.
+   - **Identity/public surfaces stay single-identity.** A public profile is
+     one actor; group projects are NOT folded into its Projects tab — the
+     bridge links out instead.
+
+2. **Write identity is per-action, explicit.** The old "acting as" bar
+   conflated read-scope and write-identity, which is how a user could post
+   under a group unintentionally. Now:
+   - **`<PostingAs>`** picker on every create/edit/respond action. Default is
+     **You**; switching to a group is deliberate. High-stakes actions
+     (endorse, award) require a **confirm** that names the parties.
+   - **"Acting as" is demoted to read-scope / focus only.**
+   - Edits write back to the **record-owner repo** (`editTargetDid`), so a
+     group record stays group-owned after an edit.
+   - The endorse-as-org backend already existed (`writeToRepo(targetDid)`);
+     we wired the picker to it rather than rebuilding.
+
+3. **Notifications aggregation is flag-gated, pending an indexer change.**
+   The notifications op is scoped by the service-auth JWT `iss`, so a group's
+   notifications can't be read from the client alone. We built the full
+   client (`recipients` plumbing, identity filter, "via {group}" rows,
+   aggregated badge) behind `NEXT_PUBLIC_NOTIFICATIONS_AGGREGATION` (default
+   OFF) and wrote the exact indexer contract:
+   `docs/org-identity/indexer-notifications-aggregation.md`. With the flag
+   off, every notifications path is byte-identical to before.
+
+## Surfaces (per-surface decision)
+
+| Surface | Treatment |
+| --- | --- |
+| Home (My projects / activities) | inline aggregation + "via {group}" |
+| `/managed` hub | full aggregation + identity focus filter |
+| Own profile | single-identity + dismissible bridge banner |
+| Foreign profile | single-identity, no bridge (never advertises a viewer's groups) |
+| Explore | unchanged (network-wide; aggregation is about *your* responsibility) |
+| Create / edit | `<PostingAs>` write picker |
+| Notifications | aggregation behind the flag (identity filter + via rows) |
+
+## Out of scope (deliberately)
+
+- **Group "seen"/read-state for notifications.** That's shared team state
+  (one admin clearing the badge for all). Phase 2; documented in the indexer
+  spec §6. The aggregated badge is informational; mark-seen stays personal.
+- **Writing to a group you don't own/admin.** The picker only offers
+  owner/admin groups.
+- **Folding group records into the public profile.** Intentional — keeps the
+  profile one public actor.
+
+## Rollout / rollback
+
+- Read-aggregation + write-reframe ship on merge (no flag).
+- Notifications aggregation stays dark until the magic-indexer `recipients`
+  change lands; then flip `NEXT_PUBLIC_NOTIFICATIONS_AGGREGATION` on a preview
+  env, verify against real data, then staging, then prod.
+- Rollback: the notifications slice is a flag flip. The read-aggregation is
+  additive (new hub + new rows); reverting the Home/profile changes restores
+  the personal-only surfaces.
+
+## Verification
+
+- Gate: typecheck 0, lint 0 errors, 600 tests, build OK.
+- Browser (Playwright, auth-mock preview harness): `/managed` hub (light +
+  dark + mobile), Home inline aggregation, own-profile bridge, create
+  `<PostingAs>` picker, notifications aggregation (filter, via rows,
+  read-only group rows, member-group exclusion, aggregated badge) — all with
+  fixture data via the `managedScenario` mock.

--- a/docs/org-identity/review-round-1.md
+++ b/docs/org-identity/review-round-1.md
@@ -1,0 +1,83 @@
+# Org-identity aggregation — review round 1 (decisions)
+
+A 6-lens review (data-flow, security, react, flag-off/backward-compat, UX,
+tests) over `feat/org-identity-aggregation`, each finding adversarially
+verified before counting. 17 confirmed findings. All but one (a documented
+non-required micro-optimization) integrated.
+
+## Accepted & fixed
+
+### Major
+1. **Home sidebar misattribution** (data-flow). When the viewer switched
+   into any group, the "via {group}" byline was dropped for *all* rows but
+   the list was never filtered to that group — so personal + other-group
+   records rendered with no provenance, implying they belonged to the
+   focused group. **Fix:** removed the `activeOrg` coupling from the Home
+   sidebar entirely. Home always shows the full managed aggregate with
+   provenance *always* visible (acting-as is read-scope and never strips
+   "yours"); the dedicated `/managed` hub is where the focus filter narrows
+   to one owner. "Show more" now points at `/managed` (the aggregate it
+   previews), not the personal profile tab.
+2. **Edit eligibility gated on `activeOrg`** (data-flow). A record surfaced
+   via read-aggregation couldn't be edited unless the viewer first switched
+   the org switcher to its group — the read→edit path was broken. **Fix:**
+   eligibility now derives from the managed-author set (`useManagedAuthors`:
+   personal + owned/admin groups), not the switcher. Both edit pages also
+   wait on the managed-author load for non-personal records so a group
+   record the viewer manages doesn't flash "you can't edit". The BFF still
+   re-checks role server-side.
+3. **ViaByline invisible to screen readers** (UX/a11y). Every child was
+   `aria-hidden` and the outer `aria-label` on a roleless span isn't
+   reliably announced. **Fix:** the visible "via {name}" text is now the
+   accessible name; only the avatar is hidden; the role is appended sr-only
+   so SR reads "via {name}, {role}".
+4. **owner-tag.ts untested** (tests). The load-bearing tagging logic,
+   including the "never label a stranger You" safety branch, had no direct
+   coverage. **Fix:** added `owner-tag.test.ts`.
+
+### Minor
+5. Home "Show more" count/destination mismatch → pointed at `/managed`
+   (folded into fix #1).
+6. Notifications fired a throwaway personal fetch + flashed personal-only
+   before `managesAnyGroup` resolved → hold both hooks (skeleton) until the
+   org roles settle; flag-off path unchanged.
+7. Follow/Endorse pickers seeded local state from `postingOptions[0]` once,
+   pinning a stale copy before handle/avatar resolved → store the selected
+   DID and derive the identity each render.
+8. Focus filter could overflow on mobile → the filter rows scroll
+   horizontally (scrollbar hidden); strip keeps its intrinsic width.
+9. PostingAs menu had no *visible* current-selection mark → reserved-width
+   check icon on the selected row.
+10. Notifications focus dropdown was full-width vs `/managed`'s 280px cap →
+    capped to match.
+11. The route's flag-gate + recipients validation was untested (the actual
+    flag-off enforcement point) → extracted `operations.ts` (flag injected
+    as a param) and added `operations.test.ts` covering both flag states.
+12. `fan-out.ts` error isolation + abort re-throw untested → added
+    `fan-out.test.ts`.
+
+### Nit
+13. `parseRecipients` used a looser DID check than `isValidDid` → now reuses
+    `isValidDid`.
+15. Orphan `.managed-row__via-label` class → dropped.
+16. Unused `.notification-row__via` class → dropped.
+17. Profile bridge link hover used `--color-accent` (lighter in light mode =
+    inverted affordance) → `--color-accent-hover` (theme-correct stronger).
+
+## Accepted but deferred (with rationale)
+
+14. **`useManagedNotifications` re-tags rows when `byDid` Map identity
+    changes on unrelated org refreshes** (react, nit). The reviewer marked
+    this "optional micro-optimization only — not required." The fix would
+    tighten `useManagedAuthors`'s memo key, which is shared by every managed
+    hook; the churn is infrequent (only on a new `groups` array identity)
+    and re-tagging a few rows is negligible. Not worth the shared-surface
+    risk under a flag. Left as-is.
+
+## Verification
+
+Re-ran the gate after integration: typecheck 0, lint 0 errors, **620 tests**
+(was 600; +20 across owner-tag/fan-out/operations + the updated edit test),
+build OK. Browser-reverified Home aggregation (via always visible, roles
+exposed to SR), the PostingAs check indicator, and the notifications/managed
+filters (light + dark + mobile).

--- a/src/app/__tests__/create-image-upload-error.test.tsx
+++ b/src/app/__tests__/create-image-upload-error.test.tsx
@@ -10,8 +10,12 @@ vi.mock("@/lib/auth/auth-context", () => ({
   useAuth: () => ({ did: "did:plc:me", isAuthenticated: true, isLoading: false }),
 }))
 
+// `groups` feeds the per-action posting picker (usePostingIdentity →
+// buildPostingOptions); the real OrgContext always supplies an array, so
+// stub it as empty here (the viewer admins no groups → static "Posting
+// as You" label, no picker).
 vi.mock("@/lib/groups/org-context", () => ({
-  useOrg: () => ({ activeOrg: null }),
+  useOrg: () => ({ activeOrg: null, groups: [] }),
 }))
 
 vi.mock("next/navigation", () => ({

--- a/src/app/activity/[did]/[rkey]/edit/page.tsx
+++ b/src/app/activity/[did]/[rkey]/edit/page.tsx
@@ -13,7 +13,7 @@ import {
   X,
 } from "lucide-react"
 import { useAuth } from "@/lib/auth/auth-context"
-import { useOrg } from "@/lib/groups/org-context"
+import { useManagedAuthors } from "@/hooks/use-managed-authors"
 import { authFetch } from "@/lib/auth/fetch"
 import EmptyState from "@/components/ui/empty-state"
 import Button from "@/components/ui/button"
@@ -178,24 +178,20 @@ export default function ActivityEditPage() {
   }, [params.rkey])
 
   const { isAuthenticated, isLoading: authLoading, did: sessionDid } = useAuth()
-  const { activeOrg } = useOrg()
+  // Eligibility derives from the viewer's MANAGED identities (personal +
+  // owned/admin groups), NOT the transient org switcher — so a cert
+  // surfaced via read-aggregation is editable without first switching the
+  // switcher to its group. `byDid` holds the personal identity + owner/admin
+  // groups (member groups excluded); the BFF re-checks role server-side.
+  const { byDid, isLoading: managedLoading } = useManagedAuthors()
 
-  // Edits write back into the repo the record LIVES in (`did`, the route
-  // owner) — never a target derived from the active org. `activeOrg` is
-  // read here ONLY to gate eligibility: editing a group-owned cert
-  // requires the operator to be operating that same group with an
-  // owner/admin role (the BFF re-checks this server-side). The write
-  // target is always the record's own repo; the active org just unlocks
-  // the affordance.
-  const canEditAsActiveOrg =
-    !!activeOrg && !!did && activeOrg.groupDid === did &&
-    (activeOrg.role === "owner" || activeOrg.role === "admin")
-  const isCreator = activeOrg
-    ? canEditAsActiveOrg
-    : !!sessionDid && sessionDid === did
-  // `editTargetDid` is the record-owner repo (group) when editing a
-  // group-owned cert, else undefined → the viewer's own PDS via XRPC.
-  const editTargetDid = canEditAsActiveOrg ? did : undefined
+  const isPersonalRecord = !!did && !!sessionDid && sessionDid === did
+  const isOwnedOrAdminGroup = !!did && byDid.get(did)?.kind === "group"
+  const isCreator = isPersonalRecord || isOwnedOrAdminGroup
+  // Edits write back into the repo the record LIVES in: the group repo for
+  // a group-owned cert (`editTargetDid` = did), else the viewer's own PDS
+  // (undefined target). Never derived from a read-scope org.
+  const editTargetDid = isOwnedOrAdminGroup ? did : undefined
 
   const { activity, isLoading: activityLoading, error: activityError } =
     useActivity(did, rkey)
@@ -456,8 +452,10 @@ export default function ActivityEditPage() {
       : null
   const displayImageUrl = pendingImagePreviewUrl ?? existingImageUrl
 
-  // Auth-loading / signed-out states. Mirrors /create's gates.
-  if (authLoading || activityLoading) {
+  // Auth-loading / signed-out states. Mirrors /create's gates. For a
+  // non-personal record we also wait on the managed-author set so a group
+  // cert the viewer manages doesn't flash "you can't edit" before roles resolve.
+  if (authLoading || activityLoading || (!isPersonalRecord && managedLoading)) {
     return (
       <div className="dashboard">
         <div className="dashboard__body">

--- a/src/app/activity/[did]/[rkey]/edit/page.tsx
+++ b/src/app/activity/[did]/[rkey]/edit/page.tsx
@@ -180,15 +180,21 @@ export default function ActivityEditPage() {
   const { isAuthenticated, isLoading: authLoading, did: sessionDid } = useAuth()
   const { activeOrg } = useOrg()
 
-  // The edit endpoint to call: own repo via XRPC proxy when the
-  // viewer's session DID matches the cert's owner; the group BFF
-  // when the cert is owned by the active org and the role permits.
+  // Edits write back into the repo the record LIVES in (`did`, the route
+  // owner) — never a target derived from the active org. `activeOrg` is
+  // read here ONLY to gate eligibility: editing a group-owned cert
+  // requires the operator to be operating that same group with an
+  // owner/admin role (the BFF re-checks this server-side). The write
+  // target is always the record's own repo; the active org just unlocks
+  // the affordance.
   const canEditAsActiveOrg =
     !!activeOrg && !!did && activeOrg.groupDid === did &&
     (activeOrg.role === "owner" || activeOrg.role === "admin")
   const isCreator = activeOrg
     ? canEditAsActiveOrg
     : !!sessionDid && sessionDid === did
+  // `editTargetDid` is the record-owner repo (group) when editing a
+  // group-owned cert, else undefined → the viewer's own PDS via XRPC.
   const editTargetDid = canEditAsActiveOrg ? did : undefined
 
   const { activity, isLoading: activityLoading, error: activityError } =
@@ -231,10 +237,12 @@ export default function ActivityEditPage() {
   } | null>(null)
   const seededRef = useRef(false)
 
-  // "Add me" needs the publishing identity's @handle/DID. Same logic
-  // as /create — group DID when acting as a group, otherwise own DID.
+  // "Add me" + new-location target need the repo this cert LIVES in —
+  // the record-owner repo (`editTargetDid` = the group when editing a
+  // group-owned cert), else the viewer's own DID. Not the active
+  // read-scope org; edits always write back to the record's repo.
   const effectivePublisherDid: string =
-    activeOrg?.groupDid ?? sessionDid ?? ""
+    editTargetDid ?? sessionDid ?? ""
   const { info: selfInfo } = useAuthorInfo(effectivePublisherDid)
 
   // -------------------------------------------------------------------
@@ -418,14 +426,17 @@ export default function ActivityEditPage() {
         return previewUrl
       })
       setImageRemoved(false)
-      const targetDid = activeOrg ? activeOrg.groupDid : null
+      // Blob lands in the repo the cert lives in (record owner), not the
+      // active read-scope org. `editTargetDid` is the group repo for a
+      // group-owned cert, else undefined → the viewer's own PDS.
+      const targetDid = editTargetDid ?? null
       const blob = await uploadBlob(
         file,
         targetDid ? { targetDid } : undefined,
       )
       setPendingImageBlob(blob)
     },
-    [activeOrg],
+    [editTargetDid],
   )
 
   const handleImageRemove = useCallback(() => {
@@ -1025,7 +1036,7 @@ export default function ActivityEditPage() {
               onImageUpload={(file) =>
                 uploadBlob(
                   file,
-                  activeOrg ? { targetDid: activeOrg.groupDid } : undefined,
+                  editTargetDid ? { targetDid: editTargetDid } : undefined,
                 )
               }
             />

--- a/src/app/api/notifications/__tests__/operations.test.ts
+++ b/src/app/api/notifications/__tests__/operations.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest"
+import {
+  buildVariables,
+  parseRecipients,
+  selectQuery,
+  OPERATIONS,
+  AGGREGATED_OPERATIONS,
+  MAX_RECIPIENTS,
+} from "../operations"
+
+const DID_A = "did:plc:aaaaaaaaaaaaaaaaaaaaaaaa"
+const DID_B = "did:plc:bbbbbbbbbbbbbbbbbbbbbbbb"
+
+describe("notifications operations — flag OFF (default / production)", () => {
+  const OFF = false
+
+  it("parseRecipients always returns null, even with valid DIDs", () => {
+    expect(parseRecipients([DID_A, DID_B], OFF)).toBeNull()
+  })
+
+  it("buildVariables(notifications) never includes recipients", () => {
+    const v = buildVariables("notifications", { first: 10, recipients: [DID_A] }, OFF)
+    expect(v).toEqual({ first: 10, after: null })
+    expect(v).not.toHaveProperty("recipients")
+  })
+
+  it("buildVariables(unreadNotificationCount) is empty", () => {
+    expect(buildVariables("unreadNotificationCount", { recipients: [DID_A] }, OFF)).toEqual({})
+  })
+
+  it("selectQuery picks the BASE (non-recipients) query", () => {
+    const v = buildVariables("notifications", { first: 10, recipients: [DID_A] }, OFF)!
+    expect(selectQuery("notifications", v)).toBe(OPERATIONS.notifications)
+    expect(selectQuery("notifications", v)).not.toContain("recipients")
+  })
+})
+
+describe("notifications operations — flag ON", () => {
+  const ON = true
+
+  it("parseRecipients keeps valid DIDs, deduped + capped", () => {
+    expect(parseRecipients([DID_A, DID_A, DID_B], ON)).toEqual([DID_A, DID_B])
+    // did:plc identifiers are 24 chars of base32 [a-z2-7]; vary two
+    // positions so the generated set is both valid and distinct.
+    const b32 = "abcdefghijklmnopqrstuvwxyz234567"
+    const many = Array.from(
+      { length: MAX_RECIPIENTS + 5 },
+      (_, i) => `did:plc:${"a".repeat(22)}${b32[i % 32]}${b32[Math.floor(i / 32) % 32]}`,
+    )
+    expect(parseRecipients(many, ON)).toHaveLength(MAX_RECIPIENTS)
+  })
+
+  it("parseRecipients rejects malformed DIDs and non-strings", () => {
+    expect(parseRecipients(["not-a-did", 42, null, "did:bogus"], ON)).toBeNull()
+  })
+
+  it("parseRecipients returns null for an empty array", () => {
+    expect(parseRecipients([], ON)).toBeNull()
+  })
+
+  it("buildVariables(notifications) includes recipients when present", () => {
+    const v = buildVariables("notifications", { first: 5, recipients: [DID_A, DID_B] }, ON)
+    expect(v).toEqual({ first: 5, after: null, recipients: [DID_A, DID_B] })
+  })
+
+  it("buildVariables omits recipients when none survive validation", () => {
+    const v = buildVariables("notifications", { first: 5, recipients: ["bad"] }, ON)
+    expect(v).not.toHaveProperty("recipients")
+  })
+
+  it("selectQuery picks the AGGREGATED variant once recipients are present", () => {
+    const v = buildVariables("notifications", { first: 5, recipients: [DID_A] }, ON)!
+    expect(selectQuery("notifications", v)).toBe(AGGREGATED_OPERATIONS.notifications)
+    expect(selectQuery("notifications", v)).toContain("recipient")
+  })
+
+  it("clamps first to [1,100]", () => {
+    expect(buildVariables("notifications", { first: 9999 }, ON)).toMatchObject({ first: 100 })
+    expect(buildVariables("notifications", { first: -3 }, ON)).toMatchObject({ first: 1 })
+  })
+})

--- a/src/app/api/notifications/operations.ts
+++ b/src/app/api/notifications/operations.ts
@@ -1,0 +1,176 @@
+import { isValidDid } from "@/lib/utils/did"
+
+/**
+ * Notifications GraphQL operations + variable normalization, factored out
+ * of route.ts so the flag-gate + recipients validation is unit-testable
+ * without standing up the full Next route (session, OAuth, service-auth).
+ *
+ * The aggregation flag is INJECTED (not read from the module) so a test can
+ * exercise both states deterministically; route.ts passes
+ * NOTIFICATIONS_AGGREGATION_ENABLED. See
+ * docs/org-identity/indexer-notifications-aggregation.md.
+ */
+
+export const MAX_FIRST = 100
+// Cap the aggregated recipient set. A user owns/admins few groups in
+// practice; this bounds the indexer query and rejects pathological input.
+export const MAX_RECIPIENTS = 25
+
+/** Allowlist of GraphQL operations we forward. The client sends only
+ *  operationName + variables; the query string is held server-side. These
+ *  base queries take no recipient arg — the indexer derives the acting DID
+ *  from the JWT `iss`. */
+export const OPERATIONS: Record<string, string> = {
+  notifications: `
+    query notifications($first: Int!, $after: String) {
+      notifications(first: $first, after: $after) {
+        edges {
+          cursor
+          node {
+            id
+            reason
+            reasonSubject
+            sortAt
+            count
+            latestRecordUri
+            latestRecordCid
+            latestAuthor
+            isRead
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }`,
+  unreadNotificationCount: `
+    query unreadNotificationCount {
+      unreadNotificationCount { count more }
+    }`,
+  updateNotificationsSeen: `
+    mutation updateNotificationsSeen($seenAt: String) {
+      updateNotificationsSeen(seenAt: $seenAt)
+    }`,
+}
+
+/**
+ * Aggregated query variants — used ONLY when the aggregation flag is on AND
+ * the client supplied a non-empty `recipients` set. Held apart from
+ * OPERATIONS so the default path's query stays byte-identical: an indexer
+ * that doesn't yet understand `recipients` never receives the argument. The
+ * node also selects the new `recipient` field so the client can tag each
+ * row "via {group}".
+ */
+export const AGGREGATED_OPERATIONS: Record<string, string> = {
+  notifications: `
+    query notifications($first: Int!, $after: String, $recipients: [String!]) {
+      notifications(first: $first, after: $after, recipients: $recipients) {
+        edges {
+          cursor
+          node {
+            id
+            reason
+            reasonSubject
+            sortAt
+            count
+            latestRecordUri
+            latestRecordCid
+            latestAuthor
+            isRead
+            recipient
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }`,
+  unreadNotificationCount: `
+    query unreadNotificationCount($recipients: [String!]) {
+      unreadNotificationCount(recipients: $recipients) { count more }
+    }`,
+}
+
+export type ClientVariables = {
+  first?: unknown
+  after?: unknown
+  seenAt?: unknown
+  recipients?: unknown
+}
+
+/**
+ * Validate a client-supplied `recipients` list. Returns null (the arg is
+ * dropped) when aggregation is off, the input is malformed, or nothing
+ * survives — so the default path never sends `recipients`. The indexer
+ * re-authorizes every DID against its own role index; this is shape + bound
+ * validation only (valid DIDs, deduped, capped).
+ */
+export function parseRecipients(
+  raw: unknown,
+  aggregationEnabled: boolean,
+): string[] | null {
+  if (!aggregationEnabled) return null
+  if (!Array.isArray(raw)) return null
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const v of raw) {
+    if (typeof v !== "string") continue
+    if (v.length > 256 || !isValidDid(v)) continue
+    if (seen.has(v)) continue
+    seen.add(v)
+    out.push(v)
+    if (out.length >= MAX_RECIPIENTS) break
+  }
+  return out.length > 0 ? out : null
+}
+
+/** Normalize client-supplied variables per-operation. Returns null for an
+ *  unknown operation. */
+export function buildVariables(
+  operationName: string,
+  vars: ClientVariables,
+  aggregationEnabled: boolean,
+): Record<string, unknown> | null {
+  switch (operationName) {
+    case "notifications": {
+      const first =
+        typeof vars.first === "number" && Number.isFinite(vars.first)
+          ? Math.min(Math.max(1, Math.floor(vars.first)), MAX_FIRST)
+          : 50
+      const after =
+        typeof vars.after === "string" &&
+        vars.after.length > 0 &&
+        vars.after.length <= 512
+          ? vars.after
+          : null
+      const recipients = parseRecipients(vars.recipients, aggregationEnabled)
+      return recipients ? { first, after, recipients } : { first, after }
+    }
+    case "unreadNotificationCount": {
+      const recipients = parseRecipients(vars.recipients, aggregationEnabled)
+      return recipients ? { recipients } : {}
+    }
+    case "updateNotificationsSeen": {
+      let seenAt: string = new Date().toISOString()
+      if (
+        typeof vars.seenAt === "string" &&
+        Number.isFinite(Date.parse(vars.seenAt))
+      ) {
+        seenAt = vars.seenAt
+      }
+      return { seenAt }
+    }
+    default:
+      return null
+  }
+}
+
+/** Pick the query string for an operation. The aggregated variant is chosen
+ *  ONLY when `buildVariables` produced a `recipients` arg — so the default
+ *  query goes out unchanged whenever the flag is off or recipients are
+ *  absent. */
+export function selectQuery(
+  operationName: string,
+  variables: Record<string, unknown>,
+): string | undefined {
+  if ("recipients" in variables && AGGREGATED_OPERATIONS[operationName]) {
+    return AGGREGATED_OPERATIONS[operationName]
+  }
+  return OPERATIONS[operationName]
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -4,6 +4,7 @@ import { getOAuthClient } from "@/lib/auth/oauth-client"
 import { getSessionDid, deleteSession } from "@/lib/auth/session"
 import { checkCsrf } from "@/lib/auth/csrf"
 import { getServiceAuthToken } from "@/lib/atproto/service-auth"
+import { NOTIFICATIONS_AGGREGATION_ENABLED } from "@/lib/utils/config"
 
 /**
  * Trust boundary between the client and the indexer's service-auth
@@ -45,6 +46,9 @@ const UPSTREAM_TIMEOUT_MS = 15_000
 const SERVICE_AUTH_TIMEOUT_MS = 5_000
 const MAX_BODY_SIZE = 16 * 1024
 const MAX_FIRST = 100
+// Cap the aggregated recipient set. A user owns/admins few groups in
+// practice; this bounds the indexer query and rejects pathological input.
+const MAX_RECIPIENTS = 25
 
 /** Allowlist of GraphQL operations we forward. The client sends only
  *  operationName + variables; the query string is held server-side.
@@ -81,10 +85,71 @@ const OPERATIONS: Record<string, string> = {
     }`,
 }
 
+/**
+ * Aggregated query variants — used ONLY when the NOTIFICATIONS_AGGREGATION
+ * flag is on AND the client supplied a non-empty `recipients` set. Held
+ * apart from OPERATIONS so the default path's query stays byte-identical:
+ * an indexer that doesn't yet understand `recipients` never receives the
+ * argument. The node also selects the new `recipient` field so the client
+ * can tag each row "via {group}". See
+ * docs/org-identity/indexer-notifications-aggregation.md.
+ */
+const AGGREGATED_OPERATIONS: Record<string, string> = {
+  notifications: `
+    query notifications($first: Int!, $after: String, $recipients: [String!]) {
+      notifications(first: $first, after: $after, recipients: $recipients) {
+        edges {
+          cursor
+          node {
+            id
+            reason
+            reasonSubject
+            sortAt
+            count
+            latestRecordUri
+            latestRecordCid
+            latestAuthor
+            isRead
+            recipient
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }`,
+  unreadNotificationCount: `
+    query unreadNotificationCount($recipients: [String!]) {
+      unreadNotificationCount(recipients: $recipients) { count more }
+    }`,
+}
+
 type ClientVariables = {
   first?: unknown
   after?: unknown
   seenAt?: unknown
+  recipients?: unknown
+}
+
+/**
+ * Validate a client-supplied `recipients` list. Returns null (the arg is
+ * dropped) when the flag is off, the input is malformed, or nothing
+ * survives — so the default path never sends `recipients`. The indexer
+ * re-authorizes every DID against its own role index; this is only shape +
+ * bound validation (DID-looking strings, deduped, capped).
+ */
+function parseRecipients(raw: unknown): string[] | null {
+  if (!NOTIFICATIONS_AGGREGATION_ENABLED) return null
+  if (!Array.isArray(raw)) return null
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const v of raw) {
+    if (typeof v !== "string") continue
+    if (!v.startsWith("did:") || v.length > 256) continue
+    if (seen.has(v)) continue
+    seen.add(v)
+    out.push(v)
+    if (out.length >= MAX_RECIPIENTS) break
+  }
+  return out.length > 0 ? out : null
 }
 
 /** Normalize client-supplied variables per-operation. */
@@ -101,10 +166,12 @@ function buildVariables(
         typeof vars.after === "string" && vars.after.length > 0 && vars.after.length <= 512
           ? vars.after
           : null
-      return { first, after }
+      const recipients = parseRecipients(vars.recipients)
+      return recipients ? { first, after, recipients } : { first, after }
     }
     case "unreadNotificationCount": {
-      return {}
+      const recipients = parseRecipients(vars.recipients)
+      return recipients ? { recipients } : {}
     }
     case "updateNotificationsSeen": {
       let seenAt: string = new Date().toISOString()
@@ -154,8 +221,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "operationName is required" }, { status: 400 })
   }
 
-  const query = OPERATIONS[parsed.operationName]
-  if (!query) {
+  // OPERATIONS is the allowlist; the AGGREGATED_OPERATIONS variants share
+  // the same names, so allowlisting against OPERATIONS covers both.
+  if (!OPERATIONS[parsed.operationName]) {
     return NextResponse.json({ error: "Unknown operation" }, { status: 400 })
   }
 
@@ -164,6 +232,14 @@ export async function POST(request: NextRequest) {
   if (!variables) {
     return NextResponse.json({ error: "Unknown operation" }, { status: 400 })
   }
+
+  // Pick the aggregated variant only when `buildVariables` actually
+  // produced a `recipients` arg (flag on + valid input). Otherwise the
+  // default query goes out unchanged — the indexer never sees the new arg.
+  const query =
+    "recipients" in variables && AGGREGATED_OPERATIONS[parsed.operationName]
+      ? AGGREGATED_OPERATIONS[parsed.operationName]
+      : OPERATIONS[parsed.operationName]
 
   // Restore OAuth agent — mirror the XRPC proxy pattern. If restore
   // fails, the session is stale: delete it and return 401 so the

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -5,6 +5,7 @@ import { getSessionDid, deleteSession } from "@/lib/auth/session"
 import { checkCsrf } from "@/lib/auth/csrf"
 import { getServiceAuthToken } from "@/lib/atproto/service-auth"
 import { NOTIFICATIONS_AGGREGATION_ENABLED } from "@/lib/utils/config"
+import { OPERATIONS, buildVariables, selectQuery } from "./operations"
 
 /**
  * Trust boundary between the client and the indexer's service-auth
@@ -45,145 +46,11 @@ if (process.env.NODE_ENV === "production" && !INDEXER_DID) {
 const UPSTREAM_TIMEOUT_MS = 15_000
 const SERVICE_AUTH_TIMEOUT_MS = 5_000
 const MAX_BODY_SIZE = 16 * 1024
-const MAX_FIRST = 100
-// Cap the aggregated recipient set. A user owns/admins few groups in
-// practice; this bounds the indexer query and rejects pathological input.
-const MAX_RECIPIENTS = 25
 
-/** Allowlist of GraphQL operations we forward. The client sends only
- *  operationName + variables; the query string is held server-side.
- *  The indexer derives the acting DID from the JWT, so these queries
- *  don't take a `$did` variable. */
-const OPERATIONS: Record<string, string> = {
-  notifications: `
-    query notifications($first: Int!, $after: String) {
-      notifications(first: $first, after: $after) {
-        edges {
-          cursor
-          node {
-            id
-            reason
-            reasonSubject
-            sortAt
-            count
-            latestRecordUri
-            latestRecordCid
-            latestAuthor
-            isRead
-          }
-        }
-        pageInfo { hasNextPage endCursor }
-      }
-    }`,
-  unreadNotificationCount: `
-    query unreadNotificationCount {
-      unreadNotificationCount { count more }
-    }`,
-  updateNotificationsSeen: `
-    mutation updateNotificationsSeen($seenAt: String) {
-      updateNotificationsSeen(seenAt: $seenAt)
-    }`,
-}
-
-/**
- * Aggregated query variants — used ONLY when the NOTIFICATIONS_AGGREGATION
- * flag is on AND the client supplied a non-empty `recipients` set. Held
- * apart from OPERATIONS so the default path's query stays byte-identical:
- * an indexer that doesn't yet understand `recipients` never receives the
- * argument. The node also selects the new `recipient` field so the client
- * can tag each row "via {group}". See
- * docs/org-identity/indexer-notifications-aggregation.md.
- */
-const AGGREGATED_OPERATIONS: Record<string, string> = {
-  notifications: `
-    query notifications($first: Int!, $after: String, $recipients: [String!]) {
-      notifications(first: $first, after: $after, recipients: $recipients) {
-        edges {
-          cursor
-          node {
-            id
-            reason
-            reasonSubject
-            sortAt
-            count
-            latestRecordUri
-            latestRecordCid
-            latestAuthor
-            isRead
-            recipient
-          }
-        }
-        pageInfo { hasNextPage endCursor }
-      }
-    }`,
-  unreadNotificationCount: `
-    query unreadNotificationCount($recipients: [String!]) {
-      unreadNotificationCount(recipients: $recipients) { count more }
-    }`,
-}
-
-type ClientVariables = {
-  first?: unknown
-  after?: unknown
-  seenAt?: unknown
-  recipients?: unknown
-}
-
-/**
- * Validate a client-supplied `recipients` list. Returns null (the arg is
- * dropped) when the flag is off, the input is malformed, or nothing
- * survives — so the default path never sends `recipients`. The indexer
- * re-authorizes every DID against its own role index; this is only shape +
- * bound validation (DID-looking strings, deduped, capped).
- */
-function parseRecipients(raw: unknown): string[] | null {
-  if (!NOTIFICATIONS_AGGREGATION_ENABLED) return null
-  if (!Array.isArray(raw)) return null
-  const out: string[] = []
-  const seen = new Set<string>()
-  for (const v of raw) {
-    if (typeof v !== "string") continue
-    if (!v.startsWith("did:") || v.length > 256) continue
-    if (seen.has(v)) continue
-    seen.add(v)
-    out.push(v)
-    if (out.length >= MAX_RECIPIENTS) break
-  }
-  return out.length > 0 ? out : null
-}
-
-/** Normalize client-supplied variables per-operation. */
-function buildVariables(
-  operationName: string,
-  vars: ClientVariables,
-): Record<string, unknown> | null {
-  switch (operationName) {
-    case "notifications": {
-      const first = typeof vars.first === "number" && Number.isFinite(vars.first)
-        ? Math.min(Math.max(1, Math.floor(vars.first)), MAX_FIRST)
-        : 50
-      const after =
-        typeof vars.after === "string" && vars.after.length > 0 && vars.after.length <= 512
-          ? vars.after
-          : null
-      const recipients = parseRecipients(vars.recipients)
-      return recipients ? { first, after, recipients } : { first, after }
-    }
-    case "unreadNotificationCount": {
-      const recipients = parseRecipients(vars.recipients)
-      return recipients ? { recipients } : {}
-    }
-    case "updateNotificationsSeen": {
-      let seenAt: string = new Date().toISOString()
-      if (typeof vars.seenAt === "string" && Number.isFinite(Date.parse(vars.seenAt))) {
-        seenAt = vars.seenAt
-      }
-      return { seenAt }
-    }
-    default:
-      return null
-  }
-}
+// The allowlist, query variants, recipient validation, and per-operation
+// variable normalization live in ./operations so they're unit-testable
+// without the full route (session, OAuth, service-auth). The aggregation
+// flag is injected from config here.
 
 export async function POST(request: NextRequest) {
   const csrfError = checkCsrf(request)
@@ -221,25 +88,26 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "operationName is required" }, { status: 400 })
   }
 
-  // OPERATIONS is the allowlist; the AGGREGATED_OPERATIONS variants share
-  // the same names, so allowlisting against OPERATIONS covers both.
+  // OPERATIONS is the allowlist; the aggregated variants share the same
+  // names, so allowlisting against OPERATIONS covers both.
   if (!OPERATIONS[parsed.operationName]) {
     return NextResponse.json({ error: "Unknown operation" }, { status: 400 })
   }
 
-  const clientVars = (parsed.variables ?? {}) as ClientVariables
-  const variables = buildVariables(parsed.operationName, clientVars)
+  const clientVars = (parsed.variables ?? {}) as Record<string, unknown>
+  const variables = buildVariables(
+    parsed.operationName,
+    clientVars,
+    NOTIFICATIONS_AGGREGATION_ENABLED,
+  )
   if (!variables) {
     return NextResponse.json({ error: "Unknown operation" }, { status: 400 })
   }
 
-  // Pick the aggregated variant only when `buildVariables` actually
-  // produced a `recipients` arg (flag on + valid input). Otherwise the
+  // `selectQuery` picks the aggregated variant only when `buildVariables`
+  // produced a `recipients` arg (flag on + valid input); otherwise the
   // default query goes out unchanged — the indexer never sees the new arg.
-  const query =
-    "recipients" in variables && AGGREGATED_OPERATIONS[parsed.operationName]
-      ? AGGREGATED_OPERATIONS[parsed.operationName]
-      : OPERATIONS[parsed.operationName]
+  const query = selectQuery(parsed.operationName, variables)!
 
   // Restore OAuth agent — mirror the XRPC proxy pattern. If restore
   // fails, the session is stale: delete it and return 401 so the

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -13,8 +13,9 @@ import {
   X,
 } from "lucide-react"
 import { useAuth } from "@/lib/auth/auth-context"
-import { useOrg } from "@/lib/groups/org-context"
 import { authFetch } from "@/lib/auth/fetch"
+import PostingAs from "@/components/create/posting-as"
+import { usePostingIdentity } from "@/hooks/use-posting-identity"
 import EmptyState from "@/components/ui/empty-state"
 import Button from "@/components/ui/button"
 import Input from "@/components/ui/input"
@@ -133,17 +134,20 @@ interface RightsOption {
 export default function CreatePage() {
   usePageTitle("New activity")
   const { isAuthenticated, isLoading, did } = useAuth()
-  const { activeOrg } = useOrg()
   const router = useRouter()
-  // "Effective identity" — the DID the cert is published as on
-  // this page. When the user has switched into a group, that's the
-  // group's DID; otherwise their own session DID. Used anywhere
-  // "self" matters here (Add me shortcut, blob target repo,
-  // submit destination) so the form treats the active identity as
-  // a first-class subject rather than always falling through to the
-  // personal user.
-  const effectiveDid: string =
-    activeOrg?.groupDid ?? did ?? ""
+  // Per-action posting identity. The write target is chosen EXPLICITLY
+  // here via <PostingAs> (default You) rather than inherited from the
+  // active org — acting-as is read-scope only. `posting.value.did` is
+  // the repo this cert publishes into; `posting.value.kind === 'group'`
+  // is what flips the submit/blob/location paths onto the group BFF.
+  const posting = usePostingIdentity()
+  const postingDid = posting.value.did
+  const postingIsGroup = posting.value.kind === "group"
+  // "Effective identity" — the DID the cert is published as on this
+  // page. Comes straight from the per-action picker. Used anywhere
+  // "self" matters here (Add me shortcut, blob target repo, location
+  // target repo, submit destination).
+  const effectiveDid: string = postingDid || did || ""
   // Author info for whoever is currently publishing — feeds the
   // "Add me" shortcut on the contributors row. `useAuthorInfo`
   // resolves the handle (preferred) and falls back to the DID.
@@ -309,9 +313,9 @@ export default function CreatePage() {
       if (prev) URL.revokeObjectURL(prev)
       return previewUrl
     })
-    // Route the blob upload to the group's repo when the active
-    // identity is a group; otherwise the user's own.
-    const targetDid = activeOrg ? activeOrg.groupDid : null
+    // Route the blob upload to the picked identity's repo when posting
+    // as a group; otherwise the viewer's own (targetDid undefined).
+    const targetDid = postingIsGroup ? postingDid : null
     try {
       const blob = await uploadBlob(
         file,
@@ -330,7 +334,7 @@ export default function CreatePage() {
         return null
       })
     }
-  }, [activeOrg])
+  }, [postingIsGroup, postingDid])
 
   const handleImageRemove = useCallback(() => {
     setPendingImageBlob(null)
@@ -516,11 +520,13 @@ export default function CreatePage() {
     }
 
     try {
-      // Route through the group BFF when the user has switched into
-      // a group identity; otherwise use the xrpc proxy on the
-      // viewer's own repo. The BFF's PUT route accepts
-      // `{ record }` with no rkey → createRecord on the group repo.
-      const useGroupRoute = activeOrg !== null
+      // Route through the group BFF only when the PICKED posting
+      // identity is a group; otherwise use the xrpc proxy on the
+      // viewer's own repo. The choice comes from <PostingAs> (default
+      // You), never from the active read-scope org. The BFF's PUT route
+      // accepts `{ record }` with no rkey → createRecord on the group
+      // repo (and re-checks the operator's owner/admin role server-side).
+      const useGroupRoute = postingIsGroup
       const url = useGroupRoute
         ? `/api/groups/${encodeURIComponent(effectiveDid)}/activity`
         : "/api/xrpc/com/atproto/repo/createRecord"
@@ -826,6 +832,20 @@ export default function CreatePage() {
         </aside>
 
         <div className="page-layout__main cert-detail__main">
+          {/* Per-action posting identity. Defaults to You; the picker
+              is the ONLY thing that targets a group repo here (the
+              active read-scope org never silently becomes the write
+              target). When the viewer admins no groups this renders a
+              static "Posting as You" label. */}
+          <div className="flex items-center">
+            <PostingAs
+              value={posting.value}
+              onChange={posting.setValue}
+              options={posting.options}
+              size="sm"
+              aria-label="Posting activity as"
+            />
+          </div>
           <header className="cert-detail__headline">
             <div className="create-cert__input-with-counter">
               {/* Bare/flush <Input> so the title typography cascades.
@@ -902,7 +922,7 @@ export default function CreatePage() {
               onImageUpload={(file) =>
                 uploadBlob(
                   file,
-                  activeOrg ? { targetDid: activeOrg.groupDid } : undefined,
+                  postingIsGroup ? { targetDid: postingDid } : undefined,
                 )
               }
             />

--- a/src/app/dev/preview/[surface]/page.tsx
+++ b/src/app/dev/preview/[surface]/page.tsx
@@ -68,6 +68,8 @@ import UserProfilePage from "@/app/profile/[handle]/page"
 import Home from "@/components/home/home"
 import SettingsPanel from "@/components/settings/settings-panel"
 import Workspace from "@/components/workspace/workspace"
+import Managed from "@/components/managed/managed"
+import CreatePage from "@/app/create/page"
 
 const SURFACES = [
   "profile",
@@ -75,6 +77,8 @@ const SURFACES = [
   "feed",
   "settings",
   "workspace",
+  "managed",
+  "write-as-org",
 ] as const
 type Surface = (typeof SURFACES)[number]
 
@@ -124,6 +128,24 @@ function SurfaceBody({ surface }: { surface: Surface }) {
           </Suspense>
         </div>
       )
+    case "managed":
+      // The /managed hub: aggregates records owned by the groups the (mock)
+      // session user owns/admins. Suspense because Managed reads useSearchParams.
+      return (
+        <div className="managed-page">
+          <Suspense fallback={null}>
+            <Managed />
+          </Suspense>
+        </div>
+      )
+    case "write-as-org":
+      // The create form with the <PostingAs> picker — under the managed
+      // scenario the user owns/admins groups, so the picker offers them.
+      return (
+        <Suspense fallback={null}>
+          <CreatePage />
+        </Suspense>
+      )
   }
 }
 
@@ -143,10 +165,24 @@ export default function PreviewPage() {
     [rawSurface],
   )
 
+  // The managed + write-as-org surfaces need the session user to own/admin
+  // groups (so aggregation + the PostingAs picker have group identities).
+  // `?managed=1` opts any other surface (e.g. feed, profile) into the same
+  // scenario so the inline Home aggregation + the self-profile bridge can be
+  // verified with groups present.
+  const managedScenario =
+    rawSurface === "managed" ||
+    rawSurface === "write-as-org" ||
+    searchParams?.get("managed") === "1"
+
   if (!isSurface(rawSurface)) notFound()
 
   return (
-    <MockFetchProvider profileScenario={profileScenario} scenario={scenario}>
+    <MockFetchProvider
+      profileScenario={profileScenario}
+      scenario={scenario}
+      managedScenario={managedScenario}
+    >
       {/* SAME provider order as app/layout.tsx, re-instantiated under the
           fetch mock so the fixture session is the one this subtree reads. */}
       <Providers>

--- a/src/app/dev/preview/[surface]/page.tsx
+++ b/src/app/dev/preview/[surface]/page.tsx
@@ -70,6 +70,7 @@ import SettingsPanel from "@/components/settings/settings-panel"
 import Workspace from "@/components/workspace/workspace"
 import Managed from "@/components/managed/managed"
 import CreatePage from "@/app/create/page"
+import NotificationsPage from "@/app/notifications/page"
 
 const SURFACES = [
   "profile",
@@ -79,6 +80,7 @@ const SURFACES = [
   "workspace",
   "managed",
   "write-as-org",
+  "notifications",
 ] as const
 type Surface = (typeof SURFACES)[number]
 
@@ -146,6 +148,16 @@ function SurfaceBody({ surface }: { surface: Surface }) {
           <CreatePage />
         </Suspense>
       )
+    case "notifications":
+      // The notifications page. Under the managed scenario + the
+      // NOTIFICATIONS_AGGREGATION flag it aggregates across the viewer's
+      // groups (identity focus filter + "via {group}" rows); otherwise it
+      // renders the personal feed.
+      return (
+        <Suspense fallback={null}>
+          <NotificationsPage />
+        </Suspense>
+      )
   }
 }
 
@@ -173,6 +185,7 @@ export default function PreviewPage() {
   const managedScenario =
     rawSurface === "managed" ||
     rawSurface === "write-as-org" ||
+    rawSurface === "notifications" ||
     searchParams?.get("managed") === "1"
 
   if (!isSurface(rawSurface)) notFound()

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,6 +24,7 @@
 @import "./styles/profile-groups.css";
 @import "./styles/smart-link.css";
 @import "./styles/settings-page.css";
+@import "./styles/managed.css";
 @import "./styles/leaflet.css";
 @import "./styles/landing.css";
 

--- a/src/app/managed/layout.tsx
+++ b/src/app/managed/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next"
+import AuthGuard from "@/components/layout/auth-guard"
+
+export const metadata: Metadata = {
+  title: "Managed",
+  description:
+    "Everything you're responsible for — yours and your groups' — in one place.",
+}
+
+export default function ManagedLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <AuthGuard>{children}</AuthGuard>
+}

--- a/src/app/managed/page.tsx
+++ b/src/app/managed/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from "react"
+import Managed from "@/components/managed/managed"
+
+export default function ManagedPage() {
+  return (
+    // Suspense boundary required by Next 16 because <Managed> reads
+    // useSearchParams() at the top level (the ?focus= filter). Without
+    // it, static prerender of /managed bails.
+    <Suspense fallback={null}>
+      <Managed />
+    </Suspense>
+  )
+}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -37,14 +37,20 @@ function NotificationsContent() {
   // viewer actually owns/admins a group. Otherwise the page is the
   // personal feed, byte-identical to before.
   const managesAnyGroup = useManagesAnyGroup()
+  const { identities, isLoading: managedLoading } = useManagedAuthors()
   const aggregating = NOTIFICATIONS_AGGREGATION_ENABLED && managesAnyGroup
+
+  // While aggregation is enabled but the org roles haven't resolved,
+  // `managesAnyGroup` is still false — firing the personal hook now would
+  // waste a fetch and flash personal-only before the aggregate engages.
+  // Hold both hooks until the role set settles. (Flag off → no wait.)
+  const orgResolving = NOTIFICATIONS_AGGREGATION_ENABLED && managedLoading
 
   // Both hooks are always called (rules of hooks); the inactive one is
   // disabled, so it does no fetch and returns empty.
-  const personal = useNotificationsFeed(isAuthenticated && !aggregating)
+  const personal = useNotificationsFeed(isAuthenticated && !aggregating && !orgResolving)
   const managed = useManagedNotifications(isAuthenticated && aggregating)
 
-  const { identities } = useManagedAuthors()
   const { focus, setFocus, focusedDid, singleGroupFocused, filterOptions, useDropdown } =
     useIdentityFocus(identities)
 
@@ -60,9 +66,11 @@ function NotificationsContent() {
     return personal.notifications.map((n) => ({ notification: n, owner: null }))
   }, [aggregating, managed.items, personal.notifications])
 
-  const { isLoading, isLoadingMore, error, hasMore, loadMore } = aggregating
-    ? managed
-    : personal
+  const activeSource = aggregating ? managed : personal
+  const { isLoadingMore, error, hasMore, loadMore } = activeSource
+  // Show the skeleton while the org roles are still resolving so we don't
+  // render an empty/personal state before the aggregated source engages.
+  const isLoading = activeSource.isLoading || orgResolving
 
   // Apply the identity focus filter (aggregated view only).
   const visibleRows = useMemo<NotificationRowData[]>(() => {
@@ -175,6 +183,7 @@ function NotificationsContent() {
                   aria-label="Focus"
                   value={focus}
                   onChange={(e) => setFocus(e.target.value)}
+                  className="notifications-filter__select"
                 >
                   {filterOptions.map((opt) => (
                     <option key={opt.value} value={opt.value}>

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,22 +1,80 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState } from "react"
+import { Suspense, useEffect, useMemo, useRef, useState } from "react"
 import { Bell, AlertCircle } from "lucide-react"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useNotifications } from "@/lib/notifications-context"
 import { usePageTitle } from "@/lib/navbar-context"
 import { useNotificationsFeed } from "@/hooks/use-notifications-feed"
-import { markNotificationsSeen } from "@/lib/atproto/notifications"
-import NotificationRow from "@/components/notifications/notification-row"
+import { useManagedNotifications } from "@/hooks/use-managed-notifications"
+import { useManagedAuthors } from "@/hooks/use-managed-authors"
+import { useManagesAnyGroup } from "@/lib/groups/managed"
+import { useIdentityFocus } from "@/hooks/use-identity-focus"
+import { markNotificationsSeen, type Notification } from "@/lib/atproto/notifications"
+import type { OwnerTag } from "@/lib/atproto/owner-tag"
+import { NOTIFICATIONS_AGGREGATION_ENABLED } from "@/lib/utils/config"
+import NotificationRow, {
+  type NotificationVia,
+} from "@/components/notifications/notification-row"
 import NotificationRowSkeleton from "@/components/notifications/notification-row-skeleton"
+import SegmentedControl from "@/components/ui/segmented-control"
+import Select from "@/components/ui/select"
 import EmptyState from "@/components/ui/empty-state"
 
-export default function NotificationsPage() {
+/** A notification paired with the identity it belongs to. `owner` is null
+ *  on the personal (non-aggregated) path. */
+interface NotificationRowData {
+  notification: Notification
+  owner: OwnerTag | null
+}
+
+function NotificationsContent() {
   usePageTitle("Notifications")
   const { isAuthenticated } = useAuth()
   const { refresh, markOptimisticallyZero } = useNotifications()
-  const { notifications, isLoading, isLoadingMore, error, hasMore, loadMore } =
-    useNotificationsFeed(isAuthenticated)
+
+  // Aggregate across managed identities only when the flag is on AND the
+  // viewer actually owns/admins a group. Otherwise the page is the
+  // personal feed, byte-identical to before.
+  const managesAnyGroup = useManagesAnyGroup()
+  const aggregating = NOTIFICATIONS_AGGREGATION_ENABLED && managesAnyGroup
+
+  // Both hooks are always called (rules of hooks); the inactive one is
+  // disabled, so it does no fetch and returns empty.
+  const personal = useNotificationsFeed(isAuthenticated && !aggregating)
+  const managed = useManagedNotifications(isAuthenticated && aggregating)
+
+  const { identities } = useManagedAuthors()
+  const { focus, setFocus, focusedDid, singleGroupFocused, filterOptions, useDropdown } =
+    useIdentityFocus(identities)
+
+  // Unify the two sources behind one shape so the snapshot / mark-seen /
+  // infinite-scroll machinery below is source-agnostic.
+  const rows = useMemo<NotificationRowData[]>(() => {
+    if (aggregating) {
+      return managed.items.map((it) => ({
+        notification: it.notification,
+        owner: it.owner,
+      }))
+    }
+    return personal.notifications.map((n) => ({ notification: n, owner: null }))
+  }, [aggregating, managed.items, personal.notifications])
+
+  const { isLoading, isLoadingMore, error, hasMore, loadMore } = aggregating
+    ? managed
+    : personal
+
+  // Apply the identity focus filter (aggregated view only).
+  const visibleRows = useMemo<NotificationRowData[]>(() => {
+    if (!aggregating || !focusedDid) return rows
+    return rows.filter((r) => r.owner?.ownerDid === focusedDid)
+  }, [aggregating, focusedDid, rows])
+
+  // The bare Notification[] backing the snapshot + mark-seen logic.
+  const notifications = useMemo(
+    () => rows.map((r) => r.notification),
+    [rows],
+  )
 
   // Snapshot unread state on first load so rows don't visually flip
   // to read mid-session after mark-seen fires.
@@ -48,6 +106,12 @@ export default function NotificationsPage() {
 
   // Fire mark-seen once after the initial load lands. Optimistic badge
   // zero; on failure, refresh() reconciles with the true value.
+  //
+  // Note: mark-seen stays personal (iss-scoped) even in the aggregated
+  // view — group read-state is shared team state we deliberately don't
+  // mutate here (see docs/org-identity/indexer-notifications-aggregation.md
+  // §6). The aggregated badge may therefore retain group unreads that this
+  // action can't clear; that's intended for phase 1.
   const markedRef = useRef(false)
   const notificationsRef = useRef(notifications)
   useEffect(() => { notificationsRef.current = notifications }, [notifications])
@@ -88,14 +152,51 @@ export default function NotificationsPage() {
     )
     observer.observe(sentinel)
     return () => observer.disconnect()
-  }, [isLoading, error, notifications.length])
+  }, [isLoading, error, visibleRows.length])
 
-  const hasAnyUnread = useMemo(() => unreadSnapshot.size > 0, [unreadSnapshot])
+  const hasAnyUnread = useMemo(
+    () => visibleRows.some((r) => unreadSnapshot.has(r.notification.id)),
+    [visibleRows, unreadSnapshot],
+  )
+
+  // The focus strip only makes sense once the viewer has groups to focus
+  // (managesAnyGroup guarantees identities.length >= 2 when aggregating).
+  const showFilter = aggregating && identities.length > 1
 
   return (
     <div className="dashboard">
       <div className="dashboard__body dashboard__body--single">
         <div className="dashboard__main">
+          {showFilter ? (
+            <div className="notifications-filter">
+              {useDropdown ? (
+                <Select
+                  size="sm"
+                  aria-label="Focus"
+                  value={focus}
+                  onChange={(e) => setFocus(e.target.value)}
+                >
+                  {filterOptions.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </Select>
+              ) : (
+                <SegmentedControl
+                  aria-label="Focus"
+                  size="md"
+                  value={focus}
+                  onValueChange={setFocus}
+                  options={filterOptions.map((opt) => ({
+                    value: opt.value,
+                    label: opt.label,
+                  }))}
+                />
+              )}
+            </div>
+          ) : null}
+
           {isLoading ? (
             <div className="notification-list">
               <NotificationRowSkeleton />
@@ -108,7 +209,7 @@ export default function NotificationsPage() {
               title="Couldn't load notifications"
               description={error}
             />
-          ) : notifications.length === 0 ? (
+          ) : visibleRows.length === 0 ? (
             <EmptyState
               icon={Bell}
               title="No notifications yet"
@@ -116,13 +217,24 @@ export default function NotificationsPage() {
             />
           ) : (
             <div className={`notification-list${hasAnyUnread ? " notification-list--has-unread" : ""}`}>
-              {notifications.map(n => (
-                <NotificationRow
-                  key={n.id}
-                  notification={n}
-                  wasUnreadOnMount={unreadSnapshot.has(n.id)}
-                />
-              ))}
+              {visibleRows.map(({ notification, owner }) => {
+                // Show "via {group}" only for group-owned rows in a mixed
+                // view — never when a single group is already focused
+                // (every row would share it) or for personal rows.
+                const via: NotificationVia | null =
+                  owner && owner.kind === "group" && owner.group && !singleGroupFocused
+                    ? { group: owner.group, role: owner.role }
+                    : null
+                return (
+                  <NotificationRow
+                    key={notification.id}
+                    notification={notification}
+                    wasUnreadOnMount={unreadSnapshot.has(notification.id)}
+                    via={via}
+                    isGroupOwned={owner?.kind === "group"}
+                  />
+                )
+              })}
               <div ref={sentinelRef} className="notification-list__sentinel">
                 {isLoadingMore && <NotificationRowSkeleton />}
               </div>
@@ -131,5 +243,17 @@ export default function NotificationsPage() {
         </div>
       </div>
     </div>
+  )
+}
+
+export default function NotificationsPage() {
+  // Suspense boundary required by Next 16: the aggregated path reads
+  // useSearchParams() (the ?focus= identity filter, via useIdentityFocus).
+  // Without it, static prerender of /notifications bails — mirrors
+  // src/app/managed/page.tsx.
+  return (
+    <Suspense fallback={null}>
+      <NotificationsContent />
+    </Suspense>
   )
 }

--- a/src/app/profile/[handle]/page.tsx
+++ b/src/app/profile/[handle]/page.tsx
@@ -433,6 +433,7 @@ export default function UserProfilePage() {
                   did={did}
                   profile={effectiveProfile}
                   basePath={pathname || ""}
+                  isOwnProfile={isOwnProfile}
                   isEditing={editing}
                   drafts={drafts}
                   onDraftChange={handleDraftChange}

--- a/src/app/project/[did]/[rkey]/edit/__tests__/save-reread-authfetch.test.tsx
+++ b/src/app/project/[did]/[rkey]/edit/__tests__/save-reread-authfetch.test.tsx
@@ -26,8 +26,15 @@ vi.mock("@/lib/auth/auth-context", () => ({
   useAuth: () => ({ isAuthenticated: true, isLoading: false, did: DID }),
 }))
 
-vi.mock("@/lib/groups/org-context", () => ({
-  useOrg: () => ({ activeOrg: null }),
+vi.mock("@/hooks/use-managed-authors", () => ({
+  // The viewer is the record owner (DID) — a personal record, so an empty
+  // managed-identity map is enough for `isPersonalRecord` to grant edit.
+  useManagedAuthors: () => ({
+    authors: [DID],
+    identities: [{ did: DID, kind: "personal", label: "You" }],
+    byDid: new Map([[DID, { did: DID, kind: "personal", label: "You" }]]),
+    isLoading: false,
+  }),
 }))
 
 vi.mock("@/lib/navbar-context", () => ({

--- a/src/app/project/[did]/[rkey]/edit/page.tsx
+++ b/src/app/project/[did]/[rkey]/edit/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link"
 import { MapPin, Plus, X, FolderGit2 } from "lucide-react"
 import Image from "next/image"
 import { useAuth } from "@/lib/auth/auth-context"
-import { useOrg } from "@/lib/groups/org-context"
+import { useManagedAuthors } from "@/hooks/use-managed-authors"
 import { authFetch } from "@/lib/auth/fetch"
 import EmptyState from "@/components/ui/empty-state"
 import Button from "@/components/ui/button"
@@ -80,26 +80,24 @@ export default function ProjectEditPage() {
   }, [params.rkey])
 
   const { isAuthenticated, isLoading: authLoading, did: sessionDid } = useAuth()
-  const { activeOrg } = useOrg()
+  // Eligibility derives from the viewer's MANAGED identities (personal +
+  // the groups they own/admin), NOT the transient org switcher. This is
+  // what lets the read-aggregation→edit path work: a record surfaced via
+  // /managed or Home is editable without first switching the switcher to
+  // its group. `byDid` holds exactly the personal identity + owner/admin
+  // groups (member groups excluded); the BFF re-checks role server-side.
+  const { byDid, isLoading: managedLoading } = useManagedAuthors()
 
-  // Edits write back into the repo the record LIVES in (`did`, the route
-  // owner) — never a target derived from the active org. `activeOrg` is
-  // read here ONLY to gate eligibility: editing a group-owned project
-  // requires the operator to be operating that same group with an
-  // owner/admin role (the BFF re-checks this server-side). The write
-  // target is always the record's own repo; the active org just unlocks
-  // the affordance.
-  const canEditAsActiveOrg =
-    !!activeOrg &&
-    !!did &&
-    activeOrg.groupDid === did &&
-    (activeOrg.role === "owner" || activeOrg.role === "admin")
-  const isOwner = activeOrg
-    ? canEditAsActiveOrg
-    : !!sessionDid && sessionDid === did
-  // `editTargetDid` is the record-owner repo (group) when editing a
-  // group-owned project, else undefined → the viewer's own PDS.
-  const editTargetDid = canEditAsActiveOrg ? did : undefined
+  const isPersonalRecord = !!did && !!sessionDid && sessionDid === did
+  // byDid only contains owner/admin groups (+ the personal identity), so a
+  // 'group' hit here means the viewer owns/admins the owning repo.
+  const isOwnedOrAdminGroup = !!did && byDid.get(did)?.kind === "group"
+  const isOwner = isPersonalRecord || isOwnedOrAdminGroup
+  // Edits write back into the repo the record LIVES in. For a group-owned
+  // record that's the group repo (`editTargetDid` = did); a personal record
+  // writes to the viewer's own PDS (undefined target). The write target is
+  // always the record's own repo — never derived from a read-scope org.
+  const editTargetDid = isOwnedOrAdminGroup ? did : undefined
 
   const { project, isLoading: projectLoading, error: projectError } = useProject(
     did,
@@ -347,8 +345,10 @@ export default function ProjectEditPage() {
       : null
   const displayBannerUrl = pendingBannerPreviewUrl ?? existingBannerUrl
 
-  // Loading / sign-in gates.
-  if (authLoading || projectLoading) {
+  // Loading / sign-in gates. For a non-personal record we also wait on the
+  // managed-author set so a group record the viewer manages doesn't flash
+  // "you can't edit" before the owner/admin roles resolve.
+  if (authLoading || projectLoading || (!isPersonalRecord && managedLoading)) {
     return (
       <div className="dashboard">
         <div className="dashboard__body">

--- a/src/app/project/[did]/[rkey]/edit/page.tsx
+++ b/src/app/project/[did]/[rkey]/edit/page.tsx
@@ -82,6 +82,13 @@ export default function ProjectEditPage() {
   const { isAuthenticated, isLoading: authLoading, did: sessionDid } = useAuth()
   const { activeOrg } = useOrg()
 
+  // Edits write back into the repo the record LIVES in (`did`, the route
+  // owner) — never a target derived from the active org. `activeOrg` is
+  // read here ONLY to gate eligibility: editing a group-owned project
+  // requires the operator to be operating that same group with an
+  // owner/admin role (the BFF re-checks this server-side). The write
+  // target is always the record's own repo; the active org just unlocks
+  // the affordance.
   const canEditAsActiveOrg =
     !!activeOrg &&
     !!did &&
@@ -90,6 +97,8 @@ export default function ProjectEditPage() {
   const isOwner = activeOrg
     ? canEditAsActiveOrg
     : !!sessionDid && sessionDid === did
+  // `editTargetDid` is the record-owner repo (group) when editing a
+  // group-owned project, else undefined → the viewer's own PDS.
   const editTargetDid = canEditAsActiveOrg ? did : undefined
 
   const { project, isLoading: projectLoading, error: projectError } = useProject(
@@ -115,8 +124,12 @@ export default function ProjectEditPage() {
     useState<string | null>(null)
   const [bannerRemoved, setBannerRemoved] = useState(false)
 
-  // Author's own certs — quick-pick list. Same fetch as /project/new.
-  const { ownCerts, isLoading: ownCertsLoading } = useOwnCerts(sessionDid)
+  // Quick-pick activities list — scoped to the repo this project LIVES
+  // in (`did`, the record owner). For a group-owned project that's the
+  // group's repo, so the checklist offers the group's activities (the
+  // ones whose strongRefs can be added here); for a personal project
+  // it's the viewer's own. Not derived from the active read-scope org.
+  const { ownCerts, isLoading: ownCertsLoading } = useOwnCerts(did)
 
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -279,7 +292,12 @@ export default function ProjectEditPage() {
         return previewUrl
       })
       setBannerRemoved(false)
-      const targetDid = activeOrg ? activeOrg.groupDid : null
+      // Edits write back into the repo the record LIVES in — the blob
+      // must land there too. `editTargetDid` is the group repo when this
+      // project is group-owned (and the operator admins it), otherwise
+      // undefined → the viewer's own PDS. It is NOT derived from the
+      // active read-scope org.
+      const targetDid = editTargetDid ?? null
       try {
         const blob = await uploadBlob(
           file,
@@ -299,7 +317,7 @@ export default function ProjectEditPage() {
         })
       }
     },
-    [activeOrg],
+    [editTargetDid],
   )
 
   const handleBannerRemove = useCallback(() => {
@@ -663,7 +681,7 @@ export default function ProjectEditPage() {
               onImageUpload={(file) =>
                 uploadBlob(
                   file,
-                  activeOrg ? { targetDid: activeOrg.groupDid } : undefined,
+                  editTargetDid ? { targetDid: editTargetDid } : undefined,
                 )
               }
             />
@@ -799,7 +817,7 @@ export default function ProjectEditPage() {
       {isLocationDialogOpen && sessionDid ? (
         <LocationPickerDialog
           ownDid={sessionDid}
-          targetDid={activeOrg ? activeOrg.groupDid : sessionDid}
+          targetDid={editTargetDid ?? sessionDid}
           onClose={() => setIsLocationDialogOpen(false)}
           onPick={(added) => {
             setLocation(added)

--- a/src/app/project/new/page.tsx
+++ b/src/app/project/new/page.tsx
@@ -6,8 +6,9 @@ import Link from "next/link"
 import { MapPin, Plus, X, FolderGit2 } from "lucide-react"
 import Image from "next/image"
 import { useAuth } from "@/lib/auth/auth-context"
-import { useOrg } from "@/lib/groups/org-context"
 import { authFetch } from "@/lib/auth/fetch"
+import PostingAs from "@/components/create/posting-as"
+import { usePostingIdentity } from "@/hooks/use-posting-identity"
 import EmptyState from "@/components/ui/empty-state"
 import Button from "@/components/ui/button"
 import LoadingSpinner from "@/components/ui/loading-spinner"
@@ -65,8 +66,16 @@ interface SelectedCert {
 export default function CreateProjectPage() {
   usePageTitle("New project")
   const { isAuthenticated, isLoading, did } = useAuth()
-  const { activeOrg } = useOrg()
   const router = useRouter()
+  // Per-action posting identity. The write target is chosen EXPLICITLY
+  // here via <PostingAs> (default You), never inherited from the active
+  // read-scope org. `posting.value.did` is the repo this project lands
+  // in; `kind === 'group'` flips the submit/blob/location/quick-pick
+  // paths onto the group BFF + the group's repo.
+  const posting = usePostingIdentity()
+  const postingDid = posting.value.did
+  const postingIsGroup = posting.value.kind === "group"
+  const effectiveDid: string = postingDid || did || ""
 
   const [arrivedFromInApp] = useState(() => {
     if (typeof window === "undefined") return false
@@ -90,11 +99,12 @@ export default function CreateProjectPage() {
   const [isLocationDialogOpen, setIsLocationDialogOpen] = useState(false)
 
   // "Your certs" quick-pick. Fetched on mount via listRecords on the
-  // active repo (own DID or active group's DID) so the author can
-  // toggle entries straight from a checklist without first typing
-  // into the CertSearch typeahead. The typeahead stays below for
-  // finding certs that aren't theirs.
-  const { ownCerts, isLoading: ownCertsLoading } = useOwnCerts(did)
+  // PICKED posting identity's repo (own DID, or the group's DID when
+  // posting as a group) so the checklist scopes to the repo the new
+  // project will actually land in — re-fetches when the user changes the
+  // posting picker. The typeahead stays below for finding certs that
+  // aren't theirs.
+  const { ownCerts, isLoading: ownCertsLoading } = useOwnCerts(effectiveDid)
 
   const [pendingBannerBlob, setPendingBannerBlob] =
     useState<UploadedBlob | null>(null)
@@ -140,7 +150,7 @@ export default function CreateProjectPage() {
         if (prev) URL.revokeObjectURL(prev)
         return previewUrl
       })
-      const targetDid = activeOrg ? activeOrg.groupDid : null
+      const targetDid = postingIsGroup ? postingDid : null
       try {
         const blob = await uploadBlob(
           file,
@@ -161,7 +171,7 @@ export default function CreateProjectPage() {
         })
       }
     },
-    [activeOrg],
+    [postingIsGroup, postingDid],
   )
 
   const handleBannerRemove = useCallback(() => {
@@ -250,12 +260,14 @@ export default function CreateProjectPage() {
     }
 
     try {
-      // Group-active → group BFF (PUT with no rkey → createRecord
-      // on the group's repo). Personal → xrpc proxy. The two
-      // routes return the same `{ uri, cid }` shape so the
+      // Posting-as-group → group BFF (PUT with no rkey → createRecord
+      // on the group's repo, server re-checks the operator's role).
+      // Personal → xrpc proxy on the viewer's own repo. The choice comes
+      // from <PostingAs> (default You), never from the active read-scope
+      // org. Both routes return the same `{ uri, cid }` shape so the
       // redirect logic below doesn't care which path was used.
-      const targetDid = activeOrg ? activeOrg.groupDid : did
-      const useGroupRoute = activeOrg !== null
+      const targetDid = postingIsGroup ? postingDid : did
+      const useGroupRoute = postingIsGroup
       const url = useGroupRoute
         ? `/api/groups/${encodeURIComponent(targetDid)}/project`
         : "/api/xrpc/com/atproto/repo/createRecord"
@@ -340,6 +352,20 @@ export default function CreateProjectPage() {
             />
           </div>
 
+          {/* Per-action posting identity. Defaults to You; the picker
+              is the ONLY thing that targets a group repo here (the
+              active read-scope org never silently becomes the write
+              target). Static "Posting as You" label when the viewer
+              admins no groups. */}
+          <div className="flex items-center">
+            <PostingAs
+              value={posting.value}
+              onChange={posting.setValue}
+              options={posting.options}
+              size="sm"
+              aria-label="Posting project as"
+            />
+          </div>
           <header className="cert-detail__headline">
             <div className="create-cert__input-with-counter">
               <input
@@ -401,7 +427,7 @@ export default function CreateProjectPage() {
               onImageUpload={(file) =>
                 uploadBlob(
                   file,
-                  activeOrg ? { targetDid: activeOrg.groupDid } : undefined,
+                  postingIsGroup ? { targetDid: postingDid } : undefined,
                 )
               }
             />
@@ -579,7 +605,7 @@ export default function CreateProjectPage() {
       {isLocationDialogOpen && did ? (
         <LocationPickerDialog
           ownDid={did}
-          targetDid={activeOrg ? activeOrg.groupDid : did}
+          targetDid={effectiveDid}
           onClose={() => setIsLocationDialogOpen(false)}
           onPick={(added) => {
             // Projects carry a single location — replace, don't push.

--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -177,10 +177,59 @@
   color: var(--fg-secondary);
 }
 
+/* Column wrapping the label + optional "via {group}" byline so a
+   group-owned row reads as two stacked lines while a personal row stays
+   a single line. The thumb stays vertically centred against either. */
+.home-row__text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
 .home-row__label {
   font-size: 0.85rem;
   color: var(--fg-primary);
   line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+/* Compact "via {group}" provenance line under a dense Home row.
+   Single muted line — small group avatar + name. The avatar is forced
+   to 14px here (the <Avatar size="sm"> primitive is 32px by default);
+   we constrain it rather than add a new size to the shared primitive. */
+.via-byline {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  font-size: 0.72rem;
+  line-height: 1.2;
+  color: var(--fg-muted);
+}
+
+.via-byline__label {
+  flex-shrink: 0;
+}
+
+.via-byline__avatar {
+  flex-shrink: 0;
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+}
+
+.via-byline__avatar > div {
+  width: 14px;
+  height: 14px;
+  font-size: 0.5rem;
+}
+
+.via-byline__name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -1292,12 +1292,16 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   }
 }
 
-/* Acting-as-group delegation bar. Mounted above all page chrome whenever
-   the viewer is operating a group, so the elevated, inverted treatment
-   reads as a persistent "you are not yourself right now" reminder.
-   Mirrors the primary button: dark bg / light text in light theme, and
-   inverts under [data-theme="dark"] via the same --btn-primary-* tokens.
-   Scrolls with the page (no sticky) so it never overlaps fixed chrome. */
+/* Acting-as-group "mode" bar. Mounted above all page chrome whenever the
+   viewer is operating a group. Treatment is a NEUTRAL elevated strip with
+   an accent left-rule — deliberately not the warning/amber-style inverted
+   primary it used to be: acting-as is READ-SCOPE, not a write-identity
+   switch, so the bar must read as a quiet "you're viewing/operating as a
+   group" mode marker rather than "everything you post goes out as the
+   group." The "Posts ask each time" hint (`.acting-as-bar__hint`) spells
+   that out. All colours are theme-aware tokens, so the bar flips under
+   [data-theme="dark"] for free. Scrolls with the page (no sticky) so it
+   never overlaps fixed chrome. */
 .acting-as-bar {
   display: flex;
   align-items: center;
@@ -1306,22 +1310,41 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   flex-wrap: wrap;
   width: 100%;
   padding: 8px 16px;
-  background: var(--btn-primary-bg);
-  color: var(--btn-primary-fg);
+  background: var(--bg-elevated);
+  color: var(--fg-secondary);
+  border-bottom: 1px solid var(--border-default);
+  border-left: 3px solid var(--color-accent);
+}
+
+.acting-as-bar__body {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  min-width: 0;
 }
 
 .acting-as-bar__text {
   margin: 0;
   font-size: 0.8125rem;
   line-height: 1.4;
+  color: var(--fg-secondary);
 }
 
 .acting-as-bar__text b {
   font-weight: 600;
+  color: var(--fg-primary);
 }
 
-/* Outlined control that stays legible against the inverted bar — borrows
-   the bar's own foreground for border + text so it tracks the theme flip. */
+/* Quiet reminder that the write identity is per-action, not this bar. */
+.acting-as-bar__hint {
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--fg-muted);
+}
+
+/* Neutral outlined control — tracks the theme flip via --fg-secondary /
+   --border-default rather than an inverted foreground. */
 .acting-as-bar__switch {
   flex-shrink: 0;
   display: inline-flex;
@@ -1331,16 +1354,19 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   font-family: inherit;
   font-size: 0.8125rem;
   font-weight: 500;
-  color: var(--btn-primary-fg);
+  color: var(--fg-secondary);
   background: transparent;
-  border: 1px solid var(--btn-primary-fg);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius);
   cursor: pointer;
-  transition: opacity var(--transition-fast);
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .acting-as-bar__switch:hover {
-  opacity: 0.8;
+  background: var(--overlay-weak);
+  border-color: var(--border-hover);
 }
 
 /* Logged-out sign-in card. At narrow rail widths (800-1299) the card

--- a/src/app/styles/managed.css
+++ b/src/app/styles/managed.css
@@ -1,0 +1,206 @@
+/* ========== /managed — the org-identity hub ==========
+   A single-column list aggregating everything the viewer is responsible
+   for (personal + owned/admin groups). Row chrome mirrors the home
+   sidebar rows (`.home-row`) but at the larger list density of a hub
+   page; the focus filter sits above the list.
+
+   The default app-shell reading column caps content at 600px on
+   desktop, which clips this list to a cramped width. The `:has()`
+   override below widens the content slot for /managed only — scoped to
+   the page wrapper so no other route is affected (same pattern as
+   `.app-shell:has(.cert-detail--wide)` and
+   `.app-shell__content:has(.apps-store)`). */
+
+.app-shell:has(.managed-page) .app-shell__content {
+  max-width: 720px;
+}
+
+@media (min-width: 800px) {
+  .app-shell:has(.managed-page) .app-shell__content {
+    max-width: 860px;
+  }
+}
+
+.managed-page__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* ---- Header: title + sub on the left, "New" affordance on the right ---- */
+.managed-page__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding-top: 16px;
+}
+
+.managed-page__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.managed-page__title {
+  margin: 0;
+  font-family: var(--font-headline), "Noto Serif", serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--fg-primary);
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+
+.managed-page__sub {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: var(--fg-muted);
+  line-height: 1.45;
+  max-width: 52ch;
+}
+
+/* Shared "New" pill — used in the header and in the empty-state CTA.
+   Mirrors `.page-tabs-bar__new` so the affordance reads the same as the
+   one on /groups. */
+.managed-page__new {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  padding: 6px 12px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.managed-page__new:hover {
+  border-color: var(--border-hover);
+  background: var(--bg-sunken);
+}
+
+.managed-page__new:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* ---- Focus filter row ---- */
+.managed-page__filter {
+  display: flex;
+  align-items: center;
+}
+
+.managed-page__filter-select {
+  max-width: 280px;
+}
+
+/* ---- States ---- */
+.managed-page__loading {
+  display: flex;
+  justify-content: center;
+  padding: 48px 0;
+}
+
+.managed-page__more {
+  display: flex;
+  justify-content: center;
+  padding: 8px 0 24px;
+}
+
+/* ---- List + rows ---- */
+.managed-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.managed-list__item {
+  border-bottom: 1px solid var(--border-default);
+}
+
+.managed-list__item:last-child {
+  border-bottom: none;
+}
+
+.managed-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 8px;
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+  text-decoration: none;
+  min-width: 0;
+  transition: background var(--transition-fast);
+}
+
+.managed-row:hover {
+  background: var(--bg-sunken);
+}
+
+.managed-row:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.managed-row__thumb {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--bg-sunken);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-secondary);
+}
+
+.managed-row__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.managed-row__thumb-icon {
+  color: var(--fg-secondary);
+}
+
+.managed-row__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.managed-row__title {
+  font-size: 0.9375rem;
+  color: var(--fg-primary);
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.managed-row__via {
+  font-size: 0.8125rem;
+  color: var(--fg-muted);
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.managed-row__via-role {
+  color: var(--fg-muted);
+}

--- a/src/app/styles/managed.css
+++ b/src/app/styles/managed.css
@@ -90,9 +90,24 @@
 }
 
 /* ---- Focus filter row ---- */
+/* Horizontally scrollable on narrow viewports so a long identity list
+   (segmented strip) never overflows or wraps; the strip keeps its
+   intrinsic width and the row scrolls instead. Scrollbar hidden to match
+   the rest of the chrome. */
 .managed-page__filter {
   display: flex;
   align-items: center;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+.managed-page__filter::-webkit-scrollbar {
+  display: none;
+}
+
+.managed-page__filter > * {
+  flex-shrink: 0;
 }
 
 .managed-page__filter-select {

--- a/src/app/styles/notifications.css
+++ b/src/app/styles/notifications.css
@@ -3,10 +3,27 @@
    ========================================================================== */
 
 /* Identity focus strip above the list — only rendered on the aggregated
-   path (notifications aggregation on + the viewer manages groups). */
+   path (notifications aggregation on + the viewer manages groups).
+   Horizontally scrollable so a long identity list never overflows; the
+   dropdown variant is width-capped to match /managed. */
 .notifications-filter {
   display: flex;
   padding: 4px 4px 14px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+.notifications-filter::-webkit-scrollbar {
+  display: none;
+}
+
+.notifications-filter > * {
+  flex-shrink: 0;
+}
+
+.notifications-filter__select {
+  max-width: 280px;
 }
 
 .notification-list {

--- a/src/app/styles/notifications.css
+++ b/src/app/styles/notifications.css
@@ -2,6 +2,13 @@
    Notifications
    ========================================================================== */
 
+/* Identity focus strip above the list — only rendered on the aggregated
+   path (notifications aggregation on + the viewer manages groups). */
+.notifications-filter {
+  display: flex;
+  padding: 4px 4px 14px;
+}
+
 .notification-list {
   display: flex;
   flex-direction: column;

--- a/src/app/styles/profile.css
+++ b/src/app/styles/profile.css
@@ -420,7 +420,7 @@
 }
 
 .profile-managed-bridge__link:hover {
-  color: var(--color-accent);
+  color: var(--color-accent-hover);
   text-decoration: underline;
 }
 

--- a/src/app/styles/profile.css
+++ b/src/app/styles/profile.css
@@ -393,3 +393,38 @@
   justify-content: center;
   padding: 24px 0;
 }
+
+/* ========== Managed bridge (own-profile overview link-out) ========== */
+/* Positioning only — the surface, border, padding and dismiss button
+   all come from the <Banner variant="info"> primitive this class sits
+   on. We only add a gap below it so it doesn't crowd the banner image /
+   About block that follows in the overview. */
+.profile-managed-bridge {
+  margin-bottom: 16px;
+}
+
+.profile-managed-bridge__text {
+  color: var(--fg-secondary);
+}
+
+.profile-managed-bridge__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 500;
+  color: var(--fg-primary);
+  text-decoration: none;
+  white-space: nowrap;
+  border-radius: var(--radius);
+  transition: color var(--transition-fast);
+}
+
+.profile-managed-bridge__link:hover {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+
+.profile-managed-bridge__link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}

--- a/src/components/__tests__/posting-as-default-you.test.tsx
+++ b/src/components/__tests__/posting-as-default-you.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { renderHook, render, cleanup } from "@testing-library/react"
+import type { Group } from "@/lib/groups/types"
+import type { PostingIdentity } from "@/lib/groups/posting-identity"
+import { buildPostingOptions } from "@/lib/groups/posting-identity"
+
+/**
+ * posting-as default: the per-action write picker must ALWAYS default to
+ * the personal "You" identity — never to the active org and never to a
+ * last-used group. The org-identity write model is per-action: each
+ * action starts from the safe personal default and the user opts into a
+ * group explicitly. These tests pin that invariant at three levels:
+ *
+ *   1. buildPostingOptions(viewer, groups) → You is first, kind personal.
+ *   2. usePostingIdentity().value defaults to You even when an active org
+ *      is set (the active-org is a red herring the hook must ignore).
+ *   3. <PostingAs> with a single option renders the static "Posting as
+ *      You" label (no menu).
+ */
+
+const VIEWER_DID = "did:plc:viewer"
+const GROUP_DID = "did:plc:group"
+
+// An "active org" that the hook MUST NOT adopt as the default. If the
+// picker ever regressed to seeding from activeOrg, value.did would equal
+// this and value.kind would be "group" — which the assertions below
+// reject.
+const activeOrg: Group = {
+  groupDid: GROUP_DID,
+  handle: "acme.example.com",
+  displayName: "Acme",
+  role: "owner",
+  accepted: true,
+}
+
+const groups: Group[] = [activeOrg]
+
+vi.mock("@/lib/auth/auth-context", () => ({
+  useAuth: () => ({ did: VIEWER_DID, isAuthenticated: true }),
+}))
+
+vi.mock("@/lib/groups/org-context", () => ({
+  // activeOrg is deliberately the group — the hook must still default to
+  // You. groups feeds the option list (You + this writable group).
+  useOrg: () => ({ activeOrg, groups }),
+}))
+
+vi.mock("@/hooks/use-author-info", () => ({
+  useAuthorInfo: () => ({
+    info: { did: VIEWER_DID, handle: "viewer.example.com", displayName: null, avatarUrl: null },
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("buildPostingOptions", () => {
+  it("puts You first as the personal identity", () => {
+    const opts = buildPostingOptions({ did: VIEWER_DID }, groups)
+    expect(opts[0].kind).toBe("personal")
+    expect(opts[0].did).toBe(VIEWER_DID)
+    expect(opts[0].label).toBe("You")
+  })
+
+  it("appends writable groups after You (never before)", () => {
+    const opts = buildPostingOptions({ did: VIEWER_DID }, groups)
+    expect(opts).toHaveLength(2)
+    expect(opts[1].kind).toBe("group")
+    expect(opts[1].did).toBe(GROUP_DID)
+  })
+
+  it("includes You even when the viewer has no groups", () => {
+    const opts = buildPostingOptions({ did: VIEWER_DID }, [])
+    expect(opts).toHaveLength(1)
+    expect(opts[0].kind).toBe("personal")
+  })
+})
+
+describe("usePostingIdentity default", () => {
+  it("defaults value to the personal You identity, not the active org", async () => {
+    const { usePostingIdentity } = await import("@/hooks/use-posting-identity")
+    const { result } = renderHook(() => usePostingIdentity())
+
+    // The default must be personal You — NOT the active org's group.
+    expect(result.current.value.kind).toBe("personal")
+    expect(result.current.value.did).toBe(VIEWER_DID)
+    expect(result.current.value.did).not.toBe(GROUP_DID)
+  })
+
+  it("still surfaces the writable group as a selectable option", async () => {
+    const { usePostingIdentity } = await import("@/hooks/use-posting-identity")
+    const { result } = renderHook(() => usePostingIdentity())
+
+    // The group is available to pick — it's just not the default.
+    expect(result.current.options.some((o) => o.did === GROUP_DID)).toBe(true)
+    expect(result.current.options[0].kind).toBe("personal")
+  })
+})
+
+describe("<PostingAs> single-option label", () => {
+  it("renders a static 'Posting as You' label when You is the only option", async () => {
+    const { default: PostingAs } = await import("@/components/create/posting-as")
+    const you: PostingIdentity = {
+      did: VIEWER_DID,
+      kind: "personal",
+      label: "You",
+    }
+    const { container, queryByRole } = render(
+      <PostingAs value={you} onChange={() => {}} options={[you]} />,
+    )
+    // No interactive trigger / menu when there's nothing to pick.
+    expect(queryByRole("button")).toBeNull()
+    expect(container.textContent).toContain("Posting as")
+    expect(container.textContent).toContain("You")
+  })
+})

--- a/src/components/create/posting-as.tsx
+++ b/src/components/create/posting-as.tsx
@@ -1,0 +1,200 @@
+"use client"
+
+import { ChevronDown } from "lucide-react"
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover"
+import IdentityRow from "@/components/ui/identity-row"
+import Badge from "@/components/ui/badge"
+import ConfirmDialog from "@/components/ui/confirm-dialog"
+import type { PostingIdentity } from "@/lib/groups/posting-identity"
+
+/**
+ * Per-action "Posting as ▾" write picker.
+ *
+ * The org-identity write model is per-action: every create/award/endorse
+ * chooses which repo it lands in at the moment of writing. This control
+ * surfaces that choice. It is presentation-only — the chosen
+ * {@link PostingIdentity} carries the target `did`, which a caller feeds
+ * to the `writeToRepo({ targetDid })` seam.
+ *
+ * Two shapes:
+ *  - When the only option is You (the viewer admins no groups), it
+ *    renders a STATIC "Posting as You" label — no menu, nothing to pick.
+ *  - Otherwise it renders a dropdown trigger ("Posting as <name> ▾")
+ *    over a single-select menu of You + each writable group. Each row is
+ *    an {@link IdentityRow} (avatar + name + @handle) tagged with a
+ *    role {@link Badge} for group rows. The menu items are
+ *    `role="menuitemradio"` (via <PopoverContent>'s native menu chrome)
+ *    so the picker reads as "pick exactly one identity".
+ *
+ * The default is always You; the picker never seeds from the active org.
+ */
+
+export interface PostingAsProps {
+  value: PostingIdentity
+  onChange: (next: PostingIdentity) => void
+  options: PostingIdentity[]
+  /** Trigger/label sizing. @default "md" */
+  size?: "sm" | "md"
+  className?: string
+  /** Accessible name for the trigger / static label. */
+  "aria-label"?: string
+}
+
+const ROLE_LABEL: Record<NonNullable<PostingIdentity["role"]>, string> = {
+  owner: "Owner",
+  admin: "Admin",
+  member: "Member",
+}
+
+/** Tiny presentational row shared by the trigger summary + each menu item. */
+function IdentitySummary({
+  identity,
+  size,
+}: {
+  identity: PostingIdentity
+  size: "sm" | "md"
+}) {
+  return (
+    <span className="inline-flex items-center gap-2 min-w-0">
+      <IdentityRow
+        did={identity.did}
+        handle={identity.handle}
+        displayName={identity.label}
+        avatarUrl={identity.avatarUrl}
+        size={size === "sm" ? "sm" : "md"}
+      />
+      {identity.kind === "group" && identity.role ? (
+        <Badge variant="role">{ROLE_LABEL[identity.role]}</Badge>
+      ) : null}
+    </span>
+  )
+}
+
+export default function PostingAs({
+  value,
+  onChange,
+  options,
+  size = "md",
+  className = "",
+  "aria-label": ariaLabel = "Posting as",
+}: PostingAsProps) {
+  const labelTextClass =
+    size === "sm" ? "text-body-sm" : "text-body"
+
+  // Single option (You only) → static label, no menu. There is nothing
+  // to choose, so don't surface an interactive trigger.
+  if (options.length <= 1) {
+    return (
+      <span
+        className={`inline-flex items-center gap-2 ${labelTextClass} text-[var(--fg-muted)] ${className}`}
+        aria-label={ariaLabel}
+      >
+        <span className="shrink-0">Posting as</span>
+        <IdentitySummary identity={value} size={size} />
+      </span>
+    )
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          className={`inline-flex items-center gap-2 ${labelTextClass} text-[var(--fg-primary)] rounded px-2 py-1 border border-[var(--border-default)] hover:border-[var(--border-hover)] transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 ${className}`}
+        >
+          <span className="shrink-0 text-[var(--fg-muted)]">Posting as</span>
+          <IdentitySummary identity={value} size={size} />
+          <ChevronDown
+            className="h-4 w-4 shrink-0 text-[var(--fg-muted)]"
+            aria-hidden="true"
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" minWidth={240}>
+        {options.map((opt) => {
+          const selected = opt.did === value.did
+          return (
+            <button
+              key={`${opt.kind}:${opt.did}`}
+              type="button"
+              role="menuitemradio"
+              aria-checked={selected}
+              tabIndex={-1}
+              onClick={() => onChange(opt)}
+              className="w-full flex items-center gap-2 px-3 py-2 text-left rounded hover:bg-[var(--overlay-weak)] focus:bg-[var(--overlay-weak)] focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 focus:outline-none"
+            >
+              <IdentitySummary identity={opt} size="sm" />
+            </button>
+          )
+        })}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export interface PostingAsConfirmProps {
+  /** The chosen group identity that will author the high-stakes record. */
+  endorser: PostingIdentity
+  /** The operating viewer (you), plus the role you hold on the group. */
+  operator: { label: string; handle?: string; role?: PostingIdentity["role"] }
+  /** Human label for the subject of the action (who is being endorsed /
+   *  awarded). Free text — callers resolve it (handle / display name). */
+  subject: string
+  /** Verb for the action, e.g. "endorse" or "award a badge to". */
+  actionLabel?: string
+  confirmLabel?: string
+  isConfirming?: boolean
+  onCancel: () => void
+  onConfirm: () => void | Promise<void>
+}
+
+/**
+ * Confirmation gate for a HIGH-STAKES group-authored write (see
+ * `HIGH_STAKES_COLLECTIONS`). Spells out the three parties so the
+ * operator can't fat-finger a reputation-bearing record under the wrong
+ * identity:
+ *
+ *   - ENDORSER — the group the record is authored AS
+ *   - OPERATOR — you, and the role you hold on that group
+ *   - SUBJECT  — who the action names
+ *
+ * Wraps the shared {@link ConfirmDialog} chrome; the body is built from
+ * the named parties. Callers show this before committing the write.
+ */
+export function PostingAsConfirm({
+  endorser,
+  operator,
+  subject,
+  actionLabel = "endorse",
+  confirmLabel = "Confirm",
+  isConfirming = false,
+  onCancel,
+  onConfirm,
+}: PostingAsConfirmProps) {
+  const operatorRole = operator.role ? ROLE_LABEL[operator.role] : null
+  const operatorWho = operator.handle
+    ? `${operator.label} (@${operator.handle})`
+    : operator.label
+  const message =
+    `You are about to ${actionLabel} ${subject} as ${endorser.label}` +
+    `${endorser.handle ? ` (@${endorser.handle})` : ""}. ` +
+    `This record is authored by the group, not by you. ` +
+    `Operating as ${operatorWho}${operatorRole ? ` — ${operatorRole}` : ""}.`
+
+  return (
+    <ConfirmDialog
+      title={`Post as ${endorser.label}?`}
+      message={message}
+      confirmLabel={confirmLabel}
+      confirmVariant="primary"
+      isConfirming={isConfirming}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+    />
+  )
+}

--- a/src/components/create/posting-as.tsx
+++ b/src/components/create/posting-as.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ChevronDown } from "lucide-react"
+import { ChevronDown, Check } from "lucide-react"
 import {
   Popover,
   PopoverTrigger,
@@ -128,6 +128,12 @@ export default function PostingAs({
               onClick={() => onChange(opt)}
               className="w-full flex items-center gap-2 px-3 py-2 text-left rounded hover:bg-[var(--overlay-weak)] focus:bg-[var(--overlay-weak)] focus-visible:outline-2 focus-visible:outline-[var(--focus-ring)] focus-visible:outline-offset-2 focus:outline-none"
             >
+              {/* Reserved-width check so the current identity is visibly
+                  marked while every row's label stays left-aligned. */}
+              <Check
+                className={`h-4 w-4 shrink-0 text-[var(--fg-primary)] ${selected ? "opacity-100" : "opacity-0"}`}
+                aria-hidden="true"
+              />
               <IdentitySummary identity={opt} size="sm" />
             </button>
           )

--- a/src/components/dev/mock-fetch-provider.tsx
+++ b/src/components/dev/mock-fetch-provider.tsx
@@ -66,6 +66,8 @@ import {
   managedMembershipRecords,
   managedOrgProfile,
   managedPlcDidDocument,
+  managedNotificationsConnection,
+  managedUnreadCount,
 } from "@/lib/dev/fixtures/managed"
 import { ORG_MEMBERSHIP_COLLECTION } from "@/lib/groups/constants"
 
@@ -449,6 +451,7 @@ function installMockFetch(
         // throws "Unread count unavailable" if the field is missing, so
         // every op the provider polls needs a valid envelope here.
         let op: string | undefined
+        let recipients: string[] | null = null
         try {
           const text =
             typeof init?.body === "string"
@@ -456,25 +459,47 @@ function installMockFetch(
               : init?.body
                 ? String(init.body)
                 : "{}"
-          op = (JSON.parse(text) as { operationName?: string }).operationName
+          const parsedBody = JSON.parse(text) as {
+            operationName?: string
+            variables?: { recipients?: unknown }
+          }
+          op = parsedBody.operationName
+          const rawRecipients = parsedBody.variables?.recipients
+          if (Array.isArray(rawRecipients)) {
+            recipients = rawRecipients.filter(
+              (r): r is string => typeof r === "string",
+            )
+          }
         } catch {
           /* fall through → default empty notifications page */
         }
+        // The aggregated path: the client sent `recipients` AND we're in the
+        // managed scenario, so serve per-recipient notices (with the new
+        // `recipient` field). Outside the managed scenario, recipients are
+        // still honoured but only the viewer has notices.
+        const aggregated = managed && recipients !== null
         if (op === "unreadNotificationCount") {
           return json({
-            data: { unreadNotificationCount: { count: 0, more: false } },
+            data: {
+              unreadNotificationCount: aggregated
+                ? managedUnreadCount(recipients)
+                : { count: 0, more: false },
+            },
           })
         }
         if (op === "updateNotificationsSeen") {
           return json({ data: { updateNotificationsSeen: { seenAt: null } } })
         }
-        // `notifications` (list) and anything else → empty, valid page.
+        // `notifications` (list) and anything else → empty, valid page,
+        // or the managed connection on the aggregated path.
         return json({
           data: {
-            notifications: {
-              edges: [],
-              pageInfo: { hasNextPage: false, endCursor: null },
-            },
+            notifications: aggregated
+              ? managedNotificationsConnection(recipients)
+              : {
+                  edges: [],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
           },
         })
       }

--- a/src/components/dev/mock-fetch-provider.tsx
+++ b/src/components/dev/mock-fetch-provider.tsx
@@ -58,6 +58,16 @@ import {
   groupsMembershipsResponse,
 } from "@/lib/dev/fixtures/groups"
 import { searchActorsResponse } from "@/lib/dev/fixtures/search"
+import {
+  isManagedAuthorsRequest,
+  managedProjectsConnection,
+  managedActivitiesConnection,
+  managedGroupsMembershipsResponse,
+  managedMembershipRecords,
+  managedOrgProfile,
+  managedPlcDidDocument,
+} from "@/lib/dev/fixtures/managed"
+import { ORG_MEMBERSHIP_COLLECTION } from "@/lib/groups/constants"
 
 export type MockScenario = "populated" | "empty"
 
@@ -68,6 +78,13 @@ interface MockFetchProviderProps {
   /** Fixture density. `empty` makes every list/connection empty so
    *  empty-state surfaces can be screenshotted too. */
   scenario?: MockScenario
+  /** Managed / write-as-org scenario. When on, the viewer belongs to the
+   *  mock managed groups (owner/admin/member) and the `/api/indexer`
+   *  Projects/Activities ops serve the org-aggregation connections for
+   *  requests that carry the managed group DIDs in `authors[]`. Default
+   *  OFF so every existing preview (profile / feed / settings / workspace)
+   *  renders byte-identically. */
+  managedScenario?: boolean
 }
 
 const JSON_HEADERS = { "Content-Type": "application/json" } as const
@@ -87,7 +104,7 @@ type IndexerBody = { operationName?: string; variables?: Record<string, unknown>
  *  fetchers treat a missing root field as an empty result). */
 function indexerResponse(
   body: IndexerBody,
-  opts: { empty: boolean },
+  opts: { empty: boolean; managed: boolean },
 ): Response {
   const op = body.operationName
   const vars = body.variables ?? {}
@@ -97,6 +114,36 @@ function indexerResponse(
     totalCount: 0,
     edges: [],
     pageInfo: { hasNextPage: false, endCursor: null },
+  }
+
+  // --- managed / write-as-org aggregation ---------------------------
+  // Only for the managed scenario AND only when the request actually
+  // carries the managed group DIDs in `authors[]` (the org-aggregation
+  // request). Every other Projects/Activities request — including the
+  // managed scenario's own per-DID profile fetches — falls through to
+  // today's behaviour, so nothing else is disturbed.
+  if (opts.managed && Array.isArray(vars.authors)) {
+    const authors = (vars.authors as unknown[]).filter(
+      (a): a is string => typeof a === "string",
+    )
+    if (isManagedAuthorsRequest(authors)) {
+      if (op === "Projects" || op === "UserProjects") {
+        return json({
+          data: { orgHypercertsCollection: managedProjectsConnection(authors) },
+        })
+      }
+      if (
+        op === "Activities" ||
+        op === "AuthoredActivities" ||
+        op === "ContributedActivities"
+      ) {
+        return json({
+          data: {
+            orgHypercertsClaimActivity: managedActivitiesConnection(authors),
+          },
+        })
+      }
+    }
   }
 
   switch (op) {
@@ -223,6 +270,7 @@ function xrpcResponse(
   url: URL,
   scenario: ProfileScenario,
   empty: boolean,
+  managed: boolean,
 ): Response {
   const method = url.pathname.replace(/^\/api\/xrpc\//, "").replace(/\//g, ".")
   const params = url.searchParams
@@ -251,6 +299,13 @@ function xrpcResponse(
     if (collection === "app.certified.graph.follow") {
       return json(empty ? { records: [] } : followRecords())
     }
+    // Managed scenario: the viewer's local membership records, so
+    // `resolveGroups` marks each managed group `accepted: true`. Only
+    // intercepts the membership collection — every other listRecords
+    // (activities-by-PDS, etc.) still returns an empty list.
+    if (managed && collection === ORG_MEMBERSHIP_COLLECTION) {
+      return json(managedMembershipRecords())
+    }
     // Memberships, activities-by-PDS, and anything else → empty list.
     return json({ records: [] })
   }
@@ -263,6 +318,7 @@ function xrpcResponse(
 function installMockFetch(
   profileScenario: ProfileScenario,
   scenario: MockScenario,
+  managed: boolean,
 ): () => void {
   if (typeof window === "undefined") return () => {}
   const realFetch = window.fetch
@@ -291,6 +347,17 @@ function installMockFetch(
 
     // --- PLC directory (resolvePdsUrl / resolveHandle fetch it directly) ---
     if (url.hostname === "plc.directory") {
+      // Managed scenario: serve a per-group DID document so each managed
+      // group's handle resolves (the path segment after the host is the
+      // DID). Falls back to the viewer's doc for any other DID so the
+      // existing own-identity resolution is unchanged.
+      if (managed) {
+        const requestedDid = decodeURIComponent(
+          path.replace(/^\//, "").split("/")[0] ?? "",
+        )
+        const groupDoc = managedPlcDidDocument(requestedDid)
+        if (groupDoc) return json(groupDoc)
+      }
       return json(plcDidDocument())
     }
 
@@ -328,7 +395,7 @@ function installMockFetch(
         } catch {
           /* fall through with empty body → default op */
         }
-        return indexerResponse(parsed, { empty })
+        return indexerResponse(parsed, { empty, managed })
       }
       if (path === "/api/resolve-did") {
         // Single resolve — the viewer's own profile (or org variant).
@@ -349,13 +416,31 @@ function installMockFetch(
         return json({ results: resolveDidsResults(identities) })
       }
       if (path.startsWith("/api/xrpc/")) {
-        return xrpcResponse(url, profileScenario, empty)
+        return xrpcResponse(url, profileScenario, empty, managed)
       }
       if (path === "/api/search-actors") {
         return json(searchActorsResponse(url.searchParams.get("q") ?? ""))
       }
       if (path === "/api/groups/memberships") {
-        return json(groupsMembershipsResponse())
+        // Managed scenario: the three managed groups (owner/admin/member)
+        // so `useOrg().groups` resolves to them. Otherwise an empty list,
+        // keeping the personal identity active for the existing previews.
+        return json(
+          managed
+            ? managedGroupsMembershipsResponse()
+            : groupsMembershipsResponse(),
+        )
+      }
+      if (managed && /^\/api\/groups\/[^/]+\/profile$/.test(path)) {
+        // Per-group org profile (`getOrgProfile`) — drives `displayName`
+        // on the resolved groups. The DID segment is URL-encoded; decode
+        // it back to `did:plc:…`. A 404-shaped miss for an unknown DID
+        // lets `resolveGroups` fall back to the handle.
+        const segment = path.split("/")[3] ?? ""
+        const groupDid = decodeURIComponent(segment)
+        const profile = managedOrgProfile(groupDid)
+        if (profile) return json(profile)
+        return json({ error: "NotFound" }, 404)
       }
       if (path === "/api/notifications") {
         // The notifications client (`lib/atproto/notifications.ts`) POSTs
@@ -412,6 +497,7 @@ export default function MockFetchProvider({
   children,
   profileScenario = "individual",
   scenario = "populated",
+  managedScenario = false,
 }: MockFetchProviderProps) {
   // Install synchronously during the FIRST render (via the useState lazy
   // initializer) so the patch is in place before any child provider's
@@ -419,7 +505,7 @@ export default function MockFetchProvider({
   // fn, which is held in state and called on unmount. Storing it in
   // state (not a ref) keeps render side-effect-free per react-hooks/refs.
   const [teardown] = useState<() => void>(() =>
-    installMockFetch(profileScenario, scenario),
+    installMockFetch(profileScenario, scenario, managedScenario),
   )
 
   useEffect(() => {

--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -92,7 +92,7 @@ export default function Home() {
     <div className="home-page">
       <div className="home__layout">
         <aside className="home__sidebar" aria-label="Your library">
-          <HomeSidebar activeDid={activeDid} isGroupFocused={!!activeOrg} />
+          <HomeSidebar activeDid={activeDid} />
         </aside>
         <main className="home__main">
           <div className="home__split">
@@ -111,22 +111,16 @@ export default function Home() {
 
 // ---------------------------- Sidebar ---------------------------------------
 
-function HomeSidebar({
-  activeDid,
-  isGroupFocused,
-}: {
-  activeDid: string
-  /** True when the viewer has switched into a single group — the "via
-   *  {group}" aggregation byline is suppressed in that mode since every
-   *  visible record already belongs to that one group. */
-  isGroupFocused: boolean
-}) {
+function HomeSidebar({ activeDid }: { activeDid: string }) {
   const { groups, isLoading: groupsLoading } = useOrg()
   // Aggregated across the viewer's managed identities (personal + every
   // owned/admin group), so group-owned projects/activities surface here
-  // too. The managed hooks anchor on the viewer's PERSONAL DID
-  // internally (via useAuth), so this aggregate is stable regardless of
-  // which identity the home page is currently focused on (activeDid).
+  // too. The managed hooks anchor on the viewer's PERSONAL DID internally
+  // (via useAuth), so this aggregate is the same regardless of which
+  // identity the page is focused on — acting-as is read-scope and never
+  // changes what's "yours" here. Every group-owned row keeps its "via
+  // {group}" provenance; the dedicated /managed hub is where the focus
+  // filter narrows to a single owner.
   const { items: projects, isLoading: projectsLoading } = useManagedProjects()
   const { items: certs, isLoading: certsLoading } = useManagedActivities()
 
@@ -165,14 +159,9 @@ function HomeSidebar({
         items={previewProjects}
         total={projects.length}
         renderItem={(p) => (
-          <ProjectRow
-            key={p.record.uri}
-            project={p.record}
-            owner={p.owner}
-            showVia={!isGroupFocused}
-          />
+          <ProjectRow key={p.record.uri} project={p.record} owner={p.owner} />
         )}
-        moreHref={`${profileBase}?tab=projects`}
+        moreHref="/managed"
         emptyLabel="No projects yet."
       />
       <SidebarSection
@@ -186,11 +175,10 @@ function HomeSidebar({
             key={c.record.uri}
             record={c.record}
             owner={c.owner}
-            showVia={!isGroupFocused}
             fallbackDid={activeDid}
           />
         )}
-        moreHref={`${profileBase}?tab=activities`}
+        moreHref="/managed"
         emptyLabel="No activities yet."
       />
     </>
@@ -278,12 +266,9 @@ function GroupRow({ group }: { group: Group }) {
 function ProjectRow({
   project,
   owner,
-  showVia,
 }: {
   project: CollectionRecord
   owner: OwnerTag
-  /** Suppress the "via {group}" byline (e.g. while focused on one group). */
-  showVia: boolean
 }) {
   const parsed = parseAtUri(project.uri)
   const did = parsed?.did ?? ""
@@ -308,7 +293,7 @@ function ProjectRow({
 
   // Only group-owned records carry a provenance line; personal records
   // are the viewer's own, so no "via" is shown.
-  const via = showVia && owner.kind === "group" && owner.group ? owner.group : null
+  const via = owner.kind === "group" && owner.group ? owner.group : null
 
   return (
     <li>
@@ -338,13 +323,10 @@ function ProjectRow({
 function CertRow({
   record,
   owner,
-  showVia,
   fallbackDid,
 }: {
   record: ActivityRecord
   owner: OwnerTag
-  /** Suppress the "via {group}" byline (e.g. while focused on one group). */
-  showVia: boolean
   fallbackDid: string
 }) {
   const parsed = parseAtUri(record.uri)
@@ -359,7 +341,7 @@ function CertRow({
 
   // Only group-owned records carry a provenance line; personal records
   // are the viewer's own, so no "via" is shown.
-  const via = showVia && owner.kind === "group" && owner.group ? owner.group : null
+  const via = owner.kind === "group" && owner.group ? owner.group : null
 
   return (
     <li>

--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -7,13 +7,14 @@ import { FolderGit2, User, Users } from "lucide-react"
 import CertIcon from "@/components/ui/cert-icon"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useOrg } from "@/lib/groups/org-context"
-import { useUserProjects } from "@/hooks/use-user-projects"
-import { useUserActivities } from "@/hooks/use-user-activities"
+import { useManagedProjects } from "@/hooks/use-managed-projects"
+import { useManagedActivities } from "@/hooks/use-managed-activities"
 import { usePageTitle } from "@/lib/navbar-context"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import Avatar from "@/components/ui/avatar"
 import Badge from "@/components/ui/badge"
 import EmptyState from "@/components/ui/empty-state"
+import ViaByline from "@/components/ui/via-byline"
 import HomeFeed from "@/components/home/home-feed"
 import NewsSection from "@/components/right-rail/news-section"
 import { resolveActivityImageUrl } from "@/lib/atproto/activity"
@@ -21,6 +22,7 @@ import { parseAtUri } from "@/lib/atproto/activity-uri"
 import { getInitials } from "@/lib/utils/initials"
 import type { CollectionRecord } from "@/lib/atproto/collection"
 import type { ActivityRecord } from "@/lib/atproto/activity-types"
+import type { OwnerTag } from "@/lib/atproto/owner-tag"
 import type { Group } from "@/lib/groups/types"
 
 /** DID of the actor whose Bluesky timeline powers the home page's
@@ -90,7 +92,7 @@ export default function Home() {
     <div className="home-page">
       <div className="home__layout">
         <aside className="home__sidebar" aria-label="Your library">
-          <HomeSidebar activeDid={activeDid} />
+          <HomeSidebar activeDid={activeDid} isGroupFocused={!!activeOrg} />
         </aside>
         <main className="home__main">
           <div className="home__split">
@@ -109,11 +111,24 @@ export default function Home() {
 
 // ---------------------------- Sidebar ---------------------------------------
 
-function HomeSidebar({ activeDid }: { activeDid: string }) {
+function HomeSidebar({
+  activeDid,
+  isGroupFocused,
+}: {
+  activeDid: string
+  /** True when the viewer has switched into a single group — the "via
+   *  {group}" aggregation byline is suppressed in that mode since every
+   *  visible record already belongs to that one group. */
+  isGroupFocused: boolean
+}) {
   const { groups, isLoading: groupsLoading } = useOrg()
-  const { projects, isLoading: projectsLoading } = useUserProjects(activeDid)
-  const { activities: certs, isLoading: certsLoading } =
-    useUserActivities(activeDid)
+  // Aggregated across the viewer's managed identities (personal + every
+  // owned/admin group), so group-owned projects/activities surface here
+  // too. The managed hooks anchor on the viewer's PERSONAL DID
+  // internally (via useAuth), so this aggregate is stable regardless of
+  // which identity the home page is currently focused on (activeDid).
+  const { items: projects, isLoading: projectsLoading } = useManagedProjects()
+  const { items: certs, isLoading: certsLoading } = useManagedActivities()
 
   const previewGroups = groups.slice(0, SIDEBAR_PREVIEW_LIMIT)
   const previewProjects = projects.slice(0, SIDEBAR_PREVIEW_LIMIT)
@@ -149,7 +164,14 @@ function HomeSidebar({ activeDid }: { activeDid: string }) {
         isLoading={projectsLoading && previewProjects.length === 0}
         items={previewProjects}
         total={projects.length}
-        renderItem={(p) => <ProjectRow key={p.uri} project={p} />}
+        renderItem={(p) => (
+          <ProjectRow
+            key={p.record.uri}
+            project={p.record}
+            owner={p.owner}
+            showVia={!isGroupFocused}
+          />
+        )}
         moreHref={`${profileBase}?tab=projects`}
         emptyLabel="No projects yet."
       />
@@ -159,7 +181,15 @@ function HomeSidebar({ activeDid }: { activeDid: string }) {
         isLoading={certsLoading && previewCerts.length === 0}
         items={previewCerts}
         total={certs.length}
-        renderItem={(c) => <CertRow key={c.uri} record={c} fallbackDid={activeDid} />}
+        renderItem={(c) => (
+          <CertRow
+            key={c.record.uri}
+            record={c.record}
+            owner={c.owner}
+            showVia={!isGroupFocused}
+            fallbackDid={activeDid}
+          />
+        )}
         moreHref={`${profileBase}?tab=activities`}
         emptyLabel="No activities yet."
       />
@@ -245,7 +275,16 @@ function GroupRow({ group }: { group: Group }) {
   )
 }
 
-function ProjectRow({ project }: { project: CollectionRecord }) {
+function ProjectRow({
+  project,
+  owner,
+  showVia,
+}: {
+  project: CollectionRecord
+  owner: OwnerTag
+  /** Suppress the "via {group}" byline (e.g. while focused on one group). */
+  showVia: boolean
+}) {
   const parsed = parseAtUri(project.uri)
   const did = parsed?.did ?? ""
   const href = parsed
@@ -267,6 +306,10 @@ function ProjectRow({ project }: { project: CollectionRecord }) {
         )
       : null
 
+  // Only group-owned records carry a provenance line; personal records
+  // are the viewer's own, so no "via" is shown.
+  const via = showVia && owner.kind === "group" && owner.group ? owner.group : null
+
   return (
     <li>
       <Link href={href} className="home-row">
@@ -283,7 +326,10 @@ function ProjectRow({ project }: { project: CollectionRecord }) {
             />
           )}
         </span>
-        <span className="home-row__label">{title}</span>
+        <span className="home-row__text">
+          <span className="home-row__label">{title}</span>
+          {via ? <ViaByline group={via} role={owner.role} /> : null}
+        </span>
       </Link>
     </li>
   )
@@ -291,9 +337,14 @@ function ProjectRow({ project }: { project: CollectionRecord }) {
 
 function CertRow({
   record,
+  owner,
+  showVia,
   fallbackDid,
 }: {
   record: ActivityRecord
+  owner: OwnerTag
+  /** Suppress the "via {group}" byline (e.g. while focused on one group). */
+  showVia: boolean
   fallbackDid: string
 }) {
   const parsed = parseAtUri(record.uri)
@@ -305,6 +356,10 @@ function CertRow({
   const imageUrl = record.value.image
     ? resolveActivityImageUrl(record.value.image, did)
     : null
+
+  // Only group-owned records carry a provenance line; personal records
+  // are the viewer's own, so no "via" is shown.
+  const via = showVia && owner.kind === "group" && owner.group ? owner.group : null
 
   return (
     <li>
@@ -322,8 +377,11 @@ function CertRow({
             />
           )}
         </span>
-        <span className="home-row__label">
-          {record.value.title || "Untitled activity"}
+        <span className="home-row__text">
+          <span className="home-row__label">
+            {record.value.title || "Untitled activity"}
+          </span>
+          {via ? <ViaByline group={via} role={owner.role} /> : null}
         </span>
       </Link>
     </li>

--- a/src/components/layout/acting-as-bar.tsx
+++ b/src/components/layout/acting-as-bar.tsx
@@ -4,12 +4,20 @@ import { useOrg } from "@/lib/groups/org-context"
 import { useSession } from "@/hooks/use-session"
 
 /**
- * Full-width banner pinned above the page chrome whenever the viewer is
- * acting AS a group (delegation). It names the org being operated, the
- * operator's own handle, and the role, and offers a one-click escape back
- * to the personal account. Renders nothing for personal sessions (the
- * common case), so it never appears on signed-out routes where activeOrg
- * is always null.
+ * Full-width bar pinned above the page chrome whenever the viewer is
+ * operating a group (READ-SCOPE delegation). It names the org being
+ * operated, the operator's own handle, and the role, and offers a
+ * one-click escape back to the personal account. Renders nothing for
+ * personal sessions (the common case), so it never appears on signed-out
+ * routes where activeOrg is always null.
+ *
+ * Treatment is a NEUTRAL elevated "mode" strip (accent left-rule +
+ * --fg-secondary text), deliberately NOT the warning/amber-style
+ * inverted primary it used to be: acting-as is read-scope, not a
+ * write-identity switch, so the bar must not imply "everything you post
+ * now goes out as the group." The "Posts ask each time" hint makes that
+ * explicit — per-action identity comes from the in-form posting picker
+ * (default You), never from this bar.
  */
 export default function ActingAsBar() {
   const { activeOrg, switchOrg } = useOrg()
@@ -19,9 +27,13 @@ export default function ActingAsBar() {
 
   return (
     <div className="acting-as-bar" role="status">
-      <p className="acting-as-bar__text">
-        Operating <b>{activeOrg.displayName || activeOrg.handle}</b> as @{handle} ({activeOrg.role})
-      </p>
+      <div className="acting-as-bar__body">
+        <p className="acting-as-bar__text">
+          Operating <b>{activeOrg.displayName || activeOrg.handle}</b> as @
+          {handle} ({activeOrg.role})
+        </p>
+        <span className="acting-as-bar__hint">Posts ask each time</span>
+      </div>
       <button
         type="button"
         className="acting-as-bar__switch"

--- a/src/components/layout/mobile-sidebar.tsx
+++ b/src/components/layout/mobile-sidebar.tsx
@@ -3,11 +3,12 @@
 import { useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Newspaper, Search, PlusCircle, Building2, Award, Bell, MessageSquare, User, Settings, LayoutGrid } from "lucide-react";
+import { Newspaper, Search, PlusCircle, Building2, Briefcase, Award, Bell, MessageSquare, User, Settings, LayoutGrid } from "lucide-react";
 import { useAuth } from "@/lib/auth/auth-context";
 import { useProfile } from "@/hooks/use-profile";
 import { useSession } from "@/hooks/use-session";
 import { useOrg } from "@/lib/groups/org-context";
+import { useManagesAnyGroup } from "@/lib/groups/managed";
 import { isRouteVisibleToActor } from "@/lib/groups/personal-only";
 import { useOrgProfile } from "@/hooks/use-org-profile";
 import { usePendingAwardsCount } from "@/hooks/use-pending-awards-count";
@@ -30,6 +31,7 @@ export default function MobileSidebar({ isOpen, onClose }: MobileSidebarProps) {
   const { handle } = useSession();
   const { activeOrg } = useOrg();
   const { orgAvatarUrl } = useOrgProfile();
+  const managesAnyGroup = useManagesAnyGroup();
   const { openFeedback } = useFeedback();
   const { count: unreadCount, more: unreadMore, ready: notificationsReady } = useNotifications();
   const pendingAwardsCount = usePendingAwardsCount();
@@ -89,12 +91,17 @@ export default function MobileSidebar({ isOpen, onClose }: MobileSidebarProps) {
   const showCreate = isRouteVisibleToActor("create", isActingAsOrg);
   const showGroups = isRouteVisibleToActor("groups", isActingAsOrg);
   const showEndorsements = isRouteVisibleToActor("endorsements", isActingAsOrg);
+  // The Managed hub is gated on owning/admining at least one group —
+  // same source of truth (useManagesAnyGroup) as the desktop drawer, so
+  // the two navs can't drift.
+  const showManaged = managesAnyGroup;
   const navLinks = [
     { href: profileHref, label: "Profile", icon: User },
     { href: "/home", label: "Home", icon: Newspaper },
     { href: "/search", label: "Explore", icon: Search },
     ...(showCreate ? [{ href: "/create", label: "Create", icon: PlusCircle }] : []),
     ...(showGroups ? [{ href: "/groups", label: "Groups", icon: Building2 }] : []),
+    ...(showManaged ? [{ href: "/managed", label: "Managed", icon: Briefcase }] : []),
     ...(showEndorsements ? [{ href: "/endorsements", label: "Endorsements", icon: Award }] : []),
     { href: "/notifications", label: "Notifications", icon: Bell },
     { href: "/apps", label: "Apps", icon: LayoutGrid },

--- a/src/components/layout/site-drawer.tsx
+++ b/src/components/layout/site-drawer.tsx
@@ -2,10 +2,11 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Compass, Home, Settings, User, X } from "lucide-react"
+import { Briefcase, Compass, Home, Settings, User, X } from "lucide-react"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useSession } from "@/hooks/use-session"
 import { useOrg } from "@/lib/groups/org-context"
+import { useManagesAnyGroup } from "@/lib/groups/managed"
 import Drawer from "@/components/ui/drawer"
 
 /**
@@ -32,6 +33,10 @@ export default function SiteDrawer({
   const { isLoading, isAuthenticated } = useAuth()
   const { handle: personalHandle } = useSession()
   const { activeOrg } = useOrg()
+  // The Managed hub is only meaningful to viewers who own or admin at
+  // least one group — for everyone else there's nothing to aggregate
+  // beyond their own work, so the item stays hidden entirely.
+  const managesAnyGroup = useManagesAnyGroup()
   // The "My profile" item — and any future identity-bound link added
   // to this drawer — must route to the account the user is currently
   // *acting as*, not their personal identity. When the account
@@ -66,6 +71,17 @@ export default function SiteDrawer({
       icon: User,
       requiresAuth: true,
     },
+    ...(managesAnyGroup
+      ? [
+          {
+            key: "managed",
+            label: "Managed",
+            href: "/managed",
+            icon: Briefcase,
+            requiresAuth: true,
+          },
+        ]
+      : []),
     { key: "settings", label: "Settings", href: "/settings", icon: Settings },
   ]
 

--- a/src/components/managed/managed.tsx
+++ b/src/components/managed/managed.tsx
@@ -1,8 +1,7 @@
 "use client"
 
-import { useCallback, useMemo } from "react"
+import { useMemo } from "react"
 import Link from "next/link"
-import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { FolderGit2, Plus } from "lucide-react"
 import CertIcon from "@/components/ui/cert-icon"
 import SegmentedControl from "@/components/ui/segmented-control"
@@ -12,6 +11,7 @@ import Button from "@/components/ui/button"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import { usePageTitle } from "@/lib/navbar-context"
 import { useManagedAuthors } from "@/hooks/use-managed-authors"
+import { useIdentityFocus } from "@/hooks/use-identity-focus"
 import { useManagedRecords, type ManagedItem } from "@/hooks/use-managed-records"
 import { resolveActivityImageUrl } from "@/lib/atproto/activity"
 import { parseAtUri } from "@/lib/atproto/activity-uri"
@@ -32,17 +32,9 @@ import type { OrgRole } from "@/lib/groups/types"
  * suppressed (it would be noise).
  *
  * Switch between a <SegmentedControl> (<=5 identities, fits a strip) and
- * a <Select> dropdown (more than 5) so the filter never overflows.
+ * a <Select> dropdown (more than 5) so the filter never overflows — both
+ * driven by the shared `useIdentityFocus` hook.
  */
-
-// Sentinel focus values. Everything is the bare default; You is the
-// personal identity. Any other value is a group DID.
-const FOCUS_EVERYTHING = "everything"
-const FOCUS_YOU = "you"
-
-// Above this many identities the segmented strip would overflow the
-// reading column, so fall back to a dropdown.
-const SEGMENTED_MAX_IDENTITIES = 5
 
 const ROLE_LABEL: Record<OrgRole, string> = {
   owner: "Owner",
@@ -97,76 +89,23 @@ function itemImageUrl(item: ManagedItem): string | null {
 export default function Managed() {
   usePageTitle("Managed")
 
-  const router = useRouter()
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
-
   const { identities, isLoading: identitiesLoading } = useManagedAuthors()
   const { items, isLoading, isLoadingMore, hasMore, loadMore } =
     useManagedRecords()
 
-  // Resolve the focus from `?focus=`. Everything is the default and the
-  // only valid sentinel besides You + the known group DIDs; an unknown
-  // value (e.g. a stale group DID after losing admin) collapses to
-  // Everything rather than showing an empty list with no way out.
-  const focus = useMemo<string>(() => {
-    const raw = searchParams?.get("focus")
-    if (!raw || raw === FOCUS_EVERYTHING) return FOCUS_EVERYTHING
-    if (raw === FOCUS_YOU) return FOCUS_YOU
-    return identities.some((i) => i.did === raw) ? raw : FOCUS_EVERYTHING
-  }, [searchParams, identities])
-
-  const setFocus = useCallback(
-    (next: string) => {
-      const params = new URLSearchParams(searchParams?.toString() ?? "")
-      if (next === FOCUS_EVERYTHING) params.delete("focus")
-      else params.set("focus", next)
-      const qs = params.toString()
-      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
-    },
-    [router, pathname, searchParams],
-  )
-
-  // Map a focus value to the DID it scopes to (null = Everything).
-  const focusedDid = useMemo<string | null>(() => {
-    if (focus === FOCUS_EVERYTHING) return null
-    if (focus === FOCUS_YOU) {
-      return identities.find((i) => i.kind === "personal")?.did ?? null
-    }
-    return focus
-  }, [focus, identities])
-
-  // Whether a single GROUP is focused — suppresses the per-row "via"
-  // line, since every visible row already shares that owner.
-  const singleGroupFocused = useMemo<boolean>(() => {
-    if (focus === FOCUS_EVERYTHING || focus === FOCUS_YOU) return false
-    return identities.some((i) => i.did === focus && i.kind === "group")
-  }, [focus, identities])
+  const {
+    focus,
+    setFocus,
+    focusedDid,
+    singleGroupFocused,
+    filterOptions,
+    useDropdown,
+  } = useIdentityFocus(identities)
 
   const visibleItems = useMemo<ManagedItem[]>(() => {
     if (!focusedDid) return items
     return items.filter((item) => item.owner.ownerDid === focusedDid)
   }, [items, focusedDid])
-
-  // Build the filter options: [Everything, You, ...each group].
-  const filterOptions = useMemo(() => {
-    const opts: { value: string; label: string }[] = [
-      { value: FOCUS_EVERYTHING, label: "Everything" },
-    ]
-    for (const identity of identities) {
-      if (identity.kind === "personal") {
-        opts.push({ value: FOCUS_YOU, label: identity.label })
-      } else {
-        opts.push({ value: identity.did, label: identity.label })
-      }
-    }
-    return opts
-  }, [identities])
-
-  // <=5 identities → segmented strip; more → dropdown. `identities`
-  // always includes the personal account, so the option count is
-  // identities.length + 1 (the Everything option).
-  const useDropdown = identities.length > SEGMENTED_MAX_IDENTITIES
 
   const showInitialSpinner = isLoading && items.length === 0
 

--- a/src/components/managed/managed.tsx
+++ b/src/components/managed/managed.tsx
@@ -239,7 +239,7 @@ function ManagedRow({
           <span className="managed-row__title">{title}</span>
           {showVia ? (
             <span className="managed-row__via">
-              <span className="managed-row__via-label">via {owner.label}</span>
+              via {owner.label}
               {roleLabel ? (
                 <span className="managed-row__via-role"> · {roleLabel}</span>
               ) : null}

--- a/src/components/managed/managed.tsx
+++ b/src/components/managed/managed.tsx
@@ -1,0 +1,313 @@
+"use client"
+
+import { useCallback, useMemo } from "react"
+import Link from "next/link"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { FolderGit2, Plus } from "lucide-react"
+import CertIcon from "@/components/ui/cert-icon"
+import SegmentedControl from "@/components/ui/segmented-control"
+import Select from "@/components/ui/select"
+import EmptyState from "@/components/ui/empty-state"
+import Button from "@/components/ui/button"
+import LoadingSpinner from "@/components/ui/loading-spinner"
+import { usePageTitle } from "@/lib/navbar-context"
+import { useManagedAuthors } from "@/hooks/use-managed-authors"
+import { useManagedRecords, type ManagedItem } from "@/hooks/use-managed-records"
+import { resolveActivityImageUrl } from "@/lib/atproto/activity"
+import { parseAtUri } from "@/lib/atproto/activity-uri"
+import type { OwnerTag } from "@/lib/atproto/owner-tag"
+import type { OrgRole } from "@/lib/groups/types"
+
+/**
+ * The dedicated /managed hub: a single place that aggregates everything
+ * the viewer is responsible for — records authored by their personal
+ * account and by every group they own or admin — behind one focus
+ * filter.
+ *
+ * The focus selection lives in `?focus=` so a refresh / shared link
+ * keeps the same view. "Everything" is the default and stays bare in
+ * the URL; "You" selects the personal identity; any other value is a
+ * group DID. When a single group is focused, every row already shares
+ * the same owner, so the per-row "via {group}" provenance line is
+ * suppressed (it would be noise).
+ *
+ * Switch between a <SegmentedControl> (<=5 identities, fits a strip) and
+ * a <Select> dropdown (more than 5) so the filter never overflows.
+ */
+
+// Sentinel focus values. Everything is the bare default; You is the
+// personal identity. Any other value is a group DID.
+const FOCUS_EVERYTHING = "everything"
+const FOCUS_YOU = "you"
+
+// Above this many identities the segmented strip would overflow the
+// reading column, so fall back to a dropdown.
+const SEGMENTED_MAX_IDENTITIES = 5
+
+const ROLE_LABEL: Record<OrgRole, string> = {
+  owner: "Owner",
+  admin: "Admin",
+  member: "Member",
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null
+}
+
+/** Title for a merged row — projects carry title/name, activities title. */
+function itemTitle(item: ManagedItem): string {
+  if (item.kind === "project") {
+    return (
+      asString(item.record.value.title) ||
+      asString(item.record.value.name) ||
+      "Untitled project"
+    )
+  }
+  return item.record.value.title || "Untitled activity"
+}
+
+/** Detail href for a merged row, by kind. Falls back to "#" on a bad URI. */
+function itemHref(item: ManagedItem): string {
+  const parsed = parseAtUri(item.uri)
+  if (!parsed) return "#"
+  const seg = item.kind === "project" ? "project" : "activity"
+  return `/${seg}/${encodeURIComponent(parsed.did)}/${encodeURIComponent(parsed.rkey)}`
+}
+
+/** Thumbnail URL for a merged row, or null when the record has no image. */
+function itemImageUrl(item: ManagedItem): string | null {
+  const parsed = parseAtUri(item.uri)
+  const did = parsed?.did ?? item.owner.ownerDid
+  if (item.kind === "project") {
+    const raw =
+      (item.record.value as Record<string, unknown>).banner ??
+      item.record.value.image
+    return raw && did
+      ? resolveActivityImageUrl(
+          raw as Parameters<typeof resolveActivityImageUrl>[0],
+          did,
+        )
+      : null
+  }
+  return item.record.value.image
+    ? resolveActivityImageUrl(item.record.value.image, did)
+    : null
+}
+
+export default function Managed() {
+  usePageTitle("Managed")
+
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const { identities, isLoading: identitiesLoading } = useManagedAuthors()
+  const { items, isLoading, isLoadingMore, hasMore, loadMore } =
+    useManagedRecords()
+
+  // Resolve the focus from `?focus=`. Everything is the default and the
+  // only valid sentinel besides You + the known group DIDs; an unknown
+  // value (e.g. a stale group DID after losing admin) collapses to
+  // Everything rather than showing an empty list with no way out.
+  const focus = useMemo<string>(() => {
+    const raw = searchParams?.get("focus")
+    if (!raw || raw === FOCUS_EVERYTHING) return FOCUS_EVERYTHING
+    if (raw === FOCUS_YOU) return FOCUS_YOU
+    return identities.some((i) => i.did === raw) ? raw : FOCUS_EVERYTHING
+  }, [searchParams, identities])
+
+  const setFocus = useCallback(
+    (next: string) => {
+      const params = new URLSearchParams(searchParams?.toString() ?? "")
+      if (next === FOCUS_EVERYTHING) params.delete("focus")
+      else params.set("focus", next)
+      const qs = params.toString()
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+    },
+    [router, pathname, searchParams],
+  )
+
+  // Map a focus value to the DID it scopes to (null = Everything).
+  const focusedDid = useMemo<string | null>(() => {
+    if (focus === FOCUS_EVERYTHING) return null
+    if (focus === FOCUS_YOU) {
+      return identities.find((i) => i.kind === "personal")?.did ?? null
+    }
+    return focus
+  }, [focus, identities])
+
+  // Whether a single GROUP is focused — suppresses the per-row "via"
+  // line, since every visible row already shares that owner.
+  const singleGroupFocused = useMemo<boolean>(() => {
+    if (focus === FOCUS_EVERYTHING || focus === FOCUS_YOU) return false
+    return identities.some((i) => i.did === focus && i.kind === "group")
+  }, [focus, identities])
+
+  const visibleItems = useMemo<ManagedItem[]>(() => {
+    if (!focusedDid) return items
+    return items.filter((item) => item.owner.ownerDid === focusedDid)
+  }, [items, focusedDid])
+
+  // Build the filter options: [Everything, You, ...each group].
+  const filterOptions = useMemo(() => {
+    const opts: { value: string; label: string }[] = [
+      { value: FOCUS_EVERYTHING, label: "Everything" },
+    ]
+    for (const identity of identities) {
+      if (identity.kind === "personal") {
+        opts.push({ value: FOCUS_YOU, label: identity.label })
+      } else {
+        opts.push({ value: identity.did, label: identity.label })
+      }
+    }
+    return opts
+  }, [identities])
+
+  // <=5 identities → segmented strip; more → dropdown. `identities`
+  // always includes the personal account, so the option count is
+  // identities.length + 1 (the Everything option).
+  const useDropdown = identities.length > SEGMENTED_MAX_IDENTITIES
+
+  const showInitialSpinner = isLoading && items.length === 0
+
+  return (
+    <div className="managed-page">
+      <div className="managed-page__inner">
+        <header className="managed-page__head">
+          <div className="managed-page__heading">
+            <h1 className="managed-page__title">Managed</h1>
+            <p className="managed-page__sub">
+              Everything you&apos;re responsible for — yours and your groups&apos; —
+              in one place
+            </p>
+          </div>
+          <Link href="/create" className="managed-page__new">
+            <Plus size={16} aria-hidden="true" />
+            <span>New</span>
+          </Link>
+        </header>
+
+        <div className="managed-page__filter">
+          {identitiesLoading && identities.length === 0 ? null : useDropdown ? (
+            <Select
+              size="sm"
+              aria-label="Focus"
+              value={focus}
+              onChange={(e) => setFocus(e.target.value)}
+              className="managed-page__filter-select"
+            >
+              {filterOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </Select>
+          ) : (
+            <SegmentedControl
+              aria-label="Focus"
+              size="md"
+              value={focus}
+              onValueChange={setFocus}
+              options={filterOptions.map((opt) => ({
+                value: opt.value,
+                label: opt.label,
+              }))}
+            />
+          )}
+        </div>
+
+        {showInitialSpinner ? (
+          <div className="managed-page__loading">
+            <LoadingSpinner size="md" />
+          </div>
+        ) : visibleItems.length === 0 ? (
+          <EmptyState
+            icon={FolderGit2}
+            title="Nothing here yet"
+            description="Projects and activities you and your groups create will collect here."
+          >
+            <Link href="/create" className="managed-page__new">
+              <Plus size={16} aria-hidden="true" />
+              <span>New</span>
+            </Link>
+          </EmptyState>
+        ) : (
+          <>
+            <ul className="managed-list">
+              {visibleItems.map((item) => (
+                <ManagedRow
+                  key={item.uri}
+                  item={item}
+                  suppressVia={singleGroupFocused}
+                />
+              ))}
+            </ul>
+            {hasMore ? (
+              <div className="managed-page__more">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={loadMore}
+                  disabled={isLoadingMore}
+                >
+                  {isLoadingMore ? "Loading…" : "Load more"}
+                </Button>
+              </div>
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ManagedRow({
+  item,
+  suppressVia,
+}: {
+  item: ManagedItem
+  suppressVia: boolean
+}) {
+  const title = itemTitle(item)
+  const href = itemHref(item)
+  const imageUrl = itemImageUrl(item)
+  const Icon = item.kind === "project" ? FolderGit2 : CertIcon
+  const owner: OwnerTag = item.owner
+
+  // The "via {group}" provenance line only appears for group-owned rows
+  // in a mixed view. Personal rows ("You") and single-group-focused
+  // views never show it.
+  const showVia = !suppressVia && owner.kind === "group"
+  const roleLabel = owner.role ? ROLE_LABEL[owner.role] : null
+
+  return (
+    <li className="managed-list__item">
+      <Link href={href} className="managed-row">
+        <span className="managed-row__thumb">
+          {imageUrl ? (
+            /* eslint-disable-next-line @next/next/no-img-element */
+            <img src={imageUrl} alt="" loading="lazy" />
+          ) : (
+            <Icon
+              size={16}
+              strokeWidth={1.5}
+              aria-hidden
+              className="managed-row__thumb-icon"
+            />
+          )}
+        </span>
+        <span className="managed-row__body">
+          <span className="managed-row__title">{title}</span>
+          {showVia ? (
+            <span className="managed-row__via">
+              <span className="managed-row__via-label">via {owner.label}</span>
+              {roleLabel ? (
+                <span className="managed-row__via-role"> · {roleLabel}</span>
+              ) : null}
+            </span>
+          ) : null}
+        </span>
+      </Link>
+    </li>
+  )
+}

--- a/src/components/notifications/notification-row.tsx
+++ b/src/components/notifications/notification-row.tsx
@@ -13,8 +13,10 @@ import { truncateDid } from "@/lib/utils/did"
 import { getInitials } from "@/lib/utils/initials"
 import Avatar from "@/components/ui/avatar"
 import ResponseButtons from "@/components/badges/response-buttons"
+import ViaByline from "@/components/ui/via-byline"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useOrg } from "@/lib/groups/org-context"
+import type { Group, OrgRole } from "@/lib/groups/types"
 
 function reasonText(
   notification: Notification,
@@ -25,7 +27,8 @@ function reasonText(
   const actor = <strong>{isHandle ? `@${displayName}` : displayName}</strong>
   if (reason === "endorsement") {
     if (count > 1) {
-      return <>{actor} and {count - 1} others endorsed you</>
+      const others = count - 1
+      return <>{actor} and {others} {others === 1 ? "other" : "others"} endorsed you</>
     }
     return <>{actor} endorsed you</>
   }
@@ -35,14 +38,36 @@ function reasonText(
   return <>{actor} {reason}</>
 }
 
+/** Provenance for an aggregated notification owned by a group the viewer
+ *  manages — drives the "via {group}" byline. Omitted/null for personal
+ *  notifications and whenever a single group is already focused. */
+export interface NotificationVia {
+  group: Group
+  role?: OrgRole
+}
+
 interface NotificationRowProps {
   notification: Notification
   /** Snapshot of read state from when the page mounted, so the row
    *  styling stays stable even after mark-seen fires. */
   wasUnreadOnMount: boolean
+  /** When set, render a "via {group}" line under the notification text
+   *  (aggregated view, group-owned row). */
+  via?: NotificationVia | null
+  /** True when this notification belongs to a GROUP the viewer manages
+   *  (aggregated view). The endorsement accept/reject control is suppressed
+   *  for these rows: responding would act as the viewer's PERSONAL account
+   *  against an award made to the group — a cross-identity action this
+   *  read-aggregation phase deliberately doesn't allow. */
+  isGroupOwned?: boolean
 }
 
-export default function NotificationRow({ notification, wasUnreadOnMount }: NotificationRowProps) {
+export default function NotificationRow({
+  notification,
+  wasUnreadOnMount,
+  via = null,
+  isGroupOwned = false,
+}: NotificationRowProps) {
   const { did: ownerDid } = useAuth()
   // Notifications are the personal account's. While delegated (acting as a
   // group) the accept/reject control is hidden — responding to your personal
@@ -84,6 +109,13 @@ export default function NotificationRow({ notification, wasUnreadOnMount }: Noti
       </div>
       <div className="notification-row__body">
         <p className="notification-row__text">{reasonText(notification, displayName, hasHandle)}</p>
+        {via ? (
+          <ViaByline
+            group={via.group}
+            role={via.role}
+            className="notification-row__via"
+          />
+        ) : null}
         <time
           dateTime={notification.sortAt}
           title={absoluteTime}
@@ -123,7 +155,7 @@ export default function NotificationRow({ notification, wasUnreadOnMount }: Noti
   return (
     <div className={className}>
       {content}
-      {isBadgeAward && !activeOrg ? (
+      {isBadgeAward && !activeOrg && !isGroupOwned ? (
         <ResponseButtons
           awardUri={notification.latestRecordUri}
           awardCid={notification.latestRecordCid}

--- a/src/components/notifications/notification-row.tsx
+++ b/src/components/notifications/notification-row.tsx
@@ -109,13 +109,7 @@ export default function NotificationRow({
       </div>
       <div className="notification-row__body">
         <p className="notification-row__text">{reasonText(notification, displayName, hasHandle)}</p>
-        {via ? (
-          <ViaByline
-            group={via.group}
-            role={via.role}
-            className="notification-row__via"
-          />
-        ) : null}
+        {via ? <ViaByline group={via.group} role={via.role} /> : null}
         <time
           dateTime={notification.sortAt}
           title={absoluteTime}

--- a/src/components/profile/profile-followers.tsx
+++ b/src/components/profile/profile-followers.tsx
@@ -73,16 +73,27 @@ const FOLLOWING_SORT_OPTIONS: { key: SortKey; label: string }[] = [
 export default function ProfileFollowers({ did }: ProfileFollowersProps) {
   const followers = useFollowers(did)
   const following = useFollowing(did)
-  // Only the profile owner can revoke their own follows. We compare
-  // the signed-in viewer's DID to the profile's DID to decide
-  // whether the per-card × renders on the Following sub-tab.
+  // Only the profile owner (or a group admin operating the group whose
+  // profile this is) can revoke its follows. The × renders on the
+  // Following sub-tab accordingly.
   const { did: viewerDid } = useAuth()
-  // When acting as a group, follow deletes must route to the group's
-  // repo via the BFF. The unfollow × only renders on the own-profile
-  // Following list (which, when delegating, is the group's profile), so
-  // the records being revoked live in the group's repo.
+  // A follow delete writes back into the repo the record LIVES in — the
+  // profile being viewed (`did`). `activeOrg` is read ONLY to gate the
+  // group case (am I operating THIS group with owner/admin?), never to
+  // pick a different write target than the record's own repo. This
+  // avoids silently routing a personal unfollow (own profile) to a group
+  // repo just because an org is active.
   const { activeOrg } = useOrg()
   const isOwnProfile = !!viewerDid && viewerDid === did
+  const canRevokeAsGroup =
+    !!activeOrg &&
+    activeOrg.groupDid === did &&
+    (activeOrg.role === "owner" || activeOrg.role === "admin")
+  // Eligible to unfollow when this is the viewer's own profile or a
+  // group they operate with owner/admin. Write target = the record's
+  // own repo: `did` for the group case (BFF), undefined for own (XRPC).
+  const canRevoke = isOwnProfile || canRevokeAsGroup
+  const revokeTargetDid = canRevokeAsGroup ? did : undefined
 
   // Sub-tab is read from the URL (`?sub=followers|following`) so the
   // sidebar counts can deep-link straight into the right list.
@@ -271,9 +282,9 @@ export default function ProfileFollowers({ did }: ProfileFollowersProps) {
           query={query}
           sort={sort}
           names={names}
-          canUnfollow={isOwnProfile}
+          canUnfollow={canRevoke}
           viewerDid={viewerDid}
-          targetDid={activeOrg?.groupDid}
+          targetDid={revokeTargetDid}
           onAfterUnfollow={() => following.refetch()}
         />
       </TabPanel>

--- a/src/components/profile/profile-managed-bridge.tsx
+++ b/src/components/profile/profile-managed-bridge.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import Link from "next/link"
+import { ArrowRight } from "lucide-react"
+import Banner from "@/components/ui/banner"
+import { useManagesAnyGroup } from "@/lib/groups/managed"
+import { useManagedProjects } from "@/hooks/use-managed-projects"
+
+const DISMISS_KEY = "certified:profile-managed-bridge:dismissed"
+
+interface ProfileManagedBridgeProps {
+  /** Only the viewer's OWN profile shows the bridge — a foreign profile
+   *  is one public identity and never advertises the viewer's groups. */
+  isOwnProfile: boolean
+}
+
+/**
+ * Own-profile bridge to the Managed surface.
+ *
+ * The public profile stays single-identity: group-owned projects are
+ * deliberately NOT folded into the profile's Projects tab. Instead, on
+ * the viewer's own profile we surface a dismissible link out — "You also
+ * manage N projects via your groups → View in Managed" — so the
+ * aggregated view is one click away without diluting the public profile.
+ *
+ * Gated three ways:
+ *   - own profile only (foreign profiles never see it),
+ *   - the viewer owns/admins at least one group, and
+ *   - that aggregate actually contains group-owned projects (N > 0).
+ *
+ * Dismissal persists for the browser session (sessionStorage) so the
+ * banner doesn't nag across tab navigations, while still returning on a
+ * fresh session.
+ */
+export default function ProfileManagedBridge({
+  isOwnProfile,
+}: ProfileManagedBridgeProps) {
+  const managesAnyGroup = useManagesAnyGroup()
+  // Only pay for the aggregation when the cheap gates already pass.
+  const eligible = isOwnProfile && managesAnyGroup
+
+  const { items, isLoading } = useManagedProjects()
+
+  // Count projects owned by a group (not the viewer's personal account).
+  const groupProjectCount = useMemo(
+    () => items.filter((it) => it.owner.kind === "group").length,
+    [items],
+  )
+
+  // Dismiss state is session-scoped. The lazy initialiser returns false
+  // during SSR (no `window`) and reads sessionStorage on the client's
+  // first render. This is hydration-safe: the banner is also gated on
+  // `isLoading` (the managed aggregation is still loading on first paint,
+  // server AND client), so both render nothing until data lands — well
+  // after hydration — by which point the dismiss flag is already settled.
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false
+    try {
+      return sessionStorage.getItem(DISMISS_KEY) === "1"
+    } catch {
+      // sessionStorage can throw in private-mode / sandboxed contexts —
+      // treat as "not dismissed" and carry on.
+      return false
+    }
+  })
+
+  const handleDismiss = () => {
+    setDismissed(true)
+    try {
+      sessionStorage.setItem(DISMISS_KEY, "1")
+    } catch {
+      // Non-fatal — the banner still hides for this render.
+    }
+  }
+
+  if (!eligible || dismissed || isLoading || groupProjectCount === 0) {
+    return null
+  }
+
+  const noun = groupProjectCount === 1 ? "project" : "projects"
+
+  return (
+    <Banner
+      variant="info"
+      icon={false}
+      onDismiss={handleDismiss}
+      dismissLabel="Dismiss"
+      className="profile-managed-bridge"
+    >
+      <span className="profile-managed-bridge__text">
+        You also manage {groupProjectCount} {noun} via your groups.
+      </span>{" "}
+      <Link href="/managed" className="profile-managed-bridge__link">
+        View in Managed
+        <ArrowRight size={14} strokeWidth={1.75} aria-hidden />
+      </Link>
+    </Banner>
+  )
+}

--- a/src/components/profile/profile-overview.tsx
+++ b/src/components/profile/profile-overview.tsx
@@ -8,6 +8,7 @@ import Avatar from "@/components/ui/avatar"
 import { buildAvatarUrlFromCid } from "@/lib/atproto/profile"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import BannerUpload from "@/components/profile/banner-upload"
+import ProfileManagedBridge from "@/components/profile/profile-managed-bridge"
 import Map from "@/components/map/map-dynamic"
 import LeafletDocument from "@/components/leaflet/leaflet-document"
 import {
@@ -22,7 +23,7 @@ import { useGivenEndorsements } from "@/hooks/use-endorsements"
 import { useUserIndexerActivities } from "@/hooks/use-user-indexer-activities"
 import { useUserProjects } from "@/hooks/use-user-projects"
 import { useAuthorInfo } from "@/hooks/use-author-info"
-import { activityDetailHref } from "@/lib/atproto/activity-uri"
+import { activityDetailHref, parseAtUri } from "@/lib/atproto/activity-uri"
 import { resolveActivityImageUrl } from "@/lib/atproto/activity"
 import type { ActivityRecord, ClaimActivity } from "@/lib/atproto/activity-types"
 import type { CertifiedProfile } from "@/lib/atproto/types"
@@ -34,6 +35,10 @@ interface ProfileOverviewProps {
   did: string
   profile: CertifiedProfile | null
   basePath: string
+  /** True when the viewer is looking at their OWN profile. Gates the
+   *  dismissible Managed bridge (group-owned records aggregation link).
+   *  The public profile itself stays single-identity regardless. */
+  isOwnProfile?: boolean
   /** True when the page is in inline-edit mode. Only sent by the page
    *  when the viewer can edit their own profile — the overview itself
    *  doesn't gate on viewer identity. */
@@ -81,6 +86,7 @@ export default function ProfileOverview({
   did,
   profile,
   basePath,
+  isOwnProfile = false,
   isEditing = false,
   drafts,
   onDraftChange,
@@ -156,6 +162,11 @@ export default function ProfileOverview({
 
   return (
     <div className="profile-overview">
+      {/* Own-profile bridge to the Managed surface. Self-gating: renders
+          nothing for foreign profiles or when there are no group-owned
+          projects. Hidden in edit mode so it doesn't crowd the editor. */}
+      {!isEditing ? <ProfileManagedBridge isOwnProfile={isOwnProfile} /> : null}
+
       {isEditing ? (
         <div className="profile-overview__banner profile-overview__banner--editing profile-overview__banner-edit-slot">
           <BannerUpload
@@ -418,11 +429,19 @@ export default function ProfileOverview({
         ) : (
           <ul className="profile-overview__activity-list">
             {previewActivities.map((a) => {
-              const href = activityDetailHref(did, uriToRkey(a.uri))
+              // Resolve each record against its OWN owner DID (the repo
+              // in its AT-URI), not the profile's `did`. The digest mixes
+              // created + contributed activities, and a contributed cert
+              // lives in another repo — using the profile DID there would
+              // build a broken link and resolve the thumbnail blob against
+              // the wrong PDS. Fall back to the profile DID only if the
+              // URI somehow won't parse.
+              const ownerDid = parseAtUri(a.uri)?.did ?? did
+              const href = activityDetailHref(ownerDid, uriToRkey(a.uri))
               return (
                 <li key={a.uri} className="profile-overview__activity-item">
                   <Link href={href} className="profile-overview__activity-link">
-                    <ActivityThumb value={a.value} did={did} />
+                    <ActivityThumb value={a.value} did={ownerDid} />
                     <span className="profile-overview__activity-text">
                       <span className="profile-overview__activity-title">
                         {a.value.title || "Untitled activity"}

--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -29,7 +29,6 @@ import { useProfilePds } from "@/hooks/use-profile-pds"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useSession } from "@/hooks/use-session"
 import { useOrg } from "@/lib/groups/org-context"
-import type { Group } from "@/lib/groups/types"
 import { useFollowing } from "@/hooks/use-following"
 import { useFollowers } from "@/hooks/use-followers"
 import { useGivenEndorsements } from "@/hooks/use-endorsements"
@@ -44,6 +43,11 @@ import EndorseReasonModal, {
   type EndorseReasonActingAs,
 } from "@/components/profile/endorse-reason-modal"
 import { runEndorseReasonConfirm } from "@/components/profile/endorse-reason-confirm"
+import PostingAs, {
+  PostingAsConfirm,
+} from "@/components/create/posting-as"
+import { usePostingIdentity } from "@/hooks/use-posting-identity"
+import type { PostingIdentity } from "@/lib/groups/posting-identity"
 import { createFollow, deleteFollow, listFollowing } from "@/lib/atproto/follow"
 import {
   createEndorsementAward,
@@ -179,21 +183,29 @@ export default function ProfileSidebar({
   // own profile (no Follow button to render in either case).
   const { did: viewerDid, isAuthenticated } = useAuth()
   const { handle: operatorHandle } = useSession()
-  // Acting-as-group context. With the group BFF write paths in place
-  // (createFollow / createEndorsementAward / deleteFollow all accept a
-  // `targetDid` that routes the write to the group's repo), Follow /
-  // Endorse now act AS the active group: the operator authors the record
-  // on the group's behalf instead of their personal repo. The DID whose
-  // follow / given-endorsement set drives button state therefore tracks
-  // the group when one is active, and the viewer otherwise.
+  // Acting-as-group context is READ-SCOPE ONLY here. `activeOrg` decides
+  // whose follow / given-endorsement set the button READS to render its
+  // Follow/Following + Endorse/Endorsed state, so the strip reflects the
+  // group's relationships while you're operating it. It does NOT decide
+  // who the Follow / Endorse write is authored AS — that comes from a
+  // per-action posting identity (default You), threaded into the write
+  // helpers' `targetDid` seam separately. Splitting the two means a
+  // viewer operating a group sees the group's state but still writes as
+  // themselves unless they explicitly pick the group in the action.
   const { activeOrg } = useOrg()
   const isOwnProfile = !!viewerDid && viewerDid === did
-  // The repo we're acting as — the active group, or the viewer when
-  // personal. Drives the Follow / Endorse button state below.
+  // READ-STATE repo — the active group (when operating one), else the
+  // viewer. Drives the displayed Follow / Endorse button state below.
+  // NOT a write target.
   const actingDid = activeOrg?.groupDid ?? viewerDid
-  // The acting repo's "following" set. Note this is keyed to `actingDid`
-  // (the group when delegating) — NOT the foreign profile — so the
-  // Follow button reflects whether the GROUP already follows the subject.
+  // Per-action WRITE identity for the social actions on this profile.
+  // Defaults to You; the Follow control offers an inline "Follow as
+  // <group>" switch and Endorse routes a group choice through a
+  // high-stakes confirm. Never seeded from `activeOrg`.
+  const posting = usePostingIdentity()
+  // The acting repo's "following" set. Keyed to `actingDid` (the group
+  // when operating one) — NOT the foreign profile — so the Follow button
+  // reflects whether the READ-SCOPE repo already follows the subject.
   const viewerFollowing = useFollowing(
     isAuthenticated && !isOwnProfile ? actingDid : null,
   )
@@ -294,29 +306,29 @@ export default function ProfileSidebar({
             <FollowButton
               viewerDid={viewerDid}
               subjectDid={did}
-              targetDid={activeOrg?.groupDid}
+              postingOptions={posting.options}
               isFollowing={viewerFollowing.subjects.has(did)}
               isLoading={viewerFollowing.isLoading}
-              onFollowed={(uri, cid) => {
-                // Both surfaces update instantly: the acting repo's
-                // "following" set gains the subject; the foreign
-                // profile's follower list (count + grid) gains the
-                // acting repo (group when delegating, viewer otherwise).
-                // Real server-side data refreshes on the next tab-mount
-                // / focus-revalidate.
+              onFollowed={(uri, cid, writerDid) => {
+                // Optimistic update reflects the WRITE identity (the
+                // per-action posting choice), not the read-scope repo:
+                // the read-state set still keys on `actingDid`, while the
+                // foreign profile's follower list gains whoever actually
+                // authored the follow. Real server data refreshes on the
+                // next tab-mount / focus-revalidate.
                 viewerFollowing.addFollow(did, uri, cid)
-                viewedFollowers.addFollower(actingDid, uri, cid)
+                viewedFollowers.addFollower(writerDid, uri, cid)
               }}
-              onUnfollowed={() => {
+              onUnfollowed={(writerDid) => {
                 viewerFollowing.removeFollow(did)
-                viewedFollowers.removeFollower(actingDid)
+                viewedFollowers.removeFollower(writerDid)
               }}
             />
             <EndorseButton
               viewerDid={viewerDid}
               subjectDid={did}
               actingDid={actingDid}
-              activeOrg={activeOrg}
+              postingOptions={posting.options}
               operatorHandle={operatorHandle}
             />
             {/* Endorsement lists are personal-only — the Add-to-list
@@ -730,52 +742,63 @@ function AvatarEditOverlay({ onFile, isUploading, hasPending }: AvatarEditOverla
 interface FollowButtonProps {
   viewerDid: string
   subjectDid: string
-  /** When set (acting-as-group), the follow write routes to the group's
-   *  repo via the BFF instead of the viewer's personal PDS. */
-  targetDid?: string
+  /** Per-action posting options (You first, then writable groups). The
+   *  Follow write target is chosen here, defaulting to You — never
+   *  inherited from the active read-scope org. A single option (You)
+   *  renders no picker. */
+  postingOptions: PostingIdentity[]
   isFollowing: boolean
   isLoading: boolean
-  /** Fired after a successful createFollow with the new record's
-   *  strong ref. Caller does the optimistic state update on both
-   *  the viewer's "following" hook and the subject's "followers"
-   *  hook. */
-  onFollowed: (uri: string, cid: string) => void
-  /** Fired after a successful deleteFollow. Caller does the
-   *  optimistic state update mirroring `onFollowed`. */
-  onUnfollowed: () => void
+  /** Fired after a successful createFollow with the new record's strong
+   *  ref and the DID it was authored as (the chosen write identity). */
+  onFollowed: (uri: string, cid: string, writerDid: string) => void
+  /** Fired after a successful deleteFollow with the DID the record was
+   *  authored as. */
+  onUnfollowed: (writerDid: string) => void
 }
 
 function FollowButton({
   viewerDid,
   subjectDid,
-  targetDid,
+  postingOptions,
   isFollowing,
   isLoading,
   onFollowed,
   onUnfollowed,
 }: FollowButtonProps) {
   const [isWriting, setIsWriting] = useState(false)
+  // Per-action write identity for THIS Follow. Default You; the picker
+  // below lets the operator opt into "Follow as <group>". Follow is
+  // low-stakes, so there's no confirm gate — just the inline choice.
+  const [posting, setPosting] = useState<PostingIdentity>(
+    () => postingOptions[0] ?? { did: viewerDid, kind: "personal", label: "You" },
+  )
   const disabled = isLoading || isWriting
-  // The repo the follow record lives in — the group when delegating, the
-  // viewer otherwise. Drives both the rkey lookup (list the right repo)
-  // and which repo's follows we delete from.
+  // Group writes route to the group's repo via the BFF (`targetDid`);
+  // personal writes leave `targetDid` undefined → the viewer's own PDS.
+  const targetDid = posting.kind === "group" ? posting.did : undefined
+  // The repo the follow record lives in — the chosen write identity's
+  // repo. Drives the rkey lookup + which repo's follows we delete from.
   const actingRepo = targetDid ?? viewerDid
+  // Only surface the "Follow as" picker when there's more than one
+  // option (i.e. the viewer admins at least one group).
+  const showPicker = postingOptions.length > 1
 
   const handleClick = async () => {
     if (disabled) return
     const next = !isFollowing
+    const writerDid = actingRepo
     setIsWriting(true)
     try {
       if (next) {
         const result = await createFollow(viewerDid, subjectDid, { targetDid })
-        // Hand the new ref to the parent so the acting repo's following
-        // set and the subject's follower list update instantly.
-        onFollowed(result.uri, result.cid)
+        // Hand the new ref + the write identity to the parent so the
+        // following set and the subject's follower list update instantly.
+        onFollowed(result.uri, result.cid, writerDid)
       } else {
-        // Unfollow path: walk the acting repo's follows to find the rkey
-        // targeting this subject. Fetched fresh here to handle the
+        // Unfollow path: walk the chosen write repo's follows to find the
+        // rkey targeting this subject. Fetched fresh here to handle the
         // duplicate-follow edge case (delete the most recent record).
-        // When acting as a group, the records live in the group's repo.
         const { records } = await listFollowing(actingRepo, undefined, {
           noCache: true,
         })
@@ -787,7 +810,7 @@ function FollowButton({
         if (match) {
           await deleteFollow(viewerDid, match.rkey, { targetDid })
         }
-        onUnfollowed()
+        onUnfollowed(writerDid)
       }
     } catch (err) {
       console.error("Follow toggle failed:", err)
@@ -797,20 +820,31 @@ function FollowButton({
   }
 
   return (
-    <Button
-      variant={isFollowing ? "secondary" : "primary"}
-      size="sm"
-      onClick={handleClick}
-      disabled={disabled}
-      aria-pressed={isFollowing}
-    >
-      {isFollowing ? (
-        <Check size={14} strokeWidth={1.75} aria-hidden />
-      ) : (
-        <UserPlus size={14} strokeWidth={1.75} aria-hidden />
-      )}
-      {isFollowing ? "Following" : "Follow"}
-    </Button>
+    <div className="flex flex-col gap-1.5 items-start">
+      <Button
+        variant={isFollowing ? "secondary" : "primary"}
+        size="sm"
+        onClick={handleClick}
+        disabled={disabled}
+        aria-pressed={isFollowing}
+      >
+        {isFollowing ? (
+          <Check size={14} strokeWidth={1.75} aria-hidden />
+        ) : (
+          <UserPlus size={14} strokeWidth={1.75} aria-hidden />
+        )}
+        {isFollowing ? "Following" : "Follow"}
+      </Button>
+      {showPicker && !isFollowing ? (
+        <PostingAs
+          value={posting}
+          onChange={setPosting}
+          options={postingOptions}
+          size="sm"
+          aria-label="Follow as"
+        />
+      ) : null}
+    </div>
   )
 }
 
@@ -846,16 +880,18 @@ function formatGraphCount(
 interface EndorseButtonProps {
   viewerDid: string
   subjectDid: string
-  /** The DID the endorsement is authored AS — the active group when
-   *  delegating, the viewer otherwise. Drives the given-endorsements
-   *  set that decides Endorse / Endorsed and the revoke rkey lookup. */
+  /** READ-STATE repo — the active group (when operating one) or the
+   *  viewer. Drives the given-endorsements set that decides the
+   *  displayed Endorse / Endorsed state and the revoke rkey lookup. NOT
+   *  the write target — that comes from the per-action posting picker. */
   actingDid: string
-  /** The active group, when the viewer is acting as one. `null` for the
-   *  personal path. Used to route the write to the group's repo and to
-   *  name the parties in the reason modal. */
-  activeOrg: Group | null
+  /** Per-action posting options (You first, then writable groups). The
+   *  endorsement write target is chosen here, defaulting to You. Endorse
+   *  is HIGH-STAKES, so a group choice routes through a
+   *  `<PostingAsConfirm>` gate naming endorser / operator / subject. */
+  postingOptions: PostingIdentity[]
   /** The signed-in operator's handle, surfaced in the delegation header
-   *  of the reason modal. */
+   *  of the reason modal + the high-stakes confirm. */
   operatorHandle: string | null
 }
 
@@ -863,21 +899,41 @@ function EndorseButton({
   viewerDid,
   subjectDid,
   actingDid,
-  activeOrg,
+  postingOptions,
   operatorHandle,
 }: EndorseButtonProps) {
-  // Acting-as-group flag + the group DID the write routes to.
-  const targetDid = activeOrg?.groupDid
+  // Per-action WRITE identity for this endorsement. Default You; the
+  // picker lets the operator opt into a group, which then routes through
+  // the high-stakes confirm before committing. Never seeded from the
+  // active read-scope org.
+  const [posting, setPosting] = useState<PostingIdentity>(
+    () => postingOptions[0] ?? { did: viewerDid, kind: "personal", label: "You" },
+  )
+  const postingIsGroup = posting.kind === "group"
+  // The group DID the write routes to (undefined when posting as You →
+  // the viewer's own repo via the personal path).
+  const targetDid = postingIsGroup ? posting.did : undefined
+  // READ-STATE set — the active group's given-endorsements when
+  // operating one, the viewer's otherwise. Decides Endorse/Endorsed.
   const ownGiven = useGivenEndorsements(actingDid)
   // Endorsement lists are personal-only — never load or surface them
-  // while acting as a group (the reason modal hides the picker too).
-  const ownLists = useEndorsementLists(activeOrg ? null : viewerDid)
+  // when the WRITE identity is a group (the reason modal hides the
+  // picker too).
+  const ownLists = useEndorsementLists(postingIsGroup ? null : viewerDid)
   const { info: subjectInfo } = useAuthorInfo(subjectDid)
   const subjectLabel =
     subjectInfo?.displayName || subjectInfo?.handle || subjectDid
   const [isWriting, setIsWriting] = useState(false)
   const [confirmRevoke, setConfirmRevoke] = useState(false)
   const [reasonOpen, setReasonOpen] = useState(false)
+  // Pending {note, listRkey} captured by the reason modal, held while the
+  // high-stakes <PostingAsConfirm> is shown for a group-authored award.
+  const [pendingAward, setPendingAward] = useState<{
+    note: string
+    listRkey: string | null
+  } | null>(null)
+  // Only show the "Endorse as" picker when there's more than one option.
+  const showPicker = postingOptions.length > 1
   // Optimistic flip — mirrors FollowButton. The hook's `endorsements`
   // refetch may lag the PDS write by a beat, so we override locally
   // until the parent value catches up.
@@ -908,7 +964,11 @@ function EndorseButton({
     setReasonOpen(true)
   }
 
-  const handleReasonConfirm = async (note: string, listRkey: string | null) => {
+  // The actual award write — issued AS the chosen posting identity. The
+  // issuer recorded in the optimistic received-overlay is the WRITE
+  // identity (`posting.did`), so the subject's "Endorsed by N" reflects
+  // who actually authored the award.
+  const runAwardWrite = async (note: string, listRkey: string | null) => {
     setOptimistic(true)
     setIsWriting(true)
     try {
@@ -926,12 +986,12 @@ function EndorseButton({
         // received-endorsements overlay so the subject's "Endorsed by N"
         // counter and the Endorsements tab reflect it immediately, ahead
         // of the 5-min scan cache / indexer catching up. The issuer is
-        // the acting repo (the group when delegating).
+        // the chosen WRITE identity (the group when posting as one).
         onAwardCreated: (award) =>
           addOptimisticReceivedEndorsement(subjectDid, {
             uri: award.uri,
             cid: award.cid,
-            issuerDid: actingDid,
+            issuerDid: posting.did,
             createdAt: new Date().toISOString(),
             note: note || undefined,
             responseState: null,
@@ -941,14 +1001,41 @@ function EndorseButton({
         refetchLists: () => ownLists.refetch(),
         setOptimistic,
       })
-      setReasonOpen(false)
-    } catch (err) {
-      // The optimistic flag is managed inside the orchestrator: cleared
-      // on an award failure, kept on a list-append failure. Just rethrow
-      // so the modal surfaces the error and stays open.
-      throw err
     } finally {
       setIsWriting(false)
+    }
+  }
+
+  // Reason-modal confirm. For a personal (You) endorse this writes
+  // immediately; for a GROUP-authored endorse (high-stakes) it stashes
+  // the note and hands off to the <PostingAsConfirm> gate, which spells
+  // out endorser / operator / subject before the irreversible-feeling,
+  // reputation-bearing record lands under the group's identity.
+  const handleReasonConfirm = async (note: string, listRkey: string | null) => {
+    if (postingIsGroup) {
+      setPendingAward({ note, listRkey })
+      setReasonOpen(false)
+      return
+    }
+    try {
+      await runAwardWrite(note, listRkey)
+      setReasonOpen(false)
+    } catch (err) {
+      // Optimistic flag managed inside the orchestrator. Rethrow so the
+      // modal surfaces the error and stays open.
+      throw err
+    }
+  }
+
+  // High-stakes confirm → commit the stashed group-authored award.
+  const handlePostingConfirm = async () => {
+    if (!pendingAward) return
+    try {
+      await runAwardWrite(pendingAward.note, pendingAward.listRkey)
+      setPendingAward(null)
+    } catch (err) {
+      console.error("Endorse-as-group failed:", err)
+      // Keep the confirm open so the operator can retry / cancel.
     }
   }
 
@@ -969,34 +1056,49 @@ function EndorseButton({
     }
   }
 
-  // Delegation naming for the reason modal — names the group, the
-  // operator, and the subject when acting as a group. `null` on the
-  // personal path leaves the modal in its default single-party shape.
-  const actingAs: EndorseReasonActingAs | undefined = activeOrg
+  // Delegation naming for the reason modal — names the chosen group, the
+  // operator, and the subject when the WRITE identity is a group.
+  // `undefined` on the personal (You) path leaves the modal in its
+  // default single-party shape. Derived from the per-action posting
+  // choice, NOT the active read-scope org.
+  const actingAs: EndorseReasonActingAs | undefined = postingIsGroup
     ? {
-        orgName: activeOrg.displayName || activeOrg.handle,
-        orgHandle: activeOrg.handle,
+        orgName: posting.label,
+        orgHandle: posting.handle ?? "",
         operatorHandle: operatorHandle ?? "you",
-        operatorRole: activeOrg.role,
+        // Group posting options always carry the viewer's role; fall back
+        // defensively so the type stays total.
+        operatorRole: posting.role ?? "admin",
       }
     : undefined
 
   return (
     <>
-      <Button
-        variant={isEndorsed ? "secondary" : "primary"}
-        size="sm"
-        onClick={isEndorsed ? () => setConfirmRevoke(true) : handleEndorseClick}
-        disabled={disabled}
-        aria-pressed={isEndorsed}
-      >
-        {isEndorsed ? (
-          <Check size={14} strokeWidth={1.75} aria-hidden />
-        ) : (
-          <ThumbsUp size={14} strokeWidth={1.75} aria-hidden />
-        )}
-        {isEndorsed ? "Endorsed" : "Endorse"}
-      </Button>
+      <div className="flex flex-col gap-1.5 items-start">
+        <Button
+          variant={isEndorsed ? "secondary" : "primary"}
+          size="sm"
+          onClick={isEndorsed ? () => setConfirmRevoke(true) : handleEndorseClick}
+          disabled={disabled}
+          aria-pressed={isEndorsed}
+        >
+          {isEndorsed ? (
+            <Check size={14} strokeWidth={1.75} aria-hidden />
+          ) : (
+            <ThumbsUp size={14} strokeWidth={1.75} aria-hidden />
+          )}
+          {isEndorsed ? "Endorsed" : "Endorse"}
+        </Button>
+        {showPicker && !isEndorsed ? (
+          <PostingAs
+            value={posting}
+            onChange={setPosting}
+            options={postingOptions}
+            size="sm"
+            aria-label="Endorse as"
+          />
+        ) : null}
+      </div>
       {reasonOpen ? (
         <EndorseReasonModal
           subjectLabel={subjectLabel}
@@ -1004,6 +1106,28 @@ function EndorseButton({
           lists={ownLists.lists.map((l) => ({ rkey: l.rkey, title: l.title }))}
           onConfirm={handleReasonConfirm}
           onClose={() => setReasonOpen(false)}
+        />
+      ) : null}
+      {pendingAward ? (
+        <PostingAsConfirm
+          endorser={posting}
+          operator={{
+            label: operatorHandle ?? "you",
+            handle: operatorHandle ?? undefined,
+            role: posting.role,
+          }}
+          subject={subjectLabel}
+          actionLabel="endorse"
+          confirmLabel="Endorse"
+          isConfirming={isWriting}
+          onConfirm={handlePostingConfirm}
+          onCancel={() => {
+            if (!isWriting) {
+              // Bail out of the group-authored endorse without writing.
+              setPendingAward(null)
+              setOptimistic(null)
+            }
+          }}
         />
       ) : null}
       {confirmRevoke ? (

--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -770,9 +770,15 @@ function FollowButton({
   // Per-action write identity for THIS Follow. Default You; the picker
   // below lets the operator opt into "Follow as <group>". Follow is
   // low-stakes, so there's no confirm gate — just the inline choice.
-  const [posting, setPosting] = useState<PostingIdentity>(
-    () => postingOptions[0] ?? { did: viewerDid, kind: "personal", label: "You" },
-  )
+  //
+  // Store only the selected DID and derive the identity object each render,
+  // so the picker always shows the FRESHEST option (handle/avatar resolve
+  // asynchronously — seeding the whole object once would pin a stale copy).
+  const [selectedDid, setSelectedDid] = useState<string | null>(null)
+  const posting: PostingIdentity =
+    postingOptions.find((o) => o.did === selectedDid) ??
+    postingOptions[0] ?? { did: viewerDid, kind: "personal", label: "You" }
+  const setPosting = (next: PostingIdentity) => setSelectedDid(next.did)
   const disabled = isLoading || isWriting
   // Group writes route to the group's repo via the BFF (`targetDid`);
   // personal writes leave `targetDid` undefined → the viewer's own PDS.
@@ -905,10 +911,13 @@ function EndorseButton({
   // Per-action WRITE identity for this endorsement. Default You; the
   // picker lets the operator opt into a group, which then routes through
   // the high-stakes confirm before committing. Never seeded from the
-  // active read-scope org.
-  const [posting, setPosting] = useState<PostingIdentity>(
-    () => postingOptions[0] ?? { did: viewerDid, kind: "personal", label: "You" },
-  )
+  // active read-scope org. Store only the selected DID and derive the
+  // identity each render so the picker shows the freshest resolved option.
+  const [selectedDid, setSelectedDid] = useState<string | null>(null)
+  const posting: PostingIdentity =
+    postingOptions.find((o) => o.did === selectedDid) ??
+    postingOptions[0] ?? { did: viewerDid, kind: "personal", label: "You" }
+  const setPosting = (next: PostingIdentity) => setSelectedDid(next.did)
   const postingIsGroup = posting.kind === "group"
   // The group DID the write routes to (undefined when posting as You →
   // the viewer's own repo via the personal path).

--- a/src/components/ui/via-byline.tsx
+++ b/src/components/ui/via-byline.tsx
@@ -30,20 +30,18 @@ export default function ViaByline({ group, role, className = "" }: ViaBylineProp
   const initials = getInitials(group.displayName ?? group.handle, group.groupDid)
 
   return (
-    <span
-      className={`via-byline${className ? ` ${className}` : ""}`}
-      // Spelled out for assistive tech — the visual avatar is decorative.
-      aria-label={`via ${name}${role ? ` (${role})` : ""}`}
-    >
-      <span className="via-byline__label" aria-hidden="true">
-        via
-      </span>
+    // The visible "via {name}" text IS the accessible name — read naturally
+    // by assistive tech. A bare aria-label on a roleless span isn't reliably
+    // announced, so we let the real text carry the meaning and only hide the
+    // decorative avatar. The role (when shown) is appended sr-only so screen
+    // readers get "via {name}, {role}" without changing the compact visual.
+    <span className={`via-byline${className ? ` ${className}` : ""}`}>
+      <span className="via-byline__label">via</span>
       <span className="via-byline__avatar" aria-hidden="true">
         <Avatar size="sm" src={group.avatarUrl} alt="" fallbackInitials={initials} />
       </span>
-      <span className="via-byline__name" aria-hidden="true">
-        {name}
-      </span>
+      <span className="via-byline__name">{name}</span>
+      {role ? <span className="sr-only">, {role}</span> : null}
     </span>
   )
 }

--- a/src/components/ui/via-byline.tsx
+++ b/src/components/ui/via-byline.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import Avatar from "@/components/ui/avatar"
+import { getInitials } from "@/lib/utils/initials"
+import type { Group, OrgRole } from "@/lib/groups/types"
+
+export interface ViaBylineProps {
+  /** The owning group whose name + avatar the byline surfaces. */
+  group: Group
+  /** The viewer's role on the group, if shown alongside the name. */
+  role?: OrgRole
+  className?: string
+}
+
+/**
+ * Compact "via {group}" provenance line for dense aggregated rows.
+ *
+ * Unlike the 3-line {@link IdentityRow} (avatar + name + @handle), this
+ * is a single muted line — a 14px group avatar followed by the group's
+ * name — sized to tuck under a list-row label without changing the
+ * row's vertical rhythm much. Used on Home's "My projects" / "My
+ * activities" rows to mark records owned by a group rather than the
+ * viewer's personal account.
+ *
+ * Presentation-only and token-correct; the avatar's own border + the
+ * `--fg-muted` text both flip with the theme.
+ */
+export default function ViaByline({ group, role, className = "" }: ViaBylineProps) {
+  const name = group.displayName || group.handle || "Group"
+  const initials = getInitials(group.displayName ?? group.handle, group.groupDid)
+
+  return (
+    <span
+      className={`via-byline${className ? ` ${className}` : ""}`}
+      // Spelled out for assistive tech — the visual avatar is decorative.
+      aria-label={`via ${name}${role ? ` (${role})` : ""}`}
+    >
+      <span className="via-byline__label" aria-hidden="true">
+        via
+      </span>
+      <span className="via-byline__avatar" aria-hidden="true">
+        <Avatar size="sm" src={group.avatarUrl} alt="" fallbackInitials={initials} />
+      </span>
+      <span className="via-byline__name" aria-hidden="true">
+        {name}
+      </span>
+    </span>
+  )
+}

--- a/src/hooks/__tests__/use-managed-records-author-set.test.tsx
+++ b/src/hooks/__tests__/use-managed-records-author-set.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, cleanup } from "@testing-library/react"
+import type { Group, OrgRole } from "@/lib/groups/types"
+
+// Controllable mocks for the two context hooks the author-set derivation
+// reads from. Each test sets `mockDid` / `mockGroups` before rendering.
+let mockDid: string | null = "did:plc:viewer"
+let mockGroups: Group[] = []
+let mockAuthLoading = false
+let mockOrgLoading = false
+
+vi.mock("@/lib/auth/auth-context", () => ({
+  useAuth: () => ({ did: mockDid, isLoading: mockAuthLoading }),
+}))
+
+vi.mock("@/lib/groups/org-context", () => ({
+  useOrg: () => ({ groups: mockGroups, isLoading: mockOrgLoading }),
+}))
+
+import { useManagedAuthors } from "../use-managed-authors"
+
+function group(groupDid: string, role: OrgRole): Group {
+  return {
+    groupDid,
+    handle: `${groupDid}.example.com`,
+    displayName: `Group ${groupDid}`,
+    role,
+    accepted: true,
+  }
+}
+
+beforeEach(() => {
+  cleanup()
+  mockDid = "did:plc:viewer"
+  mockGroups = []
+  mockAuthLoading = false
+  mockOrgLoading = false
+})
+
+describe("useManagedAuthors — author set", () => {
+  it("is [viewer, ...owner/admin group DIDs] and excludes member-role groups", () => {
+    mockGroups = [
+      group("did:plc:owned", "owner"),
+      group("did:plc:admined", "admin"),
+      group("did:plc:joined", "member"),
+    ]
+
+    const { result } = renderHook(() => useManagedAuthors())
+
+    expect(result.current.authors).toEqual([
+      "did:plc:viewer",
+      "did:plc:owned",
+      "did:plc:admined",
+    ])
+    // member-role group is not an author
+    expect(result.current.authors).not.toContain("did:plc:joined")
+  })
+
+  it("puts the viewer first", () => {
+    mockGroups = [group("did:plc:owned", "owner")]
+    const { result } = renderHook(() => useManagedAuthors())
+    expect(result.current.authors[0]).toBe("did:plc:viewer")
+  })
+
+  it("labels the personal identity 'You' and groups by displayName||handle", () => {
+    mockGroups = [group("did:plc:owned", "owner")]
+    const { result } = renderHook(() => useManagedAuthors())
+
+    const personal = result.current.byDid.get("did:plc:viewer")
+    expect(personal?.kind).toBe("personal")
+    expect(personal?.label).toBe("You")
+
+    const grp = result.current.byDid.get("did:plc:owned")
+    expect(grp?.kind).toBe("group")
+    expect(grp?.role).toBe("owner")
+    expect(grp?.label).toBe("Group did:plc:owned")
+  })
+
+  it("dedupes and yields an empty author set when there's no viewer", () => {
+    mockDid = null
+    mockGroups = [group("did:plc:owned", "owner")]
+    const { result } = renderHook(() => useManagedAuthors())
+    expect(result.current.authors).toEqual([])
+    expect(result.current.identities).toEqual([])
+  })
+
+  it("drops a downgraded admin (now member) from the author set", () => {
+    mockGroups = [group("did:plc:x", "member")]
+    const { result } = renderHook(() => useManagedAuthors())
+    expect(result.current.authors).toEqual(["did:plc:viewer"])
+  })
+})

--- a/src/hooks/use-identity-focus.ts
+++ b/src/hooks/use-identity-focus.ts
@@ -1,0 +1,106 @@
+"use client"
+
+import { useCallback, useMemo } from "react"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import type { ManagedIdentity } from "./use-managed-authors"
+
+/**
+ * Shared "focus by managed identity" filter logic for the surfaces that
+ * aggregate records across the viewer's personal account + the groups
+ * they own/admin (the /managed hub and the notifications page).
+ *
+ * The selection lives in a query param (default `?focus=`) so a refresh
+ * or shared link keeps the view. "Everything" is the bare default and is
+ * omitted from the URL; "You" selects the personal identity; any other
+ * value is a group DID. An unknown value (e.g. a stale group DID after
+ * losing admin) collapses back to Everything rather than stranding the
+ * user on an empty, inescapable list.
+ */
+
+export const FOCUS_EVERYTHING = "everything"
+export const FOCUS_YOU = "you"
+
+// Above this many identities a segmented strip would overflow the reading
+// column, so callers fall back to a dropdown.
+export const SEGMENTED_MAX_IDENTITIES = 5
+
+export interface IdentityFocus {
+  /** Current focus value: FOCUS_EVERYTHING, FOCUS_YOU, or a group DID. */
+  focus: string
+  setFocus: (next: string) => void
+  /** The DID the focus scopes to; null means Everything (no filter). */
+  focusedDid: string | null
+  /** True when a single GROUP is focused — suppress the per-row "via". */
+  singleGroupFocused: boolean
+  /** [Everything, You, ...each group] for the control. */
+  filterOptions: { value: string; label: string }[]
+  /** Render a dropdown (many identities) instead of a segmented strip. */
+  useDropdown: boolean
+}
+
+export function useIdentityFocus(
+  identities: ManagedIdentity[],
+  paramName = "focus",
+): IdentityFocus {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const focus = useMemo<string>(() => {
+    const raw = searchParams?.get(paramName)
+    if (!raw || raw === FOCUS_EVERYTHING) return FOCUS_EVERYTHING
+    if (raw === FOCUS_YOU) return FOCUS_YOU
+    return identities.some((i) => i.did === raw) ? raw : FOCUS_EVERYTHING
+  }, [searchParams, identities, paramName])
+
+  const setFocus = useCallback(
+    (next: string) => {
+      const params = new URLSearchParams(searchParams?.toString() ?? "")
+      if (next === FOCUS_EVERYTHING) params.delete(paramName)
+      else params.set(paramName, next)
+      const qs = params.toString()
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+    },
+    [router, pathname, searchParams, paramName],
+  )
+
+  const focusedDid = useMemo<string | null>(() => {
+    if (focus === FOCUS_EVERYTHING) return null
+    if (focus === FOCUS_YOU) {
+      return identities.find((i) => i.kind === "personal")?.did ?? null
+    }
+    return focus
+  }, [focus, identities])
+
+  const singleGroupFocused = useMemo<boolean>(() => {
+    if (focus === FOCUS_EVERYTHING || focus === FOCUS_YOU) return false
+    return identities.some((i) => i.did === focus && i.kind === "group")
+  }, [focus, identities])
+
+  const filterOptions = useMemo(() => {
+    const opts: { value: string; label: string }[] = [
+      { value: FOCUS_EVERYTHING, label: "Everything" },
+    ]
+    for (const identity of identities) {
+      if (identity.kind === "personal") {
+        opts.push({ value: FOCUS_YOU, label: identity.label })
+      } else {
+        opts.push({ value: identity.did, label: identity.label })
+      }
+    }
+    return opts
+  }, [identities])
+
+  // `identities` always includes the personal account, so the option
+  // count is identities.length + 1 (the Everything option).
+  const useDropdown = identities.length > SEGMENTED_MAX_IDENTITIES
+
+  return {
+    focus,
+    setFocus,
+    focusedDid,
+    singleGroupFocused,
+    filterOptions,
+    useDropdown,
+  }
+}

--- a/src/hooks/use-managed-activities.ts
+++ b/src/hooks/use-managed-activities.ts
@@ -1,0 +1,160 @@
+"use client"
+
+import { useState, useEffect, useCallback, useMemo, useRef } from "react"
+import { fetchIndexerActivities } from "@/lib/atproto/indexer"
+import type { ActivityRecord } from "@/lib/atproto/activity-types"
+import { useAuth } from "@/lib/auth/auth-context"
+import { useManagedAuthors } from "./use-managed-authors"
+import { ownerTagForDid, ownerTagForUri, type OwnerTag } from "@/lib/atproto/owner-tag"
+
+const PAGE_SIZE = 20
+
+/** An activity record plus the provenance tag of its owning identity. */
+export interface ManagedActivity {
+  record: ActivityRecord
+  owner: OwnerTag
+}
+
+export interface ManagedActivitiesResult {
+  items: ManagedActivity[]
+  isLoading: boolean
+  isLoadingMore: boolean
+  error: string | null
+  hasMore: boolean
+  loadMore: () => void
+}
+
+/**
+ * Aggregated activity feed across the viewer's managed identities
+ * (personal + owned/admin groups). Wraps `fetchIndexerActivities` with
+ * the multi-author author set from `useManagedAuthors`, excluding
+ * takedown-labelled records server-side.
+ *
+ * Each record is annotated with an `OwnerTag`. We prefer the
+ * publishing DID from the result's `dids` Map (authoritative — it's the
+ * repo that actually hosts the record) and fall back to parsing the
+ * AT-URI when a URI is somehow absent from the map.
+ */
+export function useManagedActivities(): ManagedActivitiesResult {
+  const { did } = useAuth()
+  const { authors, byDid, isLoading: authorsLoading } = useManagedAuthors()
+
+  const [records, setRecords] = useState<ActivityRecord[]>([])
+  const [didsByUri, setDidsByUri] = useState<Map<string, string>>(new Map())
+  const [cursor, setCursor] = useState<string | null>(null)
+  const [hasMore, setHasMore] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const generationRef = useRef(0)
+  const authorsKey = authors.join(",")
+
+  const loadInitial = useCallback(
+    async (signal?: AbortSignal) => {
+      const generation = ++generationRef.current
+
+      if (authorsLoading) {
+        setIsLoading(true)
+        return
+      }
+
+      if (authors.length === 0) {
+        setRecords([])
+        setDidsByUri(new Map())
+        setCursor(null)
+        setHasMore(false)
+        setIsLoading(false)
+        setError(null)
+        return
+      }
+
+      try {
+        setIsLoading(true)
+        setError(null)
+        const data = await fetchIndexerActivities({
+          authors,
+          excludeLabels: ["!takedown"],
+          first: PAGE_SIZE,
+          signal,
+        })
+        if (signal?.aborted || generation !== generationRef.current) return
+        setRecords(data.records)
+        setDidsByUri(data.dids)
+        setCursor(data.endCursor)
+        setHasMore(data.hasMore)
+      } catch (err) {
+        if (signal?.aborted || generation !== generationRef.current) return
+        console.error("Failed to fetch managed activities:", err)
+        setError(err instanceof Error ? err.message : "Failed to fetch activities")
+      } finally {
+        if (!signal?.aborted) setIsLoading(false)
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [authorsKey, authorsLoading],
+  )
+
+  useEffect(() => {
+    const controller = new AbortController()
+    loadInitial(controller.signal)
+    return () => controller.abort()
+  }, [loadInitial])
+
+  const loadMore = useCallback(async () => {
+    if (!cursor || isLoadingMore || authors.length === 0) return
+    const generation = generationRef.current
+    try {
+      setIsLoadingMore(true)
+      const data = await fetchIndexerActivities({
+        authors,
+        excludeLabels: ["!takedown"],
+        first: PAGE_SIZE,
+        after: cursor,
+      })
+      if (generation !== generationRef.current) return
+      setRecords((prev) => {
+        const seen = new Set(prev.map((r) => r.uri))
+        const append = data.records.filter((r) => !seen.has(r.uri))
+        return [...prev, ...append]
+      })
+      setDidsByUri((prev) => {
+        const next = new Map(prev)
+        for (const [uri, ownerDid] of data.dids) next.set(uri, ownerDid)
+        return next
+      })
+      setCursor(data.endCursor)
+      setHasMore(data.hasMore)
+    } catch (err) {
+      if (generation !== generationRef.current) return
+      console.error("Failed to load more managed activities:", err)
+      setError(err instanceof Error ? err.message : "Failed to load more")
+    } finally {
+      if (generation === generationRef.current) setIsLoadingMore(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cursor, isLoadingMore, authorsKey])
+
+  const items = useMemo<ManagedActivity[]>(
+    () =>
+      records.map((record) => {
+        // Prefer the indexer's authoritative publishing DID; fall back
+        // to URI-parsing when the map lacks the URI.
+        const ownerDid = didsByUri.get(record.uri)
+        const owner = ownerDid
+          ? ownerTagForDid(ownerDid, byDid, did)
+          : ownerTagForUri(record.uri, byDid, did)
+        return { record, owner }
+      }),
+    [records, didsByUri, byDid, did],
+  )
+
+  return {
+    items,
+    isLoading: isLoading || authorsLoading,
+    isLoadingMore,
+    error,
+    hasMore,
+    loadMore,
+  }
+}

--- a/src/hooks/use-managed-authors.ts
+++ b/src/hooks/use-managed-authors.ts
@@ -1,0 +1,106 @@
+"use client"
+
+import { useMemo } from "react"
+import { useAuth } from "@/lib/auth/auth-context"
+import { useOrg } from "@/lib/groups/org-context"
+import { ownedOrAdminGroups } from "@/lib/groups/managed"
+import type { Group, OrgRole } from "@/lib/groups/types"
+
+/**
+ * One identity the viewer reads-and-writes as: their personal account,
+ * plus every group they own or admin. `member`-role groups are NOT
+ * managed identities — they're excluded entirely.
+ */
+export interface ManagedIdentity {
+  did: string
+  kind: "personal" | "group"
+  /** The viewer's role on the group. Undefined for the personal identity. */
+  role?: OrgRole
+  /** The underlying group. Undefined for the personal identity. */
+  group?: Group
+  /** Display label: "You" for personal, displayName || handle for groups. */
+  label: string
+}
+
+export interface ManagedAuthorsResult {
+  /**
+   * DIDs to pass as `authors` to the indexer aggregation calls:
+   * `[viewerDid, ...ownerOrAdminGroupDids]`, deduped, viewer first.
+   * Empty array when there's no signed-in viewer.
+   */
+  authors: string[]
+  /** The personal identity plus each managed group, viewer first. */
+  identities: ManagedIdentity[]
+  /** `did -> ManagedIdentity` lookup for owner-tagging records. */
+  byDid: Map<string, ManagedIdentity>
+  /** True while either auth or the org list is still resolving. */
+  isLoading: boolean
+}
+
+/**
+ * The set of identities the signed-in viewer reads aggregated activity
+ * for and can write as: their personal account plus every group where
+ * their role is `owner` or `admin`.
+ *
+ * Freshness is inherited from org-context: `useOrg()` re-runs
+ * `resolveGroups` (which carries each group's role) whenever auth or
+ * the active org changes, so we deliberately do NOT issue a second
+ * role fetch here — we just re-derive in a `useMemo` keyed on
+ * `[did, groups]`.
+ *
+ * Returns an empty author set (and only `isLoading` reflecting the
+ * underlying loaders) when there's no signed-in `did`.
+ */
+export function useManagedAuthors(): ManagedAuthorsResult {
+  const { did, isLoading: authLoading } = useAuth()
+  const { groups, isLoading: orgLoading } = useOrg()
+
+  return useMemo<ManagedAuthorsResult>(() => {
+    if (!did) {
+      return {
+        authors: [],
+        identities: [],
+        byDid: new Map(),
+        isLoading: authLoading || orgLoading,
+      }
+    }
+
+    const personal: ManagedIdentity = {
+      did,
+      kind: "personal",
+      label: "You",
+    }
+
+    // owner/admin only — member groups are dropped by ownedOrAdminGroups.
+    const groupIdentities: ManagedIdentity[] = ownedOrAdminGroups(groups).map(
+      (group) => ({
+        did: group.groupDid,
+        kind: "group",
+        role: group.role,
+        group,
+        label: group.displayName || group.handle,
+      }),
+    )
+
+    // Viewer first, then groups; dedupe by DID. A group whose DID somehow
+    // equals the viewer's (shouldn't happen — a group is its own DID) is
+    // collapsed into the personal identity rather than double-counted.
+    const seen = new Set<string>()
+    const identities: ManagedIdentity[] = []
+    for (const identity of [personal, ...groupIdentities]) {
+      if (seen.has(identity.did)) continue
+      seen.add(identity.did)
+      identities.push(identity)
+    }
+
+    const byDid = new Map<string, ManagedIdentity>()
+    for (const identity of identities) byDid.set(identity.did, identity)
+
+    return {
+      authors: identities.map((i) => i.did),
+      identities,
+      byDid,
+      isLoading: authLoading || orgLoading,
+    }
+  }, [did, groups, authLoading, orgLoading])
+}

--- a/src/hooks/use-managed-notifications.ts
+++ b/src/hooks/use-managed-notifications.ts
@@ -1,0 +1,167 @@
+"use client"
+
+import { useState, useEffect, useCallback, useMemo, useRef } from "react"
+import {
+  fetchNotifications,
+  NotificationsUnauthenticatedError,
+  type Notification,
+} from "@/lib/atproto/notifications"
+import { useAuth } from "@/lib/auth/auth-context"
+import { useManagedAuthors } from "./use-managed-authors"
+import { ownerTagForDid, type OwnerTag } from "@/lib/atproto/owner-tag"
+
+const PAGE_SIZE = 50
+
+/** A notification plus the provenance tag of the identity it belongs to. */
+export interface ManagedNotification {
+  notification: Notification
+  /** Who this notification is for — the viewer ("You") or a group. */
+  owner: OwnerTag
+}
+
+export interface ManagedNotificationsResult {
+  items: ManagedNotification[]
+  isLoading: boolean
+  isLoadingMore: boolean
+  error: string | null
+  hasMore: boolean
+  loadMore: () => void
+}
+
+/**
+ * Aggregated notifications feed across the viewer's managed identities
+ * (personal + owned/admin groups). Mirrors {@link useNotificationsFeed}
+ * but sends the multi-recipient `recipients` set from
+ * {@link useManagedAuthors} and tags each row with the identity it
+ * belongs to (so the UI can show "via {group}").
+ *
+ * This is the aggregated counterpart used only when the
+ * NOTIFICATIONS_AGGREGATION flag is on (the page picks between this and
+ * the personal `useNotificationsFeed`). It still relies on the indexer
+ * accepting `recipients` — see
+ * docs/org-identity/indexer-notifications-aggregation.md.
+ *
+ * Pagination follows the personal feed's union-cursor caveat: a single
+ * cursor walks the merged recipient stream server-side, deduped by id on
+ * the client.
+ */
+export function useManagedNotifications(enabled: boolean): ManagedNotificationsResult {
+  const { did } = useAuth()
+  const { authors, byDid, isLoading: authorsLoading } = useManagedAuthors()
+
+  const [notifications, setNotifications] = useState<Notification[]>([])
+  const [isLoading, setIsLoading] = useState(enabled)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [hasMore, setHasMore] = useState(false)
+  const endCursorRef = useRef<string | null>(null)
+  const isLoadingMoreRef = useRef(false)
+
+  const authorsKey = authors.join(",")
+  const active = enabled && authors.length > 0
+
+  useEffect(() => {
+    if (!active) {
+      setNotifications([])
+      setHasMore(false)
+      endCursorRef.current = null
+      // Stay in the loading state while authors are still resolving so the
+      // page shows skeletons rather than a premature empty state.
+      setIsLoading(enabled && authorsLoading)
+      return
+    }
+
+    const controller = new AbortController()
+    let cancelled = false
+
+    async function load() {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const page = await fetchNotifications({
+          first: PAGE_SIZE,
+          recipients: authors,
+          signal: controller.signal,
+        })
+        if (cancelled) return
+        setNotifications(page.records)
+        setHasMore(page.hasMore)
+        endCursorRef.current = page.endCursor
+      } catch (err) {
+        if (cancelled || (err instanceof Error && err.name === "AbortError")) return
+        if (err instanceof NotificationsUnauthenticatedError) {
+          setNotifications([])
+          setHasMore(false)
+          return
+        }
+        setError(err instanceof Error ? err.message : "Failed to load notifications")
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, authorsKey, authorsLoading, enabled])
+
+  const loadMore = useCallback(async () => {
+    if (!endCursorRef.current || isLoadingMoreRef.current || !active) return
+    isLoadingMoreRef.current = true
+    setIsLoadingMore(true)
+    try {
+      const page = await fetchNotifications({
+        first: PAGE_SIZE,
+        after: endCursorRef.current,
+        recipients: authors,
+      })
+      setNotifications((prev) => {
+        const seen = new Set(prev.map((n) => n.id))
+        const merged = [...prev]
+        for (const n of page.records) {
+          if (!seen.has(n.id)) {
+            merged.push(n)
+            seen.add(n.id)
+          }
+        }
+        return merged
+      })
+      setHasMore(page.hasMore)
+      endCursorRef.current = page.endCursor
+    } catch {
+      setHasMore(false)
+    } finally {
+      isLoadingMoreRef.current = false
+      setIsLoadingMore(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, authorsKey])
+
+  const items = useMemo<ManagedNotification[]>(
+    () =>
+      notifications.map((notification) => {
+        // The recipient is the DID being notified — the identity this row
+        // belongs to. When the indexer omits it (shouldn't, on the
+        // aggregated path) fall back to the viewer so we never mislabel a
+        // personal notification as a group's.
+        const recipientDid = notification.recipient ?? did ?? ""
+        return {
+          notification,
+          owner: ownerTagForDid(recipientDid, byDid, did),
+        }
+      }),
+    [notifications, byDid, did],
+  )
+
+  return {
+    items,
+    isLoading: isLoading || (enabled && authorsLoading),
+    isLoadingMore,
+    error,
+    hasMore,
+    loadMore,
+  }
+}

--- a/src/hooks/use-managed-projects.ts
+++ b/src/hooks/use-managed-projects.ts
@@ -1,0 +1,151 @@
+"use client"
+
+import { useState, useEffect, useCallback, useMemo, useRef } from "react"
+import { fetchProjects } from "@/lib/atproto/indexer"
+import type { CollectionRecord } from "@/lib/atproto/collection"
+import { useAuth } from "@/lib/auth/auth-context"
+import { useManagedAuthors } from "./use-managed-authors"
+import { ownerTagForUri, type OwnerTag } from "@/lib/atproto/owner-tag"
+
+const PAGE_SIZE = 24
+
+/** A project record plus the provenance tag of its owning identity. */
+export interface ManagedProject {
+  record: CollectionRecord
+  owner: OwnerTag
+}
+
+export interface ManagedProjectsResult {
+  items: ManagedProject[]
+  isLoading: boolean
+  isLoadingMore: boolean
+  error: string | null
+  hasMore: boolean
+  loadMore: () => void
+}
+
+/**
+ * Aggregated project listing across the viewer's managed identities
+ * (personal + owned/admin groups). Wraps `fetchProjects({ authors })`
+ * with the multi-author author set from `useManagedAuthors`, then
+ * annotates each record with an `OwnerTag` derived from its AT-URI repo
+ * DID.
+ *
+ * Holds the spinner (`isLoading`) while the managed-author set is still
+ * resolving, so consumers never page against a half-built author list.
+ *
+ * Pagination is single-cursor: the indexer's `Projects` op paginates the
+ * union of `authors` server-side, so one `endCursor` walks the whole
+ * aggregate.
+ */
+export function useManagedProjects(): ManagedProjectsResult {
+  const { did } = useAuth()
+  const { authors, byDid, isLoading: authorsLoading } = useManagedAuthors()
+
+  const [records, setRecords] = useState<CollectionRecord[]>([])
+  const [cursor, setCursor] = useState<string | null>(null)
+  const [hasMore, setHasMore] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Bumped on every initial-load run so a late loadMore for a stale
+  // author set can't append to a freshly reset list. Mirrors
+  // use-user-activities.
+  const generationRef = useRef(0)
+
+  // Stable key so the effect only re-runs when the author DIDs actually
+  // change (not on every byDid Map identity).
+  const authorsKey = authors.join(",")
+
+  const loadInitial = useCallback(
+    async (signal?: AbortSignal) => {
+      const generation = ++generationRef.current
+
+      // While the author set is resolving, hold the spinner and don't
+      // fetch — we'd otherwise query a partial / empty author list.
+      if (authorsLoading) {
+        setIsLoading(true)
+        return
+      }
+
+      // No managed authors (logged out, or no identities) — empty result.
+      if (authors.length === 0) {
+        setRecords([])
+        setCursor(null)
+        setHasMore(false)
+        setIsLoading(false)
+        setError(null)
+        return
+      }
+
+      try {
+        setIsLoading(true)
+        setError(null)
+        const data = await fetchProjects({ authors, first: PAGE_SIZE, signal })
+        if (signal?.aborted || generation !== generationRef.current) return
+        setRecords(data.records)
+        setCursor(data.endCursor)
+        setHasMore(data.hasMore)
+      } catch (err) {
+        if (signal?.aborted || generation !== generationRef.current) return
+        console.error("Failed to fetch managed projects:", err)
+        setError(err instanceof Error ? err.message : "Failed to fetch projects")
+      } finally {
+        if (!signal?.aborted) setIsLoading(false)
+      }
+    },
+    // authorsKey stands in for the authors array identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [authorsKey, authorsLoading],
+  )
+
+  useEffect(() => {
+    const controller = new AbortController()
+    loadInitial(controller.signal)
+    return () => controller.abort()
+  }, [loadInitial])
+
+  const loadMore = useCallback(async () => {
+    if (!cursor || isLoadingMore || authors.length === 0) return
+    const generation = generationRef.current
+    try {
+      setIsLoadingMore(true)
+      const data = await fetchProjects({ authors, first: PAGE_SIZE, after: cursor })
+      if (generation !== generationRef.current) return
+      setRecords((prev) => {
+        const seen = new Set(prev.map((r) => r.uri))
+        const append = data.records.filter((r) => !seen.has(r.uri))
+        return [...prev, ...append]
+      })
+      setCursor(data.endCursor)
+      setHasMore(data.hasMore)
+    } catch (err) {
+      if (generation !== generationRef.current) return
+      console.error("Failed to load more managed projects:", err)
+      setError(err instanceof Error ? err.message : "Failed to load more")
+    } finally {
+      if (generation === generationRef.current) setIsLoadingMore(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cursor, isLoadingMore, authorsKey])
+
+  const items = useMemo<ManagedProject[]>(
+    () =>
+      records.map((record) => ({
+        record,
+        owner: ownerTagForUri(record.uri, byDid, did),
+      })),
+    [records, byDid, did],
+  )
+
+  return {
+    items,
+    // Keep the spinner up while the author set is still being assembled.
+    isLoading: isLoading || authorsLoading,
+    isLoadingMore,
+    error,
+    hasMore,
+    loadMore,
+  }
+}

--- a/src/hooks/use-managed-records.ts
+++ b/src/hooks/use-managed-records.ts
@@ -1,0 +1,104 @@
+"use client"
+
+import { useMemo } from "react"
+import type { CollectionRecord } from "@/lib/atproto/collection"
+import type { ActivityRecord } from "@/lib/atproto/activity-types"
+import type { OwnerTag } from "@/lib/atproto/owner-tag"
+import { useManagedProjects } from "./use-managed-projects"
+import { useManagedActivities } from "./use-managed-activities"
+
+/**
+ * A single row in the merged managed feed: either a project collection
+ * record or an activity claim, carrying its provenance `OwnerTag` and a
+ * `kind` discriminator so consumers can render the right card without
+ * re-parsing the record.
+ */
+export type ManagedItem =
+  | { kind: "project"; uri: string; record: CollectionRecord; owner: OwnerTag; sortKey: string }
+  | { kind: "activity"; uri: string; record: ActivityRecord; owner: OwnerTag; sortKey: string }
+
+export interface ManagedRecordsResult {
+  items: ManagedItem[]
+  isLoading: boolean
+  isLoadingMore: boolean
+  error: string | null
+  hasMore: boolean
+  loadMore: () => void
+}
+
+/**
+ * Recency sort key. Prefer the record's authored `createdAt`; fall back
+ * to the empty string (sorts last) when neither is present. Projects
+ * and activities both expose `value.createdAt`.
+ */
+function projectSortKey(record: CollectionRecord): string {
+  return typeof record.value.createdAt === "string" ? record.value.createdAt : ""
+}
+
+function activitySortKey(record: ActivityRecord): string {
+  return record.value.createdAt || ""
+}
+
+/**
+ * The unified managed feed: projects + activities authored by the
+ * viewer's managed identities (personal + owned/admin groups), merged
+ * and sorted newest-first by `createdAt`.
+ *
+ * Each item carries its `OwnerTag` and a `kind` so the consuming surface
+ * can branch on render.
+ *
+ * Union-pagination caveat: projects and activities paginate on
+ * independent cursors (two indexer ops, two `endCursor`s). `loadMore`
+ * advances BOTH underlying feeds a page, and `hasMore` is the OR of the
+ * two. Because each source is independently newest-first but they're
+ * interleaved by `createdAt`, the merged list is only globally sorted
+ * within the pages fetched so far — a later page of one source can
+ * surface a record older than items already shown from the other
+ * source. This is acceptable for a "your recent work" feed; a strict
+ * global ordering would require a unified server-side cursor the indexer
+ * doesn't expose.
+ */
+export function useManagedRecords(): ManagedRecordsResult {
+  const projects = useManagedProjects()
+  const activities = useManagedActivities()
+
+  const items = useMemo<ManagedItem[]>(() => {
+    const merged: ManagedItem[] = []
+    for (const p of projects.items) {
+      merged.push({
+        kind: "project",
+        uri: p.record.uri,
+        record: p.record,
+        owner: p.owner,
+        sortKey: projectSortKey(p.record),
+      })
+    }
+    for (const a of activities.items) {
+      merged.push({
+        kind: "activity",
+        uri: a.record.uri,
+        record: a.record,
+        owner: a.owner,
+        sortKey: activitySortKey(a.record),
+      })
+    }
+    // Newest first. Localcompare on ISO strings is a valid recency sort.
+    merged.sort((x, y) => (x.sortKey < y.sortKey ? 1 : x.sortKey > y.sortKey ? -1 : 0))
+    return merged
+  }, [projects.items, activities.items])
+
+  const loadMore = () => {
+    // Advance both sources; each no-ops if it has no more / is in flight.
+    projects.loadMore()
+    activities.loadMore()
+  }
+
+  return {
+    items,
+    isLoading: projects.isLoading || activities.isLoading,
+    isLoadingMore: projects.isLoadingMore || activities.isLoadingMore,
+    error: projects.error ?? activities.error,
+    hasMore: projects.hasMore || activities.hasMore,
+    loadMore,
+  }
+}

--- a/src/hooks/use-own-certs.ts
+++ b/src/hooks/use-own-certs.ts
@@ -1,7 +1,6 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { useOrg } from "@/lib/groups/org-context"
 import { authFetch } from "@/lib/auth/fetch"
 
 export interface OwnCert {
@@ -12,11 +11,16 @@ export interface OwnCert {
 
 /**
  * "Your certs" quick-pick fetch shared by `/project/new` and the
- * project edit page. Fetches the author's own certs once via
- * `listRecords` on the active repo (the active group's DID when one is
- * selected, otherwise the passed personal `did`) so the quick-pick
- * checklist can render straight away — the source repo always matches
- * the publish target.
+ * project edit page. Fetches certs once via `listRecords` on the
+ * passed `did` so the quick-pick checklist can render straight away.
+ *
+ * The `did` is the PICKED write target — the caller threads in whichever
+ * identity the per-action `<PostingAs>` picker (or the record's own
+ * owner, on edit) resolves to, so the quick-pick scopes to the repo the
+ * new project will actually land in. It is NOT derived from
+ * `activeOrg` here: act-as is read-scope only, and the write target is
+ * per-action (default You). When `did` is null (signed-out / pre-auth)
+ * the fetch is skipped.
  *
  * 50 is `listRecords`' default page size; it covers the typical use
  * case without pagination plumbing. The fetch is best-effort: on
@@ -28,12 +32,11 @@ export function useOwnCerts(did: string | null): {
   ownCerts: OwnCert[]
   isLoading: boolean
 } {
-  const { activeOrg } = useOrg()
   const [ownCerts, setOwnCerts] = useState<OwnCert[]>([])
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    const sourceDid = activeOrg ? activeOrg.groupDid : did
+    const sourceDid = did
     if (!sourceDid) return
     const controller = new AbortController()
     setIsLoading(true)
@@ -84,7 +87,7 @@ export function useOwnCerts(did: string | null): {
         if (!controller.signal.aborted) setIsLoading(false)
       })
     return () => controller.abort()
-  }, [did, activeOrg])
+  }, [did])
 
   return { ownCerts, isLoading }
 }

--- a/src/hooks/use-posting-identity.ts
+++ b/src/hooks/use-posting-identity.ts
@@ -1,0 +1,90 @@
+"use client"
+
+import { useCallback, useMemo, useState } from "react"
+import { useAuth } from "@/lib/auth/auth-context"
+import { useOrg } from "@/lib/groups/org-context"
+import { useAuthorInfo } from "@/hooks/use-author-info"
+import {
+  buildPostingOptions,
+  type PostingIdentity,
+} from "@/lib/groups/posting-identity"
+
+/**
+ * Per-action "posting as" state for a single write surface.
+ *
+ * Returns the ordered option list (You first, then every writable
+ * group) and the currently-chosen identity. The DEFAULT is always You —
+ * it is deliberately NOT seeded from `useOrg().activeOrg` or any
+ * last-used value, because the org-identity write model is per-action:
+ * each action starts from the safe personal default and the user
+ * opts into a group explicitly. `reset()` returns to You, which a
+ * caller should invoke after a successful write so the next action
+ * doesn't silently inherit the previous group choice.
+ *
+ * The "You" option is decorated with the viewer's resolved handle +
+ * avatar (via `useAuthorInfo`) when available; group rows carry the
+ * group's own handle/avatar/role from `useOrg().groups`.
+ *
+ * @param initial optional starting identity (e.g. to restore a draft).
+ *   Ignored if it isn't one of the currently-available options — the
+ *   value always resolves to a real option, falling back to You.
+ */
+export function usePostingIdentity({
+  initial,
+}: { initial?: PostingIdentity } = {}): {
+  options: PostingIdentity[]
+  value: PostingIdentity
+  setValue: (next: PostingIdentity) => void
+  reset: () => void
+} {
+  const { did } = useAuth()
+  const { groups } = useOrg()
+  const { info: selfInfo } = useAuthorInfo(did)
+
+  const options = useMemo(
+    () =>
+      buildPostingOptions(
+        {
+          did: did ?? "",
+          handle: selfInfo?.handle,
+          avatarUrl: selfInfo?.avatarUrl ?? undefined,
+        },
+        groups,
+      ),
+    [did, selfInfo?.handle, selfInfo?.avatarUrl, groups],
+  )
+
+  // The personal option is always first (buildPostingOptions guarantees
+  // it). It is the default, the reset target, and the fallback whenever a
+  // stored / `initial` value no longer matches an available option.
+  const youOption = options[0]
+
+  // Track the chosen DID rather than the object so identity survives the
+  // handle/avatar resolving in (which rebuilds the option objects). When
+  // an `initial` is supplied AND it is still an available option, start
+  // there; otherwise start at You.
+  const [selectedDid, setSelectedDid] = useState<string | null>(() =>
+    initial && initial.did !== youOption?.did ? initial.did : null,
+  )
+
+  const value = useMemo<PostingIdentity>(() => {
+    if (selectedDid) {
+      const match = options.find((o) => o.did === selectedDid)
+      if (match) return match
+    }
+    // Default / fallback: You. youOption is always defined once options
+    // is built; the empty-did guard keeps the type total for the brief
+    // pre-auth window.
+    return youOption ?? { did: "", kind: "personal", label: "You" }
+  }, [selectedDid, options, youOption])
+
+  const setValue = useCallback((next: PostingIdentity) => {
+    setSelectedDid(next.kind === "personal" ? null : next.did)
+  }, [])
+
+  const reset = useCallback(() => {
+    setSelectedDid(null)
+  }, [])
+
+  return { options, value, setValue, reset }
+}

--- a/src/lib/atproto/__tests__/fan-out.test.ts
+++ b/src/lib/atproto/__tests__/fan-out.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { fanOut } from "../fan-out"
+
+describe("fanOut — per-DID error isolation", () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it("returns each DID's items, preserving order", async () => {
+    const out = await fanOut(["a", "b"], async (did) => [`${did}1`, `${did}2`])
+    expect(out).toEqual([
+      { did: "a", items: ["a1", "a2"] },
+      { did: "b", items: ["b1", "b2"] },
+    ])
+  })
+
+  it("isolates a per-DID failure to an empty list, not a batch reject", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {})
+    const out = await fanOut(["a", "b"], async (did) => {
+      if (did === "b") throw new Error("PDS down")
+      return [`${did}1`]
+    })
+    expect(out).toEqual([
+      { did: "a", items: ["a1"] },
+      { did: "b", items: [] },
+    ])
+  })
+
+  it("re-throws an AbortError so the caller sees cancellation, not []", async () => {
+    const abort = async () => {
+      throw new DOMException("aborted", "AbortError")
+    }
+    await expect(fanOut(["a"], abort)).rejects.toBeInstanceOf(DOMException)
+  })
+})

--- a/src/lib/atproto/__tests__/notifications.test.ts
+++ b/src/lib/atproto/__tests__/notifications.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { parseNotificationsPage } from "../notifications"
+import {
+  parseNotificationsPage,
+  fetchNotifications,
+  fetchUnreadCount,
+} from "../notifications"
 
 /** Build a fully-populated, valid notification node. */
 function validNode(overrides: Record<string, unknown> = {}) {
@@ -79,5 +83,67 @@ describe("parseNotificationsPage — load-bearing field validation", () => {
     const page = parseNotificationsPage(pageWith([validNode(), partial]))
     expect(page.records).toHaveLength(1)
     expect(page.records[0].id).toBe("notif-1")
+  })
+
+  it("passes through the aggregated `recipient` field", () => {
+    const page = parseNotificationsPage(
+      pageWith([validNode({ recipient: "did:plc:group" })]),
+    )
+    expect(page.records).toHaveLength(1)
+    expect(page.records[0].recipient).toBe("did:plc:group")
+  })
+})
+
+describe("recipients wiring — fetchNotifications / fetchUnreadCount", () => {
+  let lastBody: { operationName?: string; variables?: Record<string, unknown> }
+
+  beforeEach(() => {
+    lastBody = {}
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        lastBody = JSON.parse((init?.body as string) ?? "{}")
+        const op = lastBody.operationName
+        const data =
+          op === "unreadNotificationCount"
+            ? { unreadNotificationCount: { count: 0, more: false } }
+            : {
+                notifications: {
+                  edges: [],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              }
+        return new Response(JSON.stringify({ data }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }),
+    )
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("omits `recipients` from the body when none are passed", async () => {
+    await fetchNotifications({ first: 10 })
+    expect(lastBody.variables).toEqual({ first: 10, after: null })
+    expect(lastBody.variables).not.toHaveProperty("recipients")
+  })
+
+  it("omits `recipients` when an empty array is passed", async () => {
+    await fetchNotifications({ first: 10, recipients: [] })
+    expect(lastBody.variables).not.toHaveProperty("recipients")
+  })
+
+  it("includes `recipients` in the notifications body when non-empty", async () => {
+    await fetchNotifications({ first: 10, recipients: ["did:plc:me", "did:plc:grp"] })
+    expect(lastBody.variables?.recipients).toEqual(["did:plc:me", "did:plc:grp"])
+  })
+
+  it("sends `recipients` for the unread count but omits it by default", async () => {
+    await fetchUnreadCount()
+    expect(lastBody.variables).toEqual({})
+    await fetchUnreadCount(["did:plc:me", "did:plc:grp"])
+    expect(lastBody.variables?.recipients).toEqual(["did:plc:me", "did:plc:grp"])
   })
 })

--- a/src/lib/atproto/__tests__/owner-tag.test.ts
+++ b/src/lib/atproto/__tests__/owner-tag.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { ownerTagForDid, ownerTagForUri } from "../owner-tag"
+import type { ManagedIdentity } from "@/hooks/use-managed-authors"
+import type { Group } from "@/lib/groups/types"
+
+const VIEWER = "did:plc:viewer0000000000000000000000"
+const GROUP = "did:plc:group00000000000000000000000"
+const STRANGER = "did:plc:stranger00000000000000000000"
+
+const groupObj = {
+  groupDid: GROUP,
+  handle: "estuary.certified.app",
+  displayName: "Estuary Alliance",
+  role: "owner",
+  accepted: true,
+} as unknown as Group
+
+function byDidMap(): Map<string, ManagedIdentity> {
+  return new Map<string, ManagedIdentity>([
+    [VIEWER, { did: VIEWER, kind: "personal", label: "You" }],
+    [GROUP, { did: GROUP, kind: "group", role: "owner", group: groupObj, label: "Estuary Alliance" }],
+  ])
+}
+
+describe("ownerTagForDid", () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it("tags the viewer's own DID as personal 'You'", () => {
+    const tag = ownerTagForDid(VIEWER, byDidMap(), VIEWER)
+    expect(tag.kind).toBe("personal")
+    expect(tag.label).toBe("You")
+    expect(tag.ownerDid).toBe(VIEWER)
+  })
+
+  it("tags a managed group DID with its role + label", () => {
+    const tag = ownerTagForDid(GROUP, byDidMap(), VIEWER)
+    expect(tag.kind).toBe("group")
+    expect(tag.role).toBe("owner")
+    expect(tag.label).toBe("Estuary Alliance")
+    expect(tag.group).toBe(groupObj)
+  })
+
+  it("falls back to personal 'You' for the viewer even when absent from the map", () => {
+    const tag = ownerTagForDid(VIEWER, new Map(), VIEWER)
+    expect(tag.kind).toBe("personal")
+    expect(tag.label).toBe("You")
+  })
+
+  it("NEVER labels a stranger DID as 'You' — defensive group tag instead", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {})
+    const tag = ownerTagForDid(STRANGER, new Map(), VIEWER)
+    expect(tag.kind).toBe("group")
+    expect(tag.label).not.toBe("You")
+    // A truncated-DID label, not the raw DID and not "You".
+    expect(tag.label).toContain("did:")
+    expect(tag.ownerDid).toBe(STRANGER)
+  })
+})
+
+describe("ownerTagForUri", () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it("resolves the owner from the AT-URI repo DID", () => {
+    const uri = `at://${GROUP}/org.hypercerts.collection/abc`
+    const tag = ownerTagForUri(uri, byDidMap(), VIEWER)
+    expect(tag.kind).toBe("group")
+    expect(tag.ownerDid).toBe(GROUP)
+    expect(tag.label).toBe("Estuary Alliance")
+  })
+
+  it("falls back to the viewer's personal identity on an unparseable URI", () => {
+    const tag = ownerTagForUri("not-an-at-uri", byDidMap(), VIEWER)
+    expect(tag.kind).toBe("personal")
+    expect(tag.label).toBe("You")
+    expect(tag.ownerDid).toBe(VIEWER)
+  })
+})

--- a/src/lib/atproto/fan-out.ts
+++ b/src/lib/atproto/fan-out.ts
@@ -1,0 +1,35 @@
+/**
+ * Generic per-DID fan-out with error isolation.
+ *
+ * Runs `fetchOne` in parallel across every DID and returns each DID's
+ * results alongside the DID. A failed DID yields an empty list rather
+ * than rejecting the whole batch — so one group's PDS being down (or a
+ * 400 on a repo with no records of the queried collection) doesn't blank
+ * the aggregate. Abort is propagated via the shared `signal`.
+ *
+ * Used by the read-aggregation surfaces (typed-lists, following,
+ * given-endorsements) that need to union a single-DID fetcher across the
+ * viewer's managed identities.
+ */
+export async function fanOut<T>(
+  dids: string[],
+  fetchOne: (did: string, signal?: AbortSignal) => Promise<T[]>,
+  signal?: AbortSignal,
+): Promise<Array<{ did: string; items: T[] }>> {
+  return Promise.all(
+    dids.map(async (did) => {
+      try {
+        const items = await fetchOne(did, signal)
+        return { did, items }
+      } catch (err) {
+        // Re-throw aborts so the caller can distinguish cancellation from
+        // a genuine per-DID failure; swallow everything else to [].
+        if (err instanceof DOMException && err.name === "AbortError") throw err
+        if (process.env.NODE_ENV !== "production") {
+          console.warn(`[fan-out] fetch failed for ${did}:`, err)
+        }
+        return { did, items: [] as T[] }
+      }
+    }),
+  )
+}

--- a/src/lib/atproto/notifications.ts
+++ b/src/lib/atproto/notifications.ts
@@ -14,6 +14,14 @@ export interface Notification {
   latestRecordCid: string
   latestAuthor: string
   isRead: boolean
+  /**
+   * The DID whose notification this is. Only present on the aggregated
+   * path (when `recipients` was sent and the indexer supports it); the
+   * personal path leaves it undefined (it would always equal the viewer).
+   * Used to tag aggregated rows "via {group}". See
+   * docs/org-identity/indexer-notifications-aggregation.md.
+   */
+  recipient?: string
 }
 
 export interface NotificationsPage {
@@ -114,22 +122,37 @@ async function callProxy<T>(
 export async function fetchNotifications(options: {
   first?: number
   after?: string | null
+  /**
+   * DIDs whose notifications to aggregate (the viewer + groups they
+   * own/admin). Sent to the proxy only when non-empty; the route then
+   * selects the `recipients` query variant — but only if the
+   * NOTIFICATIONS_AGGREGATION flag is on server-side, so an indexer that
+   * doesn't support it never sees the argument.
+   */
+  recipients?: string[]
   signal?: AbortSignal
 } = {}): Promise<NotificationsPage> {
-  const { first = 50, after, signal } = options
+  const { first = 50, after, recipients, signal } = options
+  const variables: Record<string, unknown> = { first, after: after ?? null }
+  if (recipients && recipients.length > 0) variables.recipients = recipients
   const json = await callProxy<{
     notifications?: {
       edges: { cursor: string; node: Notification | null }[]
       pageInfo: { hasNextPage: boolean; endCursor: string | null }
     } | null
-  }>("notifications", { first, after: after ?? null }, signal)
+  }>("notifications", variables, signal)
   return parseNotificationsPage(json)
 }
 
-export async function fetchUnreadCount(signal?: AbortSignal): Promise<UnreadCount> {
+export async function fetchUnreadCount(
+  recipients?: string[],
+  signal?: AbortSignal,
+): Promise<UnreadCount> {
+  const variables: Record<string, unknown> = {}
+  if (recipients && recipients.length > 0) variables.recipients = recipients
   const json = await callProxy<{
     unreadNotificationCount?: { count: number; more: boolean } | null
-  }>("unreadNotificationCount", {}, signal)
+  }>("unreadNotificationCount", variables, signal)
   const u = json.data?.unreadNotificationCount
   if (!u) {
     if (json.errors?.length) {

--- a/src/lib/atproto/owner-tag.ts
+++ b/src/lib/atproto/owner-tag.ts
@@ -1,0 +1,101 @@
+import { parseAtUri } from "./activity-uri"
+import { truncateDid } from "@/lib/utils/did"
+import type { ManagedIdentity } from "@/hooks/use-managed-authors"
+import type { Group, OrgRole } from "@/lib/groups/types"
+
+/**
+ * The provenance tag the managed feeds attach to every aggregated
+ * record: who owns it (the repo DID that hosts the AT-URI), whether
+ * that's the viewer's personal account or one of their groups, and how
+ * to label it. Records are owned by their AT-URI repo DID; a group is
+ * its own DID, and group-authored records live in the group repo — so
+ * the owner of a record is exactly the DID in its URI.
+ */
+export interface OwnerTag {
+  /** The repo DID that owns the record. */
+  ownerDid: string
+  kind: "personal" | "group"
+  /** The viewer's role on the owning group. Undefined for personal. */
+  role?: OrgRole
+  /** The owning group. Undefined for personal. */
+  group?: Group
+  /** Display label: "You" for the viewer, displayName || handle for a group. */
+  label: string
+}
+
+/**
+ * Tag a record by its owning DID, given the viewer's managed-identity
+ * map (`useManagedAuthors().byDid`) and the viewer's own DID.
+ *
+ * Resolution:
+ *   - Known DID in `byDid` -> reuse that identity's kind/role/group/label.
+ *   - `ownerDid === viewerDid` but not in the map -> personal/"You".
+ *   - Unknown DID that is NOT the viewer -> a defensive group-shaped tag
+ *     labelled with the truncated DID. We never mislabel a stranger's
+ *     record as "You"; this branch should not normally fire (the feed is
+ *     scoped to the managed author set) so we dev-warn when it does.
+ */
+export function ownerTagForDid(
+  ownerDid: string,
+  byDid: Map<string, ManagedIdentity>,
+  viewerDid: string | null,
+): OwnerTag {
+  const identity = byDid.get(ownerDid)
+  if (identity) {
+    return {
+      ownerDid: identity.did,
+      kind: identity.kind,
+      role: identity.role,
+      group: identity.group,
+      label: identity.label,
+    }
+  }
+
+  if (viewerDid && ownerDid === viewerDid) {
+    return { ownerDid, kind: "personal", label: "You" }
+  }
+
+  if (process.env.NODE_ENV !== "production") {
+    console.warn(
+      `[owner-tag] DID ${ownerDid} is not in the managed-identity map and is ` +
+        `not the viewer (${viewerDid ?? "none"}). Tagging defensively as a ` +
+        `group with a truncated-DID label.`,
+    )
+  }
+  // Defensive group-shaped tag — never "You" for a non-viewer DID.
+  return { ownerDid, kind: "group", label: truncateDid(ownerDid) }
+}
+
+/**
+ * Tag a record by its AT-URI. The owner is the repo DID in the URI.
+ * On a parse failure we fall back to the viewer's personal identity —
+ * an unparseable URI in a viewer-scoped feed is almost certainly the
+ * viewer's own malformed record, and "You" is the safe, non-leaking
+ * default.
+ */
+export function ownerTagForUri(
+  uri: string,
+  byDid: Map<string, ManagedIdentity>,
+  viewerDid: string | null,
+): OwnerTag {
+  const parsed = parseAtUri(uri)
+  if (!parsed) {
+    if (viewerDid) {
+      const identity = byDid.get(viewerDid)
+      if (identity) {
+        return {
+          ownerDid: identity.did,
+          kind: identity.kind,
+          role: identity.role,
+          group: identity.group,
+          label: identity.label,
+        }
+      }
+      return { ownerDid: viewerDid, kind: "personal", label: "You" }
+    }
+    // No viewer to anchor to — return an inert personal tag rather than
+    // throwing into the render path.
+    return { ownerDid: "", kind: "personal", label: "You" }
+  }
+  return ownerTagForDid(parsed.did, byDid, viewerDid)
+}

--- a/src/lib/dev/fixtures/__tests__/managed.test.ts
+++ b/src/lib/dev/fixtures/__tests__/managed.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest"
+import { MOCK_DID } from "@/lib/dev/fixtures/session"
+import {
+  MANAGED_GROUPS,
+  MANAGED_OWNER_GROUP_DID,
+  MANAGED_ADMIN_GROUP_DID,
+  MANAGED_MEMBER_GROUP_DID,
+  MANAGED_AGGREGATED_DIDS,
+  isManagedAuthorsRequest,
+  managedGroupsMembershipsResponse,
+  managedMembershipRecords,
+  managedProjectsConnection,
+  managedActivitiesConnection,
+  managedGroups,
+  managedOrgProfile,
+  managedPlcDidDocument,
+} from "@/lib/dev/fixtures/managed"
+
+/**
+ * The org-identity read-aggregation preview's load-bearing invariant:
+ * the viewer aggregates their PERSONAL records plus the records of the
+ * groups they OWN or ADMIN — never a group they're only a MEMBER of.
+ * These tests pin that exclusion at the fixture level so the preview the
+ * surface is verified against can't silently start including the member
+ * group's content.
+ */
+describe("managed fixtures — aggregation excludes the member group", () => {
+  it("has exactly one owner, one admin, and one member group", () => {
+    const byRole = MANAGED_GROUPS.map((g) => g.role).sort()
+    expect(byRole).toEqual(["admin", "member", "owner"])
+  })
+
+  it("MANAGED_AGGREGATED_DIDS = viewer + owner + admin (member excluded)", () => {
+    expect(MANAGED_AGGREGATED_DIDS).toContain(MOCK_DID)
+    expect(MANAGED_AGGREGATED_DIDS).toContain(MANAGED_OWNER_GROUP_DID)
+    expect(MANAGED_AGGREGATED_DIDS).toContain(MANAGED_ADMIN_GROUP_DID)
+    expect(MANAGED_AGGREGATED_DIDS).not.toContain(MANAGED_MEMBER_GROUP_DID)
+  })
+
+  it("isManagedAuthorsRequest trips on owner/admin DIDs but not member-only", () => {
+    expect(isManagedAuthorsRequest([MOCK_DID, MANAGED_OWNER_GROUP_DID])).toBe(true)
+    expect(isManagedAuthorsRequest([MANAGED_ADMIN_GROUP_DID])).toBe(true)
+    // The member group on its own is NOT an aggregation request.
+    expect(isManagedAuthorsRequest([MANAGED_MEMBER_GROUP_DID])).toBe(false)
+    // A bare personal request isn't the managed-aggregation request.
+    expect(isManagedAuthorsRequest([MOCK_DID])).toBe(false)
+    expect(isManagedAuthorsRequest(undefined)).toBe(false)
+  })
+})
+
+describe("managed fixtures — connections are owned by the requested DIDs", () => {
+  it("projects: every node is owned by an author in the request", () => {
+    const conn = managedProjectsConnection(MANAGED_AGGREGATED_DIDS)
+    expect(conn.totalCount).toBeGreaterThan(0)
+    expect(conn.totalCount).toBe(conn.edges.length)
+    for (const edge of conn.edges) {
+      expect(MANAGED_AGGREGATED_DIDS).toContain(edge.node.did)
+    }
+    // Both the viewer and at least one group contribute → "via {group}".
+    const dids = new Set(conn.edges.map((e) => e.node.did))
+    expect(dids.has(MOCK_DID)).toBe(true)
+    expect(dids.has(MANAGED_OWNER_GROUP_DID)).toBe(true)
+  })
+
+  it("activities: every node is owned by an author in the request", () => {
+    const conn = managedActivitiesConnection(MANAGED_AGGREGATED_DIDS)
+    expect(conn.totalCount).toBeGreaterThan(0)
+    for (const edge of conn.edges) {
+      expect(MANAGED_AGGREGATED_DIDS).toContain(edge.node.did)
+    }
+  })
+
+  it("the member group never contributes records, even if smuggled in", () => {
+    const withMember = [...MANAGED_AGGREGATED_DIDS, MANAGED_MEMBER_GROUP_DID]
+    const projects = managedProjectsConnection(withMember)
+    const activities = managedActivitiesConnection(withMember)
+    for (const edge of [...projects.edges, ...activities.edges]) {
+      expect(edge.node.did).not.toBe(MANAGED_MEMBER_GROUP_DID)
+    }
+  })
+
+  it("a request with no managed DIDs yields no managed records", () => {
+    expect(managedProjectsConnection([MANAGED_MEMBER_GROUP_DID]).totalCount).toBe(0)
+    expect(managedActivitiesConnection([MANAGED_MEMBER_GROUP_DID]).totalCount).toBe(0)
+  })
+})
+
+describe("managed fixtures — group resolution wiring", () => {
+  it("memberships response carries all three groups with their roles", () => {
+    const { groups, cursor } = managedGroupsMembershipsResponse()
+    expect(cursor).toBeNull()
+    expect(groups).toHaveLength(3)
+    const roleByDid = Object.fromEntries(groups.map((g) => [g.groupDid, g.role]))
+    expect(roleByDid[MANAGED_OWNER_GROUP_DID]).toBe("owner")
+    expect(roleByDid[MANAGED_ADMIN_GROUP_DID]).toBe("admin")
+    expect(roleByDid[MANAGED_MEMBER_GROUP_DID]).toBe("member")
+  })
+
+  it("local membership records mirror the groups so all resolve accepted", () => {
+    const { records } = managedMembershipRecords()
+    expect(records).toHaveLength(MANAGED_GROUPS.length)
+    const recordDids = records.map((r) => r.value.groupDid).sort()
+    const groupDids = MANAGED_GROUPS.map((g) => g.groupDid).sort()
+    expect(recordDids).toEqual(groupDids)
+    for (const r of records) {
+      expect(r.uri.startsWith(`at://${MOCK_DID}/`)).toBe(true)
+    }
+  })
+
+  it("managedGroups() returns all three as accepted with their roles", () => {
+    const resolved = managedGroups()
+    expect(resolved).toHaveLength(3)
+    expect(resolved.every((g) => g.accepted)).toBe(true)
+  })
+
+  it("org profile + PLC doc resolve for managed DIDs, null for others", () => {
+    const owner = MANAGED_GROUPS[0]
+    expect(managedOrgProfile(owner.groupDid)?.displayName).toBe(owner.displayName)
+    expect(managedPlcDidDocument(owner.groupDid)?.alsoKnownAs).toEqual([
+      `at://${owner.handle}`,
+    ])
+    expect(managedOrgProfile("did:plc:unknown")).toBeNull()
+    expect(managedPlcDidDocument("did:plc:unknown")).toBeNull()
+  })
+})

--- a/src/lib/dev/fixtures/__tests__/managed.test.ts
+++ b/src/lib/dev/fixtures/__tests__/managed.test.ts
@@ -14,6 +14,8 @@ import {
   managedGroups,
   managedOrgProfile,
   managedPlcDidDocument,
+  managedNotificationsConnection,
+  managedUnreadCount,
 } from "@/lib/dev/fixtures/managed"
 
 /**
@@ -82,6 +84,47 @@ describe("managed fixtures — connections are owned by the requested DIDs", () 
   it("a request with no managed DIDs yields no managed records", () => {
     expect(managedProjectsConnection([MANAGED_MEMBER_GROUP_DID]).totalCount).toBe(0)
     expect(managedActivitiesConnection([MANAGED_MEMBER_GROUP_DID]).totalCount).toBe(0)
+  })
+})
+
+describe("managed fixtures — notifications aggregation", () => {
+  it("every notification node carries its recipient + the new field", () => {
+    const conn = managedNotificationsConnection(MANAGED_AGGREGATED_DIDS)
+    expect(conn.edges.length).toBeGreaterThan(0)
+    for (const edge of conn.edges) {
+      // recipient is the identity the notification is FOR, and must be one
+      // of the requested (authorized) DIDs.
+      expect(MANAGED_AGGREGATED_DIDS).toContain(edge.node.recipient)
+      expect(typeof edge.node.id).toBe("string")
+      expect(edge.node.isRead).toBe(false)
+    }
+    // Both the viewer and a group are recipients → mixed "via {group}" view.
+    const recipients = new Set(conn.edges.map((e) => e.node.recipient))
+    expect(recipients.has(MOCK_DID)).toBe(true)
+    expect(recipients.has(MANAGED_OWNER_GROUP_DID)).toBe(true)
+  })
+
+  it("the member group is never a notification recipient", () => {
+    const withMember = [...MANAGED_AGGREGATED_DIDS, MANAGED_MEMBER_GROUP_DID]
+    const conn = managedNotificationsConnection(withMember)
+    for (const edge of conn.edges) {
+      expect(edge.node.recipient).not.toBe(MANAGED_MEMBER_GROUP_DID)
+    }
+  })
+
+  it("a null/personal request yields only the viewer's notifications", () => {
+    const conn = managedNotificationsConnection(null)
+    expect(conn.edges.length).toBeGreaterThan(0)
+    for (const edge of conn.edges) {
+      expect(edge.node.recipient).toBe(MOCK_DID)
+    }
+  })
+
+  it("unread count sums notice counts across requested recipients", () => {
+    const personal = managedUnreadCount(null).count
+    const aggregated = managedUnreadCount(MANAGED_AGGREGATED_DIDS).count
+    // Aggregating adds the groups' unreads on top of the personal ones.
+    expect(aggregated).toBeGreaterThan(personal)
   })
 })
 

--- a/src/lib/dev/fixtures/groups.ts
+++ b/src/lib/dev/fixtures/groups.ts
@@ -208,3 +208,11 @@ export function groupsMembershipsResponse(): {
 } {
   return { groups: [], cursor: null }
 }
+
+/** Managed-scenario `/api/groups/memberships` — the three managed groups
+ *  (owner / admin / member) with their roles, so `useOrg().groups`
+ *  resolves to them under the managed/write-as-org preview. Re-exported
+ *  from the managed fixture so the CGS shape has a single source of
+ *  truth; the member group is filtered out of AGGREGATION (not the
+ *  membership list) by the surface, not here. */
+export { managedGroupsMembershipsResponse } from "./managed"

--- a/src/lib/dev/fixtures/managed.ts
+++ b/src/lib/dev/fixtures/managed.ts
@@ -1,0 +1,338 @@
+/**
+ * Dev-only preview fixtures — managed organizations (org-identity
+ * read-aggregation + per-action write model).
+ *
+ * Backs a FUTURE managed / "write-as-org" preview surface that
+ * aggregates the viewer's PERSONAL records together with the records
+ * authored by the groups they OWN or ADMIN. A group the viewer is only
+ * a MEMBER of is intentionally excluded from aggregation — membership
+ * alone doesn't grant the read-aggregation that owner/admin do.
+ *
+ * Wiring (all under the managed scenario, gated by the MockFetchProvider
+ * `managedScenario` prop so the existing previews are untouched):
+ *
+ *   - `/api/groups/memberships` → {@link managedGroupsMembershipsResponse}
+ *     returns the three managed groups as `RemoteMembership[]` so
+ *     `fetchRemoteMemberships` (and therefore `resolveGroups` →
+ *     `useOrg().groups`) resolves to them.
+ *   - PDS `listRecords(app.certified.actor.membership)` → the matching
+ *     local membership records (see `managedMembershipRecords`) so
+ *     `resolveGroups` marks each group `accepted: true`.
+ *   - PLC directory + `/api/groups/{groupDid}/profile` → per-group
+ *     handle + displayName so the aggregation rows read "via {group}".
+ *   - `/api/indexer` `Projects` / `Activities` with an `authors[]` that
+ *     includes the owner/admin group DIDs → {@link managedProjectsConnection}
+ *     / {@link managedActivitiesConnection}, which return records OWNED
+ *     BY those DIDs (personal + owner + admin, NOT the member group) so
+ *     the aggregation visibly includes "via {group}" rows.
+ *
+ * The viewer identity ({@link MOCK_DID}) and record shapes stay
+ * consistent with the existing feed / groups fixtures.
+ */
+
+import type { RemoteMembership, OrgRole, MembershipRecord } from "@/lib/groups/types"
+import { MOCK_DID } from "./session"
+
+/** One managed group per role. Same `did:plc:` shape as MOCK_DID so
+ *  `isValidDid` and the PLC-directory URL builder accept them. The
+ *  member group is the aggregation-excluded one. */
+export interface ManagedGroupFixture {
+  groupDid: string
+  handle: string
+  displayName: string
+  role: OrgRole
+  /** Stable join timestamp surfaced on the remote-membership row. */
+  joinedAt: string
+}
+
+export const MANAGED_OWNER_GROUP_DID = "did:plc:managedowner00000000000000000"
+export const MANAGED_ADMIN_GROUP_DID = "did:plc:managedadmin00000000000000000"
+export const MANAGED_MEMBER_GROUP_DID = "did:plc:managedmember0000000000000000"
+
+/** The three managed groups. Ordered owner → admin → member. */
+export const MANAGED_GROUPS: ManagedGroupFixture[] = [
+  {
+    groupDid: MANAGED_OWNER_GROUP_DID,
+    handle: "estuary-alliance.certified.app",
+    displayName: "Estuary Alliance",
+    role: "owner",
+    joinedAt: "2024-02-01T10:00:00.000Z",
+  },
+  {
+    groupDid: MANAGED_ADMIN_GROUP_DID,
+    handle: "drawdown-collective.certified.app",
+    displayName: "Drawdown Collective",
+    role: "admin",
+    joinedAt: "2024-03-12T10:00:00.000Z",
+  },
+  {
+    groupDid: MANAGED_MEMBER_GROUP_DID,
+    handle: "watershed-guild.certified.app",
+    displayName: "Watershed Guild",
+    role: "member",
+    joinedAt: "2024-04-20T10:00:00.000Z",
+  },
+]
+
+/** Lookup by group DID. */
+export function managedGroupByDid(
+  groupDid: string,
+): ManagedGroupFixture | undefined {
+  return MANAGED_GROUPS.find((g) => g.groupDid === groupDid)
+}
+
+/** The set of DIDs whose records the aggregation SHOULD include: the
+ *  viewer plus every group they own or admin. The member group is
+ *  deliberately absent. The aggregating surface passes exactly these as
+ *  the indexer `authors[]` filter. */
+export const MANAGED_AGGREGATED_DIDS: string[] = [
+  MOCK_DID,
+  ...MANAGED_GROUPS.filter((g) => g.role !== "member").map((g) => g.groupDid),
+]
+
+/** True when an `authors[]` request is the managed-aggregation request,
+ *  i.e. it carries at least one of the owner/admin group DIDs. Used by
+ *  the mock provider to decide whether to serve the managed connections.
+ *  The member group on its own does NOT trip this — membership doesn't
+ *  aggregate. */
+export function isManagedAuthorsRequest(authors: unknown): boolean {
+  if (!Array.isArray(authors)) return false
+  const aggregating = new Set(
+    MANAGED_GROUPS.filter((g) => g.role !== "member").map((g) => g.groupDid),
+  )
+  return authors.some((a) => typeof a === "string" && aggregating.has(a))
+}
+
+/** ---- /api/groups/memberships (CGS shape) -------------------------- */
+
+/** Remote-membership rows for the managed scenario — the
+ *  `{ groups: RemoteMembership[]; cursor }` shape `fetchRemoteMemberships`
+ *  paginates. All three groups (incl. the member one) are returned: the
+ *  member group still shows up in `useOrg().groups`; it's the
+ *  aggregation that excludes it, not the membership list. */
+export function managedGroupsMembershipsResponse(): {
+  groups: RemoteMembership[]
+  cursor: null
+} {
+  return {
+    groups: MANAGED_GROUPS.map(
+      (g): RemoteMembership => ({
+        groupDid: g.groupDid,
+        role: g.role,
+        joinedAt: g.joinedAt,
+      }),
+    ),
+    cursor: null,
+  }
+}
+
+/** A `Group[]` for the session user, as `useOrg().groups` resolves it
+ *  under the managed scenario (remote memberships merged with the local
+ *  accepted records). Exposed for any preview that wants the resolved
+ *  groups directly without round-tripping through `resolveGroups`. */
+export function managedGroups(): {
+  groupDid: string
+  handle: string
+  displayName: string
+  role: OrgRole
+  accepted: boolean
+}[] {
+  return MANAGED_GROUPS.map((g) => ({
+    groupDid: g.groupDid,
+    handle: g.handle,
+    displayName: g.displayName,
+    role: g.role,
+    accepted: true,
+  }))
+}
+
+/** ---- PDS listRecords(app.certified.actor.membership) -------------- */
+
+/** Local membership records on the viewer's PDS — one per managed group,
+ *  so `resolveGroups` marks each `accepted: true`. Shape matches what
+ *  `listMemberships` reads (`{ records: [{ uri, cid, value }] }`). */
+export function managedMembershipRecords(): {
+  records: { uri: string; cid: string; value: MembershipRecord }[]
+} {
+  return {
+    records: MANAGED_GROUPS.map((g, i) => ({
+      uri: `at://${MOCK_DID}/app.certified.actor.membership/membership${i}`,
+      cid: `bafymembership${i}00000000000000000000000000000000000000000000`,
+      value: {
+        $type: "app.certified.actor.membership",
+        groupDid: g.groupDid,
+        role: g.role,
+        joinedAt: g.joinedAt,
+      },
+    })),
+  }
+}
+
+/** ---- /api/groups/{groupDid}/profile ------------------------------- */
+
+/** The org profile record `getOrgProfile` reads (used by `resolveGroups`
+ *  to populate `displayName`). Returns null for an unknown DID so the
+ *  caller falls back to the handle. */
+export function managedOrgProfile(
+  groupDid: string,
+): { displayName: string; description: string } | null {
+  const group = managedGroupByDid(groupDid)
+  if (!group) return null
+  return {
+    displayName: group.displayName,
+    description: `Managed group preview — ${group.displayName}.`,
+  }
+}
+
+/** ---- aggregation source records ----------------------------------- */
+
+/** Per-owner project/activity content. Keyed so the personal viewer and
+ *  each aggregated group contribute distinct, recognisable rows. */
+interface OwnerContent {
+  did: string
+  /** Human label used only to keep the fixtures readable. */
+  label: string
+  projectTitles: string[]
+  activityTitles: string[]
+}
+
+const OWNER_CONTENT: OwnerContent[] = [
+  {
+    did: MOCK_DID,
+    label: "personal",
+    projectTitles: ["Personal restoration portfolio"],
+    activityTitles: ["Soil-carbon protocol — personal draft"],
+  },
+  {
+    did: MANAGED_OWNER_GROUP_DID,
+    label: "Estuary Alliance",
+    projectTitles: [
+      "Estuary Alliance — Tagus tidal-marsh program",
+      "Estuary Alliance — funder portfolio 2025",
+    ],
+    activityTitles: ["Tidal-marsh planting — Q1 cohort"],
+  },
+  {
+    did: MANAGED_ADMIN_GROUP_DID,
+    label: "Drawdown Collective",
+    projectTitles: ["Drawdown Collective — measurement toolkit"],
+    activityTitles: [
+      "Open drawdown measurement — v3 release",
+      "Cover-crop carbon trial — 9 farms",
+    ],
+  },
+]
+
+/** The owner-content entries whose DID appears in `authors`. The member
+ *  group never has content here (it isn't in OWNER_CONTENT), so even a
+ *  malformed request that smuggled its DID in would yield nothing. */
+function ownersInAuthors(authors: string[]): OwnerContent[] {
+  const wanted = new Set(authors)
+  return OWNER_CONTENT.filter((o) => wanted.has(o.did))
+}
+
+/** ---- /api/indexer Projects (managed) ------------------------------ */
+
+/** Projects OWNED BY the requested authors — same `orgHypercertsCollection`
+ *  node shape as `userProjectsConnection` in `groups.ts`. Records carry
+ *  the owning DID so the aggregating surface can render the "via {group}"
+ *  byline from each node's `did`. */
+export function managedProjectsConnection(authors: string[]): {
+  totalCount: number
+  edges: { cursor: string; node: Record<string, unknown> }[]
+  pageInfo: { hasNextPage: boolean; endCursor: string | null }
+} {
+  const owners = ownersInAuthors(authors)
+  const edges: { cursor: string; node: Record<string, unknown> }[] = []
+  owners.forEach((owner) => {
+    owner.projectTitles.forEach((title, i) => {
+      const idx = edges.length
+      edges.push({
+        cursor: `managed-proj-${idx}`,
+        node: {
+          uri: `at://${owner.did}/org.hypercerts.collection/mp${i}`,
+          cid: `bafymanagedproj${idx}0000000000000000000000000000000000000`,
+          did: owner.did,
+          createdAt: "2025-01-10T09:00:00.000Z",
+          title,
+          shortDescription:
+            "A verified restoration portfolio surfaced through org aggregation.",
+          items: [],
+          banner: null,
+        },
+      })
+    })
+  })
+  return {
+    totalCount: edges.length,
+    edges,
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }
+}
+
+/** ---- /api/indexer Activities (managed) ---------------------------- */
+
+/** Activities OWNED BY the requested authors — same
+ *  `orgHypercertsClaimActivity` node shape as `activitiesConnection` in
+ *  `feed.ts`. Each node's `did` is the owning DID so the surface renders
+ *  the "via {group}" attribution. */
+export function managedActivitiesConnection(authors: string[]): {
+  totalCount: number
+  edges: { cursor: string; node: Record<string, unknown> }[]
+  pageInfo: { hasNextPage: boolean; endCursor: string | null }
+} {
+  const owners = ownersInAuthors(authors)
+  const edges: { cursor: string; node: Record<string, unknown> }[] = []
+  owners.forEach((owner) => {
+    owner.activityTitles.forEach((title, i) => {
+      const idx = edges.length
+      edges.push({
+        cursor: `managed-act-${idx}`,
+        node: {
+          uri: `at://${owner.did}/org.hypercerts.claim.activity/ma${i}`,
+          cid: `bafymanagedact${idx}00000000000000000000000000000000000000`,
+          did: owner.did,
+          title,
+          shortDescription:
+            "A verified claim surfaced through org read-aggregation.",
+          createdAt: "2025-01-12T09:00:00.000Z",
+          startDate: null,
+          endDate: null,
+          labels: [],
+          image: null,
+          workScope: { scope: "ecological-restoration" },
+        },
+      })
+    })
+  })
+  return {
+    totalCount: edges.length,
+    edges,
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }
+}
+
+/** ---- PLC DID document (managed groups) ---------------------------- */
+
+/** A minimal PLC DID document for one managed group DID, so the
+ *  `https://plc.directory/<groupDid>` fetch that `resolveHandle` makes
+ *  yields the group's handle. Returns null for an unknown DID. */
+export function managedPlcDidDocument(groupDid: string): {
+  id: string
+  alsoKnownAs: string[]
+  service: { id: string; type: string; serviceEndpoint: string }[]
+} | null {
+  const group = managedGroupByDid(groupDid)
+  if (!group) return null
+  return {
+    id: group.groupDid,
+    alsoKnownAs: [`at://${group.handle}`],
+    service: [
+      {
+        id: "#atproto_pds",
+        type: "AtprotoPersonalDataServer",
+        serviceEndpoint: "https://preview-pds.certified.app",
+      },
+    ],
+  }
+}

--- a/src/lib/dev/fixtures/managed.ts
+++ b/src/lib/dev/fixtures/managed.ts
@@ -312,6 +312,95 @@ export function managedActivitiesConnection(authors: string[]): {
   }
 }
 
+/** ---- /api/notifications (managed aggregation) --------------------- */
+
+/** Per-recipient notification content — the identity each notification is
+ *  FOR (the viewer or a group they own/admin), the reason, and who
+ *  triggered it. The member group never appears (it isn't a recipient the
+ *  aggregation authorizes). */
+interface RecipientNotice {
+  recipient: string
+  reason: "endorsement" | "activity-contributor"
+  /** Display handle of the actor who triggered the notice (latestAuthor). */
+  actorDid: string
+  sortAt: string
+  count: number
+}
+
+const RECIPIENT_NOTICES: RecipientNotice[] = [
+  {
+    recipient: MOCK_DID,
+    reason: "endorsement",
+    actorDid: "did:plc:noticeactor0000000000000000001",
+    sortAt: "2026-05-20T14:10:00.000Z",
+    count: 1,
+  },
+  {
+    recipient: MANAGED_OWNER_GROUP_DID,
+    reason: "endorsement",
+    actorDid: "did:plc:noticeactor0000000000000000002",
+    sortAt: "2026-05-20T11:40:00.000Z",
+    count: 3,
+  },
+  {
+    recipient: MANAGED_OWNER_GROUP_DID,
+    reason: "activity-contributor",
+    actorDid: "did:plc:noticeactor0000000000000000003",
+    sortAt: "2026-05-19T16:05:00.000Z",
+    count: 1,
+  },
+  {
+    recipient: MANAGED_ADMIN_GROUP_DID,
+    reason: "endorsement",
+    actorDid: "did:plc:noticeactor0000000000000000004",
+    sortAt: "2026-05-19T09:25:00.000Z",
+    count: 2,
+  },
+]
+
+/** The notices whose recipient is in the requested `recipients` set. A
+ *  request with no recipients (personal path) yields only the viewer's. */
+function noticesForRecipients(recipients: string[] | null): RecipientNotice[] {
+  const wanted = new Set(recipients && recipients.length > 0 ? recipients : [MOCK_DID])
+  return RECIPIENT_NOTICES.filter((n) => wanted.has(n.recipient))
+}
+
+/** Notifications connection for the managed aggregation — the
+ *  `{ edges, pageInfo }` shape the notifications proxy forwards, each node
+ *  carrying the new `recipient` field so the client tags "via {group}". */
+export function managedNotificationsConnection(recipients: string[] | null): {
+  edges: { cursor: string; node: Record<string, unknown> }[]
+  pageInfo: { hasNextPage: boolean; endCursor: string | null }
+} {
+  const notices = noticesForRecipients(recipients)
+  const edges = notices.map((n, i) => ({
+    cursor: `managed-notif-${i}`,
+    node: {
+      id: `managed-notif-${i}`,
+      reason: n.reason,
+      reasonSubject: `at://${n.recipient}/org.hypercerts.claim.activity/ma0`,
+      sortAt: n.sortAt,
+      count: n.count,
+      latestRecordUri: `at://${n.actorDid}/app.certified.badge.award/award${i}`,
+      latestRecordCid: `bafymanagednotif${i}000000000000000000000000000000000000`,
+      latestAuthor: n.actorDid,
+      isRead: false,
+      recipient: n.recipient,
+    },
+  }))
+  return { edges, pageInfo: { hasNextPage: false, endCursor: null } }
+}
+
+/** Aggregated unread count for the managed scenario — the sum of notice
+ *  `count`s across the requested recipients. */
+export function managedUnreadCount(recipients: string[] | null): {
+  count: number
+  more: boolean
+} {
+  const total = noticesForRecipients(recipients).reduce((sum, n) => sum + n.count, 0)
+  return { count: total, more: false }
+}
+
 /** ---- PLC DID document (managed groups) ---------------------------- */
 
 /** A minimal PLC DID document for one managed group DID, so the

--- a/src/lib/groups/__tests__/managed-role-filter.test.ts
+++ b/src/lib/groups/__tests__/managed-role-filter.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest"
+import { ownedOrAdminGroups } from "@/lib/groups/managed"
+import type { Group, OrgRole } from "@/lib/groups/types"
+
+function group(groupDid: string, role: OrgRole): Group {
+  return {
+    groupDid,
+    handle: `${groupDid}.example.com`,
+    role,
+    accepted: true,
+  }
+}
+
+describe("ownedOrAdminGroups", () => {
+  it("keeps owner and admin groups, drops member groups", () => {
+    const groups: Group[] = [
+      group("did:plc:owner", "owner"),
+      group("did:plc:admin", "admin"),
+      group("did:plc:member", "member"),
+    ]
+    const kept = ownedOrAdminGroups(groups)
+    expect(kept.map((g) => g.groupDid)).toEqual(["did:plc:owner", "did:plc:admin"])
+  })
+
+  it("drops a downgraded admin once its role is member", () => {
+    // Simulate a group the viewer used to admin but was downgraded to
+    // member: the predicate keys off the CURRENT role, so it falls out.
+    const before: Group[] = [group("did:plc:x", "admin")]
+    expect(ownedOrAdminGroups(before).map((g) => g.groupDid)).toEqual(["did:plc:x"])
+
+    const after: Group[] = [group("did:plc:x", "member")]
+    expect(ownedOrAdminGroups(after)).toEqual([])
+  })
+
+  it("returns an empty array when there are no owner/admin groups", () => {
+    expect(ownedOrAdminGroups([group("did:plc:m", "member")])).toEqual([])
+    expect(ownedOrAdminGroups([])).toEqual([])
+  })
+
+  it("preserves input order", () => {
+    const groups: Group[] = [
+      group("did:plc:a", "admin"),
+      group("did:plc:m", "member"),
+      group("did:plc:o", "owner"),
+    ]
+    expect(ownedOrAdminGroups(groups).map((g) => g.groupDid)).toEqual([
+      "did:plc:a",
+      "did:plc:o",
+    ])
+  })
+})

--- a/src/lib/groups/managed.ts
+++ b/src/lib/groups/managed.ts
@@ -1,0 +1,45 @@
+"use client"
+
+import { useMemo } from "react"
+import { useOrg } from "./org-context"
+import type { Group } from "./types"
+
+/**
+ * Org-identity gate + filter source.
+ *
+ * A viewer "manages" a group when their role on it is `owner` or
+ * `admin` — `member` is read/participate-only and does NOT grant the
+ * org-aggregation surfaces (the managed feeds, the org-as-author write
+ * affordances, etc.). This module is the single place that encodes that
+ * rule so the nav gating and the data layer can't drift apart.
+ *
+ * `accepted` is intentionally NOT part of the predicate: a pending
+ * (unaccepted) owner/admin invite still confers management for the
+ * read-aggregation surfaces. If a caller needs accepted-only groups it
+ * should filter `group.accepted` itself on top of this.
+ */
+
+/** Roles that confer org-management. `member` is excluded by design. */
+const MANAGING_ROLES = new Set(["owner", "admin"])
+
+/**
+ * Filter a list of groups down to the ones the viewer owns or
+ * administers. Pure — safe to call outside React. Preserves input
+ * order so callers control sort.
+ */
+export function ownedOrAdminGroups(groups: Group[]): Group[] {
+  return groups.filter((g) => MANAGING_ROLES.has(g.role))
+}
+
+/**
+ * Nav-gating hook: true when the viewer owns or admins at least one
+ * group. Used to decide whether org-identity surfaces (managed feeds,
+ * the org switcher's "act as org" affordances) should appear at all.
+ *
+ * Re-derives from `useOrg().groups`, so it tracks org-context refreshes
+ * (role changes, accepted invites) without a second fetch.
+ */
+export function useManagesAnyGroup(): boolean {
+  const { groups } = useOrg()
+  return useMemo(() => ownedOrAdminGroups(groups).length > 0, [groups])
+}

--- a/src/lib/groups/org-context.tsx
+++ b/src/lib/groups/org-context.tsx
@@ -14,8 +14,22 @@ import type { Group } from "./types"
 
 const ACTIVE_ORG_KEY = "certified_active_org"
 
+/**
+ * `activeOrg` is READ-SCOPE ONLY.
+ *
+ * As of the per-action posting-as model (Wave 2), the active org sets
+ * the lens the viewer reads/operates a group THROUGH — managed feeds,
+ * the "Operating <group>" mode bar, group-scoped aggregation. It does
+ * NOT, and must not, decide who a write is authored AS. Every write
+ * target comes from an explicit per-action identity (`<PostingAs>` /
+ * `usePostingIdentity`, default You) or the owner DID of the record
+ * being edited — never silently from `activeOrg`. New code must not
+ * derive a `targetDid` / write repo from `activeOrg`; if you need the
+ * write identity, take it from the picker.
+ */
 interface OrgContextValue {
-  /** The group the user is currently acting as, or null for personal account */
+  /** The group the user is currently acting as (READ-SCOPE only — see the
+   *  module note above), or null for the personal account. */
   activeOrg: Group | null
   /** All groups the user belongs to */
   groups: Group[]

--- a/src/lib/groups/personal-only.ts
+++ b/src/lib/groups/personal-only.ts
@@ -5,19 +5,24 @@
  * drift out of sync as features are added.
  *
  * The constraints are real, not cosmetic:
- *   - "create"       : xrpc proxy validates `repo === sessionDid` for
- *                      write methods, so a group-acting user can't
- *                      write a record to the group repo here.
  *   - "groups"       : would be self-referential when already in a
  *                      group context — the group is reachable via the
  *                      account switcher.
  *   - "endorsements" : the underlying record lives in the personal
  *                      repo only; no group analogue exists.
+ *
+ * Note: "create" used to live here because the write target was derived
+ * from the (sticky) active org, which the xrpc proxy then rejected as a
+ * cross-repo write. As of the per-action posting-as model the Create
+ * flow chooses its write target explicitly via `<PostingAs>` (default
+ * You, opt into a group through the picker / group BFF), so Create is
+ * available regardless of the active read-scope. It is therefore no
+ * longer personal-only — the route key is kept in the union so existing
+ * callers/tests that reference it still type-check.
  */
 export type PersonalOnlyRoute = "create" | "groups" | "endorsements"
 
 const PERSONAL_ONLY_ROUTES: readonly PersonalOnlyRoute[] = [
-  "create",
   "groups",
   "endorsements",
 ]

--- a/src/lib/groups/posting-identity.ts
+++ b/src/lib/groups/posting-identity.ts
@@ -1,0 +1,102 @@
+import type { Group, OrgRole } from "./types"
+import { ownedOrAdminGroups } from "./managed"
+
+/**
+ * Per-action "posting as" model.
+ *
+ * The org-identity write model is per-action: every create/award/endorse
+ * picks WHICH repo it lands in at the moment of writing, rather than
+ * inheriting a sticky "active org" from the switcher. This module is the
+ * shared shape + option builder that the per-action picker
+ * (`<PostingAs>` / `usePostingIdentity`) feeds, and that the write seam
+ * (`writeToRepo({ targetDid })`) ultimately consumes.
+ *
+ * A `PostingIdentity` is the viewer themselves (`kind: 'personal'`) or a
+ * group they can author into (`kind: 'group'`). The `did` is the target
+ * repo DID — the viewer's own DID for personal, the group's DID for a
+ * group — so a caller can hand it straight to `targetDid` without any
+ * further lookup.
+ */
+export type PostingIdentity = {
+  /** Target repo DID — viewer's own DID (personal) or the group's DID. */
+  did: string
+  kind: "personal" | "group"
+  /** Display label — "You" for personal, the group's name for a group. */
+  label: string
+  /** Resolved handle (without leading @), when known. */
+  handle?: string
+  avatarUrl?: string
+  /** The viewer's role on the group (group identities only). */
+  role?: OrgRole
+}
+
+/**
+ * Groups the viewer may author records INTO. Writing a group-authored
+ * record requires `owner` or `admin` on that group — `member` is
+ * read/participate-only — so this is exactly {@link ownedOrAdminGroups},
+ * the single source of truth for the owner|admin write gate. Re-exported
+ * through this name so posting-as callers don't have to know it lives in
+ * `managed.ts`. Pure; preserves input order.
+ */
+export function writableGroups(groups: Group[]): Group[] {
+  return ownedOrAdminGroups(groups)
+}
+
+/**
+ * Build the ordered option list for the picker: the viewer ("You")
+ * first, then every writable group in input order. The personal option
+ * is ALWAYS present and ALWAYS first — the picker defaults to You for
+ * every action (never seeded from the active org or a last-used value),
+ * so personal is the safe, explicit default.
+ *
+ * @param viewer the signed-in viewer's own info. `did` is required;
+ *   `handle`/`avatarUrl` decorate the "You" row when known.
+ */
+export function buildPostingOptions(
+  viewer: { did: string; handle?: string; avatarUrl?: string },
+  groups: Group[],
+): PostingIdentity[] {
+  const you: PostingIdentity = {
+    did: viewer.did,
+    kind: "personal",
+    label: "You",
+    handle: viewer.handle,
+    avatarUrl: viewer.avatarUrl,
+  }
+  const groupOptions: PostingIdentity[] = writableGroups(groups).map((g) => ({
+    did: g.groupDid,
+    kind: "group",
+    label: g.displayName || g.handle,
+    handle: g.handle,
+    avatarUrl: g.avatarUrl,
+    role: g.role,
+  }))
+  return [you, ...groupOptions]
+}
+
+/**
+ * Lexicon collections whose writes are HIGH-STAKES — irreversible-feeling,
+ * reputation-bearing actions that name a third party. When one of these is
+ * authored AS A GROUP, the caller should route through a confirm step
+ * (`<PostingAsConfirm>`) that spells out who is endorsing, who operated the
+ * action, and the subject, before committing.
+ *
+ *   - `org.hypercerts.endorsement` — endorsing someone's activity / claim
+ *   - `app.certified.badge.award`  — awarding a badge to a subject
+ *
+ * Membership is matched against an AT-URI's collection segment (see
+ * `parseAtUri(uri).collection`). The set is intentionally small and
+ * explicit; widening it is a product decision, not an accident.
+ */
+export const HIGH_STAKES_COLLECTIONS = new Set<string>([
+  "org.hypercerts.endorsement",
+  "app.certified.badge.award",
+])
+
+/**
+ * Whether a write to `collection` is high-stakes and therefore warrants
+ * the confirm step when authored as a group.
+ */
+export function isHighStakesCollection(collection: string): boolean {
+  return HIGH_STAKES_COLLECTIONS.has(collection)
+}

--- a/src/lib/notifications-context.tsx
+++ b/src/lib/notifications-context.tsx
@@ -3,6 +3,8 @@
 import React, { createContext, useContext, useEffect, useState, useCallback, useRef, useMemo } from "react"
 import { useAuth } from "@/lib/auth/auth-context"
 import { fetchUnreadCount, NotificationsUnauthenticatedError } from "@/lib/atproto/notifications"
+import { useManagedAuthors } from "@/hooks/use-managed-authors"
+import { NOTIFICATIONS_AGGREGATION_ENABLED } from "@/lib/utils/config"
 
 const POLL_INTERVAL_MS = 60_000
 
@@ -21,6 +23,20 @@ const NotificationsContext = createContext<NotificationsContextValue | null>(nul
 
 export function NotificationsProvider({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading: authLoading, did } = useAuth()
+  // The badge counts unread across the viewer's managed identities when
+  // aggregation is on. `authors` is [viewerDid, ...owned/admin groups];
+  // a lone viewer (length <= 1) needs no `recipients` arg, so the default
+  // (personal) count path runs unchanged. Safe to call here:
+  // NotificationsProvider is mounted under OrgProvider in app/layout.tsx.
+  const { authors } = useManagedAuthors()
+  const authorsKey = authors.join(",")
+  const recipients = useMemo(
+    () =>
+      NOTIFICATIONS_AGGREGATION_ENABLED && authors.length > 1 ? authors : undefined,
+    // authorsKey is the stable identity of `authors`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [authorsKey],
+  )
   const [count, setCount] = useState(0)
   const [more, setMore] = useState(false)
   const [ready, setReady] = useState(false)
@@ -32,7 +48,7 @@ export function NotificationsProvider({ children }: { children: React.ReactNode 
     const controller = new AbortController()
     abortRef.current = controller
     try {
-      const result = await fetchUnreadCount(controller.signal)
+      const result = await fetchUnreadCount(recipients, controller.signal)
       if (!controller.signal.aborted) {
         setCount(result.count)
         setMore(result.more)
@@ -54,7 +70,7 @@ export function NotificationsProvider({ children }: { children: React.ReactNode 
       // silently zeroing the badge. Next poll tick will retry.
       console.warn("[Notifications] unread count refresh failed:", err)
     }
-  }, [authLoading, isAuthenticated, did])
+  }, [authLoading, isAuthenticated, did, recipients])
 
   const markOptimisticallyZero = useCallback(() => {
     setCount(0)

--- a/src/lib/utils/config.ts
+++ b/src/lib/utils/config.ts
@@ -16,3 +16,24 @@ export const PUBLIC_URL: string =
 export const PUBLIC_URL_STRICT: string | undefined =
   process.env.PUBLIC_URL ||
   (process.env.NODE_ENV === "production" ? undefined : DEV_FALLBACK)
+
+/**
+ * Feature flag: aggregate notifications across the viewer's managed
+ * identities (the groups they own/admin) rather than only their personal
+ * account. Default OFF.
+ *
+ * This gate exists because notifications are the one aggregation surface
+ * that needs an external magic-indexer change first: the notifications op
+ * is scoped by the service-auth JWT `iss`, so reading a group's
+ * notifications requires the indexer to accept a `recipients` argument and
+ * authorize it against its own role index. See
+ * docs/org-identity/indexer-notifications-aggregation.md for the contract.
+ *
+ * Until that ships, the client must NOT send `recipients` — the current
+ * indexer would reject the variant query. The flag is read BOTH server-side
+ * (the /api/notifications route, to choose the query variant) and
+ * client-side (the hooks + the notifications UI), so it's a NEXT_PUBLIC_
+ * var. Flip it on a preview env once the indexer supports it.
+ */
+export const NOTIFICATIONS_AGGREGATION_ENABLED =
+  process.env.NEXT_PUBLIC_NOTIFICATIONS_AGGREGATION === "true"


### PR DESCRIPTION
## Why

A user reported he didn't see projects he manages — because he manages them
only *via groups he belongs to*. Records authored by a group live in the
group's repo (its own DID), so they never appeared on his personal surfaces.

This implements the **org-identity aggregation** model: read-aggregate the
records owned by the groups a user owns/admins onto their own surfaces, and
make write-identity an explicit per-action choice.

Plan + decisions: `docs/org-identity/plan.md` · `docs/org-identity/review-round-1.md` ·
indexer contract: `docs/org-identity/indexer-notifications-aggregation.md`

## What's in it

**1. Read-aggregation** (ships, no flag)
- A dedicated **`/managed` hub** with an identity focus filter (`?focus=`).
- **Inline on Home** — "My projects" / "My activities" blend personal +
  group-owned rows, each tagged "via {group}".
- A dismissible **bridge banner** on the viewer's own profile.
- **Member-role groups are excluded** everywhere (only owner/admin
  aggregate). Public/foreign profiles stay single-identity.

**2. Per-action write identity** (ships, no flag)
- A **`<PostingAs>`** picker on every create/edit/respond action. Default
  **You**; high-stakes actions (endorse/award) require a confirm that names
  the parties. **"Acting as" is demoted to read-scope/focus only** — it no
  longer silently becomes the write identity.
- Edits write back to the **record-owner repo**, and edit eligibility now
  derives from the managed-author set (so a record surfaced via aggregation
  is editable without first switching the org switcher).

**3. Notifications aggregation** (flag-gated **OFF**)
- Behind `NEXT_PUBLIC_NOTIFICATIONS_AGGREGATION` (default false) because it
  needs an external **magic-indexer** change first — the notifications op is
  scoped by the JWT `iss`. The full client is built (identity filter, "via
  {group}" rows, aggregated badge); the exact indexer contract is in
  `docs/org-identity/indexer-notifications-aggregation.md`. **With the flag
  off, every notifications path is byte-identical to before.**

## Behavior changes (no hard breaks)

- "Acting as a group" no longer routes writes — writes go through the
  picker. Users with no groups see no change (default You, no picker).
- Home "My projects / activities" now show the aggregate (personal + owned/
  admin groups) and "Show more" points at `/managed`.
- A "Managed" nav item appears only for users who own/admin >=1 group.

## Out of scope (deliberate)

- Group "seen"/read-state for notifications (shared team state — phase 2;
  see indexer spec section 6). The aggregated badge is informational;
  mark-seen stays personal.
- Writing as a group you don't own/admin (the picker only offers those).
- Folding group records into the public profile (kept single-identity).

## Follow-up required to enable slice 3

Ship the `recipients` change in magic-indexer per the spec, then flip
`NEXT_PUBLIC_NOTIFICATIONS_AGGREGATION` on a preview env -> verify ->
staging -> prod.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors (65 warnings, <= baseline)
- [x] `npm run test` — 620 passing (+20: owner-tag, fan-out, notifications
      operations flag-gate, recipients wiring, fixture aggregation)
- [x] `npm run build` — clean (`/managed`, `/notifications` static)
- [x] Browser-verified via the auth-mock preview harness (light + dark +
      mobile): `/managed` hub (aggregation, focus filter, member-group
      exclusion), Home inline aggregation, own-profile bridge, `<PostingAs>`
      picker + selected-state check, notifications aggregation (filter, via
      rows, read-only group rows, aggregated badge) with the flag on
- [x] Multi-lens review (6 lenses, adversarially verified) -> 17 findings
      integrated (see `review-round-1.md`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
