### PR TITLE
feat(public): render public views for /endorsements and /groups (no anonymous redirect to landing)

### DIFF
--- a/src/app/__tests__/public-endorsements-groups.test.tsx
+++ b/src/app/__tests__/public-endorsements-groups.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, cleanup } from "@testing-library/react"
+
+/**
+ * P1: /endorsements and /groups used to redirect anonymous (signed-out)
+ * visitors to /welcome via the route-level <AuthGuard>. That guard was
+ * removed; instead each page renders a public sign-in prompt in place.
+ *
+ * Both pages are personal, owner-scoped surfaces (a personal inbox and
+ * the viewer's own membership list, keyed on the viewer's DID), so there
+ * is no public listing to show — the "best available public view" is an
+ * explanation + a sign-in CTA. These tests pin that:
+ *   - signed-out renders the prompt (no crash, no error state),
+ *   - the CTA invokes the shared openSignIn() flow,
+ *   - signed-in still renders the real management UI.
+ *
+ * The shared SignedOutPrompt lets us assert one openSignIn() spy across
+ * both routes.
+ */
+
+const openSignIn = vi.fn().mockResolvedValue(undefined)
+const replace = vi.fn()
+
+let authState: {
+  did: string | null
+  isAuthenticated: boolean
+  isLoading: boolean
+}
+
+vi.mock("@/lib/auth/auth-context", () => ({
+  useAuth: () => ({ ...authState, openSignIn }),
+}))
+
+vi.mock("@/lib/navbar-context", () => ({
+  usePageTitle: () => undefined,
+}))
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useRouter: () => ({ replace, push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(""),
+}))
+
+// --- /groups dependencies -------------------------------------------------
+vi.mock("@/lib/groups/org-context", () => ({
+  useOrg: () => ({
+    activeOrg: null,
+    groups: [],
+    isLoading: false,
+    switchOrg: vi.fn(),
+    refetchOrgs: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+vi.mock("@/lib/groups/api", () => ({
+  putMembership: vi.fn().mockResolvedValue(undefined),
+  deleteMembership: vi.fn().mockResolvedValue(undefined),
+  removeOrgMember: vi.fn().mockResolvedValue(undefined),
+}))
+
+// --- /endorsements dependencies ------------------------------------------
+vi.mock("@/hooks/use-endorsements", () => ({
+  useGivenEndorsements: () => ({
+    endorsements: [],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+vi.mock("@/hooks/use-received-endorsements", () => ({
+  useReceivedEndorsements: () => ({
+    endorsements: [],
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+vi.mock("@/hooks/use-own-response-states", () => ({
+  useOwnResponseStates: () => ({
+    resolve: () => ({ state: null }),
+    invalidate: vi.fn(),
+    refetch: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+beforeEach(() => {
+  cleanup()
+  openSignIn.mockClear()
+  replace.mockClear()
+  authState = { did: null, isAuthenticated: false, isLoading: false }
+})
+
+describe("/endorsements public view (signed out)", () => {
+  it("renders the sign-in prompt instead of redirecting", async () => {
+    const { default: EndorsementsPage } = await import("../endorsements/page")
+    render(<EndorsementsPage />)
+
+    expect(screen.getByText("Sign in to see your endorsements")).toBeTruthy()
+    // No redirect was issued for the anonymous visitor.
+    expect(replace).not.toHaveBeenCalled()
+  })
+
+  it("invokes openSignIn when the CTA is clicked", async () => {
+    const { default: EndorsementsPage } = await import("../endorsements/page")
+    render(<EndorsementsPage />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }))
+    expect(openSignIn).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders the real Endorsements UI when authenticated", async () => {
+    authState = { did: "did:plc:me", isAuthenticated: true, isLoading: false }
+    const { default: EndorsementsPage } = await import("../endorsements/page")
+    render(<EndorsementsPage />)
+
+    // The management UI (tabs) renders; no sign-in prompt.
+    expect(screen.queryByText("Sign in to see your endorsements")).toBeNull()
+    expect(screen.getByRole("tab", { name: "Given" })).toBeTruthy()
+  })
+})
+
+describe("/groups public view (signed out)", () => {
+  it("renders the sign-in prompt instead of redirecting", async () => {
+    const { default: GroupsPage } = await import("../../app/groups/page")
+    render(<GroupsPage />)
+
+    expect(screen.getByText("Sign in to see your groups")).toBeTruthy()
+    expect(replace).not.toHaveBeenCalled()
+  })
+
+  it("invokes openSignIn when the CTA is clicked", async () => {
+    const { default: GroupsPage } = await import("../../app/groups/page")
+    render(<GroupsPage />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }))
+    expect(openSignIn).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders the real Groups UI when authenticated", async () => {
+    authState = { did: "did:plc:me", isAuthenticated: true, isLoading: false }
+    const { default: GroupsPage } = await import("../../app/groups/page")
+    render(<GroupsPage />)
+
+    expect(screen.queryByText("Sign in to see your groups")).toBeNull()
+    expect(screen.getByRole("heading", { name: "Membership" })).toBeTruthy()
+  })
+})

--- a/src/app/endorsements/layout.tsx
+++ b/src/app/endorsements/layout.tsx
@@ -1,15 +1,17 @@
 import type { Metadata } from "next"
-import AuthGuard from "@/components/layout/auth-guard"
 
 export const metadata: Metadata = {
   title: "Endorsements",
   description: "Endorsements you've received and given on Certified.",
 }
 
+// No AuthGuard here: anonymous visitors render a public sign-in prompt
+// (see EndorsementsPage) instead of being redirected to /welcome. The
+// page itself gates its personal, owner-scoped content on the session.
 export default function EndorsementsLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  return <AuthGuard>{children}</AuthGuard>
+  return <>{children}</>
 }

--- a/src/app/endorsements/layout.tsx
+++ b/src/app/endorsements/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { Suspense } from "react"
 
 export const metadata: Metadata = {
   title: "Endorsements",
@@ -8,10 +9,18 @@ export const metadata: Metadata = {
 // No AuthGuard here: anonymous visitors render a public sign-in prompt
 // (see EndorsementsPage) instead of being redirected to /welcome. The
 // page itself gates its personal, owner-scoped content on the session.
+//
+// The page is a client component that reads useSearchParams() at the top
+// level. With AuthGuard gone it enters the static prerender path and would
+// fail the Next 16 CSR-bailout check, so force the route dynamic and provide
+// a Suspense boundary here (same pattern as /explore) — there is nothing
+// static to prerender for this viewer-personalised view anyway.
+export const dynamic = "force-dynamic"
+
 export default function EndorsementsLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  return <>{children}</>
+  return <Suspense fallback={null}>{children}</Suspense>
 }

--- a/src/app/endorsements/page.tsx
+++ b/src/app/endorsements/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { profileUrl } from "@/lib/urls"
 import Link from "next/link"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
-import { Plus } from "lucide-react"
+import { Plus, Award } from "lucide-react"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useOrg } from "@/lib/groups/org-context"
 import { usePageTitle } from "@/lib/navbar-context"
@@ -22,6 +22,7 @@ import Avatar from "@/components/ui/avatar"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import ErrorMessage from "@/components/ui/error-message"
 import Skeleton from "@/components/ui/skeleton"
+import SignedOutPrompt from "@/components/layout/signed-out-prompt"
 import { formatShortDate } from "@/lib/utils/format-date"
 import { getInitials } from "@/lib/utils/initials"
 
@@ -211,7 +212,7 @@ const DEFAULT_TAB: TabKey = "given"
 
 export default function EndorsementsPage() {
   usePageTitle("Endorsements")
-  const { did } = useAuth()
+  const { did, isLoading: authLoading, isAuthenticated } = useAuth()
   const { activeOrg } = useOrg()
 
   // Tab state lives in `?tab=<key>` on the URL so refresh / shared
@@ -306,6 +307,40 @@ export default function EndorsementsPage() {
       setRevokingRkey(null)
     }
   }, [did, confirmRkey, refetch])
+
+  // Anonymous visitors used to be redirected to /welcome by AuthGuard.
+  // /endorsements is a personal inbox keyed on the viewer's own DID —
+  // there's no public listing to render — so we show a public sign-in
+  // prompt in place instead of bouncing. Wait for auth to resolve first
+  // so signed-in users never flash the prompt.
+  if (authLoading) {
+    return (
+      <div className="dashboard">
+        <div className="dashboard__body dashboard__body--single">
+          <div className="dashboard__main">
+            <div className="endorsements-loading">
+              <LoadingSpinner size="md" />
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+  if (!isAuthenticated) {
+    return (
+      <div className="dashboard">
+        <div className="dashboard__body dashboard__body--single">
+          <div className="dashboard__main">
+            <SignedOutPrompt
+              icon={Award}
+              title="Sign in to see your endorsements"
+              description="Endorsements you've received and given live here once you sign in to Certified."
+            />
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="dashboard">

--- a/src/app/groups/layout.tsx
+++ b/src/app/groups/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { Suspense } from "react"
 
 export const metadata: Metadata = {
   title: "Groups",
@@ -8,10 +9,17 @@ export const metadata: Metadata = {
 // No AuthGuard here: anonymous visitors render a public sign-in prompt
 // (see GroupsPage) instead of being redirected to /welcome. The page
 // itself gates its personal, owner-scoped membership list on the session.
+//
+// The page is a client component that reads useSearchParams() at the top
+// level. With AuthGuard gone it enters the static prerender path and would
+// fail the Next 16 CSR-bailout check, so force the route dynamic and provide
+// a Suspense boundary here (same pattern as /explore).
+export const dynamic = "force-dynamic"
+
 export default function GroupsLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  return <>{children}</>
+  return <Suspense fallback={null}>{children}</Suspense>
 }

--- a/src/app/groups/layout.tsx
+++ b/src/app/groups/layout.tsx
@@ -1,15 +1,17 @@
 import type { Metadata } from "next"
-import AuthGuard from "@/components/layout/auth-guard"
 
 export const metadata: Metadata = {
   title: "Groups",
   description: "Organizations you're a member of on Certified.",
 }
 
+// No AuthGuard here: anonymous visitors render a public sign-in prompt
+// (see GroupsPage) instead of being redirected to /welcome. The page
+// itself gates its personal, owner-scoped membership list on the session.
 export default function GroupsLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  return <AuthGuard>{children}</AuthGuard>
+  return <>{children}</>
 }

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useState, useMemo } from "react"
 import Link from "next/link"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
-import { Plus } from "lucide-react"
+import { Plus, Users } from "lucide-react"
 import { useOrg } from "@/lib/groups/org-context"
 import { useAuth } from "@/lib/auth/auth-context"
 import { usePageTitle } from "@/lib/navbar-context"
@@ -19,6 +19,7 @@ import Badge from "@/components/ui/badge"
 import Button from "@/components/ui/button"
 import ConfirmDialog from "@/components/ui/confirm-dialog"
 import { Tabs, TabList, Tab, TabPanel } from "@/components/ui/tabs"
+import SignedOutPrompt from "@/components/layout/signed-out-prompt"
 import { getInitials } from "@/lib/utils/initials"
 
 type TabKey = "public" | "private"
@@ -35,7 +36,7 @@ const ROLE_ORDER: Record<string, number> = { owner: 0, admin: 1, member: 2 }
 export default function GroupsPage() {
   usePageTitle("Groups")
   const { groups, isLoading, refetchOrgs } = useOrg()
-  const { did } = useAuth()
+  const { did, isLoading: authLoading, isAuthenticated } = useAuth()
 
   // Tab state lives in `?tab=<key>` so refresh keeps the user on the
   // same view. Public is the default and stays bare in the URL.
@@ -213,6 +214,40 @@ export default function GroupsPage() {
       )
     }
     return <div className="org-list__items">{visibleOrgs.map(renderOrgItem)}</div>
+  }
+
+  // Anonymous visitors used to be redirected to /welcome by AuthGuard.
+  // /groups lists the viewer's OWN memberships (keyed on their DID) —
+  // there's no public listing to render — so we show a public sign-in
+  // prompt in place instead of bouncing. Wait for auth to resolve first
+  // so signed-in users never flash the prompt.
+  if (authLoading) {
+    return (
+      <div className="dashboard">
+        <div className="dashboard__body dashboard__body--single">
+          <div className="dashboard__main">
+            <div className="org-list__loading">
+              <LoadingSpinner size="md" />
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+  if (!isAuthenticated) {
+    return (
+      <div className="dashboard">
+        <div className="dashboard__body dashboard__body--single">
+          <div className="dashboard__main">
+            <SignedOutPrompt
+              icon={Users}
+              title="Sign in to see your groups"
+              description="Organizations you're a member of on Certified appear here once you sign in."
+            />
+          </div>
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/src/components/layout/signed-out-prompt.tsx
+++ b/src/components/layout/signed-out-prompt.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import React from "react"
+import { useAuth } from "@/lib/auth/auth-context"
+import EmptyState, { type EmptyStateIcon } from "@/components/ui/empty-state"
+import Button from "@/components/ui/button"
+
+export interface SignedOutPromptProps {
+  /** Lucide / CertIcon-shaped icon shown above the headline. */
+  icon?: EmptyStateIcon
+  /** Headline, e.g. "Sign in to see your endorsements". */
+  title: string
+  /** One-line explanation of what lives behind sign-in. */
+  description: string
+  /** Sign-in button label. Defaults to "Sign in". */
+  ctaLabel?: string
+}
+
+/**
+ * Public placeholder for personal, owner-scoped surfaces (e.g.
+ * /endorsements, /groups) when the visitor is signed out. These pages
+ * have no public listing to render — the data is keyed on the viewer's
+ * own DID — so instead of bouncing anonymous visitors to /welcome we
+ * render an explanation plus a sign-in affordance in place.
+ *
+ * Wraps the `EmptyState` primitive and the shared `openSignIn` flow so
+ * every "this surface needs a session" prompt reads identically.
+ */
+export default function SignedOutPrompt({
+  icon,
+  title,
+  description,
+  ctaLabel = "Sign in",
+}: SignedOutPromptProps) {
+  const { openSignIn } = useAuth()
+  return (
+    <EmptyState icon={icon} title={title} description={description}>
+      <Button variant="primary" size="md" onClick={() => void openSignIn()}>
+        {ctaLabel}
+      </Button>
+    </EmptyState>
+  )
+}


### PR DESCRIPTION
## What & why

Anonymous (signed-out) visitors to `/endorsements` and `/groups` were redirected to the marketing landing (`/welcome`) by the route-level `<AuthGuard>` in each route's `layout.tsx`. The owner wants these to render a **public view** instead of bouncing.

## How the gate was removed

`<AuthGuard>` (which does `router.replace("/")` → `/welcome` for anonymous users) is removed from both `src/app/endorsements/layout.tsx` and `src/app/groups/layout.tsx`. Both layouts now render `children` directly. `AuthGuard` itself is untouched and still used by `/settings` (out of scope).

There is no middleware gate and `AppShell` renders children regardless of auth, so removing the layout guard is sufficient — the page itself now decides what to show.

## How the anonymous state is handled

Both routes are **personal, owner-scoped surfaces**, not public listings:
- `/endorsements` is the viewer's own given/received inbox (`useGivenEndorsements(did)`, `useReceivedEndorsements(did)`) with owner-only actions (create / revoke / accept / reject).
- `/groups` lists the viewer's own memberships (`useOrg().groups`) with owner-only actions (leave / make public/private / accept).

All of these are keyed on the viewer's DID, so **there is no genuinely public listing to render** for an anonymous visitor. Per the task's "best available public view" fallback, each page now renders a public explanation + a sign-in CTA in place:

- New shared `SignedOutPrompt` component (`src/components/layout/signed-out-prompt.tsx`) wraps the existing `EmptyState` primitive + a primary `Button` wired to the shared `openSignIn()` flow (CLAUDE.md rule 10 — reach for a primitive). No new CSS / BEM classes; no token/radius/breakpoint/heading rules touched.
- Each page gates on auth: while `isLoading`, show a spinner (so signed-in users never flash the prompt); when resolved and `!isAuthenticated`, render the `SignedOutPrompt`; otherwise the unchanged authenticated UI.
- The data hooks already no-op safely with a null DID (empty lists, `isLoading: false`, no error), so nothing throws for anonymous users — no crash, no error state.

The authenticated experience is unchanged (the early returns sit after all top-level hooks, before the existing `return`, so hook order is preserved).

### Limitation (noted per task)
These two surfaces have **no public data** to display — they are inherently the signed-in viewer's own inbox / membership list. The "public view" is therefore the explanation + sign-in CTA rather than a public data listing. If a public listing is desired in future, it would need new public/anonymous-fetchable data (e.g. an org directory), which is out of scope here.

## Test changes

No existing test asserted the anonymous redirect for these routes (no `auth-guard` test exists), so none needed updating. Added `src/app/__tests__/public-endorsements-groups.test.tsx` (6 tests) pinning the new behavior:
- signed-out renders the prompt and does **not** call `router.replace` (no redirect),
- the CTA invokes `openSignIn()`,
- signed-in still renders the real management UI (Endorsements tabs / "Membership" heading).

## Test plan

- [x] `npm run lint` — 0 errors (66 pre-existing warnings, none from changed files)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run typecheck:test` — clean
- [x] `npm test` — 611 passed / 84 files (was 605/83; +6 new tests)
- [x] CLAUDE.md UI checks (radii / breakpoints / legal headings) — all clean (no CSS added)
- [ ] Manual: visit `/endorsements` and `/groups` signed out → public sign-in prompt, no redirect; signed in → unchanged

## Out of scope (owned by other agents)

navbar, avatar, home-feed, notifications, record-detail, global layout/landing CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)