### PR TITLE
fix(labels): consume quality labels via magic-indexer (#145)

### DIFF
--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -19,9 +19,7 @@ import {
   HYPERLABEL_DISPLAY_LABELS,
   HYPERLABEL_DISPLAY_ORDER,
   HYPERLABEL_TIERS,
-  ORGLABEL_TIERS,
   type HyperlabelTier,
-  type OrglabelTier,
 } from "@/lib/atproto/labels"
 import CertIcon from "@/components/ui/cert-icon"
 import Input from "@/components/ui/input"
@@ -73,10 +71,10 @@ type UnlabeledSlug = typeof UNLABELED_SLUG
 const UNLABELED_LABEL = "Not labeled yet"
 
 /**
- * Orglabeler tier slugs used in the URL `?orgQuality=` param.
- * Map to the unicode-prefixed values the lexicon actually stores
- * (see `ORGLABEL_TIERS` in labels.ts) at filter-evaluation time so
- * the URL stays printable. */
+ * Orglabeler tier slugs used in the URL `?orgQuality=` param. These are
+ * also the exact kebab-case label values the indexer stores (per issue
+ * #145), so a slug is sent straight to the indexer as the org `labels` /
+ * `excludeLabels` value — no slug↔value mapping needed. */
 const ORG_TIER_SLUGS = ["high-quality", "standard", "likely-test"] as const
 type OrgTierSlug = (typeof ORG_TIER_SLUGS)[number]
 
@@ -86,27 +84,11 @@ const ORG_TIER_DISPLAY_LABEL: Record<OrgTierSlug, string> = {
   "likely-test": "Likely test",
 }
 
-/** Slug ↔ raw lexicon value (the glyph-prefixed strings the
- *  orglabeler emits). */
-const ORG_TIER_BY_SLUG: Record<OrgTierSlug, OrglabelTier> = {
-  "high-quality": "✦ High Quality",
-  standard: "● Standard",
-  "likely-test": "⚠ Likely Test",
-}
-
-/** Inverse of ORG_TIER_BY_SLUG. Used when checking which slug a raw
- *  label value belongs to. */
-const ORG_TIER_BY_VALUE = {
-  "✦ High Quality": "high-quality" as const,
-  "● Standard": "standard" as const,
-  "⚠ Likely Test": "likely-test" as const,
-} satisfies Record<OrglabelTier, OrgTierSlug>
-
 /** Default org-quality set when `?orgQuality=` is missing —
  *  everything except the labels listed in DEFAULT_HIDDEN_ORG_LABELS
- *  (today only "⚠ Likely Test"). Matches the home feed's policy. */
+ *  (today only "likely-test"). Matches the home feed's policy. */
 const DEFAULT_ORG_TIER_SLUGS: readonly OrgTierSlug[] = ORG_TIER_SLUGS.filter(
-  (slug) => !DEFAULT_HIDDEN_ORG_LABELS.includes(ORG_TIER_BY_SLUG[slug]),
+  (slug) => !DEFAULT_HIDDEN_ORG_LABELS.includes(slug),
 )
 
 function parseSort(v: string | null): SortOrder {
@@ -355,22 +337,18 @@ function ExploreMain({
     )
   }, [orgQualityParam])
   const orgIncludeUnlabeled = orgQualityIncluded.has(UNLABELED_SLUG)
-  const excludeOrgLabels = useMemo<readonly OrglabelTier[] | undefined>(
+  const excludeOrgLabels = useMemo<readonly OrgTierSlug[] | undefined>(
     () =>
       orgIncludeUnlabeled
-        ? ORG_TIER_SLUGS.filter((slug) => !orgQualityIncluded.has(slug)).map(
-            (slug) => ORG_TIER_BY_SLUG[slug],
-          )
+        ? ORG_TIER_SLUGS.filter((slug) => !orgQualityIncluded.has(slug))
         : undefined,
     [orgQualityIncluded, orgIncludeUnlabeled],
   )
-  const includeOrgLabels = useMemo<readonly OrglabelTier[] | undefined>(
+  const includeOrgLabels = useMemo<readonly OrgTierSlug[] | undefined>(
     () =>
       orgIncludeUnlabeled
         ? undefined
-        : ORG_TIER_SLUGS.filter((slug) => orgQualityIncluded.has(slug)).map(
-            (slug) => ORG_TIER_BY_SLUG[slug],
-          ),
+        : ORG_TIER_SLUGS.filter((slug) => orgQualityIncluded.has(slug)),
     [orgQualityIncluded, orgIncludeUnlabeled],
   )
   const orgQualityIsDefault = useMemo(() => {

--- a/src/lib/atproto/labels.ts
+++ b/src/lib/atproto/labels.ts
@@ -1,47 +1,51 @@
 /**
  * Hypercerts ecosystem labelers — DIDs + value sets.
  *
- * Two AppView-side labelers score record quality (see issue #97 and
+ * Two labelers score record quality (see issue #145 and
  * https://docs.hypercerts.org/tools/labelers):
  *
- *   - **Hyperlabel** on every `org.hypercerts.claim.activity` (cert):
+ *   - **Activity Labeler** (`activitylabeler.certified.one`) on every
+ *     `org.hypercerts.claim.activity` (cert):
  *     `high-quality`, `standard`, `draft`, `likely-test`
- *   - **Orglabeler** on every `app.certified.actor.organization`:
- *     `✦ High Quality`, `● Standard`, `⚠ Likely Test`
- *     (unicode glyph prefixes are PART of the value — not rendering
- *     hints; clients filter with the exact string)
+ *   - **Orglabeler** (`orglabeler.certified.one`) on every
+ *     `app.certified.actor.organization`:
+ *     `high-quality`, `standard`, `likely-test`
  *
- * Default UX policy: the feed and explore page hide records that are
- * explicitly labeled `draft` / `likely-test` (cert) or `⚠ Likely Test`
- * (org). Records with no label fall through unfiltered — important
- * during the ingestion-warmup window before labelers have caught up
- * with backfill. A filter toggle on each surface lets the viewer
- * include the hidden tiers.
+ * Label values are **kebab-case** (pinned by a regression test in the
+ * indexer). The glyph-prefixed strings the docs site historically
+ * showed (`✦ High Quality`, …) are NOT what the services emit — never
+ * filter with them, they match nothing.
+ *
+ * The app reads these labels **from the magic-indexer**, never by
+ * talking to the labelers directly: every record node carries a
+ * `labels` field, and the records connection accepts `labels` /
+ * `excludeLabels` filter args. Because the indexer only ingests the two
+ * labelers below, the optional `labelerDids` trust-set arg is omitted
+ * (omitted = labels from any ingested labeler match), so the DIDs here
+ * are documentation of the canonical trust set, not query inputs.
+ *
+ * Default UX policy: the feed and explore page hide records explicitly
+ * labeled `draft` / `likely-test`. Records with no label fall through
+ * unfiltered — important during the ingestion-warmup window before the
+ * labelers have caught up with backfill. A filter toggle on each
+ * surface lets the viewer include the hidden tiers.
  */
 
 /**
- * Hyperlabel signing DIDs. The labeler service at
- * `hyperlabel-production.up.railway.app` currently signs labels with
- * the `heisenberg.climateai.org` DID, while the canonical
- * `did:plc:5rw6of6...` (aka `einstein.climateai.org`) is registered
- * at the same endpoint but dormant. The indexer must subscribe to
- * BOTH via `LABELER_DIDS`, or the actively-signed labels never get
- * ingested and `excludeLabels: ["likely-test"]` is a no-op. See
- * hypercerts-org/magic-indexer#138.
+ * Canonical labeler DIDs ingested by the magic-indexer. Documentation
+ * only — the app doesn't query the labelers directly, and it doesn't
+ * scope by `labelerDids` (omitted = any ingested labeler). The retired
+ * "Hyperlabel" service that the Activity Labeler replaced is no longer
+ * ingested — don't reintroduce its DIDs.
  */
-export const HYPERLABEL_DIDS = [
-  "did:plc:5rw6of6lry7ihmyhm323ycwn", // canonical (einstein.climateai.org) — dormant
-  "did:plc:edod7rboajioq3jbyxsgeicc", // active signer (heisenberg.climateai.org)
-] as const
-
-/** Orglabeler's DID — scores org-record quality. */
+export const ACTIVITY_LABELER_DID = "did:plc:antf7bsm6f4ohkqfdckefyt7"
 export const ORGLABELER_DID = "did:plc:pswneepkd5lesumj7ejmkbal"
 
-/** Cert quality tiers, lowest to highest. */
+/** Cert quality tiers, lowest to highest. Emitted by the Activity Labeler. */
 export const HYPERLABEL_TIERS = ["likely-test", "draft", "standard", "high-quality"] as const
 export type HyperlabelTier = (typeof HYPERLABEL_TIERS)[number]
 
-/** Display order (best → worst) used by every Hyperlabel popover /
+/** Display order (best → worst) used by every cert-quality popover /
  *  filter chip across the app. Opposite of HYPERLABEL_TIERS which is
  *  sorted worst → best for indexer-side tier comparisons. */
 export const HYPERLABEL_DISPLAY_ORDER: readonly HyperlabelTier[] = [
@@ -60,8 +64,9 @@ export const HYPERLABEL_DISPLAY_LABELS: Record<HyperlabelTier, string> = {
   "likely-test": "Likely test",
 }
 
-/** Org quality tiers, lowest to highest. */
-export const ORGLABEL_TIERS = ["⚠ Likely Test", "● Standard", "✦ High Quality"] as const
+/** Org quality tiers, lowest to highest. Emitted by the Orglabeler.
+ *  Kebab-case (the exact strings the indexer stores) — no glyphs. */
+export const ORGLABEL_TIERS = ["likely-test", "standard", "high-quality"] as const
 export type OrglabelTier = (typeof ORGLABEL_TIERS)[number]
 
 /**
@@ -74,4 +79,4 @@ export type OrglabelTier = (typeof ORGLABEL_TIERS)[number]
 export const DEFAULT_HIDDEN_CERT_LABELS: readonly string[] = ["draft", "likely-test"]
 
 /** Same idea for org records. */
-export const DEFAULT_HIDDEN_ORG_LABELS: readonly string[] = ["⚠ Likely Test"]
+export const DEFAULT_HIDDEN_ORG_LABELS: readonly string[] = ["likely-test"]


### PR DESCRIPTION
Implements issue #145 — consume the Hypercerts quality labels exactly as the magic-indexer now exposes them, and remove leftover code about the retired labeler.

## What changed
- **Activity Labeler DID** is now `did:plc:antf7bsm6f4ohkqfdckefyt7`. Removed the retired Hyperlabel DIDs (the `*.climateai.org` signers the indexer no longer ingests) — the `HYPERLABEL_DIDS` constant is gone, replaced by documented `ACTIVITY_LABELER_DID` + `ORGLABELER_DID` constants. The app does not query the labelers directly and does not scope by `labelerDids` (omitted = any ingested labeler); labels arrive inline from the indexer.
- **Org quality tiers are kebab-case** (`high-quality` / `standard` / `likely-test`), not the glyph-prefixed strings (`✦ High Quality`, …) the docs historically showed. The running services emit kebab-case, so the glyph filters matched nothing — the org-quality filter on /explore was effectively a no-op. `ORGLABEL_TIERS` and `DEFAULT_HIDDEN_ORG_LABELS` are now kebab-case.
- **Removed dead/redundant code**: the slug→glyph indirection `ORG_TIER_BY_SLUG` and the unused `ORG_TIER_BY_VALUE` in explore. Org-tier slugs ARE the lexicon label values now, sent straight to the indexer's `labels` / `excludeLabels` args.

## How labels are consumed (per #145)
- Read from the magic-indexer (`magic-indexer-prod.up.railway.app/graphql`, already configured) via the records connection's `labels` / `excludeLabels` args; each node also returns a `labels` field.
- Kebab-case values; `labelerDids` omitted.
- The People/Organizations toggle stays separate (it's the indexer's `isOrganization` filter, not a labeler label) — unchanged.

## Explore filters use the labels
- **Activity quality** → `includeCertLabels` / `excludeCertLabels` (already kebab-case) → indexer `labels` / `excludeLabels` on `orgHypercertsClaimActivity`.
- **Account quality** → `includeOrgLabels` / `excludeOrgLabels` (now kebab-case) → org DIDs resolved by label and scoped into the activity/account queries.

## Acceptance (#145)
- [x] Quality filters query the magic-indexer with kebab-case label values.
- [x] No references to the retired Hyperlabel DIDs.

## Verification
- `npx tsc --noEmit` clean, `npm run lint` clean on touched files, `npm run build` succeeds.
- Not browser-verified (needs auth + ingested labels); worth a manual check that the /explore Account-quality filter now actually narrows results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)