### PR TITLE
fix(mobile): reserve fixed bottom-nav clearance for content, footers & sticky action bars

### DIFF
--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -3093,6 +3093,22 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   color: var(--fg-muted);
 }
 
+/* The footer is the document's bottommost element on every page and
+   sits OUTSIDE `.app-shell__content` (it's a grid sibling), so the
+   shell's own bottom-nav padding doesn't reach it. On mobile the fixed
+   `.bottom-nav` (z-index --z-bottom-nav) would otherwise overlap the
+   wordmark + copyright when the page is scrolled to its bottom. Fold the
+   bar height (+ the iOS safe-area inset) into the footer's bottom padding
+   so the last footer line always clears the nav. `--bottom-nav-height`
+   is 0px at ≥800px, so this collapses back to the base 24px on desktop. */
+@media (max-width: 799px) {
+  .site-footer {
+    padding-bottom: calc(
+      var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px) + 24px
+    );
+  }
+}
+
 .site-footer__row {
   display: flex;
   align-items: center;

--- a/src/app/styles/profile-edit.css
+++ b/src/app/styles/profile-edit.css
@@ -16,9 +16,12 @@
 .pe {
   display: flex;
   flex-direction: column;
-  /* Reserve room at the bottom for the sticky footer so the last
-     section never hides under it. */
-  padding: 0 0 96px;
+  /* Reserve room at the bottom for the sticky footer so the last section
+     never hides under it. The footer pins above the fixed mobile bottom
+     nav, so the reserve folds in `--bottom-nav-height` (+ safe-area) too —
+     both are 0px at ≥800px, leaving the original 96px on desktop. */
+  padding: 0 0
+    calc(96px + var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px));
 }
 
 .pe__loading {
@@ -291,13 +294,18 @@
    ------------------------------------------------------------------------ */
 .pe__footer {
   position: sticky;
-  bottom: 0;
+  /* Pin the bar ABOVE the fixed mobile bottom nav rather than flush to the
+     viewport bottom — otherwise it sticks under the bar (z-index 50 > 5) and
+     the Save/Cancel row is half-hidden. `--bottom-nav-height` is 0px at
+     ≥800px, so on desktop this resolves to the original `bottom: 0`
+     (+ safe-area, which is also 0px there). */
+  bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px));
   /* Negative side margins so the footer reaches the column's full width
      even though the form content sits inside the 32px column padding.
      The inner row re-applies the side padding so the buttons line up
      with the fields above. */
   margin: 24px -32px 0;
-  padding: 12px 32px calc(env(safe-area-inset-bottom, 0px) + 12px);
+  padding: 12px 32px;
   background: var(--bg-default);
   border-top: 1px solid var(--border-subtle);
   /* A subtle blur so content scrolling under the footer doesn't read as


### PR DESCRIPTION
## What

On mobile (<800px) the fixed bottom tab bar (`.bottom-nav`, `position: fixed; bottom: 0; z-index: var(--z-bottom-nav) = 50`) overlapped two surfaces that nothing was reserving space for:

1. **Global SiteFooter** — it's the document's bottommost element on every page and renders **outside** `.app-shell__content`, so the shell's existing bottom-nav padding (`calc(--bottom-nav-height + safe-area + 24px)`) never reached it. Scrolled to the page bottom, the wordmark/copyright was overlapped and the entire footer link row (About / Terms / Privacy / Imprint / Feedback) was hidden behind the nav.
2. **Edit-profile sticky Save/Cancel bar** (`.pe__footer`) — it was `position: sticky; bottom: 0`, so it stuck flush to the viewport bottom **under** the fixed nav (z-index 5 < 50), half-hiding the action row.

## Why / approach

The smallest systemic fix, reusing existing tokens:

- **`.site-footer`** (`layout.css`): at `@media (max-width: 799px)`, fold `var(--bottom-nav-height) + env(safe-area-inset-bottom)` into the footer's `padding-bottom`. Because SiteFooter renders on every non-`/welcome` page, this single rule clears the nav for **all** affected pages at once — legal (imprint/terms/dsa/privacy/about), settings, workspace, explore, help, org and record pages — without per-page hacks.
- **`.pe__footer`** (`profile-edit.css`): change `bottom: 0` → `bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom))` so the sticky bar floats above the nav, and grow the `.pe` bottom reserve by the same amount so the last field still clears the bar.

`--bottom-nav-height` is `0px` at ≥800px, so every `calc(...)` collapses to the original desktop value — **desktop layout is unchanged** (no-op).

Pages rendered inside `.app-shell__content` already get clearance from the shell padding (unchanged); the gap was the footer + the sticky bar.

## Pages affected (before → after)

Every page that renders the global footer on mobile. Verified visually at 390px (light + dark) on `/imprint`, `/terms`, `/dsa`: before, the footer brandmark + link row were hidden behind the nav; after, the full footer sits cleanly above it.

## Out of scope

- `.app-page { min-height: 100vh }` (an orphan from the pre-refactor min-height chain) is also redefined in `landing.css`, which is owned by another PR and wins the cascade — left untouched. It only produces extra whitespace, not the overlap; the footer fix resolves the P0.
- `bottom-sheet` / `toast` overlays correctly sit above the nav by design (z > 50) — untouched.

## Test plan

- [x] `npm run lint` — 0 errors (66 warnings, all pre-existing in `.tsx`/`.ts`; CSS-only change adds none)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run typecheck:test` — clean
- [x] `npm test` — 605 passed / 83 files
- [x] Hard-rule checks (radii, breakpoints) silent on changed files
- [x] Visual proof at 390px on `/imprint` `/terms` `/dsa` (light + dark): footer clears the fixed nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)