### PR TITLE
fix(dark-mode): restore contrast on landing trust section, legal wordmark, eyebrow & partner logos

### DIFF
--- a/src/app/styles/landing.css
+++ b/src/app/styles/landing.css
@@ -43,6 +43,12 @@
   margin-bottom: 24px;
 }
 
+/* Lift the eyebrow off the muted floor in dark mode so it clears AA on the
+   dark canvas (was reading as faint mid-gray). */
+:root[data-theme="dark"] .hero__label {
+  color: var(--fg-secondary);
+}
+
 .hero__title {
   font-family: var(--font-headline), 'Noto Serif', serif;
   color: var(--color-navy);
@@ -709,6 +715,13 @@
   opacity: 1;
 }
 
+/* Partner logos read as muted ghosts on the dark canvas at 0.7/grayscale(100%);
+   lift them so they stay legible in dark mode (full color still on hover). */
+:root[data-theme="dark"] .landing-network__logo {
+  filter: grayscale(45%);
+  opacity: 0.95;
+}
+
 .landing-network__name {
   font-family: var(--font-headline), 'Noto Serif', serif;
   font-size: 1.125rem;
@@ -963,11 +976,11 @@
 }
 
 .landing-faq-item {
-  border-bottom: 1px solid var(--color-light-gray);
+  border-bottom: 1px solid var(--border-default);
 }
 
 .landing-faq-item:first-child {
-  border-top: 1px solid var(--color-light-gray);
+  border-top: 1px solid var(--border-default);
 }
 
 .landing-faq-btn {
@@ -1245,7 +1258,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: rgba(255, 255, 255, 0.4);
+  /* Theme-aware so it flips with the --color-navy/--color-off-white band
+     (was pinned rgba(255,255,255,.4) → invisible on the flipped light panel
+     in dark mode). */
+  color: var(--color-off-white);
+  opacity: 0.5;
 }
 
 .landing-trust__item h4 {
@@ -1258,7 +1275,10 @@
 .landing-trust__item p {
   font-size: 0.9375rem;
   line-height: 1.6;
-  color: rgba(255, 255, 255, 0.5);
+  /* Theme-aware (see __check above): flips with the band instead of staying
+     white-on-near-white in dark mode. */
+  color: var(--color-off-white);
+  opacity: 0.72;
   margin: 0;
 }
 

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -1679,6 +1679,12 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   display: block;
 }
 
+/* Source SVG is pure black; flip via CSS filter in dark mode so the wordmark
+   stays visible on legal/marketing pages (mirrors .site-footer__wordmark). */
+:root[data-theme="dark"] .desktop-top-bar__wordmark {
+  filter: invert(1);
+}
+
 .desktop-top-bar__brand:hover {
   opacity: 0.85;
 }


### PR DESCRIPTION
## What
Dark-mode contrast fixes from a full visual audit of `staging.certified.app`.

| Fix | Severity |
|-----|----------|
| "Built for trust" section text/checks → theme-aware tokens (were pinned `rgba(255,255,255,…)` → invisible on the flipped panel in dark mode) | critical ×3 |
| Top-bar "Certified" wordmark → `filter: invert(1)` in dark (mirrors footer wordmark); was invisible on legal/marketing pages | high ×2 |
| Hero eyebrow lifted to `--fg-secondary` in dark; partner-app logos lifted from grayscale ghosts; FAQ separators → `--border-default` | medium/low |

## Why
The trust band flips light↔dark via the theme-aware `--color-navy`/`--color-off-white` tokens, but its inner body text used pinned white `rgba`, so it stayed white-on-near-white (illegible) in dark mode. The `h4` already used the theme-aware token and was fine — this brings the rest in line.

## Test plan
- [x] `npm run lint` — 0 errors (66 warnings, baseline)
- [x] `npx tsc --noEmit` — clean
- [x] `npx tsc --noEmit -p tsconfig.test.json` — clean
- [x] Local dev verify in **both** themes: trust text resolves dark on the dark-mode panel (was white), wordmark inverts, light mode unchanged
- [ ] CI green
- [ ] Vercel preview spot-check `/welcome` + `/terms` in dark mode

CSS-only; no behavior change. Scope: `src/app/styles/landing.css`, `src/app/styles/layout.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)