### PR TITLE
feat(mobile): comprehensive mobile-view overhaul

### DIFF
--- a/docs/mobile-overhaul/audit.json
+++ b/docs/mobile-overhaul/audit.json
@@ -1,0 +1,2110 @@
+[
+  {
+    "url": "https://certified.app",
+    "file": "src/app/page.tsx",
+    "desktopLayout": "Full-screen fixed overlay centered on viewport with 48x48px pulsing brandmark. Uses display: flex with align-items: center and justify-content: center to center content. The .loading-screen wrapper covers the entire viewport (inset: 0) with position: fixed and z-index: var(--z-popover). Background color is --bg-canvas. Rendered during client-side redirect from / to /home (authenticated) or /welcome (unauthenticated).",
+    "mobileCurrentState": "The desktop layout shrinks identically to mobile without any CSS overrides. The fixed positioning and flexbox centering work across all viewport sizes (< 800px). The 48x48px icon renders at the same size on mobile and desktop since there are no @media queries adjusting the LoadingSpinner component size. This works well because fixed positioning + centered flex layout is viewport-agnostic.",
+    "findings": [
+      {
+        "issue": "CSS rule .loading-screen__logo (64x64px) exists but is unused — the actual LoadingSpinner renders at 48x48px (h-12 w-12). Creates maintenance confusion and inconsistency with the CSS intent.",
+        "severity": "low",
+        "category": "consistency",
+        "location": "src/app/page.tsx (line 38) + src/app/styles/layout.css (line 80-85)",
+        "recommendation": "Either (a) apply loading-screen__logo class to LoadingSpinner's outermost div to match the 64x64px CSS rule, or (b) remove the unused CSS rule and keep the 48x48px h-12 w-12 Tailwind sizing. Option (a) is recommended to honor the hard design principle of using CSS for sizing/spacing rather than Tailwind utilities for core layout — migrate LoadingSpinner's h-12 w-12 to a BEM class that inherits from .loading-screen__logo."
+      },
+      {
+        "issue": "No viewport-specific scaling test — while the page adapts well (fixed + centered = mobile-proof), there is no explicit 16px minimum font-size override for any <a> elements that might appear in error states (.loading-screen__link). Current .loading-screen__link is 0.8125rem (13px), below iOS auto-zoom threshold.",
+        "severity": "low",
+        "category": "a11y",
+        "location": "src/app/styles/layout.css (line 113-123)",
+        "recommendation": "Add @media (max-width: 799px) rule to override .loading-screen__link to font-size: 16px on mobile. This ensures any tappable links on the loading screen (e.g., oauth/callback error recovery links) don't trigger iOS Safari auto-zoom. Update: line 114 from 'font-size: 0.8125rem;' to include media query override for mobile."
+      }
+    ]
+  },
+  {
+    "url": "https://certified.app/welcome",
+    "file": "/workspace/certified-app/src/app/styles/landing.css",
+    "desktopLayout": "Full-bleed hero with centered text (112px top, 48px bottom padding), scaled title using clamp(5rem, 7vw + 1rem, 7rem) and subtitle. Four main content sections: \"What You Get\" (2-col bento grid), \"By the Numbers\" (5-col network stats grid), \"How It Works\" (3-step protocol layout with 4/5 aspect-ratio card), \"Works Across Partner Apps\" (4-col grid), \"Built for Trust\" (3-col trust items). Sections use 96px vertical and 32px horizontal padding. All grids, spacing, typography, colors, shadows, radius use canonical tokens and breakpoints (800/1100/1300).",
+    "mobileCurrentState": "CSS partially adapts at max-width: 799px via media queries, but incompletely: Hero padding reduces (96px top, 32px bottom, 20px horizontal) and min-height becomes auto. Section padding reduces to 64px vertical, 20px horizontal. Bento grid stacks to 1 column. BUT: Partner Apps grid remains 2-column (should be 1); Network Stats uses non-canonical breakpoints (600px / 900px instead of 800 / 1100 / 1300); Hero title stays at 80px minimum (too large); Feedback button remains 28×28px (below 44px tap target); Protocol card stays 400px tall. Result: layout doesn't shrink/overflow, but usability and consistency are compromised at mobile widths.",
+    "findings": [
+      {
+        "issue": "Partner Apps grid remains 2-column at mobile, causing cells to be 167px wide with 48px horizontal padding, leaving only 119px internal space. Description text (max-width: 180px) overflows or wraps excessively, making the layout cramped and hard to read.",
+        "severity": "critical",
+        "category": "layout",
+        "location": "src/app/styles/landing.css:721-725",
+        "recommendation": "Add @media (max-width: 799px) { .landing-network { grid-template-columns: 1fr; } .landing-network__cell { padding: 32px 20px; } } to stack to single column and reduce padding for mobile screens."
+      },
+      {
+        "issue": "Network Stats section uses non-canonical breakpoints (600px and 900px) instead of the required 800/1100/1300. At exactly 799px, it shows 2-column layout when it should show 1 column. This violates the hard design rule and creates inconsistent responsive behavior.",
+        "severity": "critical",
+        "category": "consistency",
+        "location": "src/app/styles/landing.css:1246-1256",
+        "recommendation": "Replace all breakpoints in network-stats__grid with canonical ones: @media (max-width: 799px) { grid-template-columns: 1fr; } @media (min-width: 800px) { grid-template-columns: repeat(5, minmax(0, 1fr)); }. Delete the 600px and 900px media queries entirely."
+      },
+      {
+        "issue": "Hero title uses clamp(5rem, 7vw + 1rem, 7rem) which floors to 80px at mobile viewports. With line-height 0.9 and <br> in markup, the heading consumes 50%+ of viewport height on small screens, creating poor visual hierarchy against the 18px subtitle.",
+        "severity": "high",
+        "category": "typography",
+        "location": "src/app/styles/landing.css:46-54",
+        "recommendation": "Add @media (max-width: 799px) { .hero__title { font-size: clamp(2rem, 6vw, 3rem); } } to allow the title to scale down to 32px at small widths while maintaining fluidity."
+      },
+      {
+        "issue": "Feedback trigger button is 28px × 28px on mobile (padding: 8px 12px; font-size: 0.75rem). Falls below WCAG 2.5 Level AAA minimum of 44px × 44px for touch targets, violating accessibility guidelines and making it hard to tap accurately on mobile devices.",
+        "severity": "high",
+        "category": "a11y",
+        "location": "src/app/styles/landing.css:479-485",
+        "recommendation": "Increase mobile button to @media (max-width: 799px) { .feedback-trigger { padding: 12px 16px; font-size: 0.875rem; } } to achieve at least 44px × 44px minimum. Alternatively, hide the text label on mobile and show icon-only: .feedback-trigger span { display: none; } to maintain compact appearance."
+      },
+      {
+        "issue": "Hero section top padding is calc(64px + 32px) = 96px at mobile. Combined with 80px title (due to clamp floor) and line-height 0.9, this creates excessive vertical spacing before the sign-in button, pushing it far down the viewport on short screens.",
+        "severity": "high",
+        "category": "spacing",
+        "location": "src/app/styles/landing.css:153-160",
+        "recommendation": "Reduce top padding at mobile: @media (max-width: 799px) { .hero { padding: calc(64px + 24px) 20px 24px; } } to decrease overall hero height and bring the CTA button into better viewport position."
+      },
+      {
+        "issue": "Protocol card (How It Works section) has min-height: 400px at mobile viewports, which consumes most of the visible screen height at 375px width. The card content takes up significant real estate without leaving space for scrolling context.",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/landing.css:1172-1174",
+        "recommendation": "Add @media (max-width: 799px) { .landing-protocol__card { min-height: 300px; aspect-ratio: auto; } } to reduce the card's vertical footprint and allow natural content sizing on mobile."
+      },
+      {
+        "issue": "Bento cards have padding: 32px and min-height: 200px applied uniformly across desktop and mobile. At 375px width, this leaves only 267px content width (335px - 64px padding), making the layout unnecessarily constrained. min-height forces tall cards even when content is minimal.",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/styles/landing.css:870-878",
+        "recommendation": "Add @media (max-width: 799px) { .landing-bento__card { padding: 24px; min-height: auto; } } to reduce padding and allow cards to size naturally to content on mobile."
+      },
+      {
+        "issue": "FAQ button text is sized at 1.0625rem (17px) on mobile. iOS auto-zooms any form input or text smaller than 16px on focus, which while not critical here (it's a <button>, not <input>), is at the edge of the threshold and could trigger unexpected zoom on some browsers or custom implementations.",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/app/styles/landing.css:940-959",
+        "recommendation": "Add @media (max-width: 799px) { .landing-faq-btn { font-size: 1rem; } } to ensure text is at or above 16px minimum on all mobile devices, avoiding any potential auto-zoom triggers."
+      },
+      {
+        "issue": "Section padding is 20px horizontally at mobile. While acceptable at 375px, devices narrower than 360px (rare but extant: iPhone SE 1st gen, small Android phones) may need reduced padding to maximize content width. Current padding creates unnecessary horizontal constraint on ultra-narrow viewports.",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/styles/landing.css:851-854",
+        "recommendation": "Add @media (max-width: 359px) { .landing-section { padding: 48px 16px; } } to adapt for devices narrower than 360px. For most phones (375px+), keep 20px padding."
+      },
+      {
+        "issue": "Hero pattern SVG (grid, circles, lines) is rendered at full 100% width and height with opacity 0.25 on all viewport sizes. This decorative background costs paint and raster performance on mobile with no visual benefit due to small size. At 375px, grid cells are too tiny and pattern becomes visual noise.",
+        "severity": "low",
+        "category": "performance",
+        "location": "src/components/landing/landing-page.tsx:14-28 + src/app/styles/landing.css:13-25",
+        "recommendation": "Add @media (max-width: 799px) { .hero__pattern { display: none; } } to remove the SVG from mobile rendering entirely, improving paint performance. Alternatively, reduce opacity to 0.05 and use will-change: transform to hint the browser about potential animation."
+      }
+    ]
+  },
+  {
+    "url": "file:///workspace/certified-app/src/app/home/page.tsx",
+    "file": "/workspace/certified-app/src/app/styles/home.css",
+    "desktopLayout": "Two-pane layout: left sidebar (256-296px fluid, 28px gap) containing 5-item preview lists (Groups/Projects/Activities); right main pane containing feed header + list + optional news rail. Feed header has \"Feed\" title (left) + two icon filter buttons (right). Feed is three-column grid: 32px avatar | flex content | 84px right-aligned time. Below feed, optional news rail at 320px width appears at ≥1200px. Layout stretches edge-to-edge; sidebar/main divider runs full viewport height to footer.",
+    "mobileCurrentState": "Below 800px: single column, sidebar stacks above main. Sidebar keeps 28px gap between sections. Main pane padding narrows from 24px to 16px. Feed layout adapts: grid becomes 32px avatar + flex content (time moves to row 2, left-aligned instead of right). Preview cards shrink thumb from 56px to 44px. News rail hidden. Filter buttons remain 26x26px (below 44px tap target minimum). Filter popovers are 184px (quality) or 248px (evaluators) with absolute positioning right: 0—can overflow viewport on phones < 432px wide. Evaluator search dropdown uses right: 0 anchor too. No other substantial responsive adaptations beyond these grid tweaks.",
+    "findings": [
+      {
+        "issue": "Filter buttons below minimum tap target size on mobile",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "home.css:625-638",
+        "recommendation": "Increase .home-feed__filter-btn to at least 44x44px on mobile. Use @media (max-width: 799px) to override width and height from 26px to 44px, maintaining the icon's visual size with padding instead. Ensure focus-visible ring has 2px offset to avoid cutting off."
+      },
+      {
+        "issue": "Filter popovers can overflow viewport on narrow mobile screens",
+        "severity": "high",
+        "category": "overflow",
+        "location": "home.css:658-669, 754-756",
+        "recommendation": "Add mobile media query to constrain popover width and position. Use @media (max-width: 799px) to set max-width: calc(100vw - 32px) and adjust positioning logic: detect screen width and reposition popover left: 0 if right anchor would overflow. Consider max-height with overflow-y: auto for very tall evaluator lists."
+      },
+      {
+        "issue": "Filter checkbox inputs (14x14px) below WCAG touch target minimum",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "home.css:711-717, 766-772",
+        "recommendation": "Increase .home-feed__filter-item input and .home-feed__evaluator-check to 16x16px minimum on mobile. Adjust padding inside .home-feed__filter-item from 6px 8px to 8px 10px to accommodate. Keep the 14px checkbox at desktop."
+      },
+      {
+        "issue": "Sidebar section spacing (28px gap) may create excessive whitespace on small phones",
+        "severity": "low",
+        "category": "spacing",
+        "location": "home.css:63-80",
+        "recommendation": "Reduce .home__sidebar gap on mobile via @media (max-width: 799px) from 28px to 20px to make better use of space while maintaining visual separation."
+      },
+      {
+        "issue": "Preview card image thumbnails (44px) not optimized for touch interaction",
+        "severity": "low",
+        "category": "spacing",
+        "location": "home.css:594-601",
+        "recommendation": "The 44px thumb is adequate, but the entire .home-feed__preview card (10px vertical padding) should have min-height: 44px to ensure full card is a comfortable touch target. Current total height may be tighter than ideal."
+      },
+      {
+        "issue": "Endorsement group 'Show all/fewer' toggle button not explicitly sized for mobile",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "home-feed.tsx:646-655 (component uses Button variant='ghost' size='sm')",
+        "recommendation": "Ensure Button component with size='sm' is at least 44px tall on mobile. If using Tailwind, add mobile-specific class or min-height rule to achieve 44px minimum at < 800px."
+      },
+      {
+        "issue": "Feed time text left-aligned on mobile but content area may appear cramped with narrow viewport",
+        "severity": "low",
+        "category": "layout",
+        "location": "home.css:582-589",
+        "recommendation": "Consider slightly increasing top margin of time element (currently padding-top: 0) to 2-4px to visually separate from sentence above, improving readability on tight layouts."
+      },
+      {
+        "issue": "Avatar and filter button header spacing may not accommodate font size on smaller phones",
+        "severity": "low",
+        "category": "spacing",
+        "location": "home.css:315-327",
+        "recommendation": "Verify .home-feed__header gap of 8px and .home-feed__header-actions gap of 4px provide adequate breathing room between the two filter buttons when both are visible. Consider increasing to 6px on mobile if buttons feel crowded."
+      }
+    ]
+  },
+  {
+    "url": "https://certified-app.example.com/profile",
+    "file": "/workspace/certified-app/src/app/profile/page.tsx",
+    "desktopLayout": "Fixed fullscreen loading overlay with centered flexbox layout. Brandmark spinner (48x48px via h-12 w-12 Tailwind classes) pulses at the true viewport center, unaffected by navbar, bottom nav, or safe-area insets. Uses --bg-canvas background and --fg-primary color via CSS tokens. Z-index --z-popover (40) places it below navbar (50). Resolves active identity then redirects to /{handle}.",
+    "mobileCurrentState": "The CSS layout is inherently responsive and requires no mobile-specific adaptations. Fixed positioning with flex center alignment (align-items: center; justify-content: center) automatically centers content on viewports of any width. The inset: 0 property stretches the overlay to fill the viewport at all sizes. No horizontal overflow is possible due to the flex centering. The spinner scales appropriately via responsive Tailwind classes. No media query overrides are needed or present.",
+    "findings": []
+  },
+  {
+    "url": "/{handle}",
+    "file": "/workspace/certified-app/src/app/[actor]/page.tsx + supporting CSS files (profile.css, layout.css, etc.)",
+    "desktopLayout": "Two-pane layout with fixed 296px sidebar (profile identity: avatar, name, DID, followers, endorsements, action buttons, links) and fluid main pane. Main pane contains tabbed interface (Overview, Activities, Projects, Groups, Endorsements, Followers, Lists, About org-only, Settings own-profile-only). Overview tab shows banner at top, three stat cards in 3-column grid below, then previews. All padding 24px, gaps 32px between panes. Profile tabs scroll horizontally with hidden scrollbars. ProfileHeader (banner hero) completely hidden at ≥800px.",
+    "mobileCurrentState": "ProfileHeader (banner-based hero) displays full-bleed at top with 180px banner, overlapping avatar, name, handle, bio. Sidebar hidden (display: none). Page-layout collapses to single-column stack (24px padding, 24px gaps). Profile-tabs have overflow-x: auto with hidden scrollbars (-webkit-scrollbar display: none, scrollbar-width: none), allowing tabs to scroll horizontally. Tab buttons are flex: 0 0 auto with fixed width (flex-basis set by padding 14px 20px). Profile-overview__banner hidden on mobile. All content below hero stacks in single column. No overflow issues observed; layout adapts correctly via CSS media queries at 800px breakpoint.",
+    "findings": [
+      {
+        "issue": "Profile tabs (.profile-tabs) use 0.875rem (14px) font size, which is below the safe 16px minimum for iOS to avoid auto-zoom on input focus. While not an input, the tap targets (tab buttons with padding 14px 20px) are 44px+ tall, but users with magnification needs or older iOS may have usability friction.",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/styles/profile.css:206",
+        "recommendation": "Tabs are already scrollable with good tap targets, so this is minimal friction. Consider bumping font to 0.9375rem (15px) or leaving as-is since tabs don't trigger zoom. No action required—current state is acceptable."
+      },
+      {
+        "issue": "ProfileHeader buttons on mobile (Edit, Follow, Settings) use size='sm' which translates to py-1.5 px-4 text-xs (12px font). Button height is implicit from padding, approximately 32px. This meets the 44px WCAG tap target guideline only vertically; horizontal spacing between two buttons is 8px gap, so they're visually distinct. However, on very narrow phones (<360px), the button cluster may compress or wrap awkwardly if a long label is present.",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/components/profile/profile-header.tsx:111-122, src/components/ui/button.tsx:60",
+        "recommendation": "Ensure buttons stay at least 44px × 44px. Current size='sm' yields ~32px height. On mobile, consider adding a responsive wrapper that scales button size or spacing at <360px breakpoint, OR ensure the action-group (.profile-hero__action-group gap: 8px) stacks to column layout on ultra-narrow viewports (<360px). Add @media (max-width: 359px) rule to stack buttons vertically if needed."
+      },
+      {
+        "issue": "Profile hero body padding is 0 16px 16px on mobile, but the avatar overlaps the banner with margin-top: -48px and flex alignment flex-end. On devices with safe-area-inset (notches, rounded corners), the avatar and action buttons may sit too close to the viewport edge or be obscured by notch/rounded corners, especially in landscape orientation.",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/styles/profile.css:34, 37-44",
+        "recommendation": "Apply safe-area-inset padding to .profile-hero__body on mobile. Change padding from '0 16px 16px' to 'max(0px, env(safe-area-inset-top)) 16px 16px max(0px, env(safe-area-inset-left))' to honor device notches and rounded corners. Also consider adding padding-right: max(16px, env(safe-area-inset-right)) for landscape mode."
+      },
+      {
+        "issue": "Profile hero name font size is 1.5rem (24px) on mobile, dropping to 1.75rem (28px) on desktop. This is appropriate, but the hero__handle (0.875rem / 14px) and hero__eyebrow (0.6875rem / 11px) are quite small. On low-vision users or devices with <320px width, these may be hard to read.",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/styles/profile.css:82, 96, 72",
+        "recommendation": "Current sizing is consistent with design tokens. No action required unless accessibility testing identifies readability issues. If needed, increase handle to 0.9375rem (15px) and eyebrow to 0.75rem (12px) on mobile to improve clarity."
+      },
+      {
+        "issue": "Profile tabs (.profile-tabs) padding is 0 16px on mobile, creating 16px horizontal inset. Tab buttons have padding 14px 20px, so the first tab sits 16px from the left edge and can scroll left off-screen. Last tab may overflow right off-screen. Visual affordance for horizontal scrolling is implicit (hidden scrollbars). Users may not discover the scrollable tabs without attempting to swipe or noticing the tabs cut off.",
+        "severity": "medium",
+        "category": "overflow",
+        "location": "src/app/styles/profile.css:181-192",
+        "recommendation": "Add a visual affordance to hint at horizontal scrolling: (a) render a subtle gradient fade on the right side when tabs overflow (linear-gradient overlay), (b) add a small icon or indicator showing 'swipe' or 'scroll', or (c) ensure the first tab is visually distinct (e.g., bolder, highlight-color) so the user's eye is drawn to the tabpanel. Alternatively, at very narrow viewports (<360px), show only 2-3 tabs at a time and hide the rest, reducing the cognitive load."
+      },
+      {
+        "issue": "Profile page layout (.page-layout) uses padding 24px 16px on mobile with gap 24px between sidebar and main. The gap is maintained even though sidebar is hidden (display: none). This doesn't cause overflow, but it creates semantic inconsistency: the gap exists in the grid even when one column is invisible. Not a visual bug, but semantically confusing.",
+        "severity": "low",
+        "category": "layout",
+        "location": "src/app/styles/layout.css:2281-2285",
+        "recommendation": "The current approach is fine since display: none removes the sidebar from layout flow entirely. No action needed. The gap is harmless and simplifies the responsive cascade (no need to override gap at mobile breakpoint)."
+      },
+      {
+        "issue": "On mobile, profile overview stat cards (.profile-overview__stat) are arranged in a 3-column grid (grid-template-columns: repeat(3, minmax(0, 1fr))). On narrow phones (<360px), three equal-width cards may be cramped, with each card only ~100px wide (accounting for 16px padding and 8px gaps). Text inside (caption + large number) may wrap or overflow.",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/layout.css:2755-2758",
+        "recommendation": "Add a responsive grid rule for mobile: @media (max-width: 799px) { .profile-overview__stat { grid-template-columns: repeat(3, minmax(0, 1fr)); } } at <360px, switch to repeat(2, minmax(0, 1fr)) or repeat(1, minmax(0, 1fr)) to ensure cards have room to breathe. Test on iPhone SE (375px) and older Android phones (320px) to confirm text doesn't wrap awkwardly."
+      },
+      {
+        "issue": "Profile sidebar copy button (.profile-sidebar__copy-btn) is 22px × 22px. This is below the 44px WCAG tap target size. On mobile, users tapping the 'Copy DID' button may miss it.",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "src/app/styles/layout.css:2371-2386",
+        "recommendation": "Increase copy button to at least 36px × 36px on mobile (or 44px to match WCAG AAA). Apply a responsive rule: @media (max-width: 799px) { .profile-sidebar__copy-btn { width: 40px; height: 40px; } }. Since the sidebar is hidden on mobile, this only affects desktop, so check if this is shown elsewhere on mobile (it's not—sidebar is hidden). No action needed for the profile page, but flag this for any other pages that expose the copy button on mobile."
+      },
+      {
+        "issue": "Profile sidebar pronouns (.profile-sidebar__pronouns) and followers stats display on desktop only (sidebar hidden on mobile). However, this information is missing from the mobile ProfileHeader, so mobile users never see pronouns or follower counts without scrolling to the Overview tab. Inconsistency in information availability between mobile and desktop.",
+        "severity": "medium",
+        "category": "consistency",
+        "location": "src/components/profile/profile-sidebar.tsx:270-274, src/components/profile/profile-header.tsx",
+        "recommendation": "Mobile ProfileHeader could optionally display a compact pronouns chip below the name (if profile?.pronouns is set) and show follower counts in a horizontal stat row (e.g., '12 followers / 25 following'). This would match the desktop sidebar's information and improve mobile usability. For MVP, document this as 'mobile header shows less info; full sidebar appears on desktop' in UX guidelines."
+      },
+      {
+        "issue": "Profile overview about section (.profile-overview__about) on mobile uses full width with gap: 8px between title and content. On very wide content (long-form prose, code blocks, or embedded leaflet documents), there's no max-width constraint, so lines may extend to 100% viewport width, reducing readability (>80 characters per line).",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/app/styles/layout.css:2815-2827, src/app/styles/leaflet.css:487-500",
+        "recommendation": "Add a max-width constraint to the about section on mobile: @media (max-width: 799px) { .profile-page__about { max-width: 100%; } .profile-page__about-doc { max-width: 65ch; margin: 0 auto; } } to cap line length at ~65 characters for readability. This matches common typography best practices."
+      },
+      {
+        "issue": "Input fields in profile inline-edit mode (e.g., display name input in sidebar) use size='bare' borderWeight='hover' with implicit font size 16px (inherited from .profile-sidebar__name). On iOS, inputs <16px trigger auto-zoom on focus, potentially causing layout shift. While the input uses 'bare' styling, it's still an input and subject to iOS zoom rules.",
+        "severity": "medium",
+        "category": "a11y",
+        "location": "src/components/profile/profile-sidebar.tsx:245-256",
+        "recommendation": "Ensure inline-edit inputs explicitly declare font-size: 16px or larger (or use rem units scaled to 16px base). Add a CSS rule: input[type=text] { font-size: 16px; } in the profile-inline-edit.css or globally to prevent iOS auto-zoom. Verify on an actual iOS device."
+      },
+      {
+        "issue": "Edit banner (.edit-banner) appears at the top of the page when editing. On mobile, it's sticky or fixed positioning unclear. If sticky or fixed, it may overlap the profile hero or tab strip, reducing visible content.",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/[actor]/page.tsx:394-401, src/components/ui/edit-banner.tsx (not reviewed)",
+        "recommendation": "Verify the EditBanner component's positioning on mobile. If it's position: sticky or position: fixed, ensure it sits above the profile-hero and tabs with appropriate z-index. If it's static, no action needed. Check that the banner doesn't overlap interactive elements or reduce usable viewport height below 50%."
+      }
+    ]
+  },
+  {
+    "url": "/{actor}/{type}/{rkey}",
+    "file": "/workspace/certified-app/src/app/[actor]/[type]/[rkey]/page.tsx and key components: src/components/feed/activity-detail.tsx, src/components/project/project-detail.tsx, src/app/styles/cert-detail.css, src/app/styles/project-detail.css",
+    "desktopLayout": "Desktop (≥800px): 2-column layout for activity detail uses page-layout grid (296px aside on right, flexible main on left, flipped via CSS grid-column). Hero banner + title headline + byline columns (Date / Author / Project) take full width. Metadata sidebar in fixed 296px column (image, time period, work scope, contributors, rights). Main pane shows tabs (overview/description/contributors/updates) with sections for short description, locations map, full description, and contributors lists. Project detail uses centered single column (max-width 960px on desktop, 720px on tablet/mobile) with hero banner, title in header bar, short description, meta grid (1-3 columns depending on width), and activity cards grid (3 columns at ≥900px, 2 at ≥600px, 1 below).",
+    "mobileCurrentState": "Mobile (<799px): Activity detail uses single-column stack — aside columns to 100% width above the main pane (via .page-layout CSS grid collapse at max-width:799px). Headline columns collapse to single column with 12px gap. Two-column body row collapses to single column. Main issues: (1) No explicit mobile-first stacking of left/right columns in activity detail — layout depends on CSS grid fallback behavior. (2) Project detail meta grid uses hardcoded breakpoints (640px for 2-col, 800px for 3-col) which do not match the canonical 800px mobile breakpoint — below 640px it's 1 column, 640-799px is 2 columns. (3) Project detail's certs grid uses 600px and 900px breakpoints instead of canonical 800px/1100px. (4) Edit button cluster in cert detail does not have explicit mobile wrapping rules. (5) Contributor list in project detail has no explicit mobile responsive sizing.",
+    "findings": [
+      {
+        "issue": "Project detail metadata grid uses non-canonical breakpoint (640px) that conflicts with 800px primary breakpoint",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/project-detail.css:329-339",
+        "recommendation": "Change @media (min-width: 640px) to @media (min-width: 800px) for the 2-column meta grid layout. The design rule specifies only 800/1100/1300 breakpoints; hardcoding 640px creates an intermediate breakpoint that deviates from the spec. If 2-column layout is intended at smaller widths, document that exception in the design rules."
+      },
+      {
+        "issue": "Project detail certs grid uses non-canonical breakpoints (600px, 900px) instead of canonical 800px/1100px",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/project-detail.css:466-476",
+        "recommendation": "Adjust grid breakpoints to match canonical spec: Change @media (min-width: 600px) to use the base layout, @media (min-width: 800px) for 2-column, and @media (min-width: 1100px) for 3-column. This aligns with the design rule that breakpoints are ONLY 800/1100/1300."
+      },
+      {
+        "issue": "Activity detail headline columns do not have explicit mobile stacking layout — relies on flex wrapping which may cause awkward text breaks on very narrow phones",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/cert-detail.css:1309-1428",
+        "recommendation": "Add @media (max-width: 599px) rule to stack headline columns vertically and reduce font sizes for very narrow viewports (< 600px). Current 12px gap-x may be excessive on phones <375px. Ensure 'Date created', 'Author', 'Project' labels remain readable at 320px viewport width."
+      },
+      {
+        "issue": "Project detail head bar (title + author byline) does not have explicit mobile layout rules; tight 16px gap may cause overflow or improper wrapping on narrow screens",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/project-detail.css:109-145",
+        "recommendation": "Add @media (max-width: 799px) rule to reduce gap between title and actions (from 16px to 8px) and consider increasing flex-wrap aggressiveness. Alternatively, reduce .project-detail__title font-size on mobile (currently stays at 1.5rem) — consider 1.25rem at <800px to free horizontal space."
+      },
+      {
+        "issue": "Cert detail edit button cluster (Edit + Delete) does not stack vertically when space is tight; flex-wrap may allow improper layout on narrow viewports",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/cert-detail.css:523-561",
+        "recommendation": "Add @media (max-width: 799px) rule to the title row (.cert-detail__title-row) to apply flex-direction: column on mobile OR reduce the Edit button padding/font-size on mobile so it doesn't force wrap. Ensure the delete button (icon-only) doesn't collide with the title on screens <375px."
+      },
+      {
+        "issue": "Project detail contributors list (inside meta grid) renders as a flex column with no mobile-specific truncation or layout rules; long contributor names/handles may overflow container on mobile",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/project-detail.css:373-380",
+        "recommendation": "Add @media (max-width: 799px) rule to .project-detail__contributors to apply strict min-width: 0 and ensure contributor name/handle text uses ellipsis overflow handling. Currently relies on activity-contributor component which may not apply mobile-safe text truncation."
+      },
+      {
+        "issue": "Add-to-list menu icon (3-dot button) in cert meta row lacks explicit mobile tap-target sizing; button is 32x32px which meets 44px spec only if padding is included — verify actual touch target on mobile",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/components/feed/activity-detail.tsx:919-924 and src/app/styles/cert-detail.css",
+        "recommendation": "Verify the add-to-list menu trigger in the Time Period row renders with at least 44x44px touch target. If the icon button is bare (no padding), add explicit padding: 8px or explicit width/height: 44px on mobile. The current rule at cert-detail.css doesn't show sizing for this component — check src/components/lists/add-to-list-menu.tsx for button sizing."
+      },
+      {
+        "issue": "Project detail title input (inline edit mode) uses font-size 1.5rem on mobile, which may be too large and force awkward text wrapping when editing; no mobile-specific size reduction",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/styles/project-detail.css:632-652",
+        "recommendation": "Add @media (max-width: 799px) rule to reduce .project-detail__title-input font-size to 1.25rem on mobile to match the smaller desktop-mode title (1.75rem). This aligns with the @media (min-width: 800px) override that sets desktop size to 1.75rem."
+      },
+      {
+        "issue": "Cert detail headline byline may have tap-target issues: author avatar link uses 24x24px avatar (too small for 44px spec); the entire .cert-detail__headline-author link wraps it",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/app/styles/cert-detail.css:628-651",
+        "recommendation": "Verify .cert-detail__headline-author link's padding + margin creates at least 44x44px total touch target on mobile. Currently uses padding: 2px 4px and margin: -2px -4px (net zero padding). Add explicit padding: 8px 4px on mobile to ensure 44x44px compliance, or increase the 24px avatar to 32px on narrow screens."
+      },
+      {
+        "issue": "Locations list below map in activity detail uses 4px item padding which may be too tight for mobile touch targets; each location row is 40-48px tall, below the 44px minimum",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/app/styles/cert-detail.css:1239-1272",
+        "recommendation": "Add @media (max-width: 799px) rule to increase .cert-detail__map-locations-item padding from 4px 8px to 8px 10px so the row height reaches at least 44px including font line-height. Icon should remain flex-shrink: 0 to keep its size stable."
+      }
+    ]
+  },
+  {
+    "url": "/{actor}/{type}/{rkey}/edit",
+    "file": "src/app/[actor]/[type]/[rkey]/edit/page.tsx",
+    "desktopLayout": "Two-column layout via .page-layout grid: 296px aside (image + metadata) on right, flexible main content (title, description, contributors) on left. EditBanner fixed at top with Save/Cancel. Contributor rows use 4-column grid (2fr identity, 1.5fr role, 170px weight, auto remove). For projects, banner hero replaces square image.",
+    "mobileCurrentState": "At viewport &lt; 800px, .page-layout collapses to single-column stacked layout (no explicit mobile media query, just loses the 296px column definition). Contributor rows collapse to 2-column (1fr for identity+role+weight stacked via grid-column: 1/2, auto for remove button). EditBanner and aside layout don't adapt - aside column becomes very narrow. No max-width cap like project-detail has.",
+    "findings": [
+      {
+        "issue": "Mobile input font size below iOS minimum - meta inputs and date inputs are 0.8125rem, causing auto-zoom on focus on iOS",
+        "severity": "high",
+        "category": "a11y",
+        "location": "src/app/styles/cert-detail.css:784-794 (.cert-detail__meta-input), lines 214-216 (date inputs)",
+        "recommendation": "Increase .cert-detail__meta-input to min 16px on mobile (use @media max-width: 799px). Create a -mobile variant or use calc(1rem + clamp(0, 1vw, 0.125rem)) for responsive scaling while staying >= 16px."
+      },
+      {
+        "issue": "Contributor row layout breaks on mobile - role and weight inputs force to grid-column 1/2 creating vertical stack that's hard to parse; no spacing between stacked inputs",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/cert-detail.css:1730-1739 (@media max-width: 799px .create-cert__contrib-row)",
+        "recommendation": "Redesign mobile contrib row: consider single-input-per-line layout with role below identity, weight below role, remove button below all. Add gap: 8px between stacked inputs. Or use fieldset-like visual grouping to clarify the identity/role/weight trio is one logical unit."
+      },
+      {
+        "issue": "No max-width constraint on edit page at mobile - unlike project-detail (720px), this page has no reading column cap, potentially causing content to span entire narrow viewport",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/cert-detail.css (page layout rules 24-74), vs project-detail.css:28-34",
+        "recommendation": "Add .page-layout max-width: 720px or 100% at @media (max-width: 799px) to match project-detail pattern and provide breathing room. Consider also margin-left/right: auto to center the narrower column."
+      },
+      {
+        "issue": "EditBanner margin-inline combined with page-layout padding creates potential spacing confusion on mobile - mx-6 (24px margin) plus page-layout padding: 24px 16px = 40px total or inconsistent gutters",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/components/ui/edit-banner.tsx:76 (mx-6), src/app/styles/layout.css:2284 (page-layout padding: 24px 16px)",
+        "recommendation": "Audit actual rendered spacing: EditBanner should align flush with page-layout inner content. Consider using padding on app-shell__content (which is already zeroed for cert-detail) to apply consistent gutters, letting EditBanner sit at 0 margin inside that padding context."
+      },
+      {
+        "issue": "Date input row (start → end) does not wrap or stack on narrow mobile - uses flex with gap but no flex-wrap, risking overflow if labels/inputs are long",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/cert-detail.css:1455-1464 (.create-cert__date-row)",
+        "recommendation": "Add @media (max-width: 799px) rule to .create-cert__date-row: flex-direction: column; gap: 12px; align-items: stretch; so start/end inputs stack and span full width with the arrow separator hidden or repositioned above/below."
+      },
+      {
+        "issue": "Contributor remove button tap target exactly 32px (at minimum, not ideal for fat fingers); combined with crowded mobile layout makes it difficult to tap accurately",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/app/styles/cert-detail.css:1710-1722 (.create-cert__contrib-remove: width 32px, height 32px)",
+        "recommendation": "Increase to 44px x 44px or use padding-increase trick: keep visual icon at 16px, add 14px padding on all sides. Target 44x44 per WCAG. If space tight, accept 32px but ensure no competing clickable siblings within 16px."
+      },
+      {
+        "issue": "Aside column gets very narrow on mobile (inherits from page-layout which has no mobile-specific width) - metadata fields (time period, work scope, locations, rights) become cramped; image aspect 1:1 may be too large for narrow screen",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/cert-detail.css:105-111 (.cert-detail__aside), layout.css:2281-2294 (.page-layout mobile lacks explicit width constraint)",
+        "recommendation": "Add @media (max-width: 799px) rule to .cert-detail__aside: full-width stacking, or use a narrower flex-basis (e.g. 100% max-width: 300px). Consider reducing .cert-detail__image aspect ratio or capping its height on mobile (e.g. max-height: 200px)."
+      },
+      {
+        "issue": "Contributor error messages inherit .create-cert__contrib-error font-size: 0.75rem - very small on mobile, hard to read especially on small screens or in low light",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/app/styles/cert-detail.css:1648-1653 (.create-cert__contrib-error)",
+        "recommendation": "Increase error font size to 0.8125rem or 0.875rem at @media (max-width: 799px). Consider adding padding: 4px 0 to create visual separation. Use var(--color-error) which is already correct but ensure contrast ratio >= 4.5:1 against --bg-* backgrounds."
+      },
+      {
+        "issue": "Horizontal overflow risk on very small phones (< 360px) - contributor row grid cells may not shrink below intrinsic content width; no overflow-x hidden or scroll container established",
+        "severity": "medium",
+        "category": "overflow",
+        "location": "src/app/styles/cert-detail.css:1519-1544 (.create-cert__contrib-list and .create-cert__contrib-row)",
+        "recommendation": "Add min-width: 0 to .create-cert__contrib-row to allow grid cells to shrink below content. Test at 320px viewport. Consider overflow-x: auto wrapper if minwidth alone isn't enough, with a hint that mobile users should rotate to landscape or scroll horizontally."
+      },
+      {
+        "issue": "No focus-visible outline on many interactive elements at mobile - buttons, inputs have focus styles but may be hard to see on small screens due to outline-offset or small size",
+        "severity": "low",
+        "category": "a11y",
+        "location": "src/app/styles/cert-detail.css (various button/input :focus-visible rules)",
+        "recommendation": "Audit focus outlines at 320px and 480px viewports. Ensure outline-offset is <= 2px and outline width is 2px for visibility on small screens. Consider increasing focus-ring color contrast if using --focus-ring token."
+      },
+      {
+        "issue": "Typeahead dropdown z-index: 60 positioned absolutely beneath contrib identity input - no documented z-stack, risk of being hidden behind modals or popovers",
+        "severity": "low",
+        "category": "other",
+        "location": "src/app/styles/cert-detail.css:1669-1684 (.create-cert__contrib-id-dropdown: z-index: 60)",
+        "recommendation": "Ensure z-index 60 is explicitly in the z-index token naming (check tokens.css for --z-dropdown or --z-popover). Document that LocationPickerDialog and other modals use higher z-index. Or use z-index: var(--z-popover) if that token exists."
+      },
+      {
+        "issue": "Contributor card height 32px slightly below 44px tap-target minimum for touch - acceptable since it's readonly once picked, but close to limit",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/app/styles/cert-detail.css:1570-1580 (.create-cert__contrib-card: height 32px)",
+        "recommendation": "Acceptable as-is since card is display-only (user taps the remove X button which is separate, not the card itself). But if card becomes interactive in future, increase to 40px+ for better touch usability."
+      },
+      {
+        "issue": "Contributor card clear button width 22px is below 44px minimum - but acceptable since it's a secondary action; no padding comfort zone around it",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/app/styles/cert-detail.css:1607-1620 (.create-cert__contrib-card-clear: width 22px, height 22px)",
+        "recommendation": "Acceptable for secondary actions. If needed to improve, increase to 28-32px and add negative margins (e.g. margin: -6px) to visually appear 22px but have 44px+ actual tap target. Or add 10px padding all sides."
+      }
+    ]
+  },
+  {
+    "url": "/workspace/certified-app/src/app/create/page.tsx",
+    "file": "/workspace/certified-app/src/app/create/page.tsx",
+    "desktopLayout": "Two-column grid layout via `.page-layout` (grid: 296px sidebar + minmax(0, 1fr) main). `.cert-detail--wide` flips column order: main pane on left (via grid-column: 1), aside metadata sidebar on right (grid-column: 2). Aside contains image, time period, work scope, locations list, and rights selector. Main pane contains title, short description, description editor (LeafletEditor), contributors section, and action buttons. Both columns sit at gap: 32px on desktop.",
+    "mobileCurrentState": "On viewport < 800px, `.page-layout` has no grid-template-columns override defined, so it defaults to single-column layout (block flow). Both aside and main stack vertically. No explicit mobile media query breaks the two-column layout at breakpoint. The stacking behavior is correct but there are no mobile-specific adaptations for component interiors (button sizing, spacing tweaks, dropdown positioning, etc.). Layout does NOT overflow horizontally, but several interactive elements have tap targets below 44x44px guideline.",
+    "findings": [
+      {
+        "issue": ".create-cert__loc-remove button (remove location): 18x18px, far below 44x44px mobile tap target guideline",
+        "severity": "critical",
+        "category": "tap-target",
+        "location": "/workspace/certified-app/src/app/styles/cert-detail.css:1923-1924",
+        "recommendation": "Increase button to 40x40px or 44x44px, or wrap with sufficient padding/margin to create a 44px interaction zone. Adjust icon size separately (can use a smaller icon inside a larger button). Apply globally to all `:remove` buttons in location context."
+      },
+      {
+        "issue": ".create-cert__contrib-card-clear button (clear contributor): 22x22px, below 44x44px guideline",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "/workspace/certified-app/src/app/styles/cert-detail.css:1611-1612",
+        "recommendation": "Expand to 44x44px minimum. Alternatively, add padding to the card container or use a larger hit-zone. Current icon size (12-14px) can remain inside expanded button."
+      },
+      {
+        "issue": ".create-cert__loc-search-again button (search again in location picker): 22x22px, below 44x44px guideline",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "/workspace/certified-app/src/app/styles/cert-detail.css:1973-1974",
+        "recommendation": "Increase to 44x44px minimum. Position inside the input with sufficient padding-right on the input to prevent overlap. Update padding-right in `.create-cert__loc-combobox:has(.create-cert__loc-search-again) > input` from 32px to 44px."
+      },
+      {
+        "issue": "No mobile-specific media queries for location picker dialog (tabs, map, suggestions dropdown, search field)",
+        "severity": "medium",
+        "category": "layout",
+        "location": "/workspace/certified-app/src/app/styles/cert-detail.css:1939-2074",
+        "recommendation": "Add @media (max-width: 799px) block after line 2074 to: (a) Ensure suggestions dropdown width does not exceed viewport, (b) Reduce dialog padding if needed for cramped viewports, (c) Set .create-cert__loc-map min-height to sensible mobile value like 200px, (d) Adjust dialog max-width if it exceeds viewport at small screens."
+      },
+      {
+        "issue": "Contributor row grid layout at mobile (<800px) changes to 1fr + auto columns but forced positioning may cause role/weight inputs to stack vertically, creating awkward layout",
+        "severity": "medium",
+        "category": "layout",
+        "location": "/workspace/certified-app/src/app/styles/cert-detail.css:1730-1739",
+        "recommendation": "At mobile, consider alternative layout: stack all four fields vertically or use 1fr 1fr grid with role above weight. Current 1fr auto + forced column 1 placement creates asymmetric result. Test on actual mobile device to verify usability."
+      },
+      {
+        "issue": "Date input row (.create-cert__date-row) uses flex with flex: 1 1 0; on narrow viewports may compress date fields to uncomfortably narrow widths",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "/workspace/certified-app/src/app/styles/cert-detail.css:1455-1464",
+        "recommendation": "Add @media (max-width: 799px) to stack date inputs vertically (flex-direction: column) instead of side-by-side. Test with date picker UI to ensure controls remain tappable."
+      },
+      {
+        "issue": "LeafletEditor toolbar buttons (.leaflet-editor__btn): 30x30px, below 44px guideline",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "/workspace/certified-app/src/app/styles/leaflet.css:185-186",
+        "recommendation": "Add @media (max-width: 799px) in leaflet.css to expand buttons to 40x40px or 44x44px and increase gap between buttons. Note: affects all LeafletEditor uses, coordinate globally."
+      },
+      {
+        "issue": "Image editor overlay buttons (.image-edit-overlay__btn) positioned at bottom-right with 999px border-radius (pill shape); may overlap or be cut off on very narrow mobile screens (320px)",
+        "severity": "low",
+        "category": "positioning",
+        "location": "/workspace/certified-app/src/app/styles/components.css:1644-1668",
+        "recommendation": "Test on 320px viewport. If overflow occurs, reposition to top-left in @media (max-width: 799px), or add margin to ensure 8-12px clearance from edges."
+      }
+    ]
+  },
+  {
+    "url": "/project/new",
+    "file": "src/app/project/new/page.tsx",
+    "desktopLayout": "Single-column reading layout with max-width 960px at desktop (1280px shell). Vertical stack: full-width hero banner (3:1 aspect), title + counter, short description + counter, description editor (LeafletEditor), location section, activities checklist section (max-height scrollable), submit buttons at bottom (Cancel | Publish). All sections use consistent 16px side padding.",
+    "mobileCurrentState": "Below 800px the .project-detail max-width remains 720px (same 16px side padding). Layout is single-column throughout, which is correct. However, there is NO CSS-level adaptation for mobile usability issues: form inputs are NOT bumped to 16px font-size (iOS auto-zoom prevention), icon buttons (.create-project__cert-remove at 22×22px, plus icon at 14px) have tap targets below 44px minimum, quick-pick scrollable list uses fixed max-height: 280px which may overflow on short phones, and form action buttons (in .create-cert__actions) use flex-end with tight gap:8px without wrap consideration.",
+    "findings": [
+      {
+        "issue": "Form inputs lack iOS font-size 16px rule. .cert-detail__title-input is 1.875rem and .cert-detail__short-desc-input is 1rem at all viewport widths.",
+        "severity": "high",
+        "category": "a11y",
+        "location": "src/app/styles/cert-detail.css:170-236 (.cert-detail__title-input, .cert-detail__short-desc-input)",
+        "recommendation": "Add @media (max-width: 799px) rule that sets .create-project .cert-detail__title-input, .create-project .cert-detail__short-desc-input { font-size: 16px; } to prevent iOS Safari auto-zoom on focus. This is mobile usability standard practice and other forms in the app already use this pattern (username-card__subdomain-input in components.css:1632)."
+      },
+      {
+        "issue": "Remove button (.create-project__cert-remove) is 22×22px with no padding, creating tap target of only 22px. Does not meet 44×44px accessibility minimum for touch targets (WCAG 2.1 Level AAA).",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "src/app/styles/cert-detail.css:1855-1875 (.create-project__cert-remove)",
+        "recommendation": "Increase to width: 32px; height: 32px; (consistent with other icon buttons in the app). Apply negative margin trick if needed to maintain layout: margin: -5px; so visual footprint stays the same but tap area expands. Or wrap in a 44×44 hit area and center the icon inside."
+      },
+      {
+        "issue": "Plus icon inside location and activities buttons is 14px (from lucide-react). Icon-only buttons using Button size='icon' are 40×40px (h-10 w-10), meeting minimum, but the magnified icon with surrounding button padding leaves minimal visual affordance on mobile.",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/app/project/new/page.tsx:445 (Plus icon size) and src/components/ui/button.tsx:64 (icon button size)",
+        "recommendation": "Confirm Button size='icon' renders 44×44px (not 40×40px) on mobile, or increase to explicit 44×44px footprint with @media (max-width: 799px) override. Alternatively increase icon size from 14px to 16-18px at mobile to improve visual clarity without changing touch target."
+      },
+      {
+        "issue": "Quick-pick activity checklist uses fixed max-height: 280px with overflow-y: auto. On phones with viewport height <480px, this scrollable region consumes 280px, leaving minimal space for context above/below. Creates scrolling-within-scrolling friction.",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/cert-detail.css:1768-1782 (.create-project__quick-pick-list)",
+        "recommendation": "Add @media (max-width: 799px) rule: .create-project__quick-pick-list { max-height: min(200px, 40vh); } to scale the scrollable region based on available viewport height. This prevents the section from dominating the visible area on short phones."
+      },
+      {
+        "issue": "Counter text (e.g., '10/80 · min. 5 characters') in .create-cert__counter is displayed inline next to the title input with no mobile-specific wrapping or stacking. On narrow viewports, the counter may wrap awkwardly or overlap the input.",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/cert-detail.css:1477-1505 (.create-cert__counter, .create-cert__input-with-counter) and src/app/project/new/page.tsx:345-368",
+        "recommendation": "Keep .create-cert__input-with-counter stacked vertically (already flex-direction: column), which is correct. However, ensure counter renders on its own line and consider reducing counter font-size from 0.75rem (11px) to 0.7rem (10.5px) on mobile @media (max-width: 799px) to save horizontal space without compromising legibility."
+      },
+      {
+        "issue": "Form action buttons (.create-cert__actions) use justify-content: flex-end with gap: 8px and no flex-wrap consideration. On phones <360px wide, both buttons may crowd together or overflow. Desktop layout shows 'Cancel' + 'Publish' side-by-side.",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/cert-detail.css:2075-2080 (.create-cert__actions) and src/app/project/new/page.tsx:556-576",
+        "recommendation": "Add @media (max-width: 799px) rule: .create-cert__actions { flex-direction: column-reverse; gap: 12px; } to stack buttons vertically (primary 'Publish' on bottom for prominence) with increased gap. Or use flex-wrap: wrap with min-width constraint if side-by-side is essential. Verify both buttons are at least 44×44px on mobile."
+      },
+      {
+        "issue": "Title input padding is 4px 10px, very tight on mobile. Combined with 1.875rem font-size (input element), this creates cramped editing experience on narrow phones. The visual 'hit area' inside the input is small relative to the total button/field size.",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/styles/cert-detail.css:170-183 (.cert-detail__title-input, padding: 4px 10px)",
+        "recommendation": "Consider @media (max-width: 799px) increase to padding: 8px 12px; for better touch ergonomics and visual breathing room. Short description input already uses padding: 10px 12px, so this would align the two."
+      },
+      {
+        "issue": "ImageEditOverlay buttons are positioned absolutely (bottom: 10px; right: 10px;) and may collide with or obscure banner content on mobile when the banner is small due to viewport constraints. No mobile-specific repositioning.",
+        "severity": "low",
+        "category": "layout",
+        "location": "src/app/styles/components.css:1644-1698 (.image-edit-overlay) and src/app/project/new/page.tsx:335-341",
+        "recommendation": "Add @media (max-width: 799px) rule to .image-edit-overlay: bottom: 8px; right: 8px; (tighter margins) and verify the hero has enough aspect ratio (3:1 at mobile viewport = height: (viewport width / 3), minimum ~120px) to accommodate the overlay pills without visual conflict."
+      },
+      {
+        "issue": "Section title styling (.cert-detail__section-title) is 0.8125rem (13px) uppercase. On mobile, spacing between sections may feel loose when combined with 24px+ padding. No mobile-specific compression or typography adjustment.",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/styles/cert-detail.css:883-890 (.cert-detail__section-title) and src/app/styles/cert-detail.css:811-826 (.cert-detail__section)",
+        "recommendation": "No change required if consistent with mobile intent, but consider @media (max-width: 799px) tighter gap: 20px; (from 32px default) in .cert-detail__main to compress vertical rhythm and reduce perceived 'height' of the form on short phones."
+      },
+      {
+        "issue": "Location picker dialog (LocationPickerDialog component) uses AppDialog, which may render at viewport-relative size on mobile. No explicit max-height or overflow handling documented for mobile viewports.",
+        "severity": "low",
+        "category": "layout",
+        "location": "src/components/create/location-picker-dialog.tsx (component wrapping) and src/app/project/new/page.tsx:580-591",
+        "recommendation": "Verify AppDialog applies max-height: 90vh or similar on mobile and that internal map/listbox scroll independently. If using standard modal, confirm it fits within safe area insets on iOS (notch/home indicator) and Android (nav bar). Test on real devices."
+      }
+    ]
+  },
+  {
+    "url": "/explore",
+    "file": "/workspace/certified-app/src/app/explore/page.tsx",
+    "desktopLayout": "Desktop (>= 800px) uses a two-column grid layout: left sidebar with filter buttons (width: clamp(256px, 22vw, 296px)), vertical divider (1px border), and right main content area constrained to max-width: 1400px and centered. Chrome bar (dropdown + search + view/sort/quality controls) wraps with flex-wrap when needed. List rows use 3-column grids (content | author-col | time), gallery grids use auto-fill responsive columns (minmax(240-260px, 1fr)). All spacing, borders, and typography follow design tokens.",
+    "mobileCurrentState": "Mobile (< 800px) collapses the grid to 1fr, hides the vertical divider, and removes main pane padding. The sidebar becomes a single full-width column stacked above the main content. The chrome bar wraps due to flex-wrap. List rows collapse to single-column (grid-template-columns: 1fr), and author-col + time shift left with justify-self: start. However, several responsive issues remain unaddressed: the sidebar doesn't hide/scroll independently, the search field min-width: 200px can cause overflow on very small screens, chrome buttons have no mobile-specific sizing adjustments, the All view's three-block layout does not adapt to mobile (columns don't stack), and various spacing remains at desktop sizes.",
+    "findings": [
+      {
+        "issue": "Sidebar visible and full-width on mobile, creating unnecessary scroll burden",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/explore.css:50-55, 59-70",
+        "recommendation": "At @media (max-width: 799px), hide the sidebar by default (display: none) or render it behind a hamburger menu/bottom sheet. Alternatively, make it scrollable independently with position: sticky and max-height constraints, or place it as a collapsible accordion above the main content."
+      },
+      {
+        "issue": "Search field min-width: 200px causes horizontal overflow on narrow viewports < 320px",
+        "severity": "medium",
+        "category": "overflow",
+        "location": "src/app/styles/explore.css:206-209",
+        "recommendation": "Add @media (max-width: 799px) rule reducing min-width to auto or a responsive value like clamp(100px, 70vw, 200px) so the field shrinks gracefully below 320px viewports."
+      },
+      {
+        "issue": "Chrome buttons (.explore__chrome-btn) do not resize for touch targets on mobile; 32×32 icon buttons are at minimum 44px WCAG AA on touch",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/app/styles/explore.css:216-243",
+        "recommendation": "Add @media (max-width: 799px) to increase .explore__chrome-btn to at least 40px height and .explore__chrome-btn--icon to 44×44 (minimum touch target). Adjust padding/gap accordingly to maintain visual hierarchy."
+      },
+      {
+        "issue": "All view's three-block layout (.explore__all) does not stack to single column on mobile; blocks remain side-by-side or poorly spaced",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/explore.css:399-403",
+        "recommendation": "Add @media (max-width: 799px) rule for .explore__all to ensure blocks stack vertically (flex-direction column works; verify gap spacing). Alternatively, the All view should skip to single-category mode on mobile to reduce cognitive load."
+      },
+      {
+        "issue": "No responsive adjustments to .explore__chrome flex-wrap behavior; controls may overflow or wrap awkwardly",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/explore.css:194-201",
+        "recommendation": "Add @media (max-width: 799px) to adjust gap/padding or prioritize which controls show. Consider hiding less critical controls (e.g., only show sort/quality in a collapsible menu) on mobile, or use order: property to reorder wrapping."
+      },
+      {
+        "issue": "Sidebar padding (32px all sides) and filter button padding (6px 10px) create inconsistent spacing hierarchy vs main content padding (0 on mobile)",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/styles/explore.css:50-70, 112-123, 188-191",
+        "recommendation": "Harmonize padding at @media (max-width: 799px): if sidebar appears, match main content padding; if sidebar hides, ensure consistent 16px left/right padding across filter list and main pane per hard rule 'below desktop' styles."
+      },
+      {
+        "issue": "Inline-controls row (.explore__inline-controls) does not have responsive gap/wrapping tuning; pills may overflow or stack awkwardly on very small screens",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/explore.css:461-467",
+        "recommendation": "Add @media (max-width: 799px) to reduce gap from 12px and ensure flex-wrap is enabled. Consider using flex-wrap: wrap with max-content children so pills naturally reflow."
+      },
+      {
+        "issue": "Filter button text (.explore__filter) uses font-size: 0.85rem (13.6px) which may be hard to tap accurately on mobile; label collision risk with filter list gap: 1px",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/app/styles/explore.css:112-123",
+        "recommendation": "Add @media (max-width: 799px) to increase .explore__filter padding to 8px 12px (from 6px 10px) and ensure min-height: 44px for touch targets. Increase font-size to 0.9rem for legibility."
+      },
+      {
+        "issue": "Project card image aspect-ratio 3:1 may look cramped or distorted on narrow mobile screens",
+        "severity": "low",
+        "category": "layout",
+        "location": "src/app/styles/explore.css:878-886",
+        "recommendation": "Add @media (max-width: 799px) to optionally reduce aspect-ratio to 2:1 or 16:9 for better mobile framing, or adjust card layout to hide image on very narrow viewports."
+      },
+      {
+        "issue": "List row images (.cert-list-row__thumb) are 40×40, adequate for touch but no responsive scaling on density-aware displays",
+        "severity": "low",
+        "category": "layout",
+        "location": "src/app/styles/explore.css:547-558",
+        "recommendation": "No change required if 40px works on target devices, but consider responsive sizing: @media (max-width: 799px) { width: 48px; height: 48px; } to match mobile density expectations."
+      },
+      {
+        "issue": "Grid column definitions for gallery views (minmax(260px, 1fr), minmax(240px, 1fr)) may create single-column layouts on phones < 260px, wasting viewport space",
+        "severity": "low",
+        "category": "layout",
+        "location": "src/app/styles/explore.css:660-670",
+        "recommendation": "Add @media (max-width: 799px) or nested query to reduce minmax values to minmax(120px, 1fr) or use auto-fit to allow more aggressive reflow on small screens, or switch list view as default on mobile."
+      },
+      {
+        "issue": "Popover menus (.explore__chrome-btn triggers) may be positioned off-screen on mobile without viewport-aware anchoring",
+        "severity": "medium",
+        "category": "overflow",
+        "location": "src/components/ui/popover.tsx (Popover component)",
+        "recommendation": "Verify popover component has responsive positioning logic (e.g., align='start'|'end' auto-adjusts on mobile, or uses viewport constraints). If not, add @media (max-width: 799px) overrides or use a bottom-sheet modal instead of popover on mobile."
+      },
+      {
+        "issue": "Endorsement-degree pills (.explore__degree-pills) have inline-flex with gap: 4px; may overflow or require horizontal scroll on small screens",
+        "severity": "medium",
+        "category": "overflow",
+        "location": "src/app/styles/explore.css:966-969",
+        "recommendation": "Add @media (max-width: 799px) to use flex-wrap: wrap and adjust gap if needed, or reduce pill padding to fit 3 pills + reset button on a 320px screen."
+      }
+    ]
+  },
+  {
+    "url": "/endorsements",
+    "file": "src/app/endorsements/page.tsx",
+    "desktopLayout": "Tabbed interface with \"Received\" and \"Given\" tabs. Desktop shows multi-column layouts: (1) Tab bar with \"+ New\" button aligned right on same line. (2) Received tab: endorsement list with rows containing avatar (48px) + name/handle/note + date (right-aligned, flex-shrink-0) + response buttons (Accept/Reject, 4px padding each). (3) Given tab: endorsement list with avatar + name/handle/note + date + revoke button (X icon, 6px padding). (4) New Endorsement Panel: heading + close button + search + recipient list (multi-row items) + action buttons (Clear/Endorse).",
+    "mobileCurrentState": "The CSS does NOT adapt for < 800px in the endorsement-specific rules. The same flex layouts render at mobile viewport without adjustments: (1) .endorsements-tabs-bar renders as flex with space-between, so \"+ New\" button and tabs compete for space on narrow screens. (2) .endorsement-row uses the same flex layout as desktop — avatar stays 48px, which is proportionally large on mobile. (3) Date and response buttons remain flex-shrink-0 (unchanged), potentially causing horizontal overflow or cramped spacing. (4) Response buttons remain 4px padding (too small for mobile touch targets on desktop, but media query at 1518 bumps to min-height: 44px for @media max-width: 799px — GOOD). (5) Revoke button padding stays 6px (28px×28px implicit from inline-flex, but no explicit mobile bump — may be too small). (6) .endorsement-panel renders at full width with 16px padding on both sides, leaving narrow safe area on small phones. (7) .endorsement-multi-row items have 8px padding and 10px gaps (tight spacing).",
+    "findings": [
+      {
+        "issue": "Tab bar and New button fight for space on mobile — both are on same line (.endorsements-tabs-bar flex, justify-content: space-between). On very narrow phones (< 360px), button label + icon + tab text will wrap or overflow.",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/feed.css:904-910 (.endorsements-tabs-bar)",
+        "recommendation": "Add @media (max-width: 799px) rule to stack or hide the '+ New' button from the tab bar, or move it below the tabs as a full-width action. Alternatively, convert to icon-only on mobile with aria-label='New endorsement'."
+      },
+      {
+        "issue": "Endorsement row avatar (48px) is visually dominant on mobile. Row layout (.endorsement-row flex, align-items: center, gap: 12px) doesn't account for the proportional crowding at small viewport widths.",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/styles/feed.css:1102-1108, 1114-1122",
+        "recommendation": "Consider reducing avatar size to 40px on mobile (@media max-width: 799px) or adjusting gap. Ensure row still has at least 44px touch target height for the entire main link area."
+      },
+      {
+        "issue": "Response buttons on Received tab have padding: 4px 10px, font-size: 0.75rem desktop. @media (max-width: 799px) bumps to min-height: 44px at line 1520, BUT this does NOT apply min-width, so buttons may not reach 44px width on very narrow phones.",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "src/app/styles/feed.css:1207-1218 and 1518-1532",
+        "recommendation": "Update @media (max-width: 799px) rule for .response-buttons__btn to also set min-width: 44px and adjust padding symmetrically (e.g., padding: 8px 12px) to ensure both dimensions meet 44px tap target."
+      },
+      {
+        "issue": "Revoke button (.endorsement-row__revoke) has padding: 6px, no explicit mobile media query. On mobile, with 16px icon size, the button is ~28px square, below 44px minimum touch target.",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "src/app/styles/feed.css:1158-1170",
+        "recommendation": "Add @media (max-width: 799px) rule to set padding: 8px or 10px (44px total), matching the response button mobile rule. Icon size already at 16px (Lucide X), so padding alone will solve it."
+      },
+      {
+        "issue": "Endorsement panel close button (.endorsement-panel__close) has padding: 4px with 16px icon, making it ~24px square. Below 44px on mobile.",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "src/app/styles/feed.css:1011-1022",
+        "recommendation": "Add @media (max-width: 799px) rule to set padding: 10px (44px total) or use size='icon' on Button primitive if available."
+      },
+      {
+        "issue": "Multi-recipient row remove button (.endorsement-multi-row__remove) has padding: 4px with 14px icon (X). ~22px square, below tap target minimum.",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "src/app/styles/feed.css:1647-1662",
+        "recommendation": "Add @media (max-width: 799px) rule to set padding: 10px. Icon is already 14px (small), so padding will bring total to 34px (acceptable for multi-row context, but 44px preferred)."
+      },
+      {
+        "issue": "New Endorsement Panel heading uses flexible font-size (0.9375rem for title, 0.8125rem for hint) but no mobile-specific adjustments. On narrow screens, the close button may wrap text or create awkward line breaks in heading text.",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/app/styles/feed.css:1034-1043",
+        "recommendation": "Add @media (max-width: 799px) to reduce title font-size to 0.875rem and add word-break: break-word or hyphens: auto on .endorsement-panel__heading-text if heading text is long."
+      },
+      {
+        "issue": "Error message in ResponseButtons (response-buttons__error) uses font-size: 0.6875rem at line 1252. On mobile, this is tiny (9px effective) and may be hard to read. No mobile rule bumps it.",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/app/styles/feed.css:1251-1255",
+        "recommendation": "Add @media (max-width: 799px) rule to set font-size: 0.75rem (10px) for better mobile legibility."
+      },
+      {
+        "issue": ".endorsement-multi-row items have padding: 8px 10px and gap: 10px between elements. On narrow screens (< 320px), the row becomes crowded with 4 flex children (avatar + meta + status + remove button), leading to visual compression.",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/styles/feed.css:1576-1584",
+        "recommendation": "Add @media (max-width: 799px) rule to reduce vertical padding to 6px and horizontal to 8px, or consider stack status/remove on a second line if space is critical."
+      },
+      {
+        "issue": ".endorsement-panel has padding: 16px on all sides, but no max-width constraint. On ultra-narrow phones, the left/right padding + content leaves only ~100-120px for the search input and text, creating vertical scroll on small text inputs.",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/feed.css:986-995",
+        "recommendation": "No CSS fix needed if parent container (dashboard__main) already constrains width. Verify dashboard width is set; if not, add max-width: 100vw and ensure padding respects safe-area-inset on notched devices."
+      },
+      {
+        "issue": "Received tab shows .endorsements-hint (policy explanation) with padding: 12px 14px and font-size: 0.8125rem. No mobile bump; on narrow screens, text may wrap awkwardly if the viewport is < 300px wide.",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/styles/feed.css:1071-1080",
+        "recommendation": "No action required unless user feedback indicates text is too small; 0.8125rem (11px) is readable on modern devices. If needed, add font-size: 0.75rem at @media max-width: 799px and bump padding to 14px 16px for breathing room."
+      },
+      {
+        "issue": "Avatar skeleton on EndorsementRow (Skeleton circle width={48} height={48}) does not adapt to mobile. If avatar size is reduced on mobile in a future update, skeleton will be mismatched.",
+        "severity": "low",
+        "category": "consistency",
+        "location": "src/components/endorsements/endorsement-row.tsx:53",
+        "recommendation": "If avatar size is changed to 40px on mobile, update Skeleton dimensions conditionally or leave at 48px (will shrink with avatar via CSS if avatar size class is used)."
+      },
+      {
+        "issue": "Response buttons inline error message (response-buttons__error) positioned with margin-left: 6px. If buttons wrap to multiple lines on very narrow screens, the error floats next to the button instead of below, breaking layout.",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/feed.css:1251-1255 and src/components/badges/response-buttons.tsx:164-167",
+        "recommendation": "Add @media (max-width: 799px) rule to change margin-left: 0; margin-top: 4px; display: block; to move error below the buttons on mobile."
+      }
+    ]
+  },
+  {
+    "url": "https://certified.app/notifications",
+    "file": "/workspace/certified-app/src/app/notifications/page.tsx",
+    "desktopLayout": "Single-column dashboard layout with a max-width of 600px at >=800px. The notification feed is an infinite-scroll list using .notification-list (flex column) containing .notification-row elements. Each row is a flex container (32px avatar + 12px gap + flex-1 body) with 14px top/bottom padding and 4px horizontal padding. Text is 14px (0.875rem) with unread indicator (11px time text). Rows have a 1px bottom border hairline separator and optional left 2px accent bar for unread state. No responsive adjustments—the layout is identical at all viewport widths.",
+    "mobileCurrentState": "At viewport widths < 800px, the .app-shell__content applies max-width: 720px and symmetric 32px horizontal padding, but the .notification-row components do NOT adapt. The rows use the same styles as desktop: flex with 32px avatar + 12px gap + flex-1 body, with only 4px horizontal padding on the row itself. On a 375px phone, this leaves ~267px for text content; on 320px phones, only ~212px. The 14px text and 11px timestamp do not scale down. Response buttons (Show/Hide, ToggleGroup size=\"sm\") appear inline at the end of rows containing badge awards (they use h-7 28px height with px-2.5 padding, font-size text-[13px]). No media queries exist in notifications.css, so the desktop layout simply shrinks and may wrap or crowd on small screens.",
+    "findings": [
+      {
+        "issue": "Notification row padding is asymmetric and undersized on mobile. The .notification-row has padding: 14px 4px (top/bottom 14px, left/right 4px only), which is comfortable on desktop but leaves no breathing room on phones. The outer .app-shell__content adds 32px horizontal padding at all widths, creating a total 32px + 4px = 36px left/right buffer, but the 4px inner padding feels cramped when the entire row should be a touch target.",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/styles/notifications.css:14-24",
+        "recommendation": "Add a mobile-specific media query to increase .notification-row horizontal padding on <800px viewports: @media (max-width: 799px) { .notification-row { padding: 14px 12px; } }. This brings mobile padding to 12px (from 4px), matching comfortable tap-target spacing while leaving 32px outer + 12px inner = 44px total, which is the iOS HIG/WCAG 44px minimum."
+      },
+      {
+        "issue": "No responsive type scaling on mobile. Notification text uses fixed font-size: 0.875rem (14px) and time uses 0.6875rem (11px) at all viewport widths. On phones < 320px these become cramped; on large phones the 14px text with min-width: 0 body can force wrapping if display names are long.",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/styles/notifications.css:64-77",
+        "recommendation": "On mobile (<800px), reduce timestamp to a more readable size or consider line-length. Current setup is functional but not optimized. If long display names + mention count text cause wrapping, consider: @media (max-width: 799px) { .notification-row__text { font-size: 0.8125rem; } } (reducing from 14px to 13px). Verify with live testing that reason text (e.g., '@username and 5 others endorsed you') wraps gracefully."
+      },
+      {
+        "issue": "Response buttons (Show/Hide) have inline-flex styling with gap-1.5 and no responsive adjustment. When present (for badge.award notifications), these buttons render at the end of the row using ToggleGroup size='sm' (h-7 28px, px-2.5). On phones <375px with narrow content, these buttons may wrap awkwardly or crowd the text.",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/components/badges/response-buttons.tsx:137-163",
+        "recommendation": "Add mobile support: either stack response buttons below the text/time on <800px (@media (max-width: 799px) { .notification-row { flex-wrap: wrap; } } with buttons in a new flex: 1 0 100% container), OR use CSS flex-direction: column on the parent row and reorder buttons via order property. Verify the row's flex-start alignment doesn't misalign the stacked layout. Buttons should remain 44px+ tap targets."
+      },
+      {
+        "issue": "Hover-only affordances (background color change on a.notification-row:hover) don't translate to mobile touch. Desktop users see a subtle background change (--bg-raised) on hover, but mobile users get no visual feedback until they tap. This violates the mobile usability principle that interactive affordances should be always visible.",
+        "severity": "high",
+        "category": "a11y",
+        "location": "src/app/styles/notifications.css:30-32",
+        "recommendation": "Add mobile-safe affordances by rendering a subtle visual cue (e.g., a faint border or background tint) on non-clickable rows (div.notification-row when isBadgeAward && !activeOrg, showing response buttons). For clickable rows (Link elements), the text itself (strong name + reason) should be visually distinct. Consider adding @media (max-width: 799px) { a.notification-row { background: var(--bg-raised); } } to lift the base state, so the hover becomes a stronger visual cue on desktop and the baseline is readable on mobile."
+      },
+      {
+        "issue": "No tap-target size guarantee on the entire row. The .notification-row is 14px padding-top + text-height + gap + text-height = ~48-52px total height, which meets 44px minimum when measured including padding. However, the 4px horizontal padding creates a very narrow left/right tap zone. Avatar (32px) is safe, but clicking the 4px padding area on the left edge may miss the interactive target.",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/app/styles/notifications.css:14-24",
+        "recommendation": "Ensure the entire row is tappable by increasing .notification-row padding to at least 12px horizontally (recommended 16px on mobile for comfort). Use @media (max-width: 799px) { .notification-row { padding: 14px 16px; } }. If the Link wrapper (when href exists) covers the entire row, this is already safe, but visual padding should match the interactive zone."
+      },
+      {
+        "issue": "No consistency check vs desktop intent. The desktop layout at 600px max-width (>=800px) uses the same compact 4px padding and dense layout, which may have been intentional for a narrow reading column. However, the mobile version at 375px-320px uses the same spacing, which is not optimized for touch and small screens.",
+        "severity": "low",
+        "category": "consistency",
+        "location": "src/app/styles/notifications.css:14-24 vs src/app/styles/layout.css:676-694",
+        "recommendation": "Verify with design intent: if the 4px padding is intentional for both desktop (reading column) and mobile, keep it. If mobile should feel more spacious, implement the media query above. If response buttons should reflow on mobile, coordinate this with the layout decision."
+      },
+      {
+        "issue": "Unread indicator (2px left bar) does not visually distinguish on mobile. The .notification-row--unread::before creates a 2px accent bar on the left (position: absolute, left: 0). On mobile with 4px padding, this bar is adjacent to the padding edge and may not read as a distinct affordance at small scales.",
+        "severity": "low",
+        "category": "visual-hierarchy",
+        "location": "src/app/styles/notifications.css:34-46",
+        "recommendation": "On mobile, either increase the bar width to 3px or shift it inward by 1-2px so it sits closer to the avatar: @media (max-width: 799px) { .notification-row--unread::before { width: 3px; left: 1px; } }. Alternatively, increase overall row padding (per the spacing finding above) to give the bar more visual context."
+      }
+    ]
+  },
+  {
+    "url": "https://certified.app/apps",
+    "file": "/workspace/certified-app/src/app/styles/pages.css",
+    "desktopLayout": "Ecosystem header with \"Apps\" title (2.75rem headline), intro paragraph (1rem), and a 2-column grid of app cards. Each card at ≥800px contains: logo (64px) + name/tagline in left column, description below. Grid spans 1080px max-width. Cards use 18px vertical padding, 20px horizontal padding. Gap between cards is 16px. Two cards fit side-by-side with each occupying ~510px.",
+    "mobileCurrentState": "CSS has mobile overrides at @media (max-width: 799px), but a critical issue exists: the @media (min-width: 700px) rule triggers 2-column grid layout at 700px, which is BELOW the mobile breakpoint (800px). Devices at 700-799px render a cramped 2-column layout instead of single-column. Below that, single column activates but still inherits 1080px max-width from parent shell (should be capped to viewport width). Card padding reduces to 14px on all sides + 16px bottom, icon shrinks to 56px. The shell max-width is never constrained on mobile, causing potential layout issues on very small phones.",
+    "findings": [
+      {
+        "issue": "2-column grid triggers at 700px (min-width) but mobile breakpoint is 800px, causing cramped 2-column cards on 700-799px viewports",
+        "severity": "high",
+        "category": "layout",
+        "location": "pages.css:960-964",
+        "recommendation": "Change @media (min-width: 700px) to @media (min-width: 800px) so 2-column grid only activates on true desktop viewports. This respects the hard rule that breakpoints are ONLY 800/1100/1300."
+      },
+      {
+        "issue": "Shell max-width 1080px is unconditional for all viewport sizes via .app-shell__content:has(.apps-store), creating excessive width on mobile and potential overflow",
+        "severity": "high",
+        "category": "layout",
+        "location": "pages.css:812-814",
+        "recommendation": "Add mobile override to revert to default max-width on mobile: @media (max-width: 799px) { .app-shell__content:has(.apps-store) { max-width: inherit; } } This allows the shell's responsive behavior to work correctly below desktop."
+      },
+      {
+        "issue": "Title uses clamp(2rem, 3vw + 0.5rem, 2.75rem) which renders ~2.4rem on mobile (375px viewport), too large for the single-column mobile layout and inconsistent with mobile typography hierarchy",
+        "severity": "medium",
+        "category": "typography",
+        "location": "pages.css:835-836",
+        "recommendation": "Add mobile override: @media (max-width: 799px) { .apps-store__title { font-size: clamp(1.5rem, 2.5vw + 0.25rem, 2rem); } } to scale title appropriately for mobile while maintaining the headline family."
+      },
+      {
+        "issue": "Intro paragraph at 1rem font-size is not optimized for mobile screens with limited width, reducing readability on small viewports",
+        "severity": "low",
+        "category": "typography",
+        "location": "pages.css:844-850",
+        "recommendation": "Add mobile override: @media (max-width: 799px) { .apps-store__intro { font-size: 0.9375rem; } } to reduce visual dominance on mobile while maintaining adequate contrast and readability."
+      },
+      {
+        "issue": "Icon row uses 14px column-gap which is tight on mobile (56px icon + 14px gap + variable meta width on single column creates uneven visual spacing)",
+        "severity": "low",
+        "category": "spacing",
+        "location": "pages.css:889-894",
+        "recommendation": "Add mobile override: @media (max-width: 799px) { .apps-store__row { column-gap: 12px; } } to improve proportional spacing on compact mobile cards."
+      },
+      {
+        "issue": "Tile padding reduces to 14px on mobile, creating 28px horizontal effective padding (14px left + 14px right). With shell's 32px page padding, total lateral whitespace may be excessive on narrowest phones",
+        "severity": "low",
+        "category": "spacing",
+        "location": "pages.css:966-974",
+        "recommendation": "No change needed if max-width override (finding #2) is implemented. If width is properly constrained by shell, the 14px card padding will be appropriate. Otherwise, reduce to 12px: .apps-store__tile { padding: 12px 12px 14px; }"
+      }
+    ]
+  },
+  {
+    "url": "https://certified-app.example.com/groups",
+    "file": "/workspace/certified-app/src/app/groups/page.tsx",
+    "desktopLayout": "The /groups page (desktop) displays a vertical stack: page heading \"Membership\" → tab bar with \"Public\" and \"Private\" tabs on the left and a \"New group\" button on the right (sharing a single bottom border) → an org list rendered as vertical stacks, each with: avatar (40px) + name + handle on one row, followed by \"Make public/private\" and \"Leave\" action buttons below. The action buttons are Tailwind-styled with Button component (size=\"sm\": py-1.5 px-4, text-xs) using variant=\"primary|secondary|destructive\". A ConfirmDialog modal (maxWidth={440}) can appear for \"Leave\" confirmations.",
+    "mobileCurrentState": "At viewport < 800px, the desktop layout shrinks without structural CSS adaptations. The Tabs component uses hardcoded Tailwind underlineClassName (px-1 py-3 text-sm) with no media override—tabs shrink but remain styled for desktop. The page-tabs-bar (display: flex, justify-content: space-between, gap: 16px) does NOT have a mobile media query, so the tab label and \"New group\" button must fit on one row. The org-list__item-actions row (display: flex, gap: 8px, padding-left: 52px) has only padding-left reset in the @media (max-width: 799px) media query (line 773–774), removing the alignment offset but buttons stay inline. Button size=\"sm\" renders at ~20px height (py-1.5 px-4), which is below the 44px minimum touch target. The action buttons DO NOT get responsive scaling. Tab buttons (underlineClassName px-1 py-3 text-sm) are ~26px tall—above the minimum but tight. The ConfirmDialog (maxWidth={440}) becomes 100% width at <800px (max-[799px]:w-full in app-dialog.tsx line 339) but does NOT use safe-area-inset or other mobile-specific dialog adjustments for bottom/side spacing. No responsive text scaling or wrapping strategies are applied to the tab strip or buttons.",
+    "findings": [
+      {
+        "issue": "Action buttons below each org item are 20px tall (Button size='sm': py-1.5 px-4), well below WCAG 2.5.5 / Apple HIG 44px minimum for touch targets on mobile.",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "src/app/groups/page.tsx:122–149 (renderOrgItem calls Button with size='sm'), src/app/styles/pages.css:199–219 (.org-list__action-btn)",
+        "recommendation": "At @media (max-width: 799px), add mobile-specific styles to org-list__item-actions buttons: min-height: 44px; min-width: 44px; py-3 px-4 (or padding: 10px 16px). Or wrap Button usage with a mobile-specific container that enforces 44px minimum. Alternatively, use Button size='md' on mobile via a responsive wrapper component."
+      },
+      {
+        "issue": "Tab buttons (underlineClassName: px-1 py-3) have minimal horizontal padding (4px each side) and no responsive scaling on mobile. With short labels like 'Public' (40px width), the hit area is adequate, but long text or future tab additions will compress the tap zone.",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/components/ui/tabs.tsx:277–283 (underlineClassName with px-1)",
+        "recommendation": "At @media (max-width: 799px), increase tab padding via a media-scoped override: px-3 py-4 (or padding: 12px 12px) to ensure each tab is at least 44px tall and wide. Update the Tabs component or add a mobile-scoped class to the TabList container."
+      },
+      {
+        "issue": "The page-tabs-bar (display: flex; justify-content: space-between; gap: 16px) has no mobile media query, forcing the tab strip and 'New group' button to compete for space on narrow screens. At <600px viewport, both may wrap or compress, creating layout instability.",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/feed.css:903–910 (.page-tabs-bar), src/app/groups/page.tsx:225–244",
+        "recommendation": "Add @media (max-width: 799px) to feed.css for .page-tabs-bar: flex-direction: column; gap: 12px; (or similar). Move the 'New group' button below the tab strip, or make it icon-only (Plus icon, aria-label='New group') at mobile width. Ensure both the TabList and the new-group button each get adequate touch targets and spacing."
+      },
+      {
+        "issue": "The org-list__item-actions row has padding-left: 52px (aligning buttons with the org name, accounting for 40px avatar + 12px gap). On mobile, this wastes horizontal space on narrow screens. The @media (max-width: 799px) resets padding-left to 0, but doesn't stack actions vertically or provide responsive spacing.",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/pages.css:193–197 (.org-list__item-actions), 773–775 (@media reset)",
+        "recommendation": "At @media (max-width: 799px), change .org-list__item-actions to flex-direction: column; gap: 12px; width: 100%; to stack buttons vertically and allow each button to expand to full width with adequate padding. Ensures buttons are large enough and don't compete for horizontal space."
+      },
+      {
+        "issue": "The ConfirmDialog modal (maxWidth={440}) sets a fixed 440px width on desktop. At <800px, it becomes 100% width (max-[799px]:w-full in app-dialog.tsx), but padding is not adjusted (px-5 pb-5 pt-0 in AppDialogBody). On very narrow screens (<320px), the dialog padding may consume too much space, leaving minimal content area.",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/groups/page.tsx:256–264 (ConfirmDialog usage), src/components/ui/app-dialog.tsx:180 (AppDialogBody px-5), 339 (dialog chrome)",
+        "recommendation": "Add mobile-scoped padding reductions in app-dialog.tsx: At @media (max-width: 799px), reduce px from 5 (20px) to 4 (16px) on AppDialogBody and AppDialogHeader. Ensure the dialog's max-height: calc(100vh-40px) is adequate on very short viewports; consider adding env(safe-area-inset-bottom) padding for notched devices."
+      },
+      {
+        "issue": "Tab text is 0.875rem (14px) at all viewport sizes. On a <320px phone, tab labels like 'Public' (40px width at font-weight: 500) leave minimal room for icon or badge additions. No responsive font scaling or abbreviation strategy exists.",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/components/ui/tabs.tsx:277 (text-sm = 14px), src/app/groups/page.tsx:229–233",
+        "recommendation": "Optional: Add responsive font sizing to tabs via a media-scoped override: @media (max-width: 799px) { .page-tabs__tab { font-size: 0.8125rem; } } or use clamp(0.75rem, 2vw, 0.875rem). Not critical for current usage, but improves scalability."
+      },
+      {
+        "issue": "No minimum touch-target enforcement for the org-list items themselves. While the avatar + text row is clickable as a link, it relies on the 40px avatar + text area. On mobile with finger-sized touch, this may be below 44px in height and should have explicit padding or height enforcement.",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/app/groups/page.tsx:99–120 (org-list__item-main Link), src/app/styles/pages.css:146–189 (.org-list__item-*)",
+        "recommendation": "At @media (max-width: 799px), add min-height: 44px; to .org-list__item (currently padding: 16px 0). Ensure the entire row is clickable and meets WCAG minimum touch-target size without adding excessive height that breaks the card aesthetic."
+      },
+      {
+        "issue": "The Badge component (variant='role') renders with compact padding (px-2 py-0.5, text-caption), which on mobile may be too small to read at arm's length or tap reliably. It appears inline with the org name/handle section.",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/app/groups/page.tsx:119 (Badge variant='role'), src/components/ui/badge.tsx:184–186 (sizeStyles compact)",
+        "recommendation": "At @media (max-width: 799px), optionally increase badge padding or move it to its own line below the org handle. Not urgent, but improves mobile readability and accessibility if users need to tap or read the role badge."
+      },
+      {
+        "issue": "The 'New group' link in the page-tabs-bar uses text-[0.8125rem] (13px) with gap-6 between the Plus icon and text. On mobile, the icon may not be discernible at this size without explicit aria-label reflow or icon-only rendering.",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/app/groups/page.tsx:236–243 (page-tabs-bar__new Link with Plus icon), src/app/styles/feed.css:943–959 (.page-tabs-bar__new)",
+        "recommendation": "At @media (max-width: 799px), render the button as icon-only (hide the text 'New group', show Plus icon in a 44px × 44px square) with aria-label='New group'. Or ensure the text label stays and the entire button expands to 44px × 44px minimum."
+      },
+      {
+        "issue": "No overflow handling for org names + handles on mobile. The .org-list__item-name has white-space: nowrap and text-overflow: ellipsis, but if a name is long, it may overflow or require two lines, shifting the layout without responsive adjustment (e.g., moving the handle below or changing font size).",
+        "severity": "low",
+        "category": "overflow",
+        "location": "src/app/styles/pages.css:175–189 (.org-list__item-name, .org-list__item-handle)",
+        "recommendation": "At @media (max-width: 799px), ensure .org-list__item-info has a max-width or flex: 1; min-width: 0; constraint (already present, good). If names still overflow, add word-break: break-word; or reduce font size to 0.8125rem on mobile. Test with long org names (e.g., 'My Very Long Organization Name Incorporated')."
+      },
+      {
+        "issue": "The 'Leave' action button (variant='destructive') is the same size (Button size='sm': 20px height) as the other action buttons. On mobile, if a user accidentally taps the destructive action, there's minimal visual feedback that they're about to lose access to the group. The button could be more prominent or require explicit confirmation.",
+        "severity": "low",
+        "category": "a11y",
+        "location": "src/app/groups/page.tsx:142–149 (Leave button), src/app/styles/pages.css:226–233 (.org-list__action-btn--danger)",
+        "recommendation": "At @media (max-width: 799px), either (a) increase the 'Leave' button to size='md' (28px height) via responsive wrapper, or (b) reorder buttons so 'Leave' is on a new row and rendered full-width. Ensure the ConfirmDialog has sufficient visual weight and clear messaging (already done via title='Leave Group'), but mobile users benefit from larger action buttons."
+      }
+    ]
+  },
+  {
+    "url": "https://certified-app.vercel.app/groups/create",
+    "file": "src/app/groups/create/page.tsx",
+    "desktopLayout": "Two-column form on viewport >= 800px: Left column (16px padding, 960px max-width) contains a hero banner (3:1 aspect), display name input (1.375rem), short description textarea, and a 3-column metadata grid (Handle, Website, Founded, Organization type). Right-aligned action buttons (Cancel, Create group). Avatar and banner pickers sit side-by-side in an identity row (1fr 3fr grid) at the top with image edit pills in the bottom-right corner. All form fields use token-based colors, 2px radius, proper spacing (gap: 32px between sections).",
+    "mobileCurrentState": "At viewport < 800px, the layout DOES NOT adapt: the .project-detail div is still positioned with max-width: 960px but the app-shell or parent enforces a narrower viewport, causing content to shrink/reflow. The .project-detail__meta grid adapts at 640px (not 800px per hard rules) to a 2-column layout, then 1-column below 640px. The .create-group__identity-row STAYS side-by-side (1fr 3fr) at all breakpoints, which becomes cramped on phones. The cert-detail__title-input is 1.375rem (no mobile adjustment). The meta-input fields are 0.8125rem with padding 2px 6px (below 16px minimum). Image edit overlay buttons are 0.75rem padding 6px 12px (potentially under 44px minimum touch target). Desktop layout basically shrinks/wraps rather than reordering or stacking.",
+    "findings": [
+      {
+        "issue": "Avatar and banner tiles remain side-by-side (1fr 3fr grid) on mobile, causing avatar to shrink to very small size on phones (< 64px width on 375px viewport). Hard to see and interact with.",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/project-detail.css:884-890 (.create-group__identity-row)",
+        "recommendation": "Add @media (max-width: 799px) rule to stack identity row vertically: grid-template-columns: 1fr; gap: 16px. Both tiles should span full width and scale naturally."
+      },
+      {
+        "issue": "Meta grid uses non-canonical breakpoints (640px for 2-col, 800px for 3-col). Per hard rules, only 800/1100/1300 are permitted. Below 640px the grid becomes 1-column, but the breakpoint logic doesn't align with canonical breakpoints.",
+        "severity": "medium",
+        "category": "consistency",
+        "location": "src/app/styles/project-detail.css:329-339 (.project-detail__meta media queries)",
+        "recommendation": "Remove the 640px breakpoint rule. Meta should be 1-column below 800px (already is at < 640px), 2-column at 800-1100, 3-column at 1100+. Consolidate to: @media (min-width: 800px) { grid-template-columns: repeat(2, minmax(0, 1fr)); } and @media (min-width: 1100px) { grid-template-columns: repeat(3, minmax(0, 1fr)); }"
+      },
+      {
+        "issue": "Title input (1.375rem) has no mobile adjustment, causing text to be large on small screens where space is constrained. On 375px viewport with padding it may not fit well or cause awkward wrapping.",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/app/styles/cert-detail.css:1451-1453 (.create-cert .cert-detail__title-input)",
+        "recommendation": "Add @media (max-width: 799px) { .create-cert .cert-detail__title-input { font-size: 1.125rem; } } to match the project detail page mobile title sizing pattern."
+      },
+      {
+        "issue": "Meta input fields use font-size: 0.8125rem with padding: 2px 6px, resulting in total height ~20px (below 44px mobile tap target minimum). Text is also small on mobile, potentially difficult to read and interact with.",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "src/app/styles/cert-detail.css:784-794 (.cert-detail__meta-input)",
+        "recommendation": "Add @media (max-width: 799px) { .cert-detail__meta-input { font-size: 0.875rem; padding: 8px 12px; } } to increase touch target and readability. Ensure minimum 44px height for tap targets."
+      },
+      {
+        "issue": "Image edit overlay buttons use padding: 6px 12px with font-size: 0.75rem, creating buttons ~24px tall (well below 44px tap target). On mobile the pills become difficult to tap accurately, especially when overlaid on small avatar/banner tiles.",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "src/app/styles/components.css (.image-edit-overlay__btn)",
+        "recommendation": "Add @media (max-width: 799px) { .image-edit-overlay__btn { padding: 8px 14px; font-size: 0.8125rem; } } to increase touch target. Consider repositioning pills outside the image bounds on mobile or using a larger icon button (size 44x44 icon)."
+      },
+      {
+        "issue": "Short description textarea uses rows={3} which takes up significant vertical space on mobile, pushing action buttons far down. No mobile-specific height adjustment.",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/groups/create/page.tsx:437 (textarea rows={3})",
+        "recommendation": "Add mobile-specific CSS: @media (max-width: 799px) { .cert-detail__short-desc-input { min-height: 60px; rows: 2; } } to reduce vertical footprint while maintaining usability."
+      },
+      {
+        "issue": "Form section gaps are 32px on desktop (cert-detail__main gap: 32px), which doesn't adjust on mobile. Creates excessive whitespace on small screens between headline, description, and meta sections.",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/styles/cert-detail.css:360 (.cert-detail__main { gap: 32px })",
+        "recommendation": "Add @media (max-width: 799px) { .cert-detail__main { gap: 20px; } } to tighten spacing and improve content density on mobile."
+      },
+      {
+        "issue": "Action buttons (Cancel, Create group) are flex: end without mobile wrapping consideration. On very narrow viewports the button text may wrap or buttons may become too narrow. No responsive button sizing.",
+        "severity": "low",
+        "category": "layout",
+        "location": "src/app/groups/create/page.tsx:531-548 (.create-cert__actions)",
+        "recommendation": "Verify button widths on mobile. Consider adding @media (max-width: 799px) { .create-cert__actions { flex-direction: column-reverse; gap: 12px; } } to stack buttons vertically and give them full width on very narrow screens."
+      },
+      {
+        "issue": "Project detail hero banner (3:1 aspect) takes up significant vertical space on mobile (on 375px viewport ~125px height). Excessive hero space on a mobile form should be reduced.",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/styles/project-detail.css:169-187 (.project-detail__hero)",
+        "recommendation": "Add @media (max-width: 799px) { .project-detail__hero { aspect-ratio: 4 / 1; margin-bottom: 20px; } } to reduce vertical footprint from 3:1 to 4:1 aspect ratio on mobile, making banner more compact without losing visual impact."
+      },
+      {
+        "issue": "Icon buttons on meta rows (Building2, Globe size={11}) are very small and may not have sufficient touch targets. The label text is 0.6875rem (uppercase, tiny) and sits on the same line as the 11px icons.",
+        "severity": "medium",
+        "category": "a11y",
+        "location": "src/app/groups/create/page.tsx:448-450, 481-482 (icon + label in meta-row)",
+        "recommendation": "Add @media (max-width: 799px) { .project-detail__meta-label { font-size: 0.75rem; gap: 6px; } } to increase label readability. Consider moving icons to a new line or enlarging them to 14px on mobile."
+      },
+      {
+        "issue": "Meta input with placeholder text 'e.g. non-profit, cooperative, DAO (comma-separated)' is very long. On 375px viewport the placeholder may be heavily truncated, making it unclear what format is expected without interaction.",
+        "severity": "low",
+        "category": "ux",
+        "location": "src/app/groups/create/page.tsx:518 (Organization type placeholder)",
+        "recommendation": "Consider shortening placeholder to 'e.g. non-profit, DAO' on mobile or using a title/tooltip. Alternatively, ensure input width/font size allows enough visible placeholder text."
+      }
+    ]
+  },
+  {
+    "url": "/groups/[groupDid]",
+    "file": "src/app/groups/[groupDid]/page.tsx",
+    "desktopLayout": "N/A — page is a server-side redirect-only route with no rendered UI. The component executes on the server, resolves a group DID to a handle, and immediately redirects to the profile page (/{handle}) via Next.js redirect() function. No layout or visual content exists at this route.",
+    "mobileCurrentState": "N/A — same as desktop. The redirect is server-side and transparent to the browser. At any viewport size (<800px or >800px), the page does not render visual content; it only performs a server-side 307/308 redirect. The user is immediately navigated to the destination profile page, where responsive layout rules apply.",
+    "findings": []
+  },
+  {
+    "url": "File: /workspace/certified-app/src/app/groups/[groupDid]/edit-profile/page.tsx",
+    "file": "/workspace/certified-app/src/app/groups/[groupDid]/edit-profile/page.tsx",
+    "desktopLayout": "Single-column form inside `.app-shell__content` (max-width 720px, 32px side padding). Dashboard topbar with \"Edit\" title. Two card sections: (1) Banner image with overlapping avatar (56px below) + display name input beside avatar. (2) Form fields (About textarea, Website URL, Founded date) stacked vertically, then action buttons (Cancel ghost / Save primary) right-aligned at bottom. Character count beneath textarea. All elements are text inputs with labels. No multi-column layouts.",
+    "mobileCurrentState": "Below 800px the CSS in components.css/.dashboard/.edit-profile selectively adapts: (1) dashboard topbar font shrinks (1.75rem from clamp). (2) dash-card padding reduces from 32px to 24px. (3) edit-profile__actions switches to flex-direction: column-reverse when <520px. Avatar-row and name-field have NO CSS styling defined anywhere, so they stack as plain block elements (avatar on top, name field below). At <800px the BannerUpload component has no media-query override defined in profile-inline-edit.css to shrink the banner height. The page adapts narrowly (no horizontal overflow) but does NOT collapse avatar + name to stacked layout on most of the 800-520px range; they stay side-by-side until very small (520px). Input/Textarea primitives use Tailwind's `md:text-sm` which means they shrink text at 768px (Tailwind breakpoint, NOT the app's 800px breakpoint), creating a hard-to-read mismatch. Font sizes in labels do not change at mobile breakpoints.",
+    "findings": [
+      {
+        "issue": "Avatar-row (avatar + display name) does not stack to vertical on mobile (800-520px); elements stay horizontal and narrow, making tap targets tight and visual hierarchy unclear",
+        "severity": "high",
+        "category": "layout",
+        "location": "page.tsx:203-219, no CSS rules for .edit-profile__avatar-row or .edit-profile__name-field",
+        "recommendation": "Add mobile CSS at @media (max-width: 799px) to stack .edit-profile__avatar-row to flex-direction: column and center-align. Ensure avatar + name label each get full width and clear visual separation. Change gap from current (if any) to 16px vertical to breathe."
+      },
+      {
+        "issue": "BannerUpload height does not shrink below 800px; profile-inline-edit.css only defines banner at 220px max-height for edit mode, no mobile rule to reduce it",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/profile-inline-edit.css:171, .profile-banner-upload__box max-height: 220px with no @media override",
+        "recommendation": "Add @media (max-width: 799px) rule to shrink .profile-banner-upload__box max-height to ~120px and adjust aspect-ratio if needed (stay 3:1 to match desktop intent). Reduce button pill padding and font size on mobile to keep floating action button proportionate."
+      },
+      {
+        "issue": "Input/Textarea sizes use Tailwind's md:text-sm breakpoint at 768px, not app's canonical 800px breakpoint, creating CSS misalignment",
+        "severity": "medium",
+        "category": "consistency",
+        "location": "src/components/ui/input.tsx line 87: 'text-base md:text-sm', src/components/ui/textarea.tsx line 63: 'text-base md:text-sm'",
+        "recommendation": "Replace Tailwind's md: (768px) breakpoint with app's canonical 800px via custom CSS or utility override. Create @media (max-width: 799px) { .md\\:text-sm { @apply text-sm !important; } } or modify size classes to use CSS media queries instead of Tailwind breakpoints."
+      },
+      {
+        "issue": "Form field labels stay at 0.6875rem (11px) on mobile; below 14px threshold makes them harder to read on small screens",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/components/ui/input.tsx:294, src/components/ui/textarea.tsx:192, label className uses text-[0.6875rem]",
+        "recommendation": "At @media (max-width: 799px), increase label font size to 0.75rem (12px) minimum. Ensure min 14px font on input elements themselves to prevent iOS auto-zoom trigger on focus."
+      },
+      {
+        "issue": "Character count display (.edit-profile__char-count) has no CSS rules; inherits default text size and positioning, may wrap awkwardly or be too small on mobile",
+        "severity": "low",
+        "category": "typography",
+        "location": "page.tsx:234-236, no CSS for .edit-profile__char-count",
+        "recommendation": "Add CSS rule: .edit-profile__char-count { font-size: 0.75rem; color: var(--fg-muted); margin-top: 4px; }. Add mobile override at @media (max-width: 799px) to increase to 0.8125rem for readability."
+      },
+      {
+        "issue": "Textarea padding and min-height may cause layout shift on mobile; Textarea at md size uses py-3 px-4, no mobile reduction defined",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/components/ui/textarea.tsx:63, sizeClasses[md] = 'px-4 py-3'",
+        "recommendation": "At @media (max-width: 799px), add CSS to reduce textarea vertical padding or ensure min-height stays compact. Alternatively add Tailwind breakpoint to sizeClasses or override in page-specific CSS."
+      },
+      {
+        "issue": "Button 'Save Changes' and 'Cancel' use default size (md: py-2.5 px-6) on mobile; may be too wide or tall relative to viewport, but actions rule does collapse them at <520px",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "page.tsx:257-266, .edit-profile__actions rules in components.css:1230-1243",
+        "recommendation": "Verify mobile breakpoint at 520px is correct for target device. Consider widening to 680px or using app's 800px breakpoint, OR ensure button height at md size (default 44px px-2.5 py-2.5) meets 44px tap target on mobile (it does). Action already stacks buttons full-width at <520px, which is good."
+      },
+      {
+        "issue": "Dashboard topbar padding does not adjust proportionally; at <800px padding reduces from 48px to 32px top, but heading font is clamp() which may still feel unbalanced on very small screens",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/styles/layout.css:1436-1446, @media (max-width: 799px) .dashboard__topbar padding-top: 32px",
+        "recommendation": "Reduce topbar padding-top further on mobile <640px to 20px to free vertical space. Heading uses clamp() so it will shrink naturally; no change needed there."
+      },
+      {
+        "issue": "No mobile-specific hint or helper text styling; Input/Textarea helpers remain at xs (12px) on mobile, hard to read",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/components/ui/input.tsx:310, src/components/ui/textarea.tsx:214, helperText uses text-xs",
+        "recommendation": "Add @media (max-width: 799px) rule to bump helper text to text-sm (14px) for legibility on mobile. This improves readability without breaking layout."
+      }
+    ]
+  },
+  {
+    "url": "/groups/[groupDid]/settings",
+    "file": "/workspace/certified-app/src/app/groups/[groupDid]/settings/page.tsx",
+    "desktopLayout": "Two-pane layout via .page-layout grid (296px left sidebar + 1fr main). Left sidebar (.sx__menu) displays scroll-spy navigation with 4 category links (Handle, Sync social graph, Members & Roles, Activity Log). Right pane (.sx__panel) stacks sections vertically with 48px gaps. Each section (.sx-section) has a header (title + description) and body. Members and audit sections display lists with horizontal flex items (info on left, actions on right). The add-member form displays a horizontal row: label + role select + add button.",
+    "mobileCurrentState": "At viewport < 800px, .page-layout collapses to a single column stack (gap: 24px, padding: 24px 16px). The left sidebar (.sx__menu) becomes static/unpinned and sits above the main panel. Menu items have responsive padding (10px 10px on mobile vs 6px 10px on desktop) and font-size increases slightly (0.9375rem vs 0.85rem). Members list items (.org-members__item) change from flex row (align-items: center) to flex column (align-items: stretch). The add-member form row (.org-members__add-submit) stays as a horizontal flex layout with no wrapping, which can cause overflow. The role select shrinks to size=\"sm\" (h-9 = 36px) which is below WCAG 44px minimum. Selected member tags get larger touch targets (28x28 with min-width/min-height: 44px) but this is oversized relative to surrounding UI. Audit log items display metadata in stacked rows with monospace text that may wrap awkwardly on narrow screens.",
+    "findings": [
+      {
+        "issue": "Select size='sm' is 36px (h-9) — below 44px WCAG tap target minimum",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "pages.css:16-18 (Select component sizes), org-settings.tsx:456-466 (member role select)",
+        "recommendation": "On mobile (@media max-width: 799px), upgrade .org-members__item-actions > select to size='md' (h-11 = 44px). Similarly, upgrade .org-members__add-submit > select to size='md'. Add a media query in pages.css to override the sm size with md for these selects below 800px."
+      },
+      {
+        "issue": "org-members__add-submit layout is horizontal flex that doesn't wrap on narrow viewports",
+        "severity": "high",
+        "category": "layout",
+        "location": "pages.css:361-365 (org-members__add-submit)",
+        "recommendation": "Add @media (max-width: 799px) rule to change flex-direction to column, full-width inputs, and stack elements vertically for mobile. Use align-items: stretch and full-width children so label, select, and button each get 100% width at mobile."
+      },
+      {
+        "issue": "Menu items (.sx-menu__item) height is 20px at mobile (10px padding top+bottom) — below 44px tap target",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "settings-page.css:297-300 (mobile padding override)",
+        "recommendation": "Increase mobile padding to at least 12px vertical (achieving 44px+ line-height total). Change @media (max-width: 799px) .sx-menu__item from 'padding: 10px 10px' to 'padding: 12px 10px' or similar, ensuring the flex container reaches ~44px minimum height."
+      },
+      {
+        "issue": "org-members__item-actions at mobile doesn't flex-wrap or stack after column change to parent",
+        "severity": "medium",
+        "category": "layout",
+        "location": "pages.css:777-783 (mobile override), 316-321 (desktop styles)",
+        "recommendation": "When .org-members__item becomes flex-column on mobile, add @media (max-width: 799px) .org-members__item-actions { flex-direction: column; align-items: stretch; width: 100%; gap: 10px; } so the role select and remove button stack vertically and take full width."
+      },
+      {
+        "issue": "org-members__selected-remove creates 44x44 boxes with 16x16 content, wasting space and inconsistent with surrounding UI scale",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "pages.css:787-795 (mobile override)",
+        "recommendation": "Instead of min-width/min-height: 44px, use a more proportional approach: width: 32px; height: 32px on mobile, or reduce the override to ensure the visual proportions match the rest of the member tag UI. Maintain 44px+ touch target via surrounding padding/gap instead of forcing an oversized button."
+      },
+      {
+        "issue": "org-audit__detail-value with word-break: break-all on long DIDs/collection/rkey values may create awkward line breaks in monospace on narrow screens",
+        "severity": "low",
+        "category": "typography",
+        "location": "pages.css:492-496 (org-audit__detail-value)",
+        "recommendation": "Consider wrapping audit detail values in a horizontal-scrolling container on mobile, or allow overflow-x: auto on the audit item row itself. Alternatively, truncate long values with ellipsis and provide a copy button. For now, add @media (max-width: 799px) to set word-break: break-word instead of break-all for less jarring line breaks."
+      },
+      {
+        "issue": "Members pagination controls (Previous/Next buttons) are size='sm' (py-1.5 px-4, ~24px height) — below 44px tap target",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "org-settings.tsx:486-504 (pagination buttons), button.tsx:60 (size sm = 24px height)",
+        "recommendation": "On mobile, upgrade pagination buttons to size='md' (py-2.5 px-6, ~36px) or add an @media rule that overrides .pagination button to a larger height. Also ensure the pagination info text has adequate vertical spacing. For now, add .pagination { gap: 12px; } on mobile to improve spacing."
+      },
+      {
+        "issue": "Input field in HandleSearch (for adding members) may be small on mobile — verify it meets 44px height requirement",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "org-settings.tsx:512-520 (HandleSearch component), pages.css:1-60 (handle-search styles)",
+        "recommendation": "Verify HandleSearch uses <Input variant='underline' size='md'> (default). If it uses size='sm' on mobile, add a media query to upgrade it to size='md' (h-11 = 44px) for touch comfort."
+      },
+      {
+        "issue": "Audit log section heading (.sx-panel__title) scales to 1.25rem on mobile but is still serif headline — consistent with design intent, but verify readability in narrow viewport",
+        "severity": "low",
+        "category": "typography",
+        "location": "settings-page.css:293-295 (mobile title override)",
+        "recommendation": "Currently: font-size: 1.25rem (design rule compliant). No change needed — serif headlines at 1.25rem are intentional. Monitor in user testing for readability."
+      },
+      {
+        "issue": "Sticky menu navigation (.sx__menu) unpins correctly on mobile but section titles still use scroll-margin-top with --top-bar-total, creating potential jump-to misalignment if user swipes back from section",
+        "severity": "low",
+        "category": "nav",
+        "location": "settings-page.css:205-211 (sx-section scroll-margin-top), 104-109 (sx__menu unpinned)",
+        "recommendation": "The scroll-margin-top: calc(var(--top-bar-row1) + var(--top-bar-row2) + 24px) assumes a two-row navbar (52px + 44px). On mobile below 800px where the menu is inline, consider reducing this to just var(--top-bar-row1) + small buffer. Add @media (max-width: 799px) .sx-section { scroll-margin-top: calc(var(--top-bar-row1) + 8px); } to reduce wasted space."
+      },
+      {
+        "issue": "page-layout padding (24px 16px on mobile) is asymmetric — 16px horizontal is tighter than 24px vertical",
+        "severity": "low",
+        "category": "spacing",
+        "location": "layout.css:2281-2285 (page-layout defaults)",
+        "recommendation": "This is intentional (matching DESIGN.md §5: 'padding: 0 16px–20px' on mobile). Current 24px 16px follows the compact mobile spec. No change needed — verify it provides adequate breathing room in QA."
+      }
+    ]
+  },
+  {
+    "url": "/settings",
+    "file": "/workspace/certified-app/src/app/settings/page.tsx",
+    "desktopLayout": "Two-pane layout: left sticky sidebar (296px) with navigation menu items, right main pane with stacked sections. Each section has header (title + description) then body. App-wide max-width 1280px. Sidebar is sticky with max-height constraint. Menu items (padding 6px 10px = 16px min height). Main sections have 48px gap between them. Title 1.5rem, serif font.",
+    "mobileCurrentState": "Grid collapses to single column below 800px. Sidebar sits above main panel (no longer sticky). Menu is unpinned (position: static). Menu items increase padding to 10px 10px (20px height) at mobile, but this still falls short of 44px tap target minimum. Font-size increases to 0.9375rem. Layout stacks vertically correctly. Subdomain input in UsernameCard is 40px height. Modal (maxWidth={560}) may not fully adapt via inline style override. Small buttons use py-1.5 (24px height max). No other CSS adaptations for mobile spacing or affordances.",
+    "findings": [
+      {
+        "issue": "Menu item tap targets undersized on mobile (20px instead of 44px minimum)",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "src/app/styles/settings-page.css:297-300",
+        "recommendation": "Increase .sx-menu__item mobile padding from 10px 10px to 12px 16px (or equivalent to reach 44px minimum height with flex alignment). Adjust .sx-menu gap accordingly to maintain visual spacing between items."
+      },
+      {
+        "issue": "Sync social graph modal maxWidth inline style may override mobile breakpoint",
+        "severity": "medium",
+        "category": "overflow",
+        "location": "src/components/settings/sync-social-graph-section.tsx:222 (maxWidth={560}) and src/components/ui/app-dialog.tsx:339-345",
+        "recommendation": "The modal has maxWidth={560} passed as an inline style prop, which has higher CSS specificity than Tailwind classes and will override max-[799px]:max-w-none on mobile screens. Either: (a) conditionally set maxWidth only when viewport >= 800px using a media query check, or (b) remove the inline style and use responsive Tailwind sizing, or (c) ensure the AppDialog component prioritizes responsive constraints over the inline maxWidth prop."
+      },
+      {
+        "issue": "Subdomain input height undersized for comfortable mobile interaction (40px < 44px)",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/app/styles/components.css (.username-card__subdomain-input: height 40px)",
+        "recommendation": "Increase .username-card__subdomain-input and .username-card__subdomain-suffix to min-height: 44px on mobile (@media max-width: 799px), or set height: auto to allow natural sizing. Verify horizontal overflow on narrow screens does not create issues."
+      },
+      {
+        "issue": "Small buttons (sm size) may be undersized for mobile tap comfort (24px max height)",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/components/ui/button.tsx (size='sm': py-1.5 px-4 = 24px height)",
+        "recommendation": "Consider adding a mobile breakpoint in settings-page.css to use size='md' (py-2.5 = 32px+ height) for primary action buttons in settings forms, or add explicit padding boost in mobile media query for .sx-panel__body buttons."
+      },
+      {
+        "issue": "Sticky menu removed on mobile without alternative mobile nav pattern",
+        "severity": "low",
+        "category": "nav",
+        "location": "src/app/styles/settings-page.css:104-110",
+        "recommendation": "Mobile correctly unpins the sticky menu (position: static) so it scrolls with the page. However, this forces users to scroll back up to jump sections. Consider adding a mobile-specific horizontal scroll nav, pills, or tabs at the top of the main panel (below the page breadcrumb) to improve section navigation UX on small screens."
+      },
+      {
+        "issue": "Modal list scrolling (max-height 280px) may be cramped on small phone screens",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/styles/social-graph-sync.css:266 (.social-graph-sync__modal-list: max-height 280px)",
+        "recommendation": "The candidate list in the sync modal has a fixed max-height: 280px. On screens < 600px, this combined with header/footer/search consumes too much viewport. Use @media (max-width: 799px) { max-height: 40vh or 150px } to cap the list more conservatively on mobile."
+      },
+      {
+        "issue": "No responsive image or icon sizing for narrow screens in settings sections",
+        "severity": "low",
+        "category": "consistency",
+        "location": "src/components/settings/sync-social-graph-section.tsx (Avatar, Icons in modal rows)",
+        "recommendation": "While not critical, verify that avatars and icons in the sync modal (Checkbox rows with Avatar sm size) don't become disproportionate on very small screens. No hard rule violation, but watch for visual cramping in list rows below 375px width."
+      },
+      {
+        "issue": "Section header padding and title sizing could improve mobile readability",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/styles/settings-page.css:243-258 (desktop) and 293-300 (mobile)",
+        "recommendation": "Mobile section titles scale to 1.25rem (line 293), which is good. However, the .sx-panel__header padding remains unchanged (gap: 6px, padding-bottom: 16px). On narrow screens, slightly increase bottom padding to 20px and consider reducing description font-size to 0.8125rem for balance."
+      }
+    ]
+  },
+  {
+    "url": "https://certified.app/settings/edit-profile",
+    "file": "/workspace/certified-app/src/app/settings/edit-profile/page.tsx",
+    "desktopLayout": "Single-column reading form inside .app-shell__content (600px max-width, 32px padding on each side). Hero banner (140px) with overlapping avatar (64px, positioned -36px below). Stacked sections with H2 titles + hint text. Two-column split grid on Identity section (display name ~376px + pronouns 160px, gap 16px). Org URL list in 3-column grid (URL flex | label 130px | remove auto). Sticky footer with flex row of buttons, right-aligned. All text fields in .pe__fields with 16px gaps, proper 36px button height (44px target minimum), error text 0.75rem.",
+    "mobileCurrentState": "CSS adapts comprehensively at @media (max-width: 799px). Banner height reduces 140px → 112px. Avatar repositions left 16px → 12px, bottom -36px → -32px. Identity section row stacks vertically (pronouns field no longer split). Org URL grid reorganizes: URL + remove button on row 1 (grid: 1fr auto), label spans full width row 2. Footer buttons stack column-reverse (Cancel below Save) at 100% width each. Sticky footer uses safe-area-inset-bottom. All inputs use .pe__label (0.8125rem) with proper hierarchy. No overflow or shrinking — desktop layout successfully adapts.",
+    "findings": [
+      {
+        "issue": "Avatar tap target below 44px minimum on mobile",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/components/profile/avatar-upload.tsx:94 (.h-16 w-16 = 64px absolute div, but interactive surface is the wrapper div which uses role='button' without explicit tap dimensions)",
+        "recommendation": "The avatar wrapper div at line 84-100 has role='button' but no explicit min-height/min-width. While the 64px avatar itself exceeds 44px, the interactive click surface should be explicitly sized to maintain WCAG 2.5 target spacing. Add `min-h-11 min-w-11` (44px) or ensure the relative parent scales the entire interactive area to minimum 44px in all directions, or add explicit padding around the click target."
+      },
+      {
+        "issue": "Back-link affordance tap target below ideal size",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/app/styles/profile-edit.css:39-59 (.pe__back-link padding 4px 0)",
+        "recommendation": "The back-link uses padding 4px 0, giving ~8px vertical tap height + 0 horizontal padding. At 0.8125rem (13px) line height this totals ~21px vertical tap target. Add padding-y consistent with button guidelines: change `padding: 4px 0` to `padding: 6px 4px` (or use min-h-11 = 44px) to meet WCAG 2.5.5 spacing guidelines."
+      },
+      {
+        "issue": "Input fields lack explicit min-height on mobile for comfortable mobile input",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/components/ui/input.tsx:84-94 (sizeClasses for 'md' = 'h-11 px-4 text-base md:text-sm')",
+        "recommendation": "Input size='md' is 44px (h-11) on mobile but text cascades to text-base (16px), creating full-height text inside the field. On mobile viewports < 800px, inputs should maintain text-base (16px) to prevent iOS auto-zoom-on-focus that triggers when inputs are < 16px. The current md size already uses text-base, so this is acceptable; however, verify that no CSS override or cascade resets it to smaller than 16px on mobile (check profile-edit.css for any typography resets). Current state is compliant."
+      },
+      {
+        "issue": "Org URL remove button (36px × 36px) slightly below 44px tap target minimum",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/app/styles/profile-edit.css:226-245 (.pe__url-remove width: 36px, height: 36px)",
+        "recommendation": "The remove button in org URL rows is 36px × 36px, falling 8px short of the 44px × 44px WCAG 2.5.5 recommendation. On mobile, increase dimensions: change `width: 36px; height: 36px;` to `width: 44px; height: 44px;`. This maintains symmetry with the avatar tap target (64px) and button heights (36px → 44px). If 44px is too visually dominant, alternative: add 4px horizontal margin to create 44px horizontal spacing; verify vertical spacing via gap or padding."
+      },
+      {
+        "issue": "Add URL button (+) small and may be hard to tap on mobile",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/app/styles/profile-edit.css:247-268 (.pe__url-add padding: 6px 8px, font-size: 0.8125rem)",
+        "recommendation": "The '+ Add URL' button uses padding 6px 8px and 0.8125rem font, yielding minimal tap area (~28px vertical). On mobile, increase vertical padding or min-height: change `padding: 6px 8px;` to `padding: 8px 12px;` (or add `min-h-11`) to approach 44px target. Alternatively, add `min-height: 44px` and vertically center content via flex: `display: inline-flex; align-items: center; min-height: 44px;`."
+      },
+      {
+        "issue": "Section title font size (1.125rem = 18px) is optimal for mobile but could be slightly larger for hierarchy",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/styles/profile-edit.css:125-133 (.pe__section-title font-size: 1.125rem)",
+        "recommendation": "Section titles at 1.125rem (18px) are readable on mobile but fairly compact. Consider adding a mobile-specific override to increase hierarchy: add `@media (max-width: 799px) { .pe__section-title { font-size: 1rem; } }` to reduce slightly and match the desktop sense of proportion, OR keep as-is if visual weight matches intent. Current state is acceptable; this is a refinement, not a critical issue."
+      },
+      {
+        "issue": "Label font size (0.8125rem = 13px) is small but acceptable; verify contrast under dark mode",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/styles/profile-edit.css:176-185 (.pe__label font-size: 0.8125rem, color: var(--fg-primary))",
+        "recommendation": "Labels use 0.8125rem, which is below ideal readability threshold (14px minimum per WCAG AAA). The color is --fg-primary, which should have sufficient contrast. Verify in dark mode that --fg-primary meets 4.5:1 contrast ratio against --bg-elevated. If needed, increase to 0.875rem (14px) as a minor enhancement. Current state likely compliant; this is a suggestion for visual improvement."
+      },
+      {
+        "issue": "Sticky footer margin on desktop uses -32px which may clip content on some mobile insets",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/styles/profile-edit.css:292-308 (.pe__footer margin: 24px -32px 0)",
+        "recommendation": "The footer uses `margin: 24px -32px 0` to break out of the 32px column padding. On mobile < 800px, the column padding is still 32px (see layout.css:678), so the negative margin correctly aligns the footer. However, verify that on narrow mobile devices (e.g., iPhone 5, 320px viewport) the footer doesn't overflow or create horizontal scrolling. The -32px margin should be clamped if column padding varies. Current state should be safe; add a mobile-specific check if narrow-viewport testing reveals clipping."
+      },
+      {
+        "issue": "Footer buttons on mobile may benefit from larger minimum touch area and better visual separation",
+        "severity": "low",
+        "category": "tap-target",
+        "location": "src/app/styles/profile-edit.css:401-409 (mobile footer: flex-direction column-reverse, width 100%)",
+        "recommendation": "Footer buttons on mobile are 36px height and 100% width, which is good for width but slightly short vertically (44px target). The column-reverse stacking is correct (Cancel below Save). Add `min-height: 44px;` to .pe__action-btn or, more elegantly, modify the mobile footer rule: add `@media (max-width: 799px) { .pe__action-btn { height: 44px; } }` to increase tap target. Current 36px is acceptable but 44px is better for mobile."
+      },
+      {
+        "issue": "No mobile-specific line-height adjustments for longer label text that wraps",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/styles/profile-edit.css:176-185 (.pe__label line-height not set, uses browser default ~1.2)",
+        "recommendation": "Labels like 'How others see you across Certified' (hint text) use .pe__hint with line-height: 1.55, but .pe__label has no explicit line-height. If labels wrap on mobile, add `line-height: 1.4;` to .pe__label to improve readability. Current state is acceptable; this is a refinement for wrapped text."
+      }
+    ]
+  },
+  {
+    "url": "https://certified.app/oauth/callback",
+    "file": "/workspace/certified-app/src/app/oauth/callback/page.tsx",
+    "desktopLayout": "The loading screen centers a pulsing 64x64px Brandmark (animated) above error message or processing state. Uses fixed positioning (inset: 0) with flexbox centering. Fixed position viewport fill works correctly. Logo at 64x64px with animation (logoPulse 0.95x to 1x scale). Error text and link text are 0.8125rem (13px). All styling is applied uniformly — no breakpoint-specific overrides exist for desktop.",
+    "mobileCurrentState": "No mobile-specific CSS overrides exist. The desktop layout shrinks inline without adaptation: fixed positioning still centers content correctly, but text remains 0.8125rem (13px — very small on mobile), logo stays fixed 64x64px with no scaling, and there is zero padding around the content area for screen edges/safe-areas. The page does not snap to mobile viewports &lt; 800px; it simply scales the desktop layout down.",
+    "findings": [
+      {
+        "issue": "Typography too small for mobile readability: error message and link text are 0.8125rem (13px), well below recommended 16px minimum for mobile touch interfaces",
+        "severity": "high",
+        "category": "typography",
+        "location": "src/app/styles/layout.css:106-120 (.loading-screen__error, .loading-screen__link)",
+        "recommendation": "Add @media (max-width: 799px) rule to bump both .loading-screen__error and .loading-screen__link to 1rem (16px) for mobile. This ensures text is comfortably readable and does not trigger iOS zoom-on-input (font size &lt; 16px). Maintain 0.8125rem on desktop (&gt;= 800px)."
+      },
+      {
+        "issue": "Missing padding around loading screen content on mobile creates text-to-edge collision on narrow viewports. Content flush against 0-padding viewport edges on screens &lt; 360px.",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/styles/layout.css:74-78 (.loading-screen__inner)",
+        "recommendation": "Add @media (max-width: 799px) rule to .loading-screen__inner to apply padding: 16px (or min(16px, 5vw)) to ensure error message and link text have breathing room from left/right edges on narrow phones. Desktop does not need this — content is centered with implicit spacing."
+      },
+      {
+        "issue": "No focus-visible styling on 'Return to home' link. Link is tappable but lacks visible focus indicator for keyboard navigation accessibility on mobile.",
+        "severity": "medium",
+        "category": "a11y",
+        "location": "src/app/styles/layout.css:113-123 (.loading-screen__link)",
+        "recommendation": "Add .loading-screen__link:focus-visible rule with outline: 2px solid var(--focus-ring); outline-offset: 2px; border-radius: var(--radius); following the hard design rule for focus indicators. This matches the pattern used elsewhere in layout.css (e.g., .navbar__title-part:focus-visible at line 21-24)."
+      },
+      {
+        "issue": "Tap target size unchecked. The link 'Return to home' is a text link with no explicit padding or min-height. On mobile, the tap target may be &lt; 44px in height, failing WCAG touch target minimum.",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/app/oauth/callback/page.tsx:60 (Link href='/')",
+        "recommendation": "Apply min-height: 44px and padding: 12px 0 to .loading-screen__link on mobile (&lt; 800px) to guarantee WCAG AA 44×44px touch target. Alternatively, wrap the link in a button or add padding inline. Desktop can remain compact."
+      },
+      {
+        "issue": "No media query gap/margin between logo and text on mobile. Fixed 64×64px logo with no responsive spacing between logo and error/link text. On very narrow screens (&lt; 320px), vertical space may feel cramped.",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/styles/layout.css:74-78 (.loading-screen__inner)",
+        "recommendation": "Add @media (max-width: 799px) rule to .loading-screen__inner: gap: 24px (increased from implicit 0 or default flex gap) to add vertical separation between logo and text on mobile. Desktop can use implicit centering without gap."
+      }
+    ]
+  },
+  {
+    "url": "https://certified.app/about",
+    "file": "/workspace/certified-app/src/app/about/page.tsx",
+    "desktopLayout": "The /about page uses a narrow reading column layout (600px max-width at ≥800px) centered with 32px horizontal padding. Content is structured as full-width prose sections with h2 headings (1.75rem), body paragraphs (1rem), unordered lists with disc markers and pl-6 indentation, and inline text links using --color-accent token with underline hover state. The legal-page class widens the container slightly (880px), but the core reading experience is a single column of serif-headline h2s followed by prose blocks separated by space-y-8 (32px vertical gaps). Typography hierarchy is: h2 (text-h2, font-headline, color-primary), body (1rem, line-height 1.6), and list items (body size with disc bullets).",
+    "mobileCurrentState": "At viewport < 800px, the layout does NOT adapt via CSS. The .app-shell__content maintains max-width: 720px and padding: 32px horizontal without mobile overrides. The navbar becomes visible (fixed top, 56px), bottom nav becomes visible (fixed bottom, 56px), and available content area shrinks to approximately 311px (375px viewport - 64px padding). The prose class applies default Tailwind styling with NO responsive variants, so h2 remains 1.75rem (28px), body text stays 1rem (16px), and spacing (space-y-8 = 32px gap) is unchanged. The ul.list-disc.pl-6 indentation (24px left padding on 311px width) consumes ~7.7% of horizontal space. Social links and address block render as inline/stacked text with no touch-target optimization. Result: desktop layout simply shrinks, creating cramped typography, tight wrapping, undersized touch targets, and suboptimal readability.",
+    "findings": [
+      {
+        "issue": "Heading font size not responsive—h2 (1.75rem/28px) creates poor measure on mobile",
+        "severity": "high",
+        "category": "typography",
+        "location": "src/app/about/page.tsx:27 (h2 class=\"font-headline text-h2\")",
+        "recommendation": "Add @media (max-width: 799px) rule reducing h2 from text-h2 (1.75rem) to ~1.375rem (22px) or smaller to maintain optimal line length (60-75ch) on 311px available width. Apply directly to h2 elements or create a responsive prose variant."
+      },
+      {
+        "issue": "Inline link touch targets < 44px—inline links lack padding, fail WCAG 2.1 AAA tap-target requirement",
+        "severity": "high",
+        "category": "a11y",
+        "location": "src/app/about/page.tsx:30-36 (AT Protocol link) and other inline links",
+        "recommendation": "Wrap inline links in a styled <a> with explicit padding (min 8px vertical) to meet 44x44px minimum, or use Tailwind focus-ring and outline patterns to enlarge focus area. Alternative: replace prose.underline with a link component that enforces minimum hit area."
+      },
+      {
+        "issue": "Horizontal padding (32px) not optimized for narrow mobile—creates 311px available width on 375px viewport",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/styles/layout.css:678 (.app-shell__content padding)",
+        "recommendation": "Add @media (max-width: 799px) override reducing padding-left and padding-right from 32px to 16px or 20px for mobile, increasing available width to ~343px or 335px. Respect safe-area-inset on notched devices: padding: calc(...) max(16px, env(safe-area-inset-right))."
+      },
+      {
+        "issue": "Section spacing (space-y-8 = 32px) not responsive—excessive vertical rhythm on narrow mobile",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/about/page.tsx:25 (space-y-8 class)",
+        "recommendation": "Add responsive spacing: use space-y-6 or space-y-4 on mobile (<800px) instead of space-y-8. Apply via @media or use Tailwind's responsive prefix syntax if available (space-y-8 md:space-y-6, but verify current setup)."
+      },
+      {
+        "issue": "List indentation (pl-6) consumes excessive horizontal space on mobile—24px indent on 311px width",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/about/page.tsx:90 (ul class=\"list-disc pl-6\")",
+        "recommendation": "Add @media (max-width: 799px) override reducing pl-6 to pl-3 or pl-4 (12-16px). Maintain visual hierarchy while freeing horizontal space for longer list items to wrap gracefully."
+      },
+      {
+        "issue": "Social links layout (inline divider dots) not mobile-friendly—tight packing, small touch targets",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/about/page.tsx:194-228 (social link group with ' · ' separators)",
+        "recommendation": "Stack social links vertically on mobile using flex-col and @media (max-width: 799px), or increase gap/padding around dividers to create larger touch zones. Currently inline text links packed with separators make individual targets hard to tap."
+      },
+      {
+        "issue": "Contact address block uses <br /> instead of semantic structure—fragile to reflow",
+        "severity": "low",
+        "category": "a11y",
+        "location": "src/app/about/page.tsx:176-182 (address block)",
+        "recommendation": "Replace <br /> structure with <address> semantic tag and display: block or flex layout. This improves accessibility (screen readers recognize it as address block) and survives reflow better on narrow viewports without relying on hard line breaks."
+      },
+      {
+        "issue": "No safe-area insets for left/right on notched devices in landscape—content may hide behind notches",
+        "severity": "low",
+        "category": "layout",
+        "location": "src/app/styles/layout.css:678 (.app-shell__content padding applies only to bottom)",
+        "recommendation": "Extend padding declaration to include safe-area-inset-right and safe-area-inset-left: padding: ... max(32px, env(safe-area-inset-right)) max(32px, env(safe-area-inset-left)). Ensures content never hides behind notches on folded or notched devices."
+      },
+      {
+        "issue": "Heading bottom margin (mb-4 = 16px) not tuned for mobile—creates loose hierarchy on narrow viewport",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/about/page.tsx:27 (h2 mb-4 class)",
+        "recommendation": "Add @media (max-width: 799px) tightening mb-4 to mb-2 (8px) on mobile. On a 311px width, large headings + 16px gap consume vertical space. Tighter spacing maintains structure without waste."
+      },
+      {
+        "issue": "Prose class applies desktop-optimized Tailwind typography with no mobile variants",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/app/about/page.tsx:25 (prose max-w-none)",
+        "recommendation": "Create a mobile-first prose override in a CSS file targeting @media (max-width: 799px) for: body font-size (no change needed), list item padding, code blocks, blockquotes, or hr elements. Alternatively, apply Tailwind responsive modifiers to individual elements (text-sm md:text-base, etc.)."
+      }
+    ]
+  },
+  {
+    "url": "http://localhost:3000/privacy",
+    "file": "src/app/privacy/page.tsx",
+    "desktopLayout": "Single-column editorial layout. The page uses `.app-shell__content` with max-width 880px (overridden for legal pages), 32px left/right padding, and wraps all content in a `.prose` div with `max-w-none`. Headings use responsive Tailwind text-h1/h2/h3 classes (2.25rem, 1.75rem, 1.375rem). Body text and links are unstyled. Lists use Tailwind `list-disc pl-6`, creating a 24px left indent. Nested lists nest without additional responsive handling. Link styling uses underline + hover state with no explicit tap-target sizing. The page is a GDPR-compliant privacy policy with 16 sections, multiple nested lists, and several email/web links.",
+    "mobileCurrentState": "At < 800px (e.g., 375px viewport), the CSS does NOT adapt: the same 32px padding applies left and right, leaving ~311px for content. Heading sizes (text-h2 at 28px, text-h3 at 22px) do not scale down — they remain at full desktop size, consuming significant vertical real estate on narrow screens. List indentation (pl-6 = 24px) eats further into the narrow column. There is no responsive breakpoint to reduce padding, adjust typography, or reflow list indentation. The nested lists (2-3 levels deep in sections 8 and beyond) do not wrap or stack — they compress horizontally. The max-width is set at 880px globally, which has no effect at < 800px since the viewport is already narrower, but the fundamental layout shifts entirely depend on hard-coded padding values that never change. Links have no explicit tap-target sizing — they inherit inline size from text, creating targets far below the 44px accessibility minimum.",
+    "findings": [
+      {
+        "issue": "Heading font sizes (text-h2 28px, text-h3 22px) do not scale down on mobile, consuming excessive vertical space on narrow viewports",
+        "severity": "high",
+        "category": "typography",
+        "location": "src/app/privacy/page.tsx:22, 30, 61, etc. (all h1/h2/h3 tags)",
+        "recommendation": "Add responsive heading sizes via Tailwind @apply or CSS custom properties. Use text-h2 (28px) on desktop, but add @media (max-width: 799px) rule to scale h2 to ~20px and h3 to ~18px. Per DESIGN.md, use Tailwind utilities or token-based sizing that honors the 800px breakpoint."
+      },
+      {
+        "issue": "Horizontal padding (32px left/right) is excessive on mobile (375px viewport leaves only ~311px for content), leaving narrower effective reading width than intended",
+        "severity": "high",
+        "category": "spacing",
+        "location": "src/app/styles/layout.css:678 (.app-shell__content padding property)",
+        "recommendation": "Add @media (max-width: 799px) rule to reduce padding on mobile: change from 32px to 16px on left/right at < 800px. This increases content width to ~343px, improving readability and reducing line-breaking of nested list items."
+      },
+      {
+        "issue": "List indentation (pl-6 = 24px) does not adapt for mobile; nested lists (3 levels in some sections) compress the already-narrow column further, risking horizontal overflow of long list items",
+        "severity": "high",
+        "category": "overflow",
+        "location": "src/app/privacy/page.tsx:288 (nested list example: section 8, data sharing with service providers sublist)",
+        "recommendation": "Add @media (max-width: 799px) rule to reduce pl-6 to pl-3 (12px) for mobile. For deeply nested lists (3+ levels), consider converting to a flattened or indented-text structure, or reduce nesting to 2 levels max. Alternatively, use a custom nested-list component that adapts indentation responsively."
+      },
+      {
+        "issue": "Email and web links (e.g., legal@hypercerts.org, https://www.datenschutz-berlin.de) have no explicit touch-target sizing and may be < 44px in height/width, failing WCAG accessibility minimum",
+        "severity": "medium",
+        "category": "a11y",
+        "location": "src/app/privacy/page.tsx:79-84, 110-116, 354-360, 425-432, 437-442, 499-504 (all `<a>` tags with color-accent class)",
+        "recommendation": "Ensure link text has min-height of 44px by wrapping inline links in a block or inline-block wrapper with padding, or use a link component from src/components/ui/ that enforces WCAG tap targets. Alternatively, add padding: 8px 0 to all links via CSS or set min-height: 44px on links with display: inline-flex + align-items: center."
+      },
+      {
+        "issue": "No mobile-specific metadata or viewport adjustments in HTML; font sizes lock to desktop scale with no responsive typography system",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/app/privacy/page.tsx (head metadata and Tailwind font-size scale in tailwind.config.ts)",
+        "recommendation": "Ensure viewport meta tag includes viewport-fit=cover (already present per metadata in codebase). Add @media (max-width: 799px) rules in a separate CSS file or inline style block that redefine text-h2 and text-h3 sizes for mobile. Alternatively, use Tailwind's responsive prefixes (e.g., `max-lg:text-xl`) to make heading sizes conditional, but this requires rebuilding all h2/h3 declarations."
+      },
+      {
+        "issue": "Spacing between sections (space-y-8 = 32px) is not adjusted on mobile; combined with large headings and reduced content width, creates unbalanced rhythm",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/privacy/page.tsx:28 (.prose.space-y-8)",
+        "recommendation": "Add @media (max-width: 799px) rule to reduce space-y-8 to space-y-4 (16px) on mobile. This tightens vertical rhythm for narrow screens while preserving the breathing room intended at desktop width."
+      },
+      {
+        "issue": "The max-width 880px set on legal-page does not constrain mobile layout (viewport < 880px), but creates an inconsistency: on desktop the max-width is 880px (per .app-shell:has(.legal-page)), but heading and text sizes never adapt to mobile constraints",
+        "severity": "low",
+        "category": "consistency",
+        "location": "src/app/styles/layout.css:3419-3421 and src/app/privacy/page.tsx typography",
+        "recommendation": "Document or enforce that legal pages must have responsive typography. The max-width rule is correct for desktop readability (longer lines benefit dense legal text), but mobile responsiveness requires parallel responsive typography rules at @media (max-width: 799px)."
+      },
+      {
+        "issue": "No hover-only affordances detected, but link underlines may be subtle on light backgrounds; lack of explicit color contrast guidance could impact readability on older devices or in bright sunlight",
+        "severity": "low",
+        "category": "a11y",
+        "location": "src/app/privacy/page.tsx:79-84, 110-116, etc. (all links styled with --color-accent and underline)",
+        "recommendation": "Verify --color-accent has sufficient contrast against --bg-canvas in both light and dark themes (check DESIGN.md or tokens.css for WCAG AA compliance). No code change needed if contrast is already verified; consider noting the verification in a comment or accessibility audit."
+      }
+    ]
+  },
+  {
+    "url": "https://certified.app/terms",
+    "file": "/workspace/certified-app/src/app/terms/page.tsx",
+    "desktopLayout": "Terms page renders in a centered reading column within the full-width app shell. Desktop layout uses .app-shell__content (max-width: 880px for legal pages, padding: 0 32px) nested inside which is .app-page__inner (padding: 32px 24px). This creates a multi-column visual hierarchy: narrow center column surrounded by whitespace on both sides. Available content width at 1300px+ desktop viewport is approximately 816px (880 - 32*2 padding). The layout follows the \"reading column\" pattern per DESIGN.md, suitable for long-form legal text. No special desktop-only elements; all content adapts cleanly.",
+    "mobileCurrentState": "Mobile viewport (<800px) does NOT adapt well. The page uses Tailwind's .prose class and Semantic color tokens correctly, but suffers from a CSS cascade conflict: landing.css redefines .app-page__inner to padding: 32px 24px AFTER layout.css defined it as padding: 16px 0. Result on iPhone (375px): shell-level 16px padding + 24px app-page__inner padding = 375 - 32 - 48 = 295px available for text. On a 375px phone this leaves only 295px of content width. Typography does NOT scale: h1 stays 36px (10.5% of available width), h2 stays 28px, body stays 16px. Lists indent by 24px (pl-6), leaving 271px for list content. Heading margins (mb-8 = 32px) create large gaps. Links are inline text without visible tap targets. The page is technically readable but cramped and not optimized for mobile UX. No horizontal overflow, no layout collapse, but typography hierarchy breaks on small screens.",
+    "findings": [
+      {
+        "issue": "Excessive horizontal padding on mobile due to CSS cascade conflict",
+        "severity": "high",
+        "category": "spacing",
+        "location": "src/app/styles/landing.css:531-535 and layout.css:602-604",
+        "recommendation": "Add @media (max-width: 799px) rule in landing.css to override .app-page__inner padding. Change from padding: 32px 24px to padding: 16px 0 on mobile, allowing 343px content width instead of 295px. This respects the hard rule that mobile horizontal padding should be 16px (already set correctly on .app-shell__content), not duplicated in nested containers."
+      },
+      {
+        "issue": "Non-responsive heading sizes on mobile cause text wrapping and poor visual hierarchy",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/app/terms/page.tsx:23 (h1) and section h2 elements",
+        "recommendation": "Add responsive typography rules in landing.css. At @media (max-width: 799px): reduce h1 from 2.25rem to 1.75rem (use text-h2 size), reduce h2 from 1.75rem to 1.375rem (use text-h3 size). This maintains visual hierarchy while fitting mobile constraints. Or use Tailwind responsive classes: text-h1 max-width-799px:text-h2."
+      },
+      {
+        "issue": "Heading bottom margin (mb-8 = 32px) is disproportionate on narrow screens",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/terms/page.tsx:23-24 (h1 with mb-8) and section h2 elements (mb-4)",
+        "recommendation": "Add responsive margin scaling. H1 should use mb-4 on mobile (<800px) and mb-8 on desktop. H2 margins are already mb-4 which is acceptable. This prevents large vertical gaps between headings and content when the content width is tight. Use @media (max-width: 799px) or Tailwind responsive classes (mb-4 max-width-799px:mb-8)."
+      },
+      {
+        "issue": "Inline mailto: links lack visible tap target affordance and may fall below 44px minimum",
+        "severity": "medium",
+        "category": "a11y",
+        "location": "src/app/terms/page.tsx:312-317, 360-365, 384-389, 608-613 (all <a> tags with mailto:)",
+        "recommendation": "Wrap mailto: links in a proper interactive component with minimum 44px height (WCAG 2.1 AAA). Either: (1) Use <Button size='icon' aria-label='Email address'> per hard design rules, (2) Add padding/min-height to links via CSS: link padding: 4px 0 giving click area, or (3) Create an inline-link component with guaranteed tap target. Current inline text color styling (text-[var(--color-accent)]) is correct but lacks physical tap area."
+      },
+      {
+        "issue": "List item text width constrained to ~271px on mobile (295 - 24px indent)",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/terms/page.tsx:39-48, 114-118, 181-195, 225-231, 264-270, 282-287, 399-409, 500-504",
+        "recommendation": "No change required if spacing issue is fixed above. Once app-page__inner padding is corrected to 16px 0 on mobile, available width becomes 343 - 24 = 319px, which is acceptable (40 chars at 8px average width). If list indentation becomes an issue, reduce pl-6 to pl-4 (16px) at @media (max-width: 799px), but current spacing is within acceptable range after padding fix."
+      },
+      {
+        "issue": "No visual indicator that email links are clickable (no underline on hover, relies on color change only)",
+        "severity": "low",
+        "category": "consistency",
+        "location": "src/app/terms/page.tsx:312-317, 360-365, 384-389, 608-613",
+        "recommendation": "Verify hover state matches design system. Current classes include 'underline' and 'hover:text-[var(--color-accent-hover)]' which is correct. No change needed. These links already have underline class, so affordance is present in CSS. Ensure no CSS rules are hiding the underline on hover (current code is correct per examination)."
+      },
+      {
+        "issue": "Desktop max-width for legal pages (880px) is set on .app-shell__content, causing inconsistency with reading-column pattern",
+        "severity": "low",
+        "category": "layout",
+        "location": "src/app/styles/layout.css:557-560",
+        "recommendation": "This is a design choice, not a bug. The 880px max-width on .app-shell:has(.legal-page) is intentional. However, document in DESIGN.md that legal pages use 880px instead of 600px. If future audit requires narrower legal columns for better readability, consider creating a --legal-page-max-width token instead of 880px magic number."
+      }
+    ]
+  },
+  {
+    "url": "https://certified.app/dsa",
+    "file": "src/app/dsa/page.tsx",
+    "desktopLayout": "Desktop (≥800px): The page renders within a centered content column with max-width 600px and padding 0 32px. Headings use fixed sizes (h1: 2.25rem, h2: 1.75rem, h3: 1.375rem). The .prose container uses .max-w-none and .space-y-8 for vertical rhythm. Lists use pl-6 (24px) indentation. Links are inline text with underline and hover-color affordance. Sections stack vertically with consistent spacing. This is the correct, optimized desktop view.",
+    "mobileCurrentState": "Mobile (<800px): The desktop layout shrinks directly to mobile without intermediate responsive adjustments. Content flows into a 326-376px column (viewport - 64px padding). Navbar is fixed at 64px, bottom nav at 56px. Heading sizes remain fixed (h1: 36px, h2: 28px, h3: 22px) - not scaled down for small screens. List indentation stays at 24px. Link tap targets are inline-text height (likely <44px for email links). No @media (max-width: 799px) CSS adjustments on this page. The CSS adapts some navbar chrome (hidden/shown) but content styling does not adapt.",
+    "findings": [
+      {
+        "issue": "Heading sizes fixed at desktop dimensions on mobile viewports",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/app/dsa/page.tsx:23-31 (h1, h2 classes); tailwind.config.ts:29-36 (font sizes)",
+        "recommendation": "Add @media (max-width: 799px) override in src/app/styles/pages.css to reduce heading sizes on mobile. Use: .app-page h1 { font-size: 1.5rem; } or implement clamp(1.5rem, 4vw, 2.25rem) in tailwind.config.ts for responsive scaling without breakpoint."
+      },
+      {
+        "issue": "Excessive horizontal padding reduces content width to 311-326px on small phones",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/styles/layout.css:678 (.app-shell__content padding 32px)",
+        "recommendation": "Add @media (max-width: 799px) rule to reduce side padding: .app-shell__content { padding-left: 16px; padding-right: 16px; } This increases content width from 311px to 343px on 375px viewport while maintaining safe margins."
+      },
+      {
+        "issue": "Email link tap targets are less than 44px (WCAG/iOS HIG minimum)",
+        "severity": "high",
+        "category": "a11y",
+        "location": "src/app/dsa/page.tsx:61-66, 83-88, 100-105, 131-134, 261-266 (mailto links)",
+        "recommendation": "Wrap email links or add padding to increase touch target. Either use display: inline-block with min-height: 44px or apply a Button component. For inline links, add padding: 8px 4px and line-height: 1.5 to increase clickable area. Example: <a class=\"inline-block px-1 py-2 min-h-11\"> (44px height)."
+      },
+      {
+        "issue": "List indentation (pl-6 = 24px) inconsistent with paragraph alignment on narrow mobile",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/dsa/page.tsx:139, 158 (lists with pl-6)",
+        "recommendation": "On mobile, reduce list indentation to pl-4 (16px) or pl-3 (12px). Add @media (max-width: 799px) rule: .legal-page ul, .legal-page ol { padding-left: 16px; } This improves text wrap behavior and reduces horizontal crowding."
+      },
+      {
+        "issue": "Link affordance relies on hover color which doesn't work on touch devices",
+        "severity": "medium",
+        "category": "nav",
+        "location": "src/app/dsa/page.tsx:61-66, 83-88, 100-105, 131-134, 261-266 (all mailto links styled with hover:text-[var(--color-accent-hover)])",
+        "recommendation": "Add a visual indicator visible on mobile without hover. Either: (1) Use underline by default (already present), or (2) add focus-visible outline, or (3) apply a subtle background: text-[var(--color-accent)] underline bg-[var(--overlay-weak)] rounded-[var(--radius)] px-1 on mobile."
+      },
+      {
+        "issue": "No responsive adjustment for prose container max-width on mobile",
+        "severity": "low",
+        "category": "layout",
+        "location": "src/app/dsa/page.tsx:29 (.prose.max-w-none)",
+        "recommendation": "The .max-w-none class removes responsive width constraints. Add @media (max-width: 799px) in src/app/styles/pages.css: .legal-page .prose { max-width: none; } is already correct, but consider reducing padding instead to improve content width."
+      },
+      {
+        "issue": "Paragraph margins use fixed values (mt-4 = 16px, mt-2 = 8px) not responsive to mobile viewport",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/dsa/page.tsx:37, 57, 78, 99, 108, 139, 158 (various mt-X utilities)",
+        "recommendation": "Current spacing is acceptable, but for consistency with DESIGN.md hard rules, verify all spacing uses tokens. No change needed unless spacing feels cramped on mobile during user testing."
+      },
+      {
+        "issue": "Text size text-sm (0.875rem = 14px) on some content may be too small on mobile",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/dsa/page.tsx:27 (.text-sm on updated date)",
+        "recommendation": "Current size is acceptable (>12px, readable), but consider using base 1rem (16px) for body text per iOS standards. Metadata text can stay at 0.875rem but ensure sufficient line-height (current is 1.5, adequate)."
+      },
+      {
+        "issue": "No mobile-optimized column layout for contact information blocks",
+        "severity": "low",
+        "category": "layout",
+        "location": "src/app/dsa/page.tsx:46-56, 78-89 (address blocks with <br> line breaks)",
+        "recommendation": "Address blocks use <br> to separate lines. On desktop this works fine. On mobile, consider using semantic <address> element or a definition list. No CSS change needed, but ensure line breaks don't cause text to wrap awkwardly. Test on 375px viewport."
+      },
+      {
+        "issue": "No explicit focus indicators on links visible on mobile when tabbing",
+        "severity": "medium",
+        "category": "a11y",
+        "location": "src/app/dsa/page.tsx:61-66, 83-88, 100-105, 131-134, 261-266 (links missing focus-visible styles)",
+        "recommendation": "Links inherit from body a:focus-visible (defined in tokens.css:322-328) which provides 2px outline. This is sufficient, but confirm via keyboard navigation on mobile that outline is visible. If not, add explicit: a:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }"
+      }
+    ]
+  },
+  {
+    "url": "https://certified.app/imprint",
+    "file": "/workspace/certified-app/src/app/imprint/page.tsx",
+    "desktopLayout": "Desktop layout (≥800px) displays German/EU legal imprint with: (1) 880px max-width content column (overriding default 600/720px via `.app-shell:has(.legal-page)` rule); (2) 32px horizontal padding on both sides; (3) serif headline (font-headline) for h1 (2.25rem) and h2 (1.75rem) headings; (4) body text in Inter sans-serif (0.875rem for paragraphs, 0.875rem for metadata); (5) sections structured as stacked `<section>` elements with 8px vertical gaps (space-y-8); (6) inline links styled with --color-accent (#5e5e5e light, #a0a0a8 dark) and underline, hover state swaps to --color-accent-hover; (7) addresses formatted with line breaks; (8) full-bleed navbar at top (64px fixed), bottom nav hidden at ≥800px. The layout reads as formal, legible legal documentation with ample horizontal measure and breathing room.",
+    "mobileCurrentState": "At viewport <800px (mobile), the CSS does NOT adapt the page for mobile usability. Specific issues: (1) Horizontal padding remains fixed at 32px left/right (no media query reduces this for small screens) — at 320px width, usable content width is only 256px, forcing tight line breaks and reduced readability; (2) The 880px max-width rule persists (irrelevant at mobile but harmless); (3) Headings (h1 at 2.25rem, h2 at 1.75rem) are not scaled down — remain at desktop sizing, consuming 60–70% of viewport width on narrow devices; (4) The 64px navbar remains fixed at top, consuming 20% of a 320px viewport height; (5) 56px bottom nav is shown (mobile-only chrome), eating another 17.5% of viewport; (6) Together, chrome + padding leave ~54% of viewport for actual content — cramped; (7) No responsive font scaling: text-sm (0.875rem), body paragraph text (default 1rem from body tag, no Tailwind size applied except to h1/h2) do not shrink; (8) The `.prose` class has NO styling (Tailwind typography plugin is not installed) — it is a non-functional classname; (9) Paragraphs flow with browser defaults; (10) Links use `hover:text-[var(--color-accent-hover)]` — hover states work on desktop but are touch-unfriendly on mobile (no active/focus styling for touch); (11) The page simply shrinks the desktop layout rather than adapting it.",
+    "findings": [
+      {
+        "issue": "Excessive horizontal padding on mobile: 32px left/right at all viewport sizes",
+        "severity": "high",
+        "category": "spacing",
+        "location": "src/app/styles/layout.css:675 (.app-shell__content padding: calc(...) 32px ...)",
+        "recommendation": "Add media query @media (max-width: 799px) to reduce .app-shell__content horizontal padding to 16px on mobile. This recovers ~32px of content width (from 256px to 288px at 320px viewport), improving readability. The rule must appear in layout.css AFTER the base .app-shell__content rule, or use a higher-specificity selector. Example: `@media (max-width: 799px) { .app-shell__content { padding-left: 16px; padding-right: 16px; } }`"
+      },
+      {
+        "issue": "H1 heading (2.25rem) does not scale down on mobile, consuming 60% of narrow viewport width",
+        "severity": "high",
+        "category": "typography",
+        "location": "src/app/imprint/page.tsx:23 (text-h1 class applied to h1)",
+        "recommendation": "Apply responsive heading size via Tailwind modifier. Change `text-h1` to `text-[1.75rem] md:text-h1` or similar, scaling h1 from 1.75rem on mobile to 2.25rem on desktop. Alternatively, add a @media rule in layout.css or pages.css: `@media (max-width: 799px) { h1, .text-h1 { font-size: 1.75rem; line-height: 1.3; } }` to match h2 sizing on mobile, improving visual hierarchy and readability."
+      },
+      {
+        "issue": "H2 heading (1.75rem) remains at desktop size on mobile, taking ~50% of viewport width",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/app/imprint/page.tsx:31, 56, 61, 86 (text-h2 class applied to h2 elements)",
+        "recommendation": "Add responsive h2 sizing. Change `text-h2` to `text-[1.25rem] md:text-h2` via Tailwind, scaling from 1.25rem mobile to 1.75rem desktop. Or add @media rule: `@media (max-width: 799px) { h2, .text-h2 { font-size: 1.25rem; line-height: 1.35; } }` to maintain hierarchy while improving mobile fit."
+      },
+      {
+        "issue": "Hover-only link styling with no mobile active/focus state",
+        "severity": "medium",
+        "category": "a11y",
+        "location": "src/app/imprint/page.tsx:46-50, 76-81, 92-96 (links with hover:text-[var(--color-accent-hover)])",
+        "recommendation": "Add focus and active states for touch devices. Replace inline hover class with a dedicated style or Tailwind group. Example: add `focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]` to each link. Or better: create a reusable `<a className=\"text-[var(--color-accent)] underline hover:text-[var(--color-accent-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]\">` pattern. Per hard rules, focus rings must use --focus-ring token (currently #5e5e5e light, #8e8e93 dark)."
+      },
+      {
+        "issue": "No mobile-specific line-break handling for address lines",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/imprint/page.tsx:34-39, 67-72, 151-157 (address blocks with <br /> tags)",
+        "recommendation": "Address blocks using `<br />` are fine semantically, but consider adding a utility class or CSS rule to prevent addresses from collapsing at very narrow widths. At <320px, long address lines like '1209 Orange St.' + 'Wilmington, DE 19801' may wrap awkwardly. This is low-impact (addresses are typically short), but if needed, ensure `.address` or similar wrapper has `word-break: break-word` and adequate line-height. No code change required unless testing reveals issues; mark as low-priority."
+      },
+      {
+        "issue": "Page title (h1) and metadata are not optimized for mobile space constraints",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/imprint/page.tsx:23-27 (h1 + p.text-sm with mb-8 margins)",
+        "recommendation": "The h1 'Imprint — Certified' and metadata 'Last updated: May 11, 2026' use mb-8 (2rem margin-bottom) on both mobile and desktop. Consider reducing margin to mb-4 (1rem) on mobile to preserve vertical space, especially given the fixed navbar + bottom nav already consume ~37% of viewport. Add responsive margin: change `mb-8` to `mb-4 md:mb-8` on both elements, or add @media rule in pages.css: `@media (max-width: 799px) { .app-page h1, .app-page > p { margin-bottom: 1rem; } }`"
+      },
+      {
+        "issue": ".prose classname has no styling (Tailwind typography plugin not installed)",
+        "severity": "low",
+        "category": "consistency",
+        "location": "src/app/imprint/page.tsx:29 (.prose class is non-functional)",
+        "recommendation": "Remove the unused `.prose` classname from line 29. It provides no styling and adds confusion. Change `<div className=\"prose max-w-none space-y-8\">` to `<div className=\"max-w-none space-y-8\">`. The `space-y-8` is already providing vertical rhythm (which is prose's job). If prose styling IS intended for future use, document it in DESIGN.md and install @tailwindcss/typography, then configure it in tailwind.config.ts."
+      },
+      {
+        "issue": "Bottom navbar (56px) + navbar (64px) consume 37.5% of 320px mobile viewport height",
+        "severity": "low",
+        "category": "layout",
+        "location": "src/app/styles/layout.css:418 (.bottom-nav height: 56px) and :root --navbar-height: 64px",
+        "recommendation": "This is a system-level constraint, not an imprint-page issue, but the impact is worth noting: on very short mobile devices (e.g., iPhone SE, old Android), the content area is squeezed. Monitor with real device testing. If needed, reduce navbar height at <800px via @media rule (not recommended unless UX testing demands it — navbar is stable across the app). For the imprint page specifically, ensure space-y-8 gaps between sections scale proportionally; consider mb-4 md:mb-8 pattern recommended in finding #5."
+      },
+      {
+        "issue": "No max-width constraint on content at mobile (880px rule applies regardless of viewport width)",
+        "severity": "low",
+        "category": "consistency",
+        "location": "src/app/styles/layout.css:892 (.app-shell:has(.legal-page) .app-shell__content { max-width: 880px; })",
+        "recommendation": "The 880px max-width is irrelevant at mobile (viewport is 320–767px), so this is not harmful. However, for consistency with DESIGN.md hard rules (breakpoints ONLY 800/1100/1300), consider documenting why legal-page uses 880px instead of aligning to 800px breakpoint. No code change required; mark as 'consistency documentation' — ensure DESIGN.md explains the 880px choice vs. standard breakpoints."
+      }
+    ]
+  },
+  {
+    "url": "/workspace/certified-app/src/app/workspace/page.tsx",
+    "file": "/workspace/certified-app/src/app/workspace/page.tsx and src/app/styles/workspace.css",
+    "desktopLayout": "Multi-column grid layouts: Notion (240px rail + 1fr main), Mail (260px rail + 1fr main), Slack (60px icons + 220px lexicons + 1fr main). Breadcrumb is single-column with dropdowns. Bluesky is single-column with chip row. Tab strip at top with 5 layout options. Content pane renders below layouts showing scope/lexicon state.",
+    "mobileCurrentState": "Partially adapts via @media (max-width: 799px) rule that collapses multi-column grids to 1fr. However, several issues remain: (1) Slack layout icon column (60px) and lexicons column (220px) still render at stated widths even when combined they consume 280px + gaps + main content on phones <375px. (2) Tab strip uses \"flex-wrap mb-5\" Tailwind classes without responsive sizing — tabs may overflow on narrow screens. (3) Breadcrumb menus have fixed min-width: 280px which can exceed viewport width on phones. (4) Grid items and button padding not responsive to narrow viewports. (5) Input font-size not verified to meet iOS 16px minimum on mobile. (6) Workspace page padding (24px 16px) is adequate but layout components inside don't adapt secondary sizing for touch.",
+    "findings": [
+      {
+        "issue": "Slack columns layout icon column (60px) + lexicons column (220px) + main content grid doesn't scale proportionally on narrow phones (< 375px)",
+        "severity": "high",
+        "category": "layout",
+        "location": "workspace.css:511-516, bluesky-switcher-layout.tsx:102-123",
+        "recommendation": "At @media (max-width: 799px), the .wks-slack grid collapses to 1fr, but on phones < 375px the icon column should collapse to icon-only or move to tabs/accordion. Add a second breakpoint @media (max-width: 599px) to stack the icon + lexicon columns vertically or hide the lexicon sidebar entirely, prioritizing the main content pane."
+      },
+      {
+        "issue": "Breadcrumb menu has min-width: 280px (line 476) which overflows on phones < 320px and will cause horizontal scroll",
+        "severity": "high",
+        "category": "overflow",
+        "location": "workspace.css:465-480",
+        "recommendation": "Add @media (max-width: 599px) { .wks-breadcrumb__menu { min-width: auto; max-width: calc(100vw - 32px); } } to constrain the menu to viewport width with safe margins."
+      },
+      {
+        "issue": "Tab strip uses flex-wrap with no responsive font-size or padding — tab labels may overflow or wrap awkwardly on mobile",
+        "severity": "high",
+        "category": "typography",
+        "location": "workspace.tsx:152-161, tabs.tsx:160-162 (inline Tailwind gap-4, flex-wrap)",
+        "recommendation": "On mobile, reduce font-size of tab labels to 0.75rem (caption) and padding to 8px 12px, or implement icon-only tabs < 600px. Override inline flex-wrap class with @media (max-width: 599px) { .flex-wrap { flex-wrap: wrap; font-size: 0.75rem; } } or create mobile-specific tab variant."
+      },
+      {
+        "issue": "Notion rail left sidebar (240px) doesn't adapt on tablet/narrow phones — still full width after @media collapse, causing layout shift",
+        "severity": "medium",
+        "category": "layout",
+        "location": "workspace.css:201-206, notion-rail-layout.tsx:28-129",
+        "recommendation": "The @media (max-width: 799px) rule correctly sets grid-template-columns: 1fr, but on phones < 375px add a second @media (max-width: 600px) to hide the rail entirely or render it as a collapsible accordion/modal, keeping the main content pane full-width."
+      },
+      {
+        "issue": "Mail accounts rail (260px) and Slack lexicons column (220px) have fixed widths that don't shrink — consuming 260px of a 360px phone viewport leaves only 100px for main content",
+        "severity": "high",
+        "category": "overflow",
+        "location": "workspace.css:288-293, 562-567, mail-accounts-layout.tsx:42-126, slack-columns-layout.tsx:67-108",
+        "recommendation": "Add @media (max-width: 599px) to hide the rail/lexicon sidebars entirely on phones. Provide a mobile-friendly affordance (tab or button) to show/hide them. Alternatively, use a drawer/bottom-sheet pattern per DESIGN.md §5 (mobile-specific patterns)."
+      },
+      {
+        "issue": "Grid min-widths and fixed widths in breadcrumb / Bluesky menu structure not constrained by viewport — absolute positioning of .wks-blue__menu (line 466-480) can overflow to the right edge on phones",
+        "severity": "high",
+        "category": "overflow",
+        "location": "workspace.css:465-480",
+        "recommendation": "Add @media (max-width: 799px) { .wks-blue__menu { right: 0; left: auto; max-width: calc(100vw - 16px); } } to anchor menu to the right edge with viewport-safe margins instead of left: 0."
+      },
+      {
+        "issue": "Button padding (4px 8px on .wks-notion__node, 6px 10px on breadcrumb items) creates tap targets < 44px on mobile — does not meet WCAG 44x44px minimum",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "workspace.css:235-248, 144-155, 174-187",
+        "recommendation": "At @media (max-width: 799px), increase padding to 10px 12px on all interactive buttons (.wks-notion__node, .wks-mail__*, .wks-breadcrumb__*, .wks-slack__*) and ensure min-height: 44px. Current padding is 3-6px vertical — insufficient for thumb-friendly mobile interaction."
+      },
+      {
+        "issue": "Workspace page header text (1.5rem title, subtitle) does not scale or adapt for narrow phones — subtitle at max-width: 56ch may force awkward line breaks on < 400px screens",
+        "severity": "medium",
+        "category": "typography",
+        "location": "workspace.css:24-37, workspace.tsx:138-145",
+        "recommendation": "At @media (max-width: 599px), reduce title to 1.25rem and limit subtitle max-width to 100%. Maintain line-height and spacing but allow text to reflow naturally on narrow viewports."
+      },
+      {
+        "issue": "Slack layout icon buttons (.wks-slack__icon) are 40x40px and meet 44px minimum, but spacing (gap: 6px) creates tight vertical stack on phones — hard to distinguish individual buttons visually",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "workspace.css:526-539",
+        "recommendation": "At @media (max-width: 799px), increase gap to 8px and add visual dividers or background color change to improve affordance. Alternatively, collapse to horizontal scroll list or tab strip on phones."
+      },
+      {
+        "issue": "ctx-chip elements used in Bluesky layout chips are undefined — no CSS class found for ctx-chip or ctx-chip--active, causing unstyled buttons",
+        "severity": "critical",
+        "category": "consistency",
+        "location": "bluesky-switcher-layout.tsx:105, 115",
+        "recommendation": "The ctx-chip class is missing from workspace.css. Either define it (e.g., as a pill button variant matching badge styles), or import/use an existing component. Recommend using <Badge> or <Button> primitive from src/components/ui/ instead of a CSS-only approach. If inline styling: add .ctx-chip { display: inline-flex; align-items: center; gap: 4px; padding: 6px 12px; border-radius: 999px; background: var(--bg-sunken); color: var(--fg-primary); border: 1px solid var(--border-subtle); cursor: pointer; } and .ctx-chip--active { background: var(--fg-primary); color: var(--bg-canvas); }"
+      },
+      {
+        "issue": "Bluesky __main content slot has no defined min-width or height constraint — flex-direction: column on parent (.wks-blue) may cause content pane to disappear or be unreachable on phones with limited space",
+        "severity": "medium",
+        "category": "layout",
+        "location": "workspace.css:424-429, bluesky-switcher-layout.tsx:125-132",
+        "recommendation": "Ensure .wks-blue__main has min-height: 200px (matching breadcrumb) and overflow-y: auto on mobile. Add @media (max-width: 799px) { .wks-blue__main { min-height: auto; } } to allow flexible height."
+      },
+      {
+        "issue": "Grid item count labels (.wks-pane__grid-count) are 1.1rem and bold, but parent grid uses minmax(120px, 1fr) which may force very large grid items on phones when count is large (e.g., '1000+')",
+        "severity": "low",
+        "category": "spacing",
+        "location": "workspace.css:76-102",
+        "recommendation": "At @media (max-width: 799px), reduce grid min-width to 90px and font-size of count to 1rem. If needed, adjust grid-template-columns: repeat(auto-fill, minmax(80px, 1fr)) on mobile."
+      },
+      {
+        "issue": "Mail account head buttons (.wks-mail__account-head) use padding 4px 8px which is < 44px minimum on phones — difficult to tap accurately",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "workspace.css:335-349",
+        "recommendation": "At @media (max-width: 799px), increase padding to 10px 12px and min-height: 44px to meet WCAG touch target minimum."
+      },
+      {
+        "issue": "Workspace page overall responsive behavior is binary (full desktop > 799px = 1fr columns) — no intermediate steps for tablets/iPads at 600-800px viewport, causing rail layouts to jump from multi-column to full-stack with no in-between",
+        "severity": "medium",
+        "category": "consistency",
+        "location": "workspace.css:627-633",
+        "recommendation": "Introduce a tablet-friendly intermediate layout at @media (max-width: 1099px) to show icon-only rails or drawer pattern (matching DESIGN.md §5 tablet desktop mode at 800-1099px). Current rule is all-or-nothing; add @media (min-width: 800px) and (max-width: 1099px) for staggered adaptation."
+      }
+    ]
+  },
+  {
+    "url": "file:///workspace/certified-app/src/app/dev/gallery/page.tsx",
+    "file": "src/app/dev/gallery/page.tsx",
+    "desktopLayout": "Centered single-column layout with max-width 720px. Root container has px-6 padding and py-12 vertical spacing. Sections use flex flex-col gap-6 with border-top dividers. Row helper uses flex flex-wrap gap-3 to display component variants side-by-side, allowing wrapping when needed. All components (Button, Badge, Input, Tabs, Dialog, etc.) render at their full sizes. EditBanner instances in one section have negative margin to break out of content padding and achieve full-bleed width.",
+    "mobileCurrentState": "At viewport < 800px, the layout does NOT adapt properly. The desktop max-width constraint (720px) is larger than mobile viewports, so the px-6 padding (24px on each side) reduces available width to ~327px on a 375px phone. The major issue is the EditBanner section (line 915) which uses negative margins and calc-based width (w-[calc(100%+3rem)]) to escape padding constraints — this causes horizontal scroll on mobile. Fixed max-width constraints on demo components (max-w-[360px], max-w-[280px], max-w-[420px]) also don't shrink for very narrow screens. Additionally, the Input component uses Tailwind's default md: breakpoint (768px) instead of the canonical 800px, meaning input fonts shrink from 16px to 14px at 768px instead of staying at 16px for true mobile viewports below 800px.",
+    "findings": [
+      {
+        "issue": "EditBanner full-bleed hack causes horizontal overflow on mobile",
+        "severity": "critical",
+        "category": "overflow",
+        "location": "src/app/dev/gallery/page.tsx:915",
+        "recommendation": "Replace the negative margin hack with a responsive wrapper. At mobile, remove -mx-6 and w-[calc(100%+3rem)], letting EditBanner respect the standard px-6 padding. The EditBanner component itself should use responsive margins: mx-6 on mobile, wider margins on desktop if needed. Alternatively, wrap EditBanner instances in a max-width container with no negative margin, or use CSS that respects the container's natural padding bounds."
+      },
+      {
+        "issue": "Input components use Tailwind md: breakpoint (768px) instead of canonical 800px breakpoint",
+        "severity": "high",
+        "category": "responsive",
+        "location": "src/components/ui/input.tsx:87",
+        "recommendation": "Replace md:text-sm (which applies at 768px) with a custom 800px breakpoint. Either configure Tailwind to extend the md breakpoint to 800px via theme.screens in tailwind.config.ts, or use the custom @media (min-width: 800px) rule from layout.css in the Input component's sizeClasses. The goal is to keep inputs at text-base (16px) below 800px for iOS compatibility, then transition to text-sm (14px) at 800px+ when the layout becomes truly desktop."
+      },
+      {
+        "issue": "Fixed max-width constraints on demo components don't adapt to very narrow screens",
+        "severity": "medium",
+        "category": "layout",
+        "location": "src/app/dev/gallery/page.tsx:637,843,904,943,979",
+        "recommendation": "Add responsive max-width constraints that collapse to w-full (minus padding) on screens narrower than the fixed widths. Use Tailwind's max-w-[360px] only at 800px+, falling back to w-full on mobile. This applies to: Combobox demo (line 637), Theme toggle (line 904), Input density (line 843), IdentityRow list (line 943), SmartLink list (line 979). Pattern: className=\"w-full max-w-[360px] md:max-w-[360px]\" or use @media (max-width: 799px) { max-w: none; }"
+      },
+      {
+        "issue": "EditBanner component uses mx-6 margin that compounds with page padding on narrow screens",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/components/ui/edit-banner.tsx:76",
+        "recommendation": "Remove or make mx-6 responsive. At mobile, use mx-0 to let the parent's px-6 provide all lateral spacing. At desktop, apply mx-6 if the banner needs internal spacing from content. The gallery page demo's negative-margin wrapper should not be needed if EditBanner respects its container bounds: change line 915 from 'className=\"-mx-6 flex w-[calc(100%+3rem)]...' to just 'className=\"flex flex-col gap-3...' and remove the calc width."
+      },
+      {
+        "issue": "Row component uses fixed gap-3 spacing, which may crowd button groups on very narrow screens",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/dev/gallery/page.tsx:90",
+        "recommendation": "At mobile viewports below 360px, reduce gap from gap-3 (12px) to gap-2 (8px) using a responsive class. Alternatively, for gallery demo purposes only, accept this constraint as the page is dev-only and rarely viewed on ultra-narrow screens. If fixing gallery for completeness, use 'gap-2 sm:gap-3' (but note Tailwind sm = 640px by default; prefer custom 800px breakpoint class)."
+      },
+      {
+        "issue": "No explicit mobile viewport adaptation—entire page layout assumes desktop structure on narrow screens",
+        "severity": "high",
+        "category": "responsive",
+        "location": "src/app/dev/gallery/page.tsx:164-166",
+        "recommendation": "Add a media query wrapper or responsive container queries to explicitly handle mobile below 800px. The page should: (1) reduce px-6 to px-4 (16px padding) on very narrow screens (< 360px), (2) ensure all child components respect the narrower available width without horizontal scroll, (3) stack horizontally-arranged components (like button groups in Row) into single-column layouts if they don't fit naturally. Given this is a dev-only gallery, a note in comments is sufficient, but for production-grade mobile support, wrap content in a mobile-first layout: 'flex flex-col gap-12 px-4 md:px-6' or implement a media query at 800px."
+      },
+      {
+        "issue": "Tap targets on small buttons and icon-only buttons may be below WCAG 44px minimum on crowded rows",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/app/dev/gallery/page.tsx:181-195",
+        "recommendation": "Icon buttons (size='icon') are h-10 w-10 (40px), which is below the recommended 44x44px WCAG AAA minimum. On mobile, either increase to h-11 w-11 (44px), or ensure surrounding whitespace (gap-3 + flex-wrap) provides sufficient separation. For the demo, verify that buttons in Rows wrap onto separate lines when screen is narrow—this is already set up with flex flex-wrap, so hit targets should be adequate. For production components, increase icon button size to 44px or document that wrapping provides the safety margin."
+      },
+      {
+        "issue": "Popover and Dialog overlays may exceed viewport bounds on narrow screens without explicit viewport-relative positioning",
+        "severity": "medium",
+        "category": "a11y",
+        "location": "src/app/dev/gallery/page.tsx:1047-1148 (overlay sections)",
+        "recommendation": "Verify that PopoverContent, AppDialog, BottomSheet, and ResponsiveDialog all use viewport-aware positioning. AppDialog and ResponsiveDialog accept maxWidth props (e.g., maxWidth={440}), which should be capped to ~90vw on mobile for padding. Popover with portal=true already uses collision detection via collisionPadding (see popover.tsx). Ensure demo dialogs with maxWidth={440} clamp to min(440px, 90vw) on narrow screens, or test that they render correctly on 375px viewport without overflow."
+      },
+      {
+        "issue": "Typography scale does not adapt for mobile readability below 800px",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/dev/gallery/page.tsx:168-173",
+        "recommendation": "The page heading uses text-h1 (2.25rem) and body text uses text-body (1rem) without responsive adjustment. Below 800px these are fine for a dev-only page, but for production mobile support, consider using Tailwind's clamp() or custom media queries to scale headings: font-h1 becomes clamp(1.5rem, 4vw, 2.25rem). For the gallery, no change needed as it's dev-only, but the pattern should inform real product pages."
+      }
+    ]
+  },
+  {
+    "url": "http://localhost:3000/dev/preview/feed",
+    "file": "/workspace/certified-app/src/app/dev/preview/[surface]/page.tsx",
+    "desktopLayout": "Five dev-only preview surfaces render with these layouts:\n- Profile/Profile-org: Two-column (296px sidebar + 1fr main) with 32px gap. Sidebar hidden <800px.\n- Feed: Three-column (sidebar + feed 1fr + 320px news rail). News rail hidden <1200px.\n- Settings: Two-column (220px menu + 1fr sections). Menu becomes static <800px.\n- Workspace: Five layout experiments with varying multi-column grids (notion rail 240px, mail 260px, slack 3-column with 60px icons). All collapse to 1fr <800px.",
+    "mobileCurrentState": "At <800px viewport: Desktop multi-column layouts collapse to single-column stacks via CSS @media rules at 799px breakpoint. Sidebars switch from sticky/fixed positioning to static in-flow. Top bar (desktop-only, @media >=800px) is completely hidden on mobile—navigation uses bottom nav + hamburger. The CSS adaptations use canonical 800px breakpoint consistently across all surfaces. No forced horizontal overflow observed; layouts reflow properly.",
+    "findings": [
+      {
+        "issue": "Input field at size='md' has height:44px (h-11) but font-size text-base (16px) on mobile—iOS auto-zoom trap. The h-11 class maps to 44px (good tap target), but text-base (16px) will trigger iOS zoom on <16px inputs when focused.",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "src/components/ui/input.tsx:87 / sizeClasses['md']",
+        "recommendation": "Update line 87 to: `md: \"h-11 px-4 text-base\" + @media (max-width:799px) { text-sm }` so mobile gets text-sm (14px) preventing iOS auto-zoom while preserving 44px tap target."
+      },
+      {
+        "issue": "Settings page left menu (.sx__menu) has position:sticky on desktop but the scroll-margin-top calculation at line 211 (.sx-section scroll-margin-top) includes top-bar-row2, which doesn't exist on settings (no tabs row). Creates invisible 44px dead zone when jumping between sections.",
+        "severity": "medium",
+        "category": "spacing",
+        "location": "src/app/styles/settings-page.css:211 + layout.css:93-94",
+        "recommendation": "Change .sx-section scroll-margin-top to use only --top-bar-row1 + 24px buffer: `scroll-margin-top: calc(var(--top-bar-row1) + 24px);` Settings has no row 2, so the row2 addition overshoots."
+      },
+      {
+        "issue": "Home sidebar lists (Groups/Projects/Certs) and profile sidebar lists use .home-section__more link with font-size:0.78rem but no explicit tap target sizing. The link should be >=44px tall to meet WCAG touch target guidance. Currently relies on padding/line-height of ~24px.",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/app/styles/home.css:252-270 (.home-section__more)",
+        "recommendation": "Add min-height:44px and padding:12px 8px to .home-section__more, ensuring the 'Show all' link is touchable on mobile. Or wrap in a Button component (size='sm') which already enforces 44px min height."
+      },
+      {
+        "issue": "Workspace layouts (notion, mail, slack) have fixed 60/240/260px left columns that don't scale on mobile. At 320px viewport (iPhone SE), the 60px slack icons + 220px lexicons leaves only 40px for content pane. CSS collapses grid to 1fr <800px, but intermediate viewports (320-799px) create unusable narrow layouts.",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/workspace.css:202-233, 288-303, 512-517",
+        "recommendation": "Add intermediate breakpoint at 600px (between mobile 800px and full desktop). For 320-599px: use single-column stacks. For 600-799px: use 2-column with sidebar shrinking to 160px or collapsing to tabs. Apply @media (max-width:599px) with grid-template-columns:1fr."
+      },
+      {
+        "issue": "Profile .page-layout uses gap:24px on desktop (line 2283) but gap:24px on mobile (line 2284 padding). Between sections on mobile, the gap doesn't increase; however, the sidebar padding (28px left on desktop, 12px on mobile) creates asymmetric spacing. Left edge has 16px (from .home__layout padding) + sidebar's 12px left = 28px total, but right edge has only 16px.",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/styles/layout.css:2281-2294 / home.css:72-78",
+        "recommendation": "Ensure symmetric padding on mobile: use 16px left/right for .page-layout on mobile. The asymmetry is subtle but breaks visual balance vs. desktop."
+      },
+      {
+        "issue": "Workspace TabList component at line 152 (workspace.tsx) renders pills inline with flex-wrap mb-5, but doesn't constrain width. With 5 tabs (Notion/GitHub/Mail/Bluesky/Slack), the pill buttons may overflow on narrow mobile viewports (320-500px) or wrap awkwardly.",
+        "severity": "medium",
+        "category": "overflow",
+        "location": "src/components/workspace/workspace.tsx:152-160",
+        "recommendation": "Add CSS rule: @media (max-width:599px) { .workspace__tab-list { display:grid; grid-auto-columns:1fr; } } to force tabs into a stacked/multi-row responsive grid instead of single-row flex-wrap."
+      },
+      {
+        "issue": "SettingsPanel inline-edit form inputs (username, email, password sections) don't explicitly set type='text' or size. When rendered on mobile, the height defaults to 44px but padding is 4px vertical on compact inputs, creating visual inconsistency with other button/control heights on the page (bottom nav is 56px).",
+        "severity": "low",
+        "category": "consistency",
+        "location": "src/components/settings/settings-panel.tsx:226-242",
+        "recommendation": "Audit the UsernameCard / EmailSection / PasswordSection components to ensure all <Input> children use size='md' (h-11, 44px) consistently. Compact form inputs should match the mobile primary button height or explicitly be size='sm' with documented reasoning."
+      },
+      {
+        "issue": "Home page sidebar .home-row links have font-size:0.85rem on label + 1px gap between avatar/label, but no min-height declared. Rows render at ~26-30px depending on line-height. At 44px button standard, these rows are half-height touch targets and risk mis-taps on mobile.",
+        "severity": "high",
+        "category": "tap-target",
+        "location": "src/app/styles/home.css:140-199 (.home-row + .home-row__label)",
+        "recommendation": "Add min-height:44px and padding:10px 8px to .home-row. Increase gap from 8px to 10px if needed. Ensure the avatar (22px) + gap + label text sits vertically centered in a 44px row, meeting WCAG 2.1 Level AAA 44px minimum."
+      },
+      {
+        "issue": "Profile sidebar .profile-sidebar__did DID value uses font-size:0.6875rem (11px) and white-space:nowrap with text-overflow:ellipsis. On mobile with 16px lateral padding, the DID field may ellipsis aggressively (DIDs are ~50+ chars). No fallback to wrapping or monospace-optimized line-breaking is provided.",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/styles/layout.css:2352-2369 (.profile-sidebar__did)",
+        "recommendation": "On mobile (<800px), change .profile-sidebar__did to word-break:break-all or display:block with a smaller font (0.625rem) and allow wrapping. DID is read-only metadata; truncation is less harmful than tiny unreadable text."
+      },
+      {
+        "issue": "Settings panel .sx-menu__item uses padding:6px 10px + font-size:0.85rem, but on mobile (@media 799px) the padding stays 10px 10px and font-size becomes 0.9375rem (line 299). This creates a taller hit target (~32-36px) on mobile, below the 44px standard. Icon (18px) + padding + text still undersized.",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/app/styles/settings-page.css:297-300",
+        "recommendation": "Increase mobile padding to min-height:44px (e.g., padding:12px 10px) and keep font-size:0.875rem. Ensure the menu item is consistently 44px tall on mobile, matching other nav/button conventions."
+      }
+    ]
+  },
+  {
+    "url": "file:///workspace/certified-app/src/app/error.tsx",
+    "file": "/workspace/certified-app/src/app/error.tsx",
+    "desktopLayout": "Root error boundary page with centered single-column layout. Desktop (≥800px) shows a topbar with large responsive headline (clamp(2rem, 3vw + 1rem, 2.5rem)), ornamental guilloche decoration at top-right, followed by a dash-card containing error message, optional error digest reference, and two secondary action buttons (Try Again, Go Home) with 8px top padding and inline-flex display. Content max-width is 600px with 32px horizontal padding. Topbar has 48px top padding and 24px bottom padding. Dashboard back-button uses 8px vertical / 16px horizontal padding at 0.8125rem font size. All text uses semantic color tokens (--fg-primary, --fg-muted) and border token (--border-light) for card divider.",
+    "mobileCurrentState": "At <800px viewport, the layout adapts via media query overrides: topbar reduces to 32px top / 16px bottom padding, guilloche decoration hides via display: none, headline font-size fixes to 1.75rem (no longer clamp), dash-card padding reduces to 24px. Critically, buttons remain undersized: dashboard__back-btn shrinks to 6px vertical / 12px horizontal padding and font-size 0.75rem — totaling ~26px height instead of the 44px WCAG/iOS HIG tap target minimum. Buttons stay inline-flex (not full-width), causing them to crowd on narrow screens (300-400px) and rely on margin-bottom: 0.5rem for visual separation, which doesn't force stacking. The error digest text scales via inline style fontSize=\"0.85em\", making it very small on mobile. No responsive column stacking, no full-width button treatment, no mobile-optimized hit targets.",
+    "findings": [
+      {
+        "issue": "Button tap targets undersized on mobile (26px vs 44px WCAG minimum)",
+        "severity": "critical",
+        "category": "tap-target",
+        "location": "src/app/styles/components.css:1539-1542",
+        "recommendation": "Add @media (max-width: 799px) override to .dashboard__back-btn with min-height: 44px, padding: 12px 16px (or equivalent py-3 px-4), and width: 100%. Alternatively, replace with <Button> primitive from src/components/ui/button.tsx (size='md') which will inherit proper touch sizing via Tailwind utilities."
+      },
+      {
+        "issue": "Buttons use custom .dashboard__back-btn CSS instead of canonical <Button> primitive, causing inconsistent mobile hit targets and design system drift",
+        "severity": "high",
+        "category": "consistency",
+        "location": "src/app/error.tsx:26-31",
+        "recommendation": "Replace both buttons with <Button variant='secondary' size='md'> components. This ensures alignment with design tokens (--border-default, --bg-elevated, --fg-primary), inherits consistent padding/sizing, and makes future mobile adjustments apply globally. Update imports: import Button from '@/components/ui/button'."
+      },
+      {
+        "issue": "Buttons are inline-flex and not full-width on mobile, causing them to crowd horizontally on narrow viewports (300-400px)",
+        "severity": "high",
+        "category": "layout",
+        "location": "src/app/styles/components.css:1251",
+        "recommendation": "Add @media (max-width: 799px) block to .dashboard__back-btn: display: flex; flex-direction: column; width: 100%; gap: 8px; This stacks buttons vertically and makes each button span full available width, improving usability and hit targets."
+      },
+      {
+        "issue": "Mobile button font size reduced to 0.75rem (12px), below comfortable reading threshold on small screens; readability suffers vs desktop 0.8125rem",
+        "severity": "medium",
+        "category": "typography",
+        "location": "src/app/styles/components.css:1541",
+        "recommendation": "Remove the font-size: 0.75rem override for mobile, or increase to font-size: 0.8125rem (matching desktop). Alternatively, if using <Button> primitive, size='md' will inherit 0.875rem from Tailwind (text-sm), which is more readable on mobile."
+      },
+      {
+        "issue": "Inline style fontSize='0.85em' on error digest text bypasses token system and scales unpredictably; becomes illegible on mobile",
+        "severity": "medium",
+        "category": "consistency",
+        "location": "src/app/error.tsx:22",
+        "recommendation": "Remove inline fontSize style. Error digest already inherits from .dash-card__desc class, which sets color: var(--fg-muted) and font-size: 0.8125rem. If smaller size is desired, define a BEM modifier like .dash-card__desc--small { font-size: 0.75rem; } in components.css, respecting the 0.75rem floor for mobile readability. Or set it to 0.75rem unconditionally (not 0.85em)."
+      },
+      {
+        "issue": "Inline style marginBottom='0.5rem' on Try Again button uses inline CSS instead of utility class or BEM, violating design system convention",
+        "severity": "low",
+        "category": "consistency",
+        "location": "src/app/error.tsx:26",
+        "recommendation": "Remove inline marginBottom style. Wrap both buttons in a flex container (<div className='flex flex-col gap-2'>) to manage spacing declaratively, or define .dashboard__button-group { display: flex; flex-direction: column; gap: 8px; } in components.css and apply to a wrapper."
+      },
+      {
+        "issue": "Error page does not use canonical AppDialog or dedicated error boundary UI pattern; plain HTML divs lack semantic structure and ARIA roles for error reporting",
+        "severity": "low",
+        "category": "a11y",
+        "location": "src/app/error.tsx:12-36",
+        "recommendation": "Consider wrapping error content in a <section role='region' aria-live='polite' aria-label='Error message'> to ensure screen readers announce the error clearly. Or refactor using a dedicated <ErrorBoundaryUI> component that wraps the error semantically and provides a consistent accessible pattern across the app."
+      }
+    ]
+  },
+  {
+    "url": "src/app/not-found.tsx",
+    "file": "src/app/not-found.tsx",
+    "desktopLayout": "Single-column dashboard layout: top navbar (64px fixed), title \"Page not found\" using clamp(2rem, 3vw + 1rem, 2.5rem) font size centered in topbar (48px top padding, 24px bottom), centered card with dash-card class containing description text and \"Go home\" link button. Page uses app-shell with 32px horizontal padding and 80px top padding. Dashboard topbar has decorative SVG background (off-right, 200x200 at 0.04 opacity, hidden on mobile). Card uses transparent background with bottom border hairline separator. Link button is styled as inline-flex button with 8px 16px padding, 0.8125rem font, solid border, elevated background.",
+    "mobileCurrentState": "CSS adapts with @media (max-width: 799px) query that: reduces .app-shell__content horizontal padding from 32px to 16px; reduces .dashboard__topbar padding from 48px/24px to 32px/16px; hides decorative SVG background via display:none; reduces .dash-card padding from 32px to 24px; reduces .dashboard__back-btn from 8px 16px to 6px 12px padding and 0.8125rem to 0.75rem font size. Responsive headline clamp() caps at 1.75rem explicitly. Bottom nav is position:fixed, 56px height. Layout does NOT overflow or shrink incorrectly — it properly adapts, but the primary interactive element (the \"Go home\" link button) becomes too small.",
+    "findings": [
+      {
+        "issue": "Mobile tap target undersized: 'Go home' link button reduces to 6px 12px padding with 0.75rem (12px) font size, yielding approximately 24-26px vertical height. WCAG 2.5.5 and iOS HIG require minimum 44x44px tap targets.",
+        "severity": "critical",
+        "category": "tap-target",
+        "location": "src/app/styles/components.css:1539-1542 (.dashboard__back-btn mobile rule)",
+        "recommendation": "Ensure button maintains at least 44px height on mobile. Apply padding that scales: use padding: 12px 16px (or similar) on mobile to achieve ~40-44px total height with proper line-height. Keep width at least 44px as well. Consider using a standard button primitive from src/components/ui/ instead of custom styling."
+      },
+      {
+        "issue": "Button font size drops below 16px on iOS: 0.75rem (12px at 16px base) on mobile may trigger browser auto-zoom when focused on iOS Safari if input-like.",
+        "severity": "medium",
+        "category": "a11y",
+        "location": "src/app/styles/components.css:1541 (.dashboard__back-btn font-size on mobile)",
+        "recommendation": "Maintain font-size >= 16px on mobile interactive elements. Change to font-size: 0.875rem (14px) or 1rem (16px) on mobile to avoid iOS zoom behavior and improve readability."
+      },
+      {
+        "issue": "Heading font-size clamp uses 3vw component which can shrink text very small on ultra-narrow viewports (e.g., 300-350px devices). Actual computed size at 320px: 2rem + (3% of 320px) = 2rem + 9.6px ≈ 2.35rem, but clamp minimum is 2rem — fine for this case, but worth monitoring for consistency.",
+        "severity": "low",
+        "category": "typography",
+        "location": "src/app/styles/layout.css:814 (.dashboard__page-title clamp sizing)",
+        "recommendation": "Heading is acceptable as-is. No action needed unless ultra-narrow phones become a priority. If needed, increase clamp minimum from 2rem to 1.75rem and adjust formula to clamp(1.75rem, 4vw + 0.5rem, 2.5rem) for slightly larger text on small phones."
+      },
+      {
+        "issue": "Desktop button padding and font size do not meet 44px minimum either (approximately 31-32px computed height). While less critical than mobile, this creates inconsistency with WCAG guidelines.",
+        "severity": "medium",
+        "category": "tap-target",
+        "location": "src/app/styles/components.css:1250-1262 (.dashboard__back-btn desktop rule)",
+        "recommendation": "Increase button padding to 10px 16px or 12px 16px on desktop to reach 40-44px height range. This improves consistency and ergonomics, matching standard button primitives in the codebase (e.g., src/components/ui/button.tsx patterns)."
+      },
+      {
+        "issue": "Decorative SVG background (guilloche_02.svg) positioned off-right with right: -40px is correctly hidden on mobile via display: none in media query. However, this works only because the parent (.dashboard__topbar) has position: relative. No issue found, but worth noting the dependency.",
+        "severity": "low",
+        "category": "spacing",
+        "location": "src/app/styles/layout.css:798-810 and src/app/styles/components.css:1440-1442",
+        "recommendation": "No action required. Current approach is sound — decorative element is properly scoped and hidden on mobile."
+      }
+    ]
+  }
+]

--- a/docs/mobile-overhaul/release-checklist.md
+++ b/docs/mobile-overhaul/release-checklist.md
@@ -1,0 +1,70 @@
+# Mobile-view overhaul — release-readiness checklist
+
+Branch: `feat/mobile-view` → `staging`. Base captured at `staging` (tsc clean, lint 66
+warnings / 0 errors). Desktop source-of-truth baseline = the ≥1300px full-desktop view.
+
+## Implementation (6 tracks, all committed)
+
+- [x] **Track 0 — Global foundation.** Tailwind `screens` → canonical 800/1100/1300 (kills the
+  768px `md:` mismatch → inputs are 16px below 800px, no iOS focus-zoom); `<Button>` sm/md/icon meet
+  44px on mobile and revert at ≥800px; `.app-shell__content` mobile gutter; legal heading scale;
+  routing-scheme sanity (no stale `/profile//activity//project/` detection).
+- [x] **Track 1 — Static / legal / error / auth.** `.dashboard__back-btn` un-shrunk (was 26px →
+  44px full-width on mobile); error inline `fontSize` removed; oauth-callback text 16px + 44px link;
+  legal list indent + link focus.
+- [x] **Track 2 — Feed / Explore / Profile.** Added the **mobile profile tab strip** (mobile had no
+  way to switch profile tabs — the desktop top-bar tabs are `display:none` <800px); surfaced
+  pronouns + follower/following/endorsed-by on the mobile profile header (parity with the desktop
+  sidebar); explore chrome 44px; home filter button/popover/rows.
+- [x] **Track 3 — Create / Edit / Detail.** 16px meta inputs; 44px icon buttons (contributor,
+  location, cert-remove, leaflet toolbar, map-expand); project-detail breakpoints 640/600/900 →
+  800/1100; groups-create identity row stacks.
+- [x] **Track 4 — Groups / Settings / Endorsements / Notifications / Apps.** Endorsement/tab/menu
+  buttons 44px; `<Select sm>` 44px on mobile; image-overlay pills + subdomain input 44px; apps grid
+  700→800; org-members rows stack; notification `:active` tap feedback; removed a redundant 520px block.
+- [x] **Track 5 — Landing + breakpoint normalization.** Hero title de-floored (was 80px); partner
+  grid 1-col with descriptions visible on touch; feedback trigger 44px; protocol/bento tightened;
+  network-stats 600/900 → 800/1100; home news rail 1200 → 1100; `.app-page__inner` mobile gutter;
+  **zero non-canonical breakpoints remain.**
+
+## Gates
+
+- [x] `npx tsc --noEmit` — clean (0 errors, matches baseline).
+- [x] `npm run lint` — 66 warnings / 0 errors (no increase vs baseline).
+- [x] `npm run build` — green (all 31 routes).
+- [x] `npm test` — 605/605 pass (the formatGraphCount extraction + Button/Select changes are covered).
+- [x] CLAUDE.md first-checks — all silent (radii, breakpoints, headings, modal backdrops).
+- [x] No non-canonical `@media` width breakpoints anywhere in `src/app/styles/`.
+
+## Adversarial review (workflow `wwebm4byv`, 7 agents)
+
+- [x] **Desktop regression** — none. ≥1300px confirmed identical to `staging`; the only desktop
+  shifts are the sanctioned breakpoint normalizations in intermediate bands (the ≥1300 baseline is
+  preserved). The Tailwind `screens` remap only affects `md:text-sm` (3 input primitives), unchanged
+  at ≥800px; Button/Select mobile bumps revert at `md`.
+- [x] **Hard-rule compliance** — zero violations introduced.
+- [x] **Logic correctness** — mobile tab strip mirrors the desktop `visibleProfileTabs` gating;
+  `formatGraphCount` extraction is byte-equivalent; no duplicate DOM ids; hooks shared with the
+  always-mounted sidebar (cache hit, no double-fetch).
+- [x] All 3 completeness items raised were verified as non-issues (notification rows sit inside the
+  16px app-shell gutter; the stat grid uses `minmax(0,1fr)` and a <360px breakpoint would violate the
+  hard rule; apps `max-width:1080` is a no-op on mobile).
+
+## Browser verification (Playwright, chromium)
+
+- [x] 50 screenshots across public pages at 320 / 375 / 1300px, light + dark — all HTTP 200.
+- [x] **No horizontal overflow** on any public page (320 & 375px). The lone 6px on `/dev/preview/*`
+  is a dev-mode artifact (Next dev indicator + mocked-session hydration notice — present on the
+  untouched feed preview too); `probe3` found zero real overflow leaves.
+- [x] Profile mobile renders correctly: pronouns, "N followers · N following", "Endorsed by N", and
+  the new scrollable tab strip with the active underline.
+- [x] Landing mobile: hero scaled, network-stats stacked 1-col, partner grid 1-col with visible
+  descriptions; bento single-column.
+- [x] Dark mode verified at 375 & 1300px across welcome / explore / apps / legal pages.
+
+### Caveat for the human reviewer
+- The **authenticated** home feed could not be exercised logged-out except via `/dev/preview/feed`,
+  whose harness nests an extra wrapper that narrows the feed column (a harness artifact — production
+  renders `<Home />` directly in `.app-shell__content`, full-width on mobile per the unchanged
+  home.css). Recommend one real signed-in smoke test of `/home`, `/create`, `/endorsements`,
+  `/notifications`, `/groups`, `/settings` on a phone before promoting `staging → main`.

--- a/docs/mobile-overhaul/routes.json
+++ b/docs/mobile-overhaul/routes.json
@@ -1,0 +1,332 @@
+[
+  {
+    "url": "/",
+    "file": "src/app/page.tsx",
+    "auth": "public",
+    "title": "Root Redirect",
+    "keyComponents": [
+      "LoadingSpinner"
+    ],
+    "summary": "Client-side router that redirects authenticated users to /home and unauthenticated users to /welcome. Shows a loading spinner during the redirect."
+  },
+  {
+    "url": "/welcome",
+    "file": "src/app/welcome/page.tsx",
+    "auth": "public",
+    "title": "Landing Page",
+    "keyComponents": [
+      "LandingPage"
+    ],
+    "summary": "Marketing landing page with FAQ, testimonials, and value prop for passwordless AT Protocol identity. Full-bleed hero and bento layout sections."
+  },
+  {
+    "url": "/home",
+    "file": "src/app/home/page.tsx",
+    "auth": "auth-gated",
+    "title": "Activity Feed",
+    "keyComponents": [
+      "Home"
+    ],
+    "summary": "Signed-in home feed showing activities, endorsements, and network activity. Two-pane layout with sidebar and scrollable feed main content."
+  },
+  {
+    "url": "/profile",
+    "file": "src/app/profile/page.tsx",
+    "auth": "auth-gated",
+    "title": "Profile Redirect",
+    "keyComponents": [
+      "LoadingSpinner"
+    ],
+    "summary": "Redirect stub that resolves the active identity (personal or active org) and forwards to /{handle} with loading spinner."
+  },
+  {
+    "url": "/{handle}",
+    "file": "src/app/[actor]/page.tsx",
+    "auth": "public",
+    "title": "User/Group Profile",
+    "keyComponents": [
+      "ProfileHeader",
+      "ProfileSidebar",
+      "ProfileOverview",
+      "ProfileCerts",
+      "ProfileEndorsements",
+      "ProfileFollowers",
+      "ProfileGroups",
+      "SettingsPanel"
+    ],
+    "summary": "Unified profile page for individuals and groups with tabbed interface: Overview, Activities, Projects, Groups, Endorsements, Followers, Lists, About (org-only), Settings (own-profile only). Sidebar with avatar, name, stats. Desktop two-pane, mobile stacked."
+  },
+  {
+    "url": "/{actor}/{type}/{rkey}",
+    "file": "src/app/[actor]/[type]/[rkey]/page.tsx",
+    "auth": "public",
+    "title": "Activity or Project Detail",
+    "keyComponents": [
+      "ActivityDetailRoute",
+      "ProjectDetailRoute"
+    ],
+    "summary": "Record detail page that routes to either activity or project display. Resolves actor handle/DID, canonicalizes URL to handle form. Shows full record with metadata, contributors, locations."
+  },
+  {
+    "url": "/{actor}/{type}/{rkey}/edit",
+    "file": "src/app/[actor]/[type]/[rkey]/edit/page.tsx",
+    "auth": "auth-gated",
+    "title": "Activity or Project Editor",
+    "keyComponents": [
+      "ActivityEditRoute",
+      "ProjectEditRoute"
+    ],
+    "summary": "In-place editor for activities or projects. Routes to the matching editor component based on record type. Validates ownership before allowing edit."
+  },
+  {
+    "url": "/create",
+    "file": "src/app/create/page.tsx",
+    "auth": "auth-gated",
+    "title": "New Activity",
+    "keyComponents": [
+      "LeafletEditor",
+      "ContributorIdentityField",
+      "LocationPickerDialog",
+      "ImageEditOverlay"
+    ],
+    "summary": "Activity creation form with title, short description, full description editor, date range, work scope, contributors, image, locations, and rights selector. Mirrors detail page layout. Wide sidebar + main form."
+  },
+  {
+    "url": "/project/new",
+    "file": "src/app/project/new/page.tsx",
+    "auth": "auth-gated",
+    "title": "New Project",
+    "keyComponents": [
+      "LeafletEditor",
+      "LocationPickerDialog",
+      "ImageEditOverlay"
+    ],
+    "summary": "Project creation form with title, short description, banner image, full description, location picker, and activity selector (checklist of user's own certs). Wide hero + main form."
+  },
+  {
+    "url": "/explore",
+    "file": "src/app/explore/page.tsx",
+    "auth": "public",
+    "title": "Explore",
+    "keyComponents": [
+      "Explore"
+    ],
+    "summary": "Browsable directory of users, projects, and activities with multi-faceted filters (kind, filter, sub, sort, view, degree). Dynamic search params-driven interface with sidebar filters."
+  },
+  {
+    "url": "/endorsements",
+    "file": "src/app/endorsements/page.tsx",
+    "auth": "auth-gated",
+    "title": "Endorsements",
+    "keyComponents": [
+      "EndorsementRow",
+      "NewEndorsementPanel",
+      "ResponseButtons"
+    ],
+    "summary": "Tabbed endorsement manager (Received/Given). Received tab shows accept/reject controls. Given tab shows issued endorsements with revoke. Tabpanel interface with 'New' button."
+  },
+  {
+    "url": "/notifications",
+    "file": "src/app/notifications/page.tsx",
+    "auth": "auth-gated",
+    "title": "Notifications",
+    "keyComponents": [
+      "NotificationRow",
+      "NotificationRowSkeleton"
+    ],
+    "summary": "Infinite-scroll notification feed showing endorsements and contributor mentions. Marks all as seen on first load. Dashboard single-column layout."
+  },
+  {
+    "url": "/apps",
+    "file": "src/app/apps/page.tsx",
+    "auth": "public",
+    "title": "Apps",
+    "keyComponents": [
+      "Image"
+    ],
+    "summary": "Ecosystem apps directory showing apps built on AT Protocol. Grid of app cards with logo, name, description, and deep-link SSO URLs for signed-in users."
+  },
+  {
+    "url": "/groups",
+    "file": "src/app/groups/page.tsx",
+    "auth": "auth-gated",
+    "title": "Group Membership",
+    "keyComponents": [
+      "Avatar",
+      "Badge",
+      "Tabs",
+      "ConfirmDialog"
+    ],
+    "summary": "Group/organization membership manager with Public (accepted) and Private (pending) tabs. Shows role, membership actions (Make public/private, Leave). 'New group' link in tab bar."
+  },
+  {
+    "url": "/groups/create",
+    "file": "src/app/groups/create/page.tsx",
+    "auth": "auth-gated",
+    "title": "New Group",
+    "keyComponents": [
+      "ImageEditOverlay",
+      "Input",
+      "Textarea"
+    ],
+    "summary": "Group creation form with avatar picker, banner picker, display name, short description, handle, website, founded date, organization type. Validates handle availability. Wide hero + form."
+  },
+  {
+    "url": "/groups/[groupDid]",
+    "file": "src/app/groups/[groupDid]/page.tsx",
+    "auth": "public",
+    "title": "Group Profile Redirect",
+    "keyComponents": [],
+    "summary": "Server-side redirect from legacy group-detail URL to /{group-handle}. Resolves group DID to handle and redirects to profile page."
+  },
+  {
+    "url": "/groups/[groupDid]/edit-profile",
+    "file": "src/app/groups/[groupDid]/edit-profile/page.tsx",
+    "auth": "auth-gated",
+    "title": "Edit Group Profile",
+    "keyComponents": [
+      "AvatarUpload",
+      "BannerUpload",
+      "Input",
+      "Textarea"
+    ],
+    "summary": "Group admin form to edit display name, description, website, founded date. Banner + avatar upload. Dashboard topbar + single-column card layout."
+  },
+  {
+    "url": "/groups/[groupDid]/settings",
+    "file": "src/app/groups/[groupDid]/settings/page.tsx",
+    "auth": "auth-gated",
+    "title": "Group Settings",
+    "keyComponents": [
+      "OrgSettings"
+    ],
+    "summary": "Group admin settings panel. Delegates to OrgSettings component which shows membership, roles, and organizational configuration."
+  },
+  {
+    "url": "/settings",
+    "file": "src/app/settings/page.tsx",
+    "auth": "auth-gated",
+    "title": "Settings",
+    "keyComponents": [
+      "SettingsPanel"
+    ],
+    "summary": "Standalone deep-link entry point to settings. Same panel as /profile/{handle}?tab=settings. Breadcrumb above showing current identity link."
+  },
+  {
+    "url": "/settings/edit-profile",
+    "file": "src/app/settings/edit-profile/page.tsx",
+    "auth": "auth-gated",
+    "title": "Edit Profile",
+    "keyComponents": [
+      "ProfileEditForm"
+    ],
+    "summary": "Personal profile editor (text fields, avatar, banner, org URLs if account is org). Fetches raw certs record with blob refs to avoid data loss. Breadcrumb navigation."
+  },
+  {
+    "url": "/oauth/callback",
+    "file": "src/app/oauth/callback/page.tsx",
+    "auth": "public",
+    "title": "OAuth Callback",
+    "keyComponents": [
+      "Brandmark"
+    ],
+    "summary": "OAuth/OIDC callback handler. Processes callback query params, validates session, and redirects to post-signin path. Shows brandmark while processing."
+  },
+  {
+    "url": "/about",
+    "file": "src/app/about/page.tsx",
+    "auth": "public",
+    "title": "About",
+    "keyComponents": [],
+    "summary": "Static about page explaining Certified, AT Protocol, portability, and operator (Hypercerts Foundation). Full-width prose sections with links to privacy/DSA pages."
+  },
+  {
+    "url": "/privacy",
+    "file": "src/app/privacy/page.tsx",
+    "auth": "public",
+    "title": "Privacy Policy",
+    "keyComponents": [],
+    "summary": "GDPR-compliant privacy policy covering data processing, storage, retention, rights, federated architecture implications, and EU representative details."
+  },
+  {
+    "url": "/terms",
+    "file": "src/app/terms/page.tsx",
+    "auth": "public",
+    "title": "Terms of Service",
+    "keyComponents": [],
+    "summary": "Terms of service covering acceptable use, AT Protocol identity ownership, federated network disclaimers, account termination, and liability limitations."
+  },
+  {
+    "url": "/dsa",
+    "file": "src/app/dsa/page.tsx",
+    "auth": "public",
+    "title": "DSA Compliance",
+    "keyComponents": [],
+    "summary": "Digital Services Act (EU 2022/2065) compliance page. Notice-and-action procedure for illegal content reports, trusted flagger info, transparency reporting, and contact details."
+  },
+  {
+    "url": "/imprint",
+    "file": "src/app/imprint/page.tsx",
+    "auth": "public",
+    "title": "Imprint (Impressum)",
+    "keyComponents": [],
+    "summary": "German/EU legal imprint (Impressum) with operator details, authorized representatives, EU representative for GDPR/DSA, and legal contact info."
+  },
+  {
+    "url": "/workspace",
+    "file": "src/app/workspace/page.tsx",
+    "auth": "public",
+    "title": "Workspace",
+    "keyComponents": [
+      "Workspace"
+    ],
+    "summary": "Dev tool: navigation structure comparison explorer. Compare routing between network, actors, per-lexicon listings. Search params-driven dynamic content."
+  },
+  {
+    "url": "/dev/gallery",
+    "file": "src/app/dev/gallery/page.tsx",
+    "auth": "public",
+    "title": "Component Gallery",
+    "keyComponents": [
+      "Button",
+      "Badge",
+      "Card",
+      "Avatar",
+      "Input",
+      "Textarea",
+      "Tabs",
+      "Dialog"
+    ],
+    "summary": "Dev-only interactive component gallery rendering all @/components/ui primitives with variants and states. Centered column on canvas background. 404 in production."
+  },
+  {
+    "url": "/dev/preview/[surface]",
+    "file": "src/app/dev/preview/[surface]/page.tsx",
+    "auth": "public",
+    "title": "Preview Harness",
+    "keyComponents": [
+      "MockFetchProvider",
+      "UserProfilePage",
+      "Home",
+      "SettingsPanel",
+      "Workspace"
+    ],
+    "summary": "Dev-only preview harness rendering auth-gated surfaces (profile/feed/settings/workspace) with mocked fixture data. Surfaces: profile, profile-org, feed, settings, workspace. 404 in production."
+  },
+  {
+    "url": "/error",
+    "file": "src/app/error.tsx",
+    "auth": "public",
+    "title": "Error Boundary",
+    "keyComponents": [],
+    "summary": "Root error boundary catching segment-level errors. Shows error message with digest. Offers 'Try again' and 'Go home' links."
+  },
+  {
+    "url": "/not-found",
+    "file": "src/app/not-found.tsx",
+    "auth": "public",
+    "title": "404 Not Found",
+    "keyComponents": [],
+    "summary": "Catch-all 404 page. Shows 'page not found' message with 'Go home' link. Dashboard-style single-card layout."
+  }
+]

--- a/src/app/[actor]/page.tsx
+++ b/src/app/[actor]/page.tsx
@@ -278,10 +278,10 @@ export default function UserProfilePage() {
   // when they have content OR when an admin can edit / is editing.
   const aboutEditingForOrg = isEditing && canEditInline && sidebarIsOrg
   const isViewerThisEntity = isOwnProfile || isActingAsThisGroup
-  useProfileAboutAvailable(
+  const aboutAvailable =
     sidebarIsOrg &&
-      (!!displayLongDescription || isViewerThisEntity || aboutEditingForOrg),
-  )
+    (!!displayLongDescription || isViewerThisEntity || aboutEditingForOrg)
+  useProfileAboutAvailable(aboutAvailable)
   // Gate the Groups tab: only visible when the viewer's currently
   // *active* identity matches the viewed profile. So the personal
   // user sees it on their own profile only when no org is active;
@@ -293,6 +293,21 @@ export default function UserProfilePage() {
   const isActiveIdentityThisProfile =
     (isOwnProfile && !activeOrg) || isActingAsThisGroup
   useProfileGroupsAvailable(isActiveIdentityThisProfile)
+
+  // Mobile profile tab strip. The desktop top bar's row-2 tabs are the only
+  // tab navigation, and that bar is hidden below 800px — so without this strip
+  // mobile users can't switch profile sections at all. Mirror the desktop
+  // `visibleProfileTabs` gating exactly (Settings stays drawer-only on both).
+  const mobileTabs = useMemo<{ key: TabKey; label: string }[]>(
+    () =>
+      TABS.filter((t) => {
+        if (t.key === "settings") return false
+        if (t.key === "groups") return isActiveIdentityThisProfile
+        if (t.key === "about") return aboutAvailable
+        return true
+      }),
+    [isActiveIdentityThisProfile, aboutAvailable],
+  )
 
   // Mobile <ProfileHeader> still uses the legacy edit pages as a
   // fallback (inline edit isn't wired on the compact mobile header
@@ -388,8 +403,35 @@ export default function UserProfilePage() {
           settingsHref={settingsHref}
           eyebrow={eyebrow}
           hasCertifiedProfile={hasCertifiedProfile}
+          basePath={pathname || ""}
         />
       </div>
+
+      {/* Mobile-only tab strip (hidden ≥800px, where the top bar carries the
+          tabs). Horizontally scrollable; reuses the .profile-tabs styling. */}
+      <nav
+        className="profile-page__mobile-tabs profile-tabs"
+        aria-label="Profile sections"
+      >
+        {mobileTabs.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            aria-current={activeTab === t.key ? "page" : undefined}
+            className={`profile-tabs__tab${
+              activeTab === t.key ? " profile-tabs__tab--active" : ""
+            }`}
+            onClick={() =>
+              router.push(
+                t.key === "overview" ? pathname : `${pathname}?tab=${t.key}`,
+                { scroll: false },
+              )
+            }
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
 
       {editing ? (
         <EditBanner

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -19,7 +19,7 @@ export default function ErrorPage({ error, reset }: ErrorPageProps) {
           <div className="dash-card">
             <p className="dash-card__desc">An unexpected error occurred.</p>
             {error.digest && (
-              <p className="dash-card__desc" style={{ fontSize: "0.85em", opacity: 0.7 }}>
+              <p className="dash-card__desc" style={{ opacity: 0.7 }}>
                 Reference: {error.digest}
               </p>
             )}

--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -1987,6 +1987,38 @@
   color: var(--fg-primary);
 }
 
+/* ---------- Mobile (<800px) accessibility for the create/edit forms ----------
+   Placed after the base rules above so it wins the cascade. Bumps the small
+   meta inputs to 16px (no iOS focus-zoom) and a ~44px field, and expands every
+   compact icon button to the 44px WCAG tap target. Desktop is untouched. */
+@media (max-width: 799px) {
+  .cert-detail__meta-input {
+    font-size: 16px;
+    padding: 10px 10px;
+  }
+  .create-cert__contrib-card-clear,
+  .create-cert__contrib-remove,
+  .create-project__cert-remove,
+  .create-cert__loc-remove,
+  .create-cert__loc-search-again,
+  .cert-detail__map-expand-btn {
+    width: 44px;
+    height: 44px;
+  }
+  /* Search-again is absolutely placed inside the combobox input; widen the
+     input's right padding so the larger button never overlaps typed text. */
+  .create-cert__loc-search-again {
+    right: 2px;
+  }
+  .create-cert__loc-combobox:has(.create-cert__loc-search-again) > input {
+    padding-right: 48px;
+  }
+  /* Let the Cancel/Publish action row wrap instead of crowding on tiny phones. */
+  .create-cert__actions {
+    flex-wrap: wrap;
+  }
+}
+
 .create-cert__loc-suggestions {
   list-style: none;
   margin: 0;

--- a/src/app/styles/components.css
+++ b/src/app/styles/components.css
@@ -1535,10 +1535,16 @@
     width: 100%;
   }
 
-  /* Dashboard back button */
+  /* Dashboard back/action buttons: on mobile they stack full-width with a
+     44px tap target and readable text (desktop keeps the compact inline pill
+     from the base rule). Previously this shrank them to ~26px. */
   .dashboard__back-btn {
-    padding: 6px 12px;
-    font-size: 0.75rem;
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    min-height: 44px;
+    padding: 12px 16px;
+    font-size: 0.875rem;
   }
 
   /* Right sidebar cards: reduce desc margin */

--- a/src/app/styles/components.css
+++ b/src/app/styles/components.css
@@ -1227,20 +1227,9 @@
   padding: 4px 0 8px;
 }
 
-@media (max-width: 520px) {
-  .edit-profile__actions {
-    flex-direction: column-reverse;
-    gap: 10px;
-  }
-  .edit-profile__actions > * {
-    width: 100%;
-  }
-  .edit-profile__actions :is(button, a) {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-  }
-}
+/* (Removed a non-canonical `@media (max-width: 520px)` block for
+   `.edit-profile__actions`; the ≤799px block already stacks the actions
+   full-width across the whole mobile range.) */
 
 /* Dashboard body single-column variant (kept for compatibility) */
 .dashboard__body--single {
@@ -1518,14 +1507,18 @@
     gap: 6px;
   }
 
-  /* Edit profile */
+  /* Edit profile: actions stack full-width on mobile (covers both <button>
+     Save and <a> Cancel). Consolidated here from a separate, mostly-overridden
+     520px block. */
   .edit-profile__actions {
     flex-direction: column;
     gap: 8px;
   }
 
-  .edit-profile__actions button {
+  .edit-profile__actions :is(button, a) {
     width: 100%;
+    display: flex;
+    justify-content: center;
   }
 
   /* Dashboard back/action buttons: on mobile they stack full-width with a

--- a/src/app/styles/components.css
+++ b/src/app/styles/components.css
@@ -1408,16 +1408,9 @@
 
 /* Tighter rows on small screens. Drop the description to keep each
    row compact — the user can tap through for more. */
-@media (max-width: 520px) {
-  .connected-apps__item {
-    gap: 10px;
-    padding: 12px;
-  }
-
-  .connected-apps__desc {
-    display: none;
-  }
-}
+/* (Removed a non-canonical `@media (max-width: 520px)` block that tightened
+   `.connected-apps__item` and hid `.connected-apps__desc`; the ≤799px block
+   below already does both across the whole mobile range, so it was redundant.) */
 
 /* ========== Responsive: Dashboard & Pages (≤799px / mobile) ========== */
 @media (max-width: 799px) {
@@ -1637,6 +1630,10 @@
   .domain-modal__input {
     font-size: 16px;
   }
+  /* 44px tap target on mobile (the bottom-border field is 40px on desktop). */
+  .username-card__subdomain-input {
+    height: 44px;
+  }
 }
 
 /* ==================================================================
@@ -1686,6 +1683,16 @@
 .image-edit-overlay__btn:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
+}
+
+/* Mobile: the image-edit pills (Change / Remove over an avatar or banner)
+   meet the 44px tap target instead of the compact ~26px desktop pill. */
+@media (max-width: 799px) {
+  .image-edit-overlay__btn {
+    min-height: 44px;
+    padding: 10px 16px;
+    font-size: 0.8125rem;
+  }
 }
 
 /* Quiet variant — same shape as the primary pill but a brighter,

--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -249,6 +249,24 @@
   background: var(--bg-sunken);
 }
 
+/* Mobile: chrome filter buttons meet the 44px tap target (the chrome row
+   already wraps, so taller buttons just reflow), and the search field may
+   shrink below its 200px desktop minimum on very narrow phones. */
+@media (max-width: 799px) {
+  .explore__chrome-btn {
+    min-height: 44px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+  .explore__chrome-btn--icon {
+    width: 44px;
+    height: 44px;
+  }
+  .explore__search-field {
+    min-width: 0;
+  }
+}
+
 .explore__loading {
   display: flex;
   justify-content: center;

--- a/src/app/styles/feed.css
+++ b/src/app/styles/feed.css
@@ -1518,7 +1518,11 @@
 @media (max-width: 799px) {
   .response-buttons__btn {
     min-height: 44px;
+    min-width: 44px;
     padding: 8px 14px;
+    font-size: 0.8125rem;
+  }
+  .response-buttons__error {
     font-size: 0.8125rem;
   }
   .response-menu__trigger {
@@ -1528,6 +1532,23 @@
   .response-menu__item {
     min-height: 44px;
     padding: 10px 12px;
+  }
+  /* Endorsement row controls → 44px tap targets. */
+  .endorsement-panel__close,
+  .endorsement-row__revoke {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 10px;
+  }
+  /* Tab-bar tabs + "New" buttons (endorsements, groups) → 44px tall. */
+  .page-tabs__tab {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+  }
+  .page-tabs-bar__new,
+  .endorsements-new-btn {
+    min-height: 44px;
   }
 }
 
@@ -1659,6 +1680,15 @@
 .endorsement-multi-row__remove:hover {
   background: var(--overlay-weak);
   color: var(--fg-primary);
+}
+
+/* Mobile: the multi-recipient row's remove button → 44px tap target. */
+@media (max-width: 799px) {
+  .endorsement-multi-row__remove {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 10px;
+  }
 }
 
 .endorsement-multi-summary {

--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -292,13 +292,12 @@
   margin: 0 auto;
 }
 
-/* News rail shows at >=1200px. Decoupled from the sidebar-width
-   breakpoint (1300px / --bp-gt-desktop) so the news appears one
-   step earlier than the sidebar widens — the 1200–1299px band
-   gets the news rail alongside the trimmed 260px sidebar. Below
-   1200px the layout collapses to a single column and the rail
-   is hidden entirely (never stacked under the feed). */
-@media (max-width: 1199.98px) {
+/* News rail shows at the canonical 1100px step (was a non-canonical 1200px).
+   It still appears one step before the sidebar widens at 1300px — the
+   1100–1299px band gets the news rail alongside the trimmed sidebar. Below
+   1100px the layout collapses to a single column and the rail is hidden
+   entirely (never stacked under the feed). */
+@media (max-width: 1099.98px) {
   .home__split {
     grid-template-columns: minmax(0, 1fr);
     gap: 0;

--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -655,6 +655,25 @@ a.home-feed__preview:hover {
   background: var(--bg-sunken);
 }
 
+/* Mobile: 44px tap targets for the feed filter trigger and sidebar/list
+   rows, roomier checkbox rows, and a viewport-constrained popover so the
+   right-anchored menu can't overflow off a narrow screen. */
+@media (max-width: 799px) {
+  .home-feed__filter-btn {
+    width: 44px;
+    height: 44px;
+  }
+  .home-feed__filter-pop {
+    max-width: calc(100vw - 32px);
+  }
+  .home-feed__filter-item {
+    padding: 10px 8px;
+  }
+  .home-row {
+    min-height: 44px;
+  }
+}
+
 .home-feed__filter-pop {
   position: absolute;
   top: calc(100% + 6px);

--- a/src/app/styles/landing.css
+++ b/src/app/styles/landing.css
@@ -152,11 +152,17 @@
 
 @media (max-width: 799px) {
   .hero {
-    padding: calc(var(--navbar-height) + 32px) 20px 32px;
+    padding: calc(var(--navbar-height) + 24px) 20px 32px;
     min-height: auto;
   }
   .hero--landing {
     min-height: 100vh;
+  }
+  /* The fluid title floors at 5rem (80px) — far too tall on a phone, where it
+     ate ~half the viewport. Re-scale it down for small screens. */
+  .hero__title {
+    font-size: clamp(2rem, 9vw, 3rem);
+    margin-bottom: 20px;
   }
 }
 
@@ -480,8 +486,9 @@
   .feedback-trigger {
     bottom: 16px;
     right: 16px;
-    padding: 8px 12px;
-    font-size: 0.75rem;
+    min-height: 44px;
+    padding: 10px 16px;
+    font-size: 0.8125rem;
   }
 
   .feedback-modal__backdrop--desktop {
@@ -532,6 +539,16 @@
   max-width: 1024px;
   margin: 0 auto;
   padding: 32px 24px;
+}
+
+/* On mobile the app-shell already supplies the 16px lateral gutter, so the
+   inner wrapper drops its 24px horizontal padding — otherwise legal/app pages
+   carried ~40px of combined inset and a cramped reading column. */
+@media (max-width: 799px) {
+  .app-page__inner {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 /* ========== Cards (app pages) ========== */
@@ -719,8 +736,19 @@
 }
 
 @media (max-width: 799px) {
+  /* Single column on mobile: the 2-up grid squeezed each cell to ~119px of
+     usable width, wrapping the description badly. */
   .landing-network {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: 1fr;
+  }
+  .landing-network__cell {
+    padding: 24px 20px;
+  }
+  /* The description is revealed on hover on desktop; touch devices can't hover,
+     so show it by default and let it use the full cell width. */
+  .landing-network__desc {
+    opacity: 1;
+    max-width: none;
   }
 }
 
@@ -864,6 +892,11 @@
 @media (max-width: 799px) {
   .landing-bento {
     grid-template-columns: 1fr;
+  }
+  /* Slightly tighter cards on a single-column phone layout. */
+  .landing-bento__card {
+    padding: 24px;
+    min-height: 0;
   }
 }
 
@@ -1169,9 +1202,11 @@
     padding: 24px;
     border-width: 8px;
   }
+  /* 400px ate most of a 375px-tall viewport; 280px keeps the decorative card
+     present without crowding out the surrounding copy. */
   .landing-protocol__card {
     aspect-ratio: auto;
-    min-height: 400px;
+    min-height: 280px;
   }
 }
 
@@ -1243,13 +1278,15 @@
   gap: 12px;
 }
 
-@media (min-width: 600px) {
+/* Canonical breakpoints (was 600px / 900px): single column on mobile, two at
+   the 800px desktop step, the full five-up at 1100px. */
+@media (min-width: 800px) {
   .network-stats__grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1100px) {
   .network-stats__grid {
     grid-template-columns: repeat(5, minmax(0, 1fr));
   }
@@ -1285,7 +1322,7 @@
   font-variant-numeric: tabular-nums;
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1100px) {
   .network-stats__value {
     font-size: 2.25rem;
   }

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -685,6 +685,18 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   box-sizing: border-box;
 }
 
+/* Mobile reading gutter. DESIGN.md §8 specifies 16px horizontal padding on
+   mobile, but the base rule keeps 32px at all widths; below 800px we narrow
+   it to 16px so narrow phones recover ~32px of content width. Desktop (≥800px)
+   is unchanged. Full-bleed (profile) and page-frame (home/explore) pages set
+   their own lateral padding at higher specificity, so they are unaffected. */
+@media (max-width: 799px) {
+  .app-shell__content {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+}
+
 /* Desktop: reading width narrows to 600px (matches bsky/x). The flanking
    rails (mounted in PR2) provide the lateral context the mobile column
    had to carry alone. */
@@ -3418,6 +3430,26 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
    This bumps it to ~880px on both mobile and desktop. */
 .app-shell:has(.legal-page) .app-shell__content {
   max-width: 880px;
+}
+
+/* Mobile heading scale for prose pages. The `text-h1..h3` Tailwind tokens are
+   fixed (2.25/1.75/1.375rem) and eat the narrow column on phones. Scoped to
+   `.legal-page`, these out-specify the utility class (0,1,1 > 0,1,0) and shrink
+   the headings below 800px only — app feed/card headings elsewhere are
+   untouched, and desktop (≥800px) keeps the full scale. */
+@media (max-width: 799px) {
+  .legal-page :is(h1, .text-h1) {
+    font-size: 1.75rem;
+    line-height: 1.25;
+  }
+  .legal-page :is(h2, .text-h2) {
+    font-size: 1.375rem;
+    line-height: 1.3;
+  }
+  .legal-page :is(h3, .text-h3) {
+    font-size: 1.125rem;
+    line-height: 1.35;
+  }
 }
 
 .site-footer__brand {

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -122,6 +122,32 @@ html[data-theme="dark"] .signin-mark__img--light {
   color: var(--fg-primary);
 }
 
+.loading-screen__link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius);
+  color: var(--fg-primary);
+}
+
+/* Mobile: bump the error text + return link to a readable 16px, give the link
+   a 44px tap target, and keep the inner box off the viewport edge. */
+@media (max-width: 799px) {
+  .loading-screen__inner {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+  .loading-screen__error {
+    font-size: 1rem;
+  }
+  .loading-screen__link {
+    font-size: 1rem;
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 0 12px;
+  }
+}
+
 /* ========== Navbar ========== */
 .navbar {
   position: fixed;
@@ -684,18 +710,8 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
      the min-height so the content slot is exactly 100vh tall. */
   box-sizing: border-box;
 }
-
-/* Mobile reading gutter. DESIGN.md §8 specifies 16px horizontal padding on
-   mobile, but the base rule keeps 32px at all widths; below 800px we narrow
-   it to 16px so narrow phones recover ~32px of content width. Desktop (≥800px)
-   is unchanged. Full-bleed (profile) and page-frame (home/explore) pages set
-   their own lateral padding at higher specificity, so they are unaffected. */
-@media (max-width: 799px) {
-  .app-shell__content {
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-}
+/* Note: the <800px reading gutter (16px horizontal + max-width:100%) is set
+   in components.css's mobile block, which loads after this file and wins. */
 
 /* Desktop: reading width narrows to 600px (matches bsky/x). The flanking
    rails (mounted in PR2) provide the lateral context the mobile column
@@ -3450,6 +3466,18 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
     font-size: 1.125rem;
     line-height: 1.35;
   }
+  /* Trim list indentation so deeply-nested items keep usable width on phones
+     (Tailwind `pl-6` = 24px is generous for a ~300px column). */
+  .legal-page :is(ul, ol) {
+    padding-left: 1.25rem;
+  }
+}
+
+/* Keyboard focus affordance for inline links in long-form legal/about copy. */
+.legal-page a:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius);
 }
 
 .site-footer__brand {

--- a/src/app/styles/leaflet.css
+++ b/src/app/styles/leaflet.css
@@ -213,6 +213,15 @@ ol.leaflet-doc__list {
   cursor: not-allowed;
 }
 
+/* Mobile: format-toolbar buttons meet the 44px tap target. The toolbar
+   already wraps (flex-wrap), so the larger buttons reflow cleanly. */
+@media (max-width: 799px) {
+  .leaflet-editor__btn {
+    width: 44px;
+    height: 44px;
+  }
+}
+
 .leaflet-editor__content {
   border: 1.5px solid var(--border-hover);
   border-radius: var(--radius);

--- a/src/app/styles/notifications.css
+++ b/src/app/styles/notifications.css
@@ -27,7 +27,9 @@
   border-bottom: none;
 }
 
-a.notification-row:hover {
+/* `:active` gives touch devices (no hover) a press affordance on tap. */
+a.notification-row:hover,
+a.notification-row:active {
   background: var(--bg-raised);
 }
 

--- a/src/app/styles/pages.css
+++ b/src/app/styles/pages.css
@@ -794,6 +794,16 @@
     justify-content: center;
   }
 
+  /* Add-member row (label + role select + button) stacks full-width so the
+     controls don't crowd; the member-row actions wrap instead of overflowing. */
+  .org-members__add-submit {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .org-members__item-actions {
+    flex-wrap: wrap;
+  }
 }
 
 /* ============================================================================
@@ -955,9 +965,9 @@
   text-align: center;
 }
 
-/* Two-column grid once there's room — caps at two so each card stays
-   wide and the editorial feel is preserved. */
-@media (min-width: 700px) {
+/* Two-column grid at the canonical desktop step (was a non-canonical 700px) —
+   caps at two so each card stays wide and the editorial feel is preserved. */
+@media (min-width: 800px) {
   .apps-store__grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/src/app/styles/profile.css
+++ b/src/app/styles/profile.css
@@ -147,6 +147,59 @@
   word-break: break-word;
 }
 
+/* Pronouns + social-graph strip. Mobile-only (this whole header is hidden at
+   ≥800px); mirrors the desktop sidebar so mobile reaches information parity. */
+.profile-hero__pronouns {
+  margin: 8px 0 0;
+  font-size: 0.8125rem;
+  color: var(--fg-muted);
+}
+
+.profile-hero__graph {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.profile-hero__graph-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--fg-secondary);
+  flex-wrap: wrap;
+}
+
+.profile-hero__graph-count {
+  font-weight: 600;
+  color: var(--fg-primary);
+}
+
+.profile-hero__graph-link {
+  color: inherit;
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.profile-hero__graph-link:hover,
+.profile-hero__graph-link:focus-visible {
+  color: var(--fg-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.profile-hero__graph-sep {
+  color: var(--fg-muted);
+}
+
+/* Endorsed-by count sits inside its link (unlike the followers row), so it
+   inherits the link colour and the whole string lights up together on hover. */
+.profile-hero__graph-row[aria-label="Endorsed by"] .profile-hero__graph-count {
+  color: inherit;
+}
+
 /* Desktop: banner is center-column-bleed (not viewport-bleed) and the
    column is 600px wide. Keep close to 3:1 aspect so the banner still
    reads as a panoramic header rather than a letterbox card. 200px on
@@ -189,6 +242,14 @@
   overflow-y: hidden;
   scrollbar-width: none;
   -webkit-overflow-scrolling: touch;
+}
+
+/* The in-page tab strip is mobile-only — on desktop the top bar's row 2
+   carries the profile tabs. Hidden at ≥800px to avoid a duplicate strip. */
+@media (min-width: 800px) {
+  .profile-page__mobile-tabs {
+    display: none;
+  }
 }
 
 .profile-tabs::-webkit-scrollbar {

--- a/src/app/styles/project-detail.css
+++ b/src/app/styles/project-detail.css
@@ -326,12 +326,10 @@
   border-radius: var(--radius);
 }
 
-@media (min-width: 640px) {
-  .project-detail__meta {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
+/* Single column below the canonical 800px breakpoint, three columns at
+   desktop. (Previously stepped to two columns at a non-canonical 640px; that
+   band is mobile, so dropping it just keeps the meta strip single-column on
+   phones — the ≥800px desktop layout is unchanged.) */
 @media (min-width: 800px) {
   .project-detail__meta {
     grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -463,13 +461,15 @@
   justify-content: start;
 }
 
-@media (min-width: 600px) {
+/* Canonical breakpoints (was 600px / 900px): one column on mobile, two at the
+   800px desktop step, three at 1100px. */
+@media (min-width: 800px) {
   .project-detail__certs .feed {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1100px) {
   .project-detail__certs .feed {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
@@ -887,6 +887,15 @@
   gap: 20px;
   align-items: stretch;
   margin-bottom: 24px;
+}
+
+/* On mobile the 1fr/3fr split squeezed the avatar tile to ~64px; stack the
+   avatar above the banner so both are full-width and comfortably tappable. */
+@media (max-width: 799px) {
+  .create-group__identity-row {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
 }
 
 /* Circular avatar dropzone. Important: the tile itself does NOT clip

--- a/src/app/styles/settings-page.css
+++ b/src/app/styles/settings-page.css
@@ -107,6 +107,11 @@
     max-height: none;
     overflow: visible;
   }
+  /* Settings menu items meet the 44px tap target on mobile (the compact
+     ~32px desktop padding is too small to tap reliably). */
+  .sx-menu__item {
+    min-height: 44px;
+  }
 }
 
 .sx-menu {

--- a/src/components/profile/profile-header.tsx
+++ b/src/components/profile/profile-header.tsx
@@ -2,10 +2,14 @@
 
 import { useEffect, useState } from "react"
 import Link from "next/link"
-import { Pencil, UserPlus, Settings as SettingsIcon } from "lucide-react"
+import { Pencil, UserPlus, Settings as SettingsIcon, Users, ThumbsUp } from "lucide-react"
 import Avatar from "@/components/ui/avatar"
 import Button from "@/components/ui/button"
 import { getInitials } from "@/lib/utils/initials"
+import { formatGraphCount } from "@/lib/utils/format-graph-count"
+import { useFollowers } from "@/hooks/use-followers"
+import { useFollowing } from "@/hooks/use-following"
+import { useReceivedEndorsements } from "@/hooks/use-received-endorsements"
 import type { CertifiedProfile } from "@/lib/atproto/types"
 
 interface ProfileHeaderProps {
@@ -25,6 +29,10 @@ interface ProfileHeaderProps {
   /** Small uppercase tag above the display name ("Your profile",
    *  "Acting as this group", etc.). */
   eyebrow?: string
+  /** Current profile path (e.g. "/alice.certified.one"), used to link the
+   *  follower / following / endorsed-by counts to their tabs. Mirrors the
+   *  desktop sidebar's `basePath`. */
+  basePath?: string
   /** True when an `app.certified.actor.profile` record with a
    *  populated displayName exists. When false, the displayName /
    *  description / avatar / banner all came from `app.bsky.actor.profile`
@@ -57,9 +65,18 @@ export default function ProfileHeader({
   settingsHref,
   eyebrow,
   hasCertifiedProfile = false,
+  basePath = "",
 }: ProfileHeaderProps) {
   const displayName = profile?.displayName || (handle ? `@${handle}` : "Anonymous")
   const initials = getInitials(profile?.displayName, did)
+
+  // Follower / following / endorsed-by counts for THIS profile. The desktop
+  // sidebar (always mounted, just CSS-hidden on mobile) already fetches these,
+  // so reading them here is a cache hit — it surfaces the same social signal on
+  // mobile that the ≥1300px sidebar shows, closing the parity gap.
+  const viewedFollowers = useFollowers(did)
+  const viewedFollowing = useFollowing(did)
+  const viewedReceived = useReceivedEndorsements(did)
 
   // Track banner load failures so we fall back to the plain gradient
   // instead of showing the browser's broken-image icon. Reset the flag
@@ -151,12 +168,65 @@ export default function ProfileHeader({
           </p>
         ) : null}
 
+        {profile?.pronouns ? (
+          <p className="profile-hero__pronouns">{profile.pronouns}</p>
+        ) : null}
+
         <p className="profile-hero__count">
           <span className="profile-hero__count-value">{activityCountLabel}</span>
           <span className="profile-hero__count-label">
             {activityCountLabel === "1" ? "activity claim" : "activity claims"}
           </span>
         </p>
+
+        {/* Social-graph strip — mirrors the desktop sidebar so mobile viewers
+            see follower / following / endorsed-by counts too. */}
+        <div className="profile-hero__graph">
+          <p className="profile-hero__graph-row" aria-label="Followers and following">
+            <Users size={16} strokeWidth={1.75} aria-hidden />
+            <span>
+              <span className="profile-hero__graph-count">
+                {formatGraphCount(viewedFollowers.count ?? viewedFollowers.entries.length)}
+              </span>{" "}
+              <Link href={`${basePath}?tab=followers`} scroll={false} className="profile-hero__graph-link">
+                followers
+              </Link>
+            </span>
+            <span aria-hidden className="profile-hero__graph-sep">·</span>
+            <span>
+              <span
+                className="profile-hero__graph-count"
+                title={
+                  viewedFollowing.truncated
+                    ? "Hit the 10,000 follow display cap; the underlying repo has more."
+                    : undefined
+                }
+              >
+                {formatGraphCount(viewedFollowing.count, viewedFollowing.truncated)}
+              </span>{" "}
+              <Link
+                href={`${basePath}?tab=followers&sub=following`}
+                scroll={false}
+                className="profile-hero__graph-link"
+              >
+                following
+              </Link>
+            </span>
+          </p>
+          <p className="profile-hero__graph-row" aria-label="Endorsed by">
+            <ThumbsUp size={16} strokeWidth={1.75} aria-hidden />
+            <Link
+              href={`${basePath}?tab=endorsements&sub=received`}
+              scroll={false}
+              className="profile-hero__graph-link"
+            >
+              Endorsed by{" "}
+              <span className="profile-hero__graph-count">
+                {formatGraphCount(viewedReceived.endorsements.length)}
+              </span>
+            </Link>
+          </p>
+        </div>
 
         {profile?.description ? (
           <p className="profile-hero__bio">{profile.description}</p>

--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -32,6 +32,7 @@ import { useOrg } from "@/lib/groups/org-context"
 import type { Group } from "@/lib/groups/types"
 import { useFollowing } from "@/hooks/use-following"
 import { useFollowers } from "@/hooks/use-followers"
+import { formatGraphCount } from "@/lib/utils/format-graph-count"
 import { useGivenEndorsements } from "@/hooks/use-endorsements"
 import {
   useReceivedEndorsements,
@@ -820,14 +821,8 @@ function FollowButton({
  * a real, meaningful value to viewers ("nobody follows this account
  * yet").
  */
-function formatGraphCount(
-  n: number | null | undefined,
-  truncated = false,
-): string {
-  if (n === null || n === undefined) return "—"
-  const formatted = new Intl.NumberFormat().format(n)
-  return truncated ? `${formatted}+` : formatted
-}
+/* `formatGraphCount` now lives in @/lib/utils/format-graph-count and is shared
+   with the mobile <ProfileHeader> so both surfaces render identical counts. */
 
 /* ----------------------------- Endorse ------------------------------
  *

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -56,12 +56,17 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         "bg-[var(--color-error-bg)] text-[var(--color-error)] border border-[var(--color-error-border)] hover:opacity-90",
     };
 
+    // Mobile tap targets: every size meets the 44px WCAG 2.5.5 minimum below
+    // 800px, then reverts to its compact desktop dimensions at `md` (= 800px,
+    // the canonical breakpoint). `min-h-11` (44px) wins over the smaller
+    // padding-driven height on mobile without touching the desktop look.
     const sizeStyles: Record<ButtonSize, string> = {
-      sm: "py-1.5 px-4 text-xs",
-      md: "py-2.5 px-6 text-sm",
+      sm: "py-1.5 px-4 text-xs min-h-11 md:min-h-0",
+      md: "py-2.5 px-6 text-sm min-h-11 md:min-h-0",
       lg: "py-3 px-8 text-sm",
-      // 40 x 40 square. Padding zeroed; children (an icon) sit in the centered flex slot.
-      icon: "h-10 w-10 p-0 text-sm",
+      // 44 x 44 on mobile, 40 x 40 on desktop. Padding zeroed; the icon child
+      // sits in the centered flex slot.
+      icon: "h-11 w-11 md:h-10 md:w-10 p-0 text-sm",
     };
 
     const disabledStyles = disabled || loading ? "opacity-50 cursor-not-allowed" : "";

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -12,8 +12,10 @@ export interface SelectProps
 }
 
 // Mirrors Input's size axis. Right padding leaves room for the chevron overlay.
+// `sm` keeps its compact 36px height on desktop but meets the 44px tap target
+// below the canonical 800px breakpoint (mirrors Button's mobile bump).
 const sizeClasses: Record<SelectSize, string> = {
-  sm: "h-9 pl-3 pr-9 text-sm",
+  sm: "h-9 pl-3 pr-9 text-sm min-h-11 md:min-h-0",
   md: "h-11 pl-4 pr-10 text-base md:text-sm",
   lg: "h-14 pl-5 pr-11 text-base",
 };

--- a/src/lib/utils/format-graph-count.ts
+++ b/src/lib/utils/format-graph-count.ts
@@ -1,0 +1,17 @@
+/**
+ * Formats a social-graph count (followers / following / endorsements) for
+ * display. Returns an em dash for unknown values so an absent count reads as
+ * "not loaded" rather than implying zero, and appends "+" when the underlying
+ * list hit its display cap (e.g. the 10,000-follow ceiling).
+ *
+ * Shared by the desktop profile sidebar and the mobile profile header so both
+ * surfaces render identical counts.
+ */
+export function formatGraphCount(
+  n: number | null | undefined,
+  truncated = false,
+): string {
+  if (n === null || n === undefined) return "—";
+  const formatted = new Intl.NumberFormat().format(n);
+  return truncated ? `${formatted}+` : formatted;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,18 @@ export default {
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
+    /* Breakpoints are the design system's canonical set ONLY (DESIGN.md /
+       CLAUDE.md hard rule): 800 / 1100 / 1300. Defining `screens` here
+       (not under `extend`) REPLACES Tailwind's defaults (640/768/1024/…),
+       so a stray `md:`/`lg:` utility can never resolve to a non-canonical
+       breakpoint. `md` = the "gt-mobile" 800px threshold — this is why
+       `md:text-sm` on inputs now flips at 800px (16px below it → no iOS
+       auto-zoom on focus), instead of Tailwind's old 768px default. */
+    screens: {
+      md: "800px",
+      lg: "1100px",
+      xl: "1300px",
+    },
     extend: {
       colors: {
         /* Semantic status colors — used sparingly via Tailwind utilities.


### PR DESCRIPTION
## Summary

Comprehensive overhaul of the **mobile view (<800px)** across every user-facing page. Desktop is the source of truth and is preserved — the **≥1300px full-desktop view renders identically to `staging`**. The one sanctioned exception (agreed up front) is normalizing non-canonical breakpoints to the canonical 800/1100/1300 set, which may shift intermediate desktop bands but preserves the ≥1300 baseline.

Driven by a read-only audit of all 31 routes (266 findings) plus an adversarial review and Playwright browser verification. Plan: `docs/mobile-overhaul/`; release checklist + verification summary: `docs/mobile-overhaul/release-checklist.md`.

## What changed (6 tracks)

- **Track 0 — foundation:** Tailwind `screens` → canonical 800/1100/1300 (fixes the 768px `md:` mismatch so inputs are 16px below 800px → no iOS focus-zoom); `<Button>`/`<Select>` meet the 44px tap target on mobile and revert at ≥800px; legal heading scale; `.app-shell__content` mobile gutter.
- **Track 1 — static/legal/error/auth:** un-shrunk error buttons, oauth-callback legibility, legal list/heading/link polish.
- **Track 2 — feed/explore/profile:** **new mobile profile tab strip** (mobile previously had no way to switch profile sections — the desktop top-bar tabs are hidden <800px); **information parity** — pronouns + follower/following/endorsed-by now shown on the mobile profile header (desktop-only sidebar content); explore + home tap targets/popovers.
- **Track 3 — create/edit/detail:** 16px form inputs, 44px icon buttons, contributor/date layout, project-detail breakpoint normalization.
- **Track 4 — groups/settings/endorsements/notifications/apps:** 44px tap targets across hand-rolled buttons, row stacking, touch (`:active`) feedback, redundant-block cleanup.
- **Track 5 — landing + breakpoints:** de-floored hero title, 1-col partner grid with touch-visible descriptions, tightened cards; **all non-canonical breakpoints normalized** (600/640/700/900/1200/520 → 800/1100/1300).

## Breaking changes

None. Desktop ≥1300px is unchanged; shared primitives (`Button`, `Select`) only gain mobile-only min-heights that reset at ≥800px.

## Test plan

- [x] `tsc --noEmit` clean; `lint` 66 warnings/0 errors (baseline); `build` green; `test` 605/605.
- [x] CLAUDE.md first-checks all silent; zero non-canonical breakpoints in `src/app/styles/`.
- [x] Adversarial review (7 agents): 0 confirmed issues; desktop ≥1300px confirmed identical.
- [x] Playwright: 50 shots at 320/375/1300px light+dark across public pages; no real horizontal overflow; profile + landing mobile verified.
- [ ] **Reviewer:** one signed-in phone smoke test of `/home`, `/create`, `/endorsements`, `/notifications`, `/groups`, `/settings` (these are auth-gated; verified logged-out via the dev preview harness only — see checklist caveat).

## Out of scope (→ follow-up cleanup PR)

`/workspace`, `/dev/gallery`, `/dev/preview/[surface]` (unlinked dev/experimental surfaces) get no mobile work here and are candidates for removal in the dead-code cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)