### PR TITLE
fix(a11y): single h1 per page, alt text on shared images, larger dismiss tap targets

### DIFF
--- a/src/app/styles/feed.css
+++ b/src/app/styles/feed.css
@@ -1158,8 +1158,15 @@
 .endorsement-row__revoke {
   background: transparent;
   border: 1px solid transparent;
-  color: var(--fg-muted);
+  /* --fg-secondary (not --fg-muted) so the icon-only control clears the
+     contrast bar without a visible label; hover lifts it to --fg-primary. */
+  color: var(--fg-secondary);
   border-radius: var(--radius);
+  /* ≥44×44 hit area on every viewport (the icon stays 16px). The
+     <=799px media block already enforced this on touch; promote it to
+     the base rule so desktop pointers get the same target. */
+  min-width: 44px;
+  min-height: 44px;
   padding: 6px;
   cursor: pointer;
   display: inline-flex;
@@ -1669,8 +1676,12 @@
   background: transparent;
   border: none;
   cursor: pointer;
+  /* ≥44×44 hit area on every viewport (the X icon stays 14px); higher
+     resting contrast via --fg-secondary, hover lifts to --fg-primary. */
+  min-width: 44px;
+  min-height: 44px;
   padding: 4px;
-  color: var(--fg-muted);
+  color: var(--fg-secondary);
   border-radius: var(--radius);
   display: inline-flex;
   align-items: center;

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -395,7 +395,7 @@ export default function DesktopTopBar() {
             )}
           </Link>
           {breadcrumb ? (
-            <h1 className="desktop-top-bar__title" aria-live="polite">
+            <div className="desktop-top-bar__title" aria-live="polite">
               <Link href={breadcrumb.left.href} className="desktop-top-bar__title-part">
                 {breadcrumb.left.text}
               </Link>
@@ -407,9 +407,9 @@ export default function DesktopTopBar() {
                   </Link>
                 </>
               ) : null}
-            </h1>
+            </div>
           ) : pageTitle ? (
-            <h1 className="desktop-top-bar__title" aria-live="polite">{pageTitle}</h1>
+            <div className="desktop-top-bar__title" aria-live="polite">{pageTitle}</div>
           ) : null}
         </div>
 

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -379,7 +379,7 @@ const Navbar: React.FC = () => {
               </Tooltip>
             )}
           </div>
-          <div className="navbar__title" role="heading" aria-level={1}>
+          <div className="navbar__title">
             {breadcrumb ? (
               <>
                 <Link href={breadcrumb.left.href} className="navbar__title-part">


### PR DESCRIPTION
## What

Accessibility & semantics pass (P1):

1. **Single `<h1>` per page (systemic).** Both top-bar chromes rendered the page title as a top-level heading on top of each page's own `<h1>`, so every titled app page carried two h1s in the accessibility tree:
   - `navbar.tsx` (mobile): removed `role="heading"` + `aria-level={1}` from the title row — it is now a plain styled label.
   - `desktop-top-bar.tsx` (≥800px): the title is now a `<div>` (keeps `aria-live="polite"` for title-change announcements) instead of an `<h1>`.

   With the chrome title demoted, each titled page is left with exactly **one** h1 — its own page heading. Verified for: apps, groups (Membership), profile / org profile, settings (standalone + group settings), help, edit-profile, record/activity detail. The mobile vs. desktop profile identity blocks (`profile-header` vs. `profile-sidebar`) are a `display:none` responsive pair, so only one is ever in the a11y tree.

2. **Alt text on shared images.** Audited every `<img>`/`<Image>` in `src/` (multiline-aware): all already render an `alt`. The shared `Avatar` (`ui/avatar.tsx`) already defaults `alt=""` and always emits the attribute; the apps-store logo (`apps/page.tsx`) correctly uses decorative `alt=""` with an `aria-label`ed link. No regression-inducing changes were needed here; the `.connected-apps__logo` selector the audit referenced no longer exists in the codebase.

3. **Dismiss tap targets + contrast.** `.endorsement-row__revoke` and `.endorsement-multi-row__remove` only got a 44×44 hit area below 800px. Promoted `min-width`/`min-height: 44px` to the base rule so desktop pointers get the same target, and raised the resting icon color from `--fg-muted` to `--fg-secondary` (hover still lifts to `--fg-primary`).

## Why

WCAG: one h1 per document, perceivable icon-only controls (contrast + 44×44 target). The duplicate-h1 was systemic across all titled pages because it originated in shared chrome.

## Out of scope

`home-feed.tsx` bare thumbnail `<img>`, `notifications-context.tsx`, layout/landing CSS, and record-detail components are owned by other agents.

## Test plan

- [x] `npm run lint` — 0 errors, 66 warnings (unchanged from baseline)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run typecheck:test` — clean
- [x] `npm test` — 605 passed
- [x] CLAUDE.md UI guards (radii / breakpoints / legal headings / hand-rolled modals) — all clean
- [ ] Visual spot-check: navbar + desktop top-bar titles render identically; endorsement revoke/remove buttons are larger & higher-contrast; dark mode flip intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)