### PR TITLE
feat(seo): per-page Open Graph metadata for shared pages

### DIFF
--- a/src/app/[actor]/[type]/[rkey]/layout.tsx
+++ b/src/app/[actor]/[type]/[rkey]/layout.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next"
+import { recordMetadata } from "@/lib/og-metadata"
+import { collectionForType, isRecordType } from "@/lib/urls"
+
+/**
+ * Server layout for the `/[actor]/{type}/{rkey}` record subtree. Attaches
+ * per-record Open Graph / Twitter metadata (activity or project), overriding
+ * the profile metadata from the parent `[actor]` layout. The page and its
+ * edit/update children are client components, so the metadata lives here.
+ */
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ actor: string; type: string; rkey: string }>
+}): Promise<Metadata> {
+  const { actor, type, rkey } = await params
+  if (!isRecordType(type)) return {}
+  return recordMetadata(
+    decodeURIComponent(actor),
+    type,
+    collectionForType(type),
+    decodeURIComponent(rkey),
+  )
+}
+
+export default function RecordLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/src/app/[actor]/layout.tsx
+++ b/src/app/[actor]/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next"
+import { profileMetadata } from "@/lib/og-metadata"
+
+/**
+ * Server layout for the `/[actor]` subtree. Its sole job is to attach
+ * per-profile Open Graph / Twitter metadata — the page itself is a client
+ * component and can't export `generateMetadata`. Record routes nested below
+ * (`/[actor]/{type}/{rkey}`) override this with their own metadata.
+ */
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ actor: string }>
+}): Promise<Metadata> {
+  const { actor } = await params
+  return profileMetadata(decodeURIComponent(actor))
+}
+
+export default function ActorLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/src/app/apps/layout.tsx
+++ b/src/app/apps/layout.tsx
@@ -4,6 +4,32 @@ export const metadata: Metadata = {
   title: "Apps",
   description:
     "Apps built on the AT Protocol — sign in with your Certified identity to get started.",
+  openGraph: {
+    title: "Apps — Certified",
+    description:
+      "Apps built on the AT Protocol — sign in with your Certified identity to get started.",
+    siteName: "Certified",
+    locale: "en_US",
+    type: "website",
+    url: "/apps",
+    images: [
+      {
+        url: "/assets/certs-hero-1200x630.png",
+        width: 1200,
+        height: 630,
+        alt: "Apps built on the AT Protocol",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: "@hypercerts",
+    creator: "@hypercerts",
+    title: "Apps — Certified",
+    description:
+      "Apps built on the AT Protocol — sign in with your Certified identity to get started.",
+    images: ["/assets/certs-hero-1200x630.png"],
+  },
 }
 
 export default function AppsLayout({

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -6,6 +6,32 @@ export const metadata: Metadata = {
   title: "Explore — Certified",
   description:
     "Browse users, projects, and activities across the Certified network.",
+  openGraph: {
+    title: "Explore Certified",
+    description:
+      "Browse users, projects, and activities across the Certified network.",
+    siteName: "Certified",
+    locale: "en_US",
+    type: "website",
+    url: "/explore",
+    images: [
+      {
+        url: "/assets/certs-hero-1200x630.png",
+        width: 1200,
+        height: 630,
+        alt: "Explore the Certified network",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: "@hypercerts",
+    creator: "@hypercerts",
+    title: "Explore Certified",
+    description:
+      "Browse users, projects, and activities across the Certified network.",
+    images: ["/assets/certs-hero-1200x630.png"],
+  },
 }
 
 /**

--- a/src/components/explore-page/__tests__/explore-popover-canonical.test.tsx
+++ b/src/components/explore-page/__tests__/explore-popover-canonical.test.tsx
@@ -57,7 +57,7 @@ describe("Explore Sort dropdown uses the canonical Popover", () => {
   it("opens a role=menu wired to the trigger via aria-controls", async () => {
     const { default: Explore } = await import("../explore")
     render(<Explore />)
-    const trigger = screen.getByRole("button", { name: /^Sort:/ })
+    const trigger = screen.getByRole("button", { name: "Sort" })
     // Closed initially.
     expect(screen.queryByRole("menu")).toBeNull()
     expect(trigger.getAttribute("aria-expanded")).toBe("false")
@@ -71,13 +71,15 @@ describe("Explore Sort dropdown uses the canonical Popover", () => {
     expect(menu.id).toBeTruthy()
   })
 
-  it("renders the sort options as role=menuitem", async () => {
+  it("renders the sort options as role=menuitemradio", async () => {
     const { default: Explore } = await import("../explore")
     render(<Explore />)
-    const trigger = screen.getByRole("button", { name: /^Sort:/ })
+    const trigger = screen.getByRole("button", { name: "Sort" })
     fireEvent.click(trigger)
     const menu = screen.getByRole("menu")
-    const items = within(menu).getAllByRole("menuitem")
+    // Each option carries `selected`, so the canonical PopoverItem renders
+    // as a selectable `menuitemradio` rather than a plain `menuitem`.
+    const items = within(menu).getAllByRole("menuitemradio")
     const labels = items.map((el) => el.textContent)
     expect(labels).toContain("Newest first")
     expect(labels).toContain("Oldest first")
@@ -87,7 +89,7 @@ describe("Explore Sort dropdown uses the canonical Popover", () => {
   it("closes on Escape", async () => {
     const { default: Explore } = await import("../explore")
     render(<Explore />)
-    const trigger = screen.getByRole("button", { name: /^Sort:/ })
+    const trigger = screen.getByRole("button", { name: "Sort" })
     fireEvent.click(trigger)
     expect(screen.getByRole("menu")).toBeTruthy()
     fireEvent.keyDown(document, { key: "Escape" })

--- a/src/components/explore-page/__tests__/explore-popover-haspopup.test.tsx
+++ b/src/components/explore-page/__tests__/explore-popover-haspopup.test.tsx
@@ -51,8 +51,8 @@ describe("Explore popover triggers expose aria-haspopup", () => {
   it("Sort trigger advertises a popup", async () => {
     const { default: Explore } = await import("../explore")
     render(<Explore />)
-    // The Sort trigger is labelled by its visible text ("Sort: …").
-    const sortTrigger = screen.getByRole("button", { name: /^Sort:/ })
+    // The Sort trigger is an icon-only button labelled `aria-label="Sort"`.
+    const sortTrigger = screen.getByRole("button", { name: "Sort" })
     expect(sortTrigger.getAttribute("aria-haspopup")).not.toBeNull()
   })
 

--- a/src/lib/atproto/get-record-server.ts
+++ b/src/lib/atproto/get-record-server.ts
@@ -1,0 +1,40 @@
+import { resolvePdsUrl } from "./did"
+
+/**
+ * Fetch a single ATProto record server-side, unauthenticated, from the
+ * repo's own PDS. This mirrors the `getCertsProfile` pattern in
+ * `app/api/resolve-did/resolve-core.ts`: resolve the DID to its PDS, then
+ * hit the public `com.atproto.repo.getRecord` XRPC directly so records for
+ * users on any PDS in the network resolve (not just our own).
+ *
+ * Returns null on any failure (missing record, unreachable PDS, malformed
+ * response) — callers fall back to generic metadata. Server-only: uses bare
+ * `fetch`, no auth context, no React hooks.
+ */
+export async function getRecordServer<T = Record<string, unknown>>(
+  did: string,
+  collection: string,
+  rkey: string,
+): Promise<{ uri: string; cid?: string; value: T } | null> {
+  try {
+    const targetPds = await resolvePdsUrl(did)
+    if (!targetPds) return null
+
+    const params = new URLSearchParams({ repo: did, collection, rkey })
+    const res = await fetch(
+      `${targetPds}/xrpc/com.atproto.repo.getRecord?${params.toString()}`,
+      { signal: AbortSignal.timeout(8_000) },
+    )
+    if (!res.ok) return null
+
+    const data = (await res.json()) as {
+      uri?: string
+      cid?: string
+      value?: T
+    }
+    if (!data.value) return null
+    return { uri: data.uri ?? "", cid: data.cid, value: data.value }
+  } catch {
+    return null
+  }
+}

--- a/src/lib/og-metadata.ts
+++ b/src/lib/og-metadata.ts
@@ -1,0 +1,209 @@
+import type { Metadata } from "next"
+import { buildProfilePayload } from "@/app/api/resolve-did/resolve-core"
+import { resolveHandle, resolveHandleToDid, resolveHandleViaWellKnown } from "@/lib/atproto/did"
+import { getRecordServer } from "@/lib/atproto/get-record-server"
+import { parseActor, profileUrl, recordUrl, type RecordType } from "@/lib/urls"
+
+// Generic share defaults. The per-page builders below only fall back to
+// these when the entity carries no specific value of its own.
+const SITE_NAME = "Certified"
+const DEFAULT_OG_IMAGE = "/assets/certs-hero-1200x630.png"
+const TWITTER_HANDLE = "@hypercerts"
+
+/** Collapse whitespace and cap a description at OG-friendly length. */
+function clampDescription(text: string | null | undefined, max = 200): string | undefined {
+  if (!text) return undefined
+  const flat = text.replace(/\s+/g, " ").trim()
+  if (!flat) return undefined
+  return flat.length > max ? `${flat.slice(0, max - 1).trimEnd()}…` : flat
+}
+
+/** A blob `ref` as it arrives in raw getRecord JSON: `{ $link: "bafy…" }`. */
+function blobLink(ref: unknown): string | null {
+  if (ref && typeof ref === "object" && "$link" in ref) {
+    const link = (ref as { $link?: unknown }).$link
+    if (typeof link === "string") return link
+  }
+  return null
+}
+
+/**
+ * Best-effort OG image URL for a record's polymorphic `image` field. Mirrors
+ * `resolveActivityImageUrl` but is self-contained (no client-import chain) and
+ * skips `data:` URIs, which crawlers can't fetch as `og:image`.
+ */
+function ogImageFromField(image: unknown, did: string): string | null {
+  if (image == null) return null
+  if (typeof image === "string") {
+    return /^https?:\/\//.test(image) ? image : null
+  }
+  if (typeof image !== "object") return null
+  const obj = image as Record<string, unknown>
+
+  if (typeof obj.uri === "string" && obj.uri) {
+    return /^https?:\/\//.test(obj.uri) ? obj.uri : null
+  }
+  // { image: { ref: { $link } } } (smallImage / largeImage)
+  const nested = obj.image as { ref?: unknown } | undefined
+  const nestedCid = nested ? blobLink(nested.ref) : null
+  if (nestedCid) {
+    return `/api/xrpc/com/atproto/sync/getBlob?did=${encodeURIComponent(did)}&cid=${encodeURIComponent(nestedCid)}`
+  }
+  // bare blob ref { ref: { $link } }
+  const bareCid = blobLink(obj.ref)
+  if (bareCid) {
+    return `/api/xrpc/com/atproto/sync/getBlob?did=${encodeURIComponent(did)}&cid=${encodeURIComponent(bareCid)}`
+  }
+  return null
+}
+
+/** Resolve an `[actor]` segment (handle or DID) to a DID, best-effort. */
+async function actorToDid(actorParam: string): Promise<{ did: string; handle: string | null } | null> {
+  const actor = parseActor(actorParam)
+  if (actor.kind === "invalid") return null
+  if (actor.kind === "did") return { did: actor.value, handle: null }
+  // handle → DID via the public appView, falling back to .well-known.
+  const did =
+    (await resolveHandleToDid(actor.value)) ??
+    (await resolveHandleViaWellKnown(actor.value))
+  if (!did) return null
+  return { did, handle: actor.value }
+}
+
+/** Assemble a complete, self-contained Metadata object for a share target. */
+function buildShareMetadata(opts: {
+  title: string
+  description?: string
+  url: string
+  image: string | null
+  imageAlt: string
+  ogType: "profile" | "article"
+}): Metadata {
+  const image = opts.image ?? DEFAULT_OG_IMAGE
+  // openGraph/twitter are replaced wholesale by the deepest segment that
+  // sets them (Next.js does not deep-merge them across segments), so each
+  // builder returns the full object rather than a partial override.
+  return {
+    title: opts.title,
+    description: opts.description,
+    openGraph: {
+      title: opts.title,
+      description: opts.description,
+      siteName: SITE_NAME,
+      locale: "en_US",
+      type: opts.ogType,
+      url: opts.url,
+      images: [{ url: image, width: 1200, height: 630, alt: opts.imageAlt }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: TWITTER_HANDLE,
+      creator: TWITTER_HANDLE,
+      title: opts.title,
+      description: opts.description,
+      images: [image],
+    },
+  }
+}
+
+/**
+ * Per-page Open Graph metadata for a profile route (`/[actor]`). Resolves the
+ * actor to its Certified profile and surfaces the display name, bio, and
+ * avatar/banner so a shared profile link renders that person — not the
+ * generic "Certified" card. Returns `{}` (inherit the root defaults) when the
+ * actor can't be resolved.
+ */
+export async function profileMetadata(actorParam: string): Promise<Metadata> {
+  try {
+    const resolved = await actorToDid(actorParam)
+    if (!resolved) return {}
+
+    const profile = await buildProfilePayload(resolved.did)
+    const handle = profile.handle || resolved.handle || resolved.did
+    const name = profile.displayName?.trim() || handle
+
+    const title = profile.displayName?.trim()
+      ? `${profile.displayName.trim()} (@${handle})`
+      : `@${handle}`
+    const description =
+      clampDescription(profile.description) ??
+      `${name} on Certified — one account, any app.`
+
+    return buildShareMetadata({
+      title,
+      description,
+      url: profileUrl(handle),
+      image: profile.banner ?? profile.avatar ?? null,
+      imageAlt: `${name} on Certified`,
+      ogType: "profile",
+    })
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Per-page Open Graph metadata for a record route
+ * (`/[actor]/{activity|project}/{rkey}`). Fetches the record server-side and
+ * surfaces its title, short description, and image. Returns `{}` (inherit the
+ * root defaults) when the record can't be resolved.
+ */
+export async function recordMetadata(
+  actorParam: string,
+  type: RecordType,
+  collection: string,
+  rkey: string,
+): Promise<Metadata> {
+  try {
+    const resolved = await actorToDid(actorParam)
+    if (!resolved) return {}
+    const { did } = resolved
+
+    const record = await getRecordServer<Record<string, unknown>>(did, collection, rkey)
+    if (!record) return {}
+    const value = record.value
+
+    const handle = resolved.handle ?? (await resolveHandle(did).catch(() => null)) ?? did
+    const byline = `@${handle} on Certified`
+
+    if (type === "activity") {
+      const rawTitle = typeof value.title === "string" ? value.title.trim() : ""
+      const title = rawTitle || "Activity"
+      const description =
+        clampDescription(
+          typeof value.shortDescription === "string" ? value.shortDescription : undefined,
+        ) ?? `An activity by ${byline}.`
+      return buildShareMetadata({
+        title,
+        description,
+        url: recordUrl(handle, type, rkey),
+        image: ogImageFromField(value.image, did),
+        imageAlt: title,
+        ogType: "article",
+      })
+    }
+
+    // project / collection
+    const rawTitle =
+      (typeof value.title === "string" && value.title.trim()) ||
+      (typeof value.name === "string" && value.name.trim()) ||
+      ""
+    const title = rawTitle || "Project"
+    const description =
+      clampDescription(
+        (typeof value.shortDescription === "string" && value.shortDescription) ||
+          (typeof value.description === "string" && value.description) ||
+          undefined,
+      ) ?? `A project by ${byline}.`
+    return buildShareMetadata({
+      title,
+      description,
+      url: recordUrl(handle, type, rkey),
+      image: ogImageFromField(value.image, did),
+      imageAlt: title,
+      ogType: "article",
+    })
+  } catch {
+    return {}
+  }
+}


### PR DESCRIPTION
## Problem

Every shared link rendered the **same** generic Open Graph card — "Certified — Your identity, everywhere." with the hero image — regardless of what it pointed to. Profiles and activity/project records (the things users actually share) had no metadata of their own because those pages are client components and can't export `generateMetadata`.

## What this does

Adds server-side `generateMetadata` for the dynamic share targets via thin **passthrough layouts** (server components that just `return children`, so no DOM/visual change):

- **`/[actor]`** (`src/app/[actor]/layout.tsx`) — profile display name, `@handle`, bio, and avatar/banner as the OG image.
- **`/[actor]/{activity|project}/{rkey}`** (`src/app/[actor]/[type]/[rkey]/layout.tsx`) — record title, short description, and record image. Overrides the parent profile metadata for record routes.

Both resolve their data **server-side, unauthenticated**, against the target repo's own PDS:
- Profiles reuse `buildProfilePayload` from the existing `resolve-did` path.
- Records use a new `getRecordServer` helper (`src/lib/atproto/get-record-server.ts`) that mirrors the established `getCertsProfile` pattern (`resolvePdsUrl` → public `com.atproto.repo.getRecord`).
- All metadata building lives in `src/lib/og-metadata.ts`, which clamps descriptions to OG length, builds blob image URLs, and **falls back to the generic root metadata on any failure** (bad handle, missing record, unreachable PDS).

Also gives the public **`/explore`** and **`/apps`** pages their own complete `openGraph`/`twitter` blocks. (Next.js replaces `openGraph` wholesale at the deepest segment rather than deep-merging, so each redeclares `siteName` + image to avoid dropping them.)

## Scope notes

- Auth-gated personal pages (`/home`, `/settings`, `/notifications`, `/endorsements`, `/groups`) intentionally keep the default card — they aren't public share targets and their content is personalized.
- The static info/legal pages (`/about`, `/welcome`, `/help`, `/privacy`, `/terms`, `/dsa`, `/imprint`) already had specific OG and are unchanged.
- OG images reuse existing entity images (avatar/banner/record image); no dynamic OG-image generation (`ImageResponse`) was added — that's a possible follow-up for branded cards.

## Verification

- `npx tsc --noEmit` — clean.
- `npm run lint` — 66 warnings, identical to the `staging` baseline (0 added).
- `npm run build` — succeeds; both `/[actor]` and `/[actor]/[type]/[rkey]` build as dynamic (`ƒ`, server-rendered on demand), so `generateMetadata` runs per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)