### PR TITLE
feat: explore-page redesign; simplify desktop top bar

### DIFF
--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -394,6 +394,112 @@
   color: var(--fg-primary);
 }
 
+/* ---------- Combined "All" view (search across kinds) ---------- */
+
+.explore__all {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.explore__all-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.explore__all-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.explore__all-section-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-secondary);
+}
+
+/* Thin "Show all" row — the last <li> inside a capped block's list, so
+   it sits flush against the rows above (no gap) and shares the list's
+   border + clipped corners. Clicking collapses the All view to that
+   single category. */
+.explore__show-all {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 100%;
+  padding: 5px;
+  border: 0;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.explore__show-all:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+/* All view, single-category mode: the row that hosts the inline
+   sub-option pills and/or the endorsement-degree pills, in place of the
+   chrome's sub-dropdown + the standalone degree bar. Low vertical
+   footprint so it doesn't read as a tall band under the chrome. */
+.explore__inline-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+/* Light vertical rule between the sub-option pills and the degree pills
+   when both are shown. */
+.explore__inline-divider {
+  width: 1px;
+  align-self: stretch;
+  min-height: 20px;
+  background: var(--border-medium);
+}
+
+/* Inline variant of the degree bar — drops the standalone bar's block
+   padding/margin so the pills sit flush in the inline-controls row.
+   Doubled class so it beats the base `.explore__degree-bar` rule, which
+   is declared later in this file. */
+.explore__degree-bar.explore__degree-bar--inline {
+  padding: 0;
+  margin: 0;
+}
+
+.explore__all-empty {
+  margin: 0;
+  padding: 14px;
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+}
+
+.explore__all-loading {
+  display: flex;
+  justify-content: center;
+  padding: 20px 0;
+}
+
 /* ---------- List view (certs + projects) ---------- */
 
 .explore__list {

--- a/src/components/explore-page/__tests__/explore-popover-canonical.test.tsx
+++ b/src/components/explore-page/__tests__/explore-popover-canonical.test.tsx
@@ -1,18 +1,24 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
 import { render, screen, cleanup, within, fireEvent } from "@testing-library/react"
 
-// judgment-008: the Explore Sort dropdown and Sub-category dropdown were
-// migrated from a local hand-rolled <Popover> onto the canonical
+// judgment-008: the Explore Sort dropdown was migrated from a local
+// hand-rolled <Popover> onto the canonical
 // <Popover>/<PopoverTrigger>/<PopoverContent>/<PopoverItem> primitive
 // (src/components/ui/popover.tsx). These tests pin the canonical
 // behaviour the migration must preserve: the trigger wires
 // aria-controls to the menu, the menu renders role="menuitem"
 // children, click opens / re-click and Escape close.
 //
+// (The sub-category control was also once a canonical Popover, but the
+// explore redesign replaced it with an inline pill SegmentedControl, so
+// there is no sub-category menu to pin here anymore.)
+//
 // Explore pulls in auth, navbar, navigation, and the explore-data hook;
 // none of those are under test, so they're stubbed to inert defaults
-// just enough for the component to mount on its default kind=certs
-// state (where both the Sort and Sub-category triggers render).
+// just enough for the component to mount in a single-kind state
+// (`?show=accounts`), where the Sort trigger renders. The default
+// `?show=all` landing renders the capped-blocks view with no single-kind
+// toolbar.
 
 vi.mock("@/lib/auth/auth-context", () => ({
   useAuth: () => ({ did: null, isAuthenticated: false }),
@@ -25,7 +31,7 @@ vi.mock("@/lib/navbar-context", () => ({
 vi.mock("next/navigation", () => ({
   usePathname: () => "/explore",
   useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(""),
+  useSearchParams: () => new URLSearchParams("show=accounts"),
 }))
 
 vi.mock("@/hooks/use-explore", () => ({
@@ -87,30 +93,5 @@ describe("Explore Sort dropdown uses the canonical Popover", () => {
     fireEvent.keyDown(document, { key: "Escape" })
     expect(screen.queryByRole("menu")).toBeNull()
     expect(trigger.getAttribute("aria-expanded")).toBe("false")
-  })
-})
-
-describe("Explore Sub-category dropdown uses the canonical Popover", () => {
-  it("opens a role=menu of single-select options and closes on Escape", async () => {
-    const { default: Explore } = await import("../explore")
-    render(<Explore />)
-    // The sub-prefix trigger on kind=certs shows the active option,
-    // whose accessible name is exactly "All" (the chevron is aria-hidden).
-    // The sidebar's "All certs" filter has a different name, so an exact
-    // match disambiguates while the menu is still closed.
-    const trigger = screen.getByRole("button", { name: "All" })
-    expect(trigger.getAttribute("aria-haspopup")).toBe("menu")
-    expect(screen.queryByRole("menu")).toBeNull()
-
-    fireEvent.click(trigger)
-    const menu = screen.getByRole("menu")
-    expect(trigger.getAttribute("aria-controls")).toBe(menu.id)
-    const items = within(menu).getAllByRole("menuitem")
-    const labels = items.map((el) => el.textContent)
-    expect(labels).toContain("Created")
-    expect(labels).toContain("Contributed")
-
-    fireEvent.keyDown(document, { key: "Escape" })
-    expect(screen.queryByRole("menu")).toBeNull()
   })
 })

--- a/src/components/explore-page/__tests__/explore-popover-haspopup.test.tsx
+++ b/src/components/explore-page/__tests__/explore-popover-haspopup.test.tsx
@@ -5,8 +5,10 @@ import { render, screen, cleanup } from "@testing-library/react"
 // buttons in Explore omitted `aria-haspopup`, unlike the sibling
 // sub-prefix dropdown trigger (and the home-feed menu buttons) which
 // already announce a popup to assistive tech. This test mounts Explore
-// on its default (`kind=certs`) state — where both triggers render —
-// and pins that each trigger advertises a popup via `aria-haspopup`.
+// in a single-kind state (`?show=accounts`) — where the Sort and quality
+// triggers render — and pins that each advertises a popup via
+// `aria-haspopup`. (The default `?show=all` landing renders the
+// capped-blocks view, which has no single-kind toolbar.)
 //
 // Explore pulls in auth, navbar, navigation, and the explore-data hook;
 // none of those are under test, so they're stubbed to inert defaults
@@ -23,7 +25,7 @@ vi.mock("@/lib/navbar-context", () => ({
 vi.mock("next/navigation", () => ({
   usePathname: () => "/explore",
   useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(""),
+  useSearchParams: () => new URLSearchParams("show=accounts"),
 }))
 
 vi.mock("@/hooks/use-explore", () => ({

--- a/src/components/explore-page/explore-types.ts
+++ b/src/components/explore-page/explore-types.ts
@@ -1,5 +1,11 @@
 export type ExploreKind = "accounts" | "projects" | "activities"
 
+/** The kind switcher in the top bar plus the synthetic "all" tab,
+ *  which isn't a real loader kind — it's a combined view that runs the
+ *  three per-kind queries side by side. Used for tab + sidebar wiring;
+ *  the data hook still only ever sees a concrete `ExploreKind`. */
+export type ExploreView = ExploreKind | "all"
+
 export type SortOrder = "newest" | "oldest" | "alphabetical"
 
 export interface FilterOption {
@@ -45,10 +51,32 @@ const CERT_FILTERS: FilterOption[] = [
   { key: "all", label: "All activities" },
 ]
 
+/** Filters for the combined "All" view. Same building blocks as the
+ *  per-kind lists, with two deliberate edits per the All-tab spec:
+ *    - the "mine" filters (My activities / My projects / My
+ *      organizations) are dropped — the All view is a cross-section
+ *      browse/search surface, not a personal-records one;
+ *    - the per-kind "All activities" / "All projects" / "All accounts"
+ *      collapse to a single "All".
+ *  The follows + endorsed keys here are the unified All-view keys;
+ *  `viewFilterToKindFilter` maps them to each kind's concrete key. */
+const ALL_FILTERS: FilterOption[] = [
+  ...FEATURED_FILTERS,
+  { key: "recent", label: "Recently viewed" },
+  { key: "follows", label: "Accounts I follow", requiresAuth: true },
+  { key: "endorsed", label: "Endorsed accounts", requiresAuth: true },
+  { key: "all", label: "All" },
+]
+
 export function filtersForKind(kind: ExploreKind): FilterOption[] {
   if (kind === "accounts") return ACCOUNT_FILTERS
   if (kind === "projects") return PROJECT_FILTERS
   return CERT_FILTERS
+}
+
+export function filtersForView(view: ExploreView): FilterOption[] {
+  if (view === "all") return ALL_FILTERS
+  return filtersForKind(view)
 }
 
 export function defaultFilterForKind(_kind: ExploreKind): string {
@@ -57,6 +85,39 @@ export function defaultFilterForKind(_kind: ExploreKind): string {
   // featured set; the All / By me / etc. filters stay one click
   // away in the standard list below the divider.
   return "ma-earth"
+}
+
+export function defaultFilterForView(view: ExploreView): string {
+  // The All view defaults to "All" rather than the curated Ma Earth
+  // front door the single-kind tabs use: a search on the All tab
+  // should hit the whole index, not just the curated set.
+  if (view === "all") return "all"
+  return defaultFilterForKind(view)
+}
+
+/**
+ * Map a unified All-view filter key to the concrete per-kind filter
+ * key the loader (`useExploreData`) expects. Most keys are shared
+ * across kinds (`ma-earth`, `recent`, `all`); only the social-graph
+ * filters diverge — accounts use `follows` / `endorsed`, while
+ * projects and certs use `by-follows` / `by-endorsed`.
+ */
+export function viewFilterToKindFilter(
+  filter: string,
+  kind: ExploreKind,
+): string {
+  switch (filter) {
+    case "follows":
+      return kind === "accounts" ? "follows" : "by-follows"
+    case "endorsed":
+      return kind === "accounts" ? "endorsed" : "by-endorsed"
+    case "ma-earth":
+    case "recent":
+    case "all":
+      return filter
+    default:
+      return "all"
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -75,11 +136,9 @@ export const SUB_OPTIONS: Record<
     { key: "organizations", label: "Organizations" },
   ],
   projects: [],
-  activities: [
-    { key: "all", label: "All" },
-    { key: "created", label: "Created", requiresAuth: true },
-    { key: "contributed", label: "Contributed", requiresAuth: true },
-  ],
+  // Activities have no sub-toggle — the "Created" / "Contributed"
+  // options were removed; an empty list renders no sub-pills.
+  activities: [],
 }
 
 function defaultSubForKind(): string {

--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import {
   ArrowUpDown,
   ChevronDown,
+  ChevronRight,
   Filter as FilterIcon,
   FolderGit2,
   LayoutGrid,
@@ -43,10 +44,12 @@ import ProjectListRow from "./project-list-row"
 import AccountListRow from "./account-list-row"
 import {
   SUB_OPTIONS,
-  defaultFilterForKind,
-  filtersForKind,
+  defaultFilterForView,
+  filtersForView,
   parseSubForKind,
+  viewFilterToKindFilter,
   type ExploreKind,
+  type FilterOption,
   type SortOrder,
 } from "./explore-types"
 import { useExploreData } from "@/hooks/use-explore"
@@ -105,16 +108,6 @@ const ORG_TIER_BY_VALUE = {
 const DEFAULT_ORG_TIER_SLUGS: readonly OrgTierSlug[] = ORG_TIER_SLUGS.filter(
   (slug) => !DEFAULT_HIDDEN_ORG_LABELS.includes(ORG_TIER_BY_SLUG[slug]),
 )
-
-function parseKind(v: string | null): ExploreKind {
-  if (v === "accounts" || v === "projects" || v === "activities") return v
-  // Migration shim — old URLs with ?kind=users or ?kind=profiles resolve
-  // to accounts, and the legacy ?kind=certs resolves to activities, so
-  // external links keep working.
-  if (v === "users" || v === "profiles") return "accounts"
-  if (v === "certs") return "activities"
-  return "activities"
-}
 
 function parseSort(v: string | null): SortOrder {
   if (v === "newest" || v === "oldest" || v === "alphabetical") return v
@@ -202,21 +195,62 @@ function isEndorsementFilter(kind: ExploreKind, filter: string): boolean {
   return filter === "by-endorsed"
 }
 
-
-function isValidFilter(kind: ExploreKind, filter: string): boolean {
-  return filtersForKind(kind).some((f) => f.key === filter)
+/**
+ * /explore entry point. The page is always the combined "All" view now
+ * (the old per-kind top tabs were removed); category switching happens
+ * via the on-page dropdown, which drives `?show=`. {@link ExploreAll}
+ * branches that into the three-block layout or a single-category pane.
+ */
+export default function Explore() {
+  // Register the page title in the top bar's title slot — mirrors the
+  // convention every other top-level page uses (Apps, Settings…).
+  usePageTitle("Explore")
+  return <ExploreAll />
 }
 
-export default function Explore() {
+/** Icon component shape shared by lucide icons + the bespoke CertIcon —
+ *  used for the All view's per-section headers. */
+type SectionIcon = React.ComponentType<{
+  size?: number
+  strokeWidth?: number
+  "aria-hidden"?: boolean
+}>
+
+interface ExploreMainProps {
+  kind: ExploreKind
+  /** Already resolved to the kind-specific filter key. The All view
+   *  maps its unified key through `viewFilterToKindFilter` before
+   *  passing it here; the single-kind tab passes the URL filter as-is. */
+  filter: string
+  /** Optional control rendered at the start of the chrome row, before
+   *  the sub-dropdown. The All view hosts its category dropdown here. */
+  leadingControl?: React.ReactNode
+  /** Render the endorsement-degree control in its compact, low-padding
+   *  variant instead of the standalone bar. Used by the All view's
+   *  single-category mode (no section header there, so the pills sit
+   *  tight under the chrome). */
+  compactDegrees?: boolean
+}
+
+/**
+ * The single-kind chrome + results pane (everything right of the filter
+ * sidebar). Shared by the dedicated Activities/Projects/Accounts tabs
+ * and by the All view when one category is selected from its dropdown —
+ * which is what gives that mode the same sub-dropdown, view toggle,
+ * sort, and quality controls as the real tabs. `kind` + `filter` come
+ * in as props; everything else (sub / sort / view / quality / degrees /
+ * q) is read from and written to the URL.
+ */
+function ExploreMain({
+  kind,
+  filter,
+  leadingControl,
+  compactDegrees,
+}: ExploreMainProps) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const router = useRouter()
 
-  const kind = parseKind(searchParams?.get("kind") ?? null)
-  const rawFilter = searchParams?.get("filter") ?? null
-  const filter = rawFilter && isValidFilter(kind, rawFilter)
-    ? rawFilter
-    : defaultFilterForKind(kind)
   const sub = parseSubForKind(kind, searchParams?.get("sub") ?? null)
   const search = searchParams?.get("q") ?? ""
   const sort = parseSort(searchParams?.get("sort") ?? null)
@@ -364,22 +398,12 @@ export default function Explore() {
 
   // Read the target's `data-*` attribute instead of capturing the
   // iteration variable in a closure. The SWC minifier (Next 16's
-  // default prod-build pipeline) was hoisting `f` out of the per-
-  // iteration `.map()` scope and sharing it across every button's
-  // onClick — meaning every sidebar filter ended up calling
-  // setUrl({ filter: <last_filter_key> }), which on certs is "all"
-  // and produces no observable change. Reading from the DOM dataset
-  // is minifier-proof because there's no captured variable. Same
-  // pattern applied to the sub-category dropdown's option buttons
-  // below.
-  const onFilterButtonClick = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
-      const key = e.currentTarget.dataset.filterKey
-      if (key) setUrl({ filter: key })
-    },
-    [setUrl],
-  )
-
+  // default prod-build pipeline) was hoisting the loop variable out of
+  // the per-iteration `.map()` scope and sharing it across every
+  // button's onClick. Reading from the DOM dataset is minifier-proof
+  // because there's no captured variable. (The sidebar filter buttons
+  // use the same pattern; their handler lives in the parent that owns
+  // the sidebar.)
   const onSubOptionClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
       const key = e.currentTarget.dataset.subKey
@@ -551,70 +575,18 @@ export default function Explore() {
   const [qualityOpen, setQualityOpen] = useState(false)
   const [subPrefixOpen, setSubPrefixOpen] = useState(false)
 
-  // Register the page title in the top bar's title slot — the chrome
-  // already pairs the brandmark with this. Mirrors the convention
-  // every other top-level page uses (Apps, Settings, Endorsements…).
-  usePageTitle("Explore")
-
   return (
-    <div className="explore">
-      <div className="explore__layout">
-        <aside className="explore__sidebar" aria-label="Explore filters">
-          {/* Kind switcher used to live here but didn't fit in 220px
-              with three labels; promoted to the top of the main pane
-              (see below). Sidebar is now filter-list-only. */}
-          {(() => {
-            const all = filtersForKind(kind)
-            const featured = all.filter((f) => f.featured)
-            const standard = all.filter((f) => !f.featured)
-            return (
-              <>
-                <ul className="explore__filter-list">
-                  {standard.map((f) => (
-                    <li key={f.key}>
-                      <button
-                        type="button"
-                        className={`explore__filter${filter === f.key ? " explore__filter--active" : ""}`}
-                        data-filter-key={f.key}
-                        onClick={onFilterButtonClick}
-                      >
-                        {f.label}
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-                {featured.length > 0 ? (
-                  <>
-                    <hr className="explore__filter-divider" aria-hidden="true" />
-                    <h3 className="explore__filter-heading">Featured</h3>
-                    <ul className="explore__filter-list explore__filter-list--indented">
-                      {featured.map((f) => (
-                        <li key={f.key}>
-                          <button
-                            type="button"
-                            className={`explore__filter${filter === f.key ? " explore__filter--active" : ""}`}
-                            data-filter-key={f.key}
-                            onClick={onFilterButtonClick}
-                          >
-                            {f.label}
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  </>
-                ) : null}
-              </>
-            )
-          })()}
-        </aside>
-
-        <main className="explore__main">
+    <main className="explore__main">
           {/* Kind switcher (Certs / Projects / Accounts) is now
               rendered as a second row in the top navbar — same
               pattern profile pages use for their tab strip. See
               EXPLORE_TABS in desktop-top-bar.tsx. */}
           <div className="explore__chrome">
-            {SUB_OPTIONS[kind].length > 0 ? (
+            {leadingControl}
+            {/* The All view's single-category mode renders the sub-options
+                as inline pills below the chrome (see the inline-controls
+                row), so the dropdown is suppressed there. */}
+            {!compactDegrees && SUB_OPTIONS[kind].length > 0 ? (
               <SubPrefixDropdown
                 kind={kind}
                 sub={sub}
@@ -805,7 +777,46 @@ export default function Explore() {
             </div>
           </div>
 
-          {showsDegreeControl ? (
+          {compactDegrees ? (
+            // All-view single-category mode: the sub-options (e.g.
+            // People / Organizations) and the endorsement-degree pills
+            // share one inline row in place of the chrome's sub-dropdown
+            // and the standalone degree bar. A light divider separates
+            // them when both are present.
+            SUB_OPTIONS[kind].length > 0 || showsDegreeControl ? (
+              <div className="explore__inline-controls">
+                {SUB_OPTIONS[kind].length > 0 ? (
+                  <SegmentedControl
+                    aria-label={`${kind === "accounts" ? "Account" : "Activity"} sub-category`}
+                    value={sub}
+                    onValueChange={(next) =>
+                      setUrl({ sub: next === "all" ? null : next })
+                    }
+                    options={SUB_OPTIONS[kind].map((o) => ({
+                      value: o.key,
+                      label: o.label,
+                      disabled: !!o.requiresAuth && !viewerDid,
+                    }))}
+                    size="sm"
+                    shape="pill"
+                    joined={false}
+                  />
+                ) : null}
+                {SUB_OPTIONS[kind].length > 0 && showsDegreeControl ? (
+                  <span className="explore__inline-divider" aria-hidden="true" />
+                ) : null}
+                {showsDegreeControl ? (
+                  <EndorsementDegreeBar
+                    degrees={degrees}
+                    onChange={onDegreesChange}
+                    onReset={onResetDegrees}
+                    meta={data.endorsementClosure}
+                    inline
+                  />
+                ) : null}
+              </div>
+            ) : null
+          ) : showsDegreeControl ? (
             <EndorsementDegreeBar
               degrees={degrees}
               onChange={onDegreesChange}
@@ -826,9 +837,468 @@ export default function Explore() {
               isLoading={data.isLoadingMore}
             />
           ) : null}
+    </main>
+  )
+}
+
+/**
+ * The filter list in the left rail. Shared by the single-kind browser
+ * and the All view — each passes the filter set its view exposes
+ * (`filtersForKind` vs the trimmed `filtersForView("all")`). Splits
+ * the list into a standard group and a "Featured" group below a
+ * divider; the active filter is highlighted. Click handling is hoisted
+ * to the parent via `data-filter-key` so the SWC minifier can't share
+ * a hoisted loop variable across buttons (see `onFilterButtonClick`).
+ */
+function ExploreFilterSidebar({
+  filters,
+  activeFilter,
+  onFilterClick,
+}: {
+  filters: FilterOption[]
+  activeFilter: string
+  onFilterClick: (e: React.MouseEvent<HTMLButtonElement>) => void
+}) {
+  const featured = filters.filter((f) => f.featured)
+  const standard = filters.filter((f) => !f.featured)
+  return (
+    <aside className="explore__sidebar" aria-label="Explore filters">
+      <ul className="explore__filter-list">
+        {standard.map((f) => (
+          <li key={f.key}>
+            <button
+              type="button"
+              className={`explore__filter${activeFilter === f.key ? " explore__filter--active" : ""}`}
+              data-filter-key={f.key}
+              onClick={onFilterClick}
+            >
+              {f.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+      {featured.length > 0 ? (
+        <>
+          <hr className="explore__filter-divider" aria-hidden="true" />
+          <h3 className="explore__filter-heading">Featured</h3>
+          <ul className="explore__filter-list explore__filter-list--indented">
+            {featured.map((f) => (
+              <li key={f.key}>
+                <button
+                  type="button"
+                  className={`explore__filter${activeFilter === f.key ? " explore__filter--active" : ""}`}
+                  data-filter-key={f.key}
+                  onClick={onFilterClick}
+                >
+                  {f.label}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+    </aside>
+  )
+}
+
+// ----------------------------- All view -------------------------------------
+
+/** How many results each block on the All view shows. The loader still
+ *  fetches a full page per kind; we just render the head of each list. */
+const ALL_VIEW_BLOCK_SIZE = 5
+
+function isValidViewFilter(filter: string): boolean {
+  return filtersForView("all").some((f) => f.key === filter)
+}
+
+/** Which category the All view is showing. "all" renders all three
+ *  capped blocks; a concrete kind collapses to that one section shown
+ *  in full (with pagination). Backed by the `?show=` URL param. */
+type AllShow = "all" | ExploreKind
+
+function parseAllShow(v: string | null): AllShow {
+  if (v === "activities" || v === "projects" || v === "accounts") return v
+  return "all"
+}
+
+const SHOW_OPTIONS: { key: AllShow; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "activities", label: "Activities" },
+  { key: "projects", label: "Projects" },
+  { key: "accounts", label: "Accounts" },
+]
+
+/** Shared URL state for the All view — the unified sidebar filter, the
+ *  `?show=` category, and the writers both All-view modes need. */
+function useAllView() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const router = useRouter()
+
+  const rawFilter = searchParams?.get("filter") ?? null
+  const filter =
+    rawFilter && isValidViewFilter(rawFilter)
+      ? rawFilter
+      : defaultFilterForView("all")
+  const show = parseAllShow(searchParams?.get("show") ?? null)
+
+  const setUrl = useCallback(
+    (patch: Record<string, string | null>) => {
+      const params = new URLSearchParams(searchParams?.toString() ?? "")
+      for (const [k, v] of Object.entries(patch)) {
+        if (v === null || v === "") params.delete(k)
+        else params.set(k, v)
+      }
+      const qs = params.toString()
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+    },
+    [pathname, searchParams, router],
+  )
+
+  const onFilterButtonClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      const key = e.currentTarget.dataset.filterKey
+      if (key) setUrl({ filter: key === defaultFilterForView("all") ? null : key })
+    },
+    [setUrl],
+  )
+
+  // Category selection — "all" is the default, so it clears the param.
+  const setShow = useCallback(
+    (next: AllShow) => setUrl({ show: next === "all" ? null : next }),
+    [setUrl],
+  )
+  const [showOpen, setShowOpen] = useState(false)
+  const onShowOptionClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      const key = e.currentTarget.dataset.showKey as AllShow | undefined
+      if (key) {
+        setShow(key)
+        setShowOpen(false)
+      }
+    },
+    [setShow],
+  )
+
+  return {
+    filter,
+    show,
+    setUrl,
+    onFilterButtonClick,
+    setShow,
+    showOpen,
+    setShowOpen,
+    onShowOptionClick,
+  }
+}
+
+/**
+ * Combined "All" view. A category dropdown sits before the search field.
+ * Its default ("All") shows the first {@link ALL_VIEW_BLOCK_SIZE} of
+ * each kind as its own block (Activities, Projects, Accounts), each
+ * ending in a thin "Show all" row. Picking a concrete category — via the
+ * dropdown OR a "Show all" row — collapses to that one category, shown
+ * with the full single-kind chrome (sub / view / sort / quality) through
+ * {@link ExploreMain}. Selection rides the `?show=` URL param.
+ *
+ * Split so the two modes are separate components: the blocks mode runs
+ * three loaders, the single mode runs exactly one (inside ExploreMain).
+ * Branching at this boundary keeps the other two loaders from firing
+ * wasted queries while a single category is selected.
+ */
+function ExploreAll() {
+  const searchParams = useSearchParams()
+  const show = parseAllShow(searchParams?.get("show") ?? null)
+  return show === "all" ? <ExploreAllBlocks /> : <ExploreAllSingle show={show} />
+}
+
+/** All view, default mode: three capped blocks side by side. */
+function ExploreAllBlocks() {
+  const {
+    filter,
+    setUrl,
+    onFilterButtonClick,
+    setShow,
+    showOpen,
+    setShowOpen,
+    onShowOptionClick,
+  } = useAllView()
+  const searchParams = useSearchParams()
+  const search = searchParams?.get("q") ?? ""
+
+  // Search debounce — same pattern as the single-kind view. Keeps
+  // typing snappy, hits the indexer once typing stops, and reconciles
+  // external URL changes (filter switch / back-forward) into the input.
+  const [localQuery, setLocalQuery] = useState(search)
+  const lastWroteToUrlRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (search === lastWroteToUrlRef.current) return
+    setLocalQuery(search)
+  }, [search])
+  useEffect(() => {
+    const t = setTimeout(() => {
+      if (localQuery !== search) {
+        lastWroteToUrlRef.current = localQuery
+        setUrl({ q: localQuery || null })
+      }
+    }, 350)
+    return () => clearTimeout(t)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [localQuery])
+
+  // Three independent loaders — one per kind. Each maps the unified
+  // All-view filter to that kind's concrete filter key. `sub` is pinned
+  // to "all" (the All view has no People/Created sub-toggle).
+  const activities = useExploreData({
+    kind: "activities",
+    filter: viewFilterToKindFilter(filter, "activities"),
+    sub: "all",
+    search,
+  })
+  const projects = useExploreData({
+    kind: "projects",
+    filter: viewFilterToKindFilter(filter, "projects"),
+    sub: "all",
+    search,
+  })
+  const accounts = useExploreData({
+    kind: "accounts",
+    filter: viewFilterToKindFilter(filter, "accounts"),
+    sub: "all",
+    search,
+  })
+
+  const activityItems = useMemo(
+    () => sortCerts(activities.certs, "newest").slice(0, ALL_VIEW_BLOCK_SIZE),
+    [activities.certs],
+  )
+  const projectItems = useMemo(
+    () => sortProjects(projects.projects, "newest").slice(0, ALL_VIEW_BLOCK_SIZE),
+    [projects.projects],
+  )
+  const accountItems = useMemo(
+    () => sortUsers(accounts.users, "newest").slice(0, ALL_VIEW_BLOCK_SIZE),
+    [accounts.users],
+  )
+
+  return (
+    <div className="explore">
+      <div className="explore__layout">
+        <ExploreFilterSidebar
+          filters={filtersForView("all")}
+          activeFilter={filter}
+          onFilterClick={onFilterButtonClick}
+        />
+
+        <main className="explore__main">
+          <div className="explore__chrome">
+            <AllCategoryDropdown
+              show="all"
+              onSelect={onShowOptionClick}
+              open={showOpen}
+              setOpen={setShowOpen}
+            />
+
+            <div className="explore__search-field">
+              <Input
+                type="search"
+                size="sm"
+                leadingIcon={<Search size={14} strokeWidth={1.75} aria-hidden />}
+                placeholder="Search Certified"
+                value={localQuery}
+                onChange={(e) => setLocalQuery(e.target.value)}
+                aria-label="Search Certified"
+              />
+            </div>
+          </div>
+
+          <div className="explore__all">
+            <AllSection
+              title="Activities"
+              icon={CertIcon}
+              isLoading={activities.isLoading}
+              isEmpty={activityItems.length === 0}
+            >
+              <ul className="explore__list explore__list--certs">
+                {activityItems.map((rec) => {
+                  const did = activities.certDids.get(rec.uri) ?? ""
+                  return (
+                    <li key={rec.uri}>
+                      <CertListRow record={rec} did={did} />
+                    </li>
+                  )
+                })}
+                <ShowAllRow onClick={() => setShow("activities")} />
+              </ul>
+            </AllSection>
+
+            <AllSection
+              title="Projects"
+              icon={FolderGit2}
+              isLoading={projects.isLoading}
+              isEmpty={projectItems.length === 0}
+            >
+              <ul className="explore__list explore__list--projects">
+                {projectItems.map((p) => (
+                  <li key={p.uri}>
+                    <ProjectListRow project={p} />
+                  </li>
+                ))}
+                <ShowAllRow onClick={() => setShow("projects")} />
+              </ul>
+            </AllSection>
+
+            <AllSection
+              title="Accounts"
+              icon={Users}
+              isLoading={accounts.isLoading}
+              isEmpty={accountItems.length === 0}
+            >
+              <ul className="explore__list explore__list--accounts">
+                {accountItems.map((a) => (
+                  <li key={a.did}>
+                    <AccountListRow actor={a} />
+                  </li>
+                ))}
+                <ShowAllRow onClick={() => setShow("accounts")} />
+              </ul>
+            </AllSection>
+          </div>
         </main>
       </div>
     </div>
+  )
+}
+
+/** All view, single-category mode: the chosen kind rendered with the
+ *  full single-kind chrome via {@link ExploreMain}, behind the trimmed
+ *  All-view sidebar and the category dropdown. */
+function ExploreAllSingle({ show }: { show: ExploreKind }) {
+  const {
+    filter,
+    onFilterButtonClick,
+    showOpen,
+    setShowOpen,
+    onShowOptionClick,
+  } = useAllView()
+  return (
+    <div className="explore">
+      <div className="explore__layout">
+        <ExploreFilterSidebar
+          filters={filtersForView("all")}
+          activeFilter={filter}
+          onFilterClick={onFilterButtonClick}
+        />
+        <ExploreMain
+          kind={show}
+          filter={viewFilterToKindFilter(filter, show)}
+          compactDegrees
+          leadingControl={
+            <AllCategoryDropdown
+              show={show}
+              onSelect={onShowOptionClick}
+              open={showOpen}
+              setOpen={setShowOpen}
+            />
+          }
+        />
+      </div>
+    </div>
+  )
+}
+
+/** The thin "Show all" row pinned as the last item inside a capped
+ *  block's list — collapses the All view to that single category. Lives
+ *  inside the bordered list so it reads as the list's final row (no gap
+ *  to the rows above). */
+function ShowAllRow({ onClick }: { onClick: () => void }) {
+  return (
+    <li>
+      <button type="button" className="explore__show-all" onClick={onClick}>
+        Show all
+        <ChevronRight size={14} strokeWidth={1.75} aria-hidden />
+      </button>
+    </li>
+  )
+}
+
+/** Category dropdown that sits before the All view's search field —
+ *  All / Activities / Projects / Accounts. Mirrors the single-kind
+ *  SubPrefixDropdown's chrome + the data-attr click handoff (so the SWC
+ *  minifier can't share a hoisted loop variable across the options). */
+function AllCategoryDropdown({
+  show,
+  onSelect,
+  open,
+  setOpen,
+}: {
+  show: AllShow
+  onSelect: (e: React.MouseEvent<HTMLButtonElement>) => void
+  open: boolean
+  setOpen: (next: boolean) => void
+}) {
+  const active = SHOW_OPTIONS.find((o) => o.key === show) ?? SHOW_OPTIONS[0]
+  return (
+    <UiPopover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger>
+        <button type="button" className="explore__sub-dropdown-trigger">
+          <span className="explore__sub-dropdown-label">{active.label}</span>
+          <ChevronDown size={13} strokeWidth={1.75} aria-hidden />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start">
+        {SHOW_OPTIONS.map((opt) => (
+          <PopoverItem
+            key={opt.key}
+            className={show === opt.key ? "font-medium" : ""}
+            data-show-key={opt.key}
+            onClick={onSelect}
+          >
+            {opt.label}
+          </PopoverItem>
+        ))}
+      </PopoverContent>
+    </UiPopover>
+  )
+}
+
+/**
+ * One block on the All view's default (three-block) layout: an uppercase
+ * section heading, then either a spinner (still loading), a muted empty
+ * line (no matches), or the result list passed as children. The list
+ * itself carries the trailing {@link ShowAllRow}.
+ */
+function AllSection({
+  title,
+  icon: Icon,
+  isLoading,
+  isEmpty,
+  children,
+}: {
+  title: string
+  icon: SectionIcon
+  isLoading: boolean
+  isEmpty: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <section className="explore__all-section">
+      <div className="explore__all-section-head">
+        <h2 className="explore__all-section-title">
+          <Icon size={14} strokeWidth={1.75} aria-hidden />
+          {title}
+        </h2>
+      </div>
+      {isLoading ? (
+        <div className="explore__all-loading">
+          <LoadingSpinner size="sm" />
+        </div>
+      ) : isEmpty ? (
+        <p className="explore__all-empty">No {title.toLowerCase()} found</p>
+      ) : (
+        children
+      )}
+    </section>
   )
 }
 
@@ -866,18 +1336,25 @@ function EndorsementDegreeBar({
   onChange,
   onReset,
   meta,
+  inline = false,
 }: {
   degrees: Set<Degree>
   onChange: (next: Set<Degree>) => void
   onReset: () => void
   meta: ReturnType<typeof useExploreData>["endorsementClosure"]
+  /** Compact layout for the All view's single-category section header —
+   *  drops the standalone bar's block padding so the pills sit inline
+   *  next to the section title. */
+  inline?: boolean
 }) {
   // Default is {1}. Hide the reset affordance when we're already
   // there so the inline control doesn't read as "active" on a fresh
   // visit.
   const isDefault = degrees.size === 1 && degrees.has(1)
   return (
-    <div className="explore__degree-bar">
+    <div
+      className={`explore__degree-bar${inline ? " explore__degree-bar--inline" : ""}`}
+    >
       <div className="explore__degree-pills">
         <ToggleGroup
           aria-label="Endorsement rings — mark one or more"

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -38,6 +38,12 @@ import { Tabs, TabList, Tab } from "@/components/ui/tabs";
 
 const ROLE_ORDER: Record<string, number> = { owner: 0, admin: 1, member: 2 };
 
+// Temporarily hide the top-left hamburger (site-navigation drawer trigger).
+// We're considering removing it entirely; flip this back to `true` to restore.
+// The button + <SiteDrawer> wiring is kept intact below so nothing has to be
+// rebuilt if we decide to bring it back.
+const SHOW_SITE_NAV_HAMBURGER = false;
+
 interface ProfileTab {
   key: string;
   label: string;
@@ -82,16 +88,6 @@ const PROFILE_TABS: ProfileTab[] = [
  *  (`<pathname>/<subRoute>`) instead — used by `Explore` which has
  *  its own page. */
 type DetailTab = { key: string; label: string; subRoute?: string };
-
-/** /explore page tabs. Mirror the kind switcher that lived inside
- *  the explore main pane (Certs / Projects / Accounts). Switching
- *  tabs replaces ?kind= on /explore and clears the kind-specific
- *  state to match the on-page behavior. */
-const EXPLORE_TABS: { key: string; label: string }[] = [
-  { key: "activities", label: "Activities" },
-  { key: "projects", label: "Projects" },
-  { key: "accounts", label: "Accounts" },
-];
 
 const CERT_DETAIL_TABS: DetailTab[] = [
   { key: "overview", label: "Overview" },
@@ -195,7 +191,6 @@ export default function DesktopTopBar() {
     (pathname?.startsWith("/project/") ?? false) &&
     pathname !== "/project/new" &&
     !(pathname?.endsWith("/edit") ?? false);
-  const isOnExplore = pathname === "/explore";
   // Create flows (`/create`, `/project/new`) are single-page forms with
   // no tab strip, but they still get a row-2 Back affordance so the
   // navigation rhythm matches detail pages. The form's own Cancel button
@@ -204,7 +199,7 @@ export default function DesktopTopBar() {
   const showBackRow = isOnCertDetail || isOnProjectDetail || isOnCreatePage;
   // Settings is its own standalone surface now (reachable from the
   // site drawer); no tab strip there.
-  const showTabsRow = isOnProfile || isOnExplore;
+  const showTabsRow = isOnProfile;
   // Compare the URL handle slug to the signed-in user's handle to decide
   // whether to show own-only tabs (e.g. Settings). Activeorg switches the
   // "you" identity to the org, so we compare against `identity.handle`.
@@ -238,20 +233,6 @@ export default function DesktopTopBar() {
     if (v && visibleProfileTabs.some((t) => t.key === v)) return v;
     return "overview";
   }, [searchParams, visibleProfileTabs]);
-
-  // Active /explore kind — reads ?kind= with the same migration shim
-  // <Explore> uses (users / profiles legacy → accounts; certs → activities).
-  // Drives the explore tab strip's selected state.
-  const exploreKind = useMemo(() => {
-    const raw = searchParams?.get("kind") ?? null;
-    return raw === "accounts" || raw === "projects" || raw === "activities"
-      ? raw
-      : raw === "users" || raw === "profiles"
-        ? "accounts"
-        : raw === "certs"
-          ? "activities"
-          : "activities";
-  }, [searchParams]);
 
   // Switcher dropdown — now the canonical <Popover> (portal + side="bottom"
   // + align="end"), which escapes the bar's overflow/transform context and
@@ -360,15 +341,17 @@ export default function DesktopTopBar() {
       <SiteDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
       <div className="desktop-top-bar__row desktop-top-bar__row--chrome">
         <div className="desktop-top-bar__left">
-          <button
-            type="button"
-            className="desktop-top-bar__menu"
-            aria-label="Open site navigation"
-            aria-expanded={drawerOpen}
-            onClick={() => setDrawerOpen(true)}
-          >
-            <Menu size={18} strokeWidth={1.75} aria-hidden />
-          </button>
+          {SHOW_SITE_NAV_HAMBURGER ? (
+            <button
+              type="button"
+              className="desktop-top-bar__menu"
+              aria-label="Open site navigation"
+              aria-expanded={drawerOpen}
+              onClick={() => setDrawerOpen(true)}
+            >
+              <Menu size={18} strokeWidth={1.75} aria-hidden />
+            </button>
+          ) : null}
           <Link
             href={brandHref}
             className={`desktop-top-bar__brand${breadcrumb || pageTitle ? "" : " desktop-top-bar__brand--wordmark"}`}
@@ -557,31 +540,7 @@ export default function DesktopTopBar() {
         </div>
       </div>
 
-      {isOnExplore ? (
-        <div className="desktop-top-bar__row desktop-top-bar__row--tabs">
-          {/* Explore kind strip — canonical <Tabs> (underline). The row
-              wrapper owns the bottom border, so TabList drops its own
-              (border-0). onChange replaces ?kind= in place with
-              scroll:false to match the on-page kind switcher (which resets
-              filter/sub/q/sort/view/attrs). */}
-          <Tabs
-            value={exploreKind}
-            onChange={(next) => {
-              const params = new URLSearchParams();
-              params.set("kind", next);
-              router.replace(`/explore?${params.toString()}`, { scroll: false });
-            }}
-          >
-            <TabList aria-label="Explore sections" className="border-0">
-              {EXPLORE_TABS.map((t) => (
-                <Tab key={t.key} value={t.key}>
-                  {t.label}
-                </Tab>
-              ))}
-            </TabList>
-          </Tabs>
-        </div>
-      ) : showTabsRow ? (
+      {showTabsRow ? (
         <div className="desktop-top-bar__row desktop-top-bar__row--tabs">
           {/* Profile ?tab= strip — canonical <Tabs> (underline). onChange
               pushes the ?tab= URL (scroll:false) so the page mirrors it,


### PR DESCRIPTION
## Summary

Reworks the explore page and streamlines the desktop top bar as part of the positioning redesign.

- Explore page redesign (`explore.tsx`, `explore-types.ts`, `explore.css`)
- Move section tabs out of the desktop top bar
- Temporarily hide the top-left site-navigation hamburger (`SHOW_SITE_NAV_HAMBURGER = false`)

## Changes

| File | +/- |
|---|---|
| `src/components/explore-page/explore.tsx` | +669 lines reworked |
| `src/app/styles/explore.css` | +106 |
| `src/components/explore-page/explore-types.ts` | +69 |
| `src/components/layout/desktop-top-bar.tsx` | -79 net |

## Notes

- Branched off current `staging` (`becc274`), single commit on top.
- Not yet run through `tsc`/lint in CI locally — relying on PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)