### PR TITLE
fix(auth): land on /home after sign-in (not the user's profile)

### DIFF
--- a/src/lib/auth/__tests__/post-signin-redirect.test.ts
+++ b/src/lib/auth/__tests__/post-signin-redirect.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest"
+import { resolvePostSigninPath } from "../post-signin"
+
+const PATH_KEY = "post-signin-path"
+
+describe("resolvePostSigninPath", () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it("lands on /home when signing in from the marketing landing", () => {
+    sessionStorage.setItem(PATH_KEY, "/welcome")
+    expect(resolvePostSigninPath("did:plc:abc")).toBe("/home")
+  })
+
+  it("lands on /home from any marketing/legal route", () => {
+    for (const route of ["/welcome", "/about", "/terms", "/privacy", "/imprint"]) {
+      sessionStorage.setItem(PATH_KEY, route)
+      expect(resolvePostSigninPath("did:plc:abc")).toBe("/home")
+    }
+  })
+
+  it("lands on /home when no prior path was stashed", () => {
+    expect(resolvePostSigninPath("did:plc:abc")).toBe("/home")
+  })
+
+  it("preserves a non-marketing prior location", () => {
+    sessionStorage.setItem(PATH_KEY, "/explore")
+    expect(resolvePostSigninPath("did:plc:abc")).toBe("/explore")
+  })
+})

--- a/src/lib/auth/post-signin.ts
+++ b/src/lib/auth/post-signin.ts
@@ -8,8 +8,6 @@
  * looking at, not at `/`.
  */
 
-import { profileUrl } from "@/lib/urls"
-
 const PATH_KEY = "post-signin-path"
 const HANDLE_KEY = "pre-signin-handle"
 
@@ -96,7 +94,8 @@ export function rewritePathForNewIdentity(
  * Marketing / legal pages. A user who signs in from one of these
  * is treated as a new entry into the app, not as someone reading X
  * who happened to sign in mid-flow — so the saved-path restore is
- * bypassed and they land on their own profile instead.
+ * bypassed and they land on the home feed (`/home`) rather than the
+ * marketing page they came from or their own profile.
  */
 const MARKETING_ROUTES = [
   "/welcome",
@@ -114,18 +113,18 @@ function isMarketingPath(path: string): boolean {
 }
 
 /**
- * Convenience: combine the lookup + rewrite. Returns `/` when no
- * saved path is present — preserving the previous fallback.
+ * Convenience: combine the lookup + rewrite. Returns `/home` when no
+ * saved path is present, so a fresh sign-in lands on the activity feed.
  *
- * Sign-ins originating from a {@link MARKETING_ROUTES} page route
- * the user to their own profile. Sign-ins from any other page
+ * Sign-ins originating from a {@link MARKETING_ROUTES} page route the
+ * user to `/home` (the activity feed). Sign-ins from any other page
  * preserve the user's prior location.
  */
 export function resolvePostSigninPath(newIdentifier: string | null): string {
   const { path, handle } = consumePreSigninLocation()
-  if (!path) return "/"
-  if (newIdentifier && isMarketingPath(path)) {
-    return profileUrl(newIdentifier)
+  if (!path) return "/home"
+  if (isMarketingPath(path)) {
+    return "/home"
   }
   return rewritePathForNewIdentity(path, handle, newIdentifier)
 }


### PR DESCRIPTION
## What
Signing in from the landing page dropped the user on **their profile** instead of the **home feed**. `resolvePostSigninPath` routed all marketing-route (`/welcome`, `/about`, `/terms`, `/privacy`, `/imprint`) sign-ins to `profileUrl(newIdentifier)`; this changes them (and the no-stashed-path fallback) to `/home`.

Mid-flow sign-ins from non-marketing pages still restore the user's prior location.

## Why
Reported in review: "when I sign in, I should land on /home, not on my profile."

## Test plan
- [x] New `post-signin-redirect.test.ts`: marketing routes -> `/home`, empty -> `/home`, non-marketing path preserved
- [x] `npm run lint` 0 errors · `tsc --noEmit` clean · `typecheck:test` clean · `npm test` 609 pass
- [ ] CI green

Scope: `src/lib/auth/post-signin.ts` (+ test). Removed the now-unused `profileUrl` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)