### PR TITLE
fix(record-detail): mobile project title truncation + activity author row

### DIFF
--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -1439,10 +1439,20 @@
   overflow-wrap: anywhere;
 }
 
+/* Mobile: the byline is a flex (not grid) container, so the old
+   `grid-template-columns` rule was silently ignored. The 32px
+   horizontal gap + flex-wrap let the Author column wrap mid-cell,
+   splitting the avatar from the name/handle (reads as an icon bar
+   with a missing value). Stack the labelled columns vertically and
+   keep the author avatar + meta on one line. */
 @media (max-width: 799px) {
   .cert-detail__headline-cols {
-    grid-template-columns: 1fr;
+    flex-direction: column;
     gap: 12px;
+  }
+
+  .cert-detail__headline-author {
+    flex-wrap: nowrap;
   }
 }
 

--- a/src/app/styles/project-detail.css
+++ b/src/app/styles/project-detail.css
@@ -245,6 +245,28 @@
   }
 }
 
+/* Mobile: the Edit + Delete actions cluster starves the title's flex
+   basis in the single row, collapsing the nowrap+ellipsis title to a
+   single truncated letter. Stack the bar so the title gets the full
+   width above the actions, and let it wrap instead of ellipsizing. */
+@media (max-width: 799px) {
+  .project-detail__head-bar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .project-detail__head-actions {
+    margin-left: 0;
+  }
+
+  .project-detail__title {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+  }
+}
+
 .project-detail__lead {
   font-size: 1.0625rem;
   line-height: 1.55;


### PR DESCRIPTION
## What

Fixes two P0 mobile (<=799px) record-detail layout bugs.

### Bug 1 — Project title collapses to a single truncated letter
On a project page the head bar is a single flex row (title group + Edit/Delete actions cluster). On mobile the actions cluster starved the title group's flex basis; combined with the title's `white-space: nowrap` + `text-overflow: ellipsis` + `min-width: 0`, the title truncated to ~1 character.

**Fix:** at `@media (max-width: 799px)`, stack `.project-detail__head-bar` (`flex-direction: column; align-items: flex-start`) so the title gets full width above the actions, drop the actions cluster's `margin-left: auto`, and relax the title to wrap (`white-space: normal; overflow: visible; text-overflow: clip; overflow-wrap: anywhere`). Desktop/tablet unchanged.

### Bug 2 — Activity AUTHOR row broken (icon bar between label and missing value)
The cert-detail headline byline is a **flex** container, but its mobile rule set `grid-template-columns: 1fr` — an invalid declaration on a flex container, silently ignored. The 32px horizontal gap + `flex-wrap: wrap` let the Author column wrap mid-cell, splitting the avatar from the name/handle so it read as a stray icon bar with a missing value.

**Fix:** replace the invalid grid rule with valid flex CSS — at `@media (max-width: 799px)`, `.cert-detail__headline-cols { flex-direction: column; gap: 12px; }` (each labelled column stacks) and `.cert-detail__headline-author { flex-wrap: nowrap; }` so the avatar + name/handle stay on one line.

## Files changed
- `src/app/styles/project-detail.css`
- `src/app/styles/cert-detail.css`

## Test plan
- [ ] At 390px wide, project page title renders in full (wraps if long), no single-letter truncation
- [ ] At 390px wide, activity AUTHOR row shows the AUTHOR label with the author avatar + name/handle together on one line
- [ ] Desktop (>=1300px) and tablet (800-1299px) layouts unchanged
- [ ] Dark mode unaffected (no color changes)
- [x] `npm run lint` — 0 errors (66 warnings, baseline)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run typecheck:test` — clean
- [x] `npm test` — 605/605 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)