### PR TITLE
fix(responsive): balanced tablet grids, profile/org stat-card labels, legal width, create field order, truncation

### DIFF
--- a/src/app/styles/landing.css
+++ b/src/app/styles/landing.css
@@ -1225,6 +1225,15 @@
   max-width: 1200px;
 }
 
+/* Tablet band (800–1099): three columns squeeze the check + heading + copy too
+   tightly, so step down to two so each item keeps a readable measure. */
+@media (min-width: 800px) and (max-width: 1099px) {
+  .landing-trust {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 28px;
+  }
+}
+
 @media (max-width: 799px) {
   .landing-trust {
     grid-template-columns: 1fr;
@@ -1278,11 +1287,13 @@
   gap: 12px;
 }
 
-/* Canonical breakpoints (was 600px / 900px): single column on mobile, two at
-   the 800px desktop step, the full five-up at 1100px. */
+/* Canonical breakpoints (was 600px / 900px): single column on mobile, three at
+   the 800px tablet step, the full five-up at 1100px. Three columns avoids the
+   orphaned lone cell a two-column grid leaves with five tiles (2x3 with an empty
+   trailing slot) across the 800–1099 tablet band. */
 @media (min-width: 800px) {
   .network-stats__grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -1997,6 +1997,24 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   min-width: 0;
 }
 
+/* /create mobile field order. The create form reuses the cert-detail two-pane
+   shell: in source order the metadata <aside> comes first and the Title/
+   description main pane second (so desktop can explicit-place the aside in
+   column 2). On mobile `.page-layout` collapses to a single grid column and
+   honours source order, which stacked the metadata sidebar ABOVE the Title.
+   Re-order so the primary Title/description main pane leads and the metadata
+   sidebar follows. Scoped to `.create-cert` so the cert-detail read view is
+   untouched; only applies below the 800px desktop breakpoint where no explicit
+   grid placement is set. */
+@media (max-width: 799px) {
+  .create-cert.page-layout > .page-layout__main {
+    order: 0;
+  }
+  .create-cert.page-layout > .cert-detail__aside {
+    order: 1;
+  }
+}
+
 /* ---------- Identity sidebar ---------- */
 
 .profile-sidebar {
@@ -2455,6 +2473,15 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   gap: 8px;
 }
 
+/* On mobile three equal columns squeeze each card so the uppercase
+   letter-spaced labels ("ENDORSEMENTS") and sub-rows clip; drop to a single
+   column so each stat keeps its full label + value rows. */
+@media (max-width: 799px) {
+  .profile-overview__stats {
+    grid-template-columns: 1fr;
+  }
+}
+
 .profile-overview__stat {
   display: flex;
   flex-direction: column;
@@ -2479,6 +2506,13 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--fg-muted);
+  /* Keep the uppercase letter-spaced label on one line so the tablet column
+     width doesn't break it mid-word ("ENDORSE MENTS"); ellipsize if it still
+     overflows rather than wrapping. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .profile-overview__stat-split {
@@ -2505,6 +2539,9 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   font-size: 0.75rem;
   color: var(--fg-muted);
   letter-spacing: 0.01em;
+  /* Keep the descriptor ("created"/"received"/…) whole — at tablet widths the
+     split row was breaking it mid-word ("crea ted"/"recei ved"). */
+  white-space: nowrap;
 }
 
 /* ---------- About section ---------- */

--- a/src/app/styles/settings-page.css
+++ b/src/app/styles/settings-page.css
@@ -61,6 +61,17 @@
   padding: 0;
 }
 
+/* Mobile: the navbar is `position: fixed` (64px) and overlays the content
+   slot, so zeroing the slot's padding above slid the section-nav under the
+   navbar and clipped its top. The desktop top bar sits in normal flow, so this
+   clearance is only needed below the 800px breakpoint. `.page-layout`'s own
+   24px top padding then adds the breathing gap below the navbar. */
+@media (max-width: 799px) {
+  .app-shell:has(.sx) .app-shell__content {
+    padding-top: var(--navbar-height);
+  }
+}
+
 @media (min-width: 800px) {
   .app-shell:has(.sx) .app-shell__content {
     max-width: 1280px;


### PR DESCRIPTION
## What & why

Tablet/mobile responsive polish across the landing and app surfaces. All changes are **CSS-only** and scoped so the >=1300px desktop baseline is unchanged. Breakpoints stay on the canonical 800/1100/1300 grid.

### 1. Landing network-stats band — tablet orphan (`landing.css`)
The grid jumped `repeat(2,…)` at 800px to `repeat(5,…)` at 1100px, so five tiles formed an unbalanced 2x3 with an orphaned lone cell on the 800–1099 tablet band. Added a 3-column step for that band so the five tiles read as a balanced 3+2 grid (no lone orphan).

### 2. Landing "Built for trust" — cramped on tablet (`landing.css`)
Only had desktop (3-col) + mobile (1-col) rules; three columns squeezed the check + heading + copy at tablet. Added an 800–1099 two-column step with a readable measure.

### 3. Profile **and org** stat cards (`layout.css`)
`.profile-overview__stats` (shared by person and org profiles) was `repeat(3, …)` with no mobile override, clipping the uppercase letter-spaced labels on mobile. Dropped to a single column below 800px. Also kept the label and descriptor sub-rows on one line (`white-space: nowrap`, ellipsis fallback) so they no longer break mid-word ("ENDORSE MENTS" / "crea ted" / "recei ved") at tablet. This single component covers both the personal-profile and org-profile stat cards, so item 5 (org) is handled by the same fix.

### 4. Settings section nav clipped at top on mobile (`settings-page.css`)
The settings page zeroes `.app-shell__content` padding so the page frame meets flush, but on mobile the fixed 64px navbar then overlaid and clipped the top of the nav. Restored `padding-top: var(--navbar-height)` below 800px only (the desktop top bar is in normal flow and needs no clearance).

### 5. /create mobile field order inverted (`layout.css`)
The create form reuses the cert-detail two-pane shell (metadata `<aside>` first in source order so desktop can explicit-place it in column 2). On mobile the single-column grid honoured source order and stacked the metadata sidebar ABOVE the Title. Re-ordered with `order` (scoped to `.create-cert`, mobile only) so Title/description lead. Desktop grid placement is untouched.

### Items already satisfied on the current `staging` base
- **Legal/long-form width + mobile type (item 3):** Verified with Playwright at 390/820/1366/1500/1920px — the about/privacy/dsa/imprint pages are already capped at a centered 880px reading column (`.app-shell:has(.legal-page)`), body copy is already 16px on mobile, and headings already scale down below 800px. No change needed.
- **Aggressive truncation on explore/home/endorsements (item 8):** Audited explore.css, home.css, feed.css, profile-endorsements.css — the truncation chains already use `min-width: 0` + `text-overflow: ellipsis` / `max-width: 100%` throughout, so titles/handles ellipsis correctly rather than collapsing. No regression reproducible; left as-is to avoid speculative churn.

## Test plan
- [x] `npm run lint` — 0 errors (66 pre-existing warnings, none from these CSS-only changes)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run typecheck:test` — clean
- [x] `npm test` — 605 passed (83 files)
- [x] Playwright at 390/900/1366px: network-stats grid resolves 1/3/5 cols, trust 1/2/3 cols; desktop baseline unchanged
- [x] Verified balanced 3+2 stats and 2-col trust at tablet via cropped screenshots
- [x] No off-spec radii or non-canonical breakpoints introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)