### PR TITLE
fix(feed): degrade gracefully on unresolvable group profiles (closes #156)

### DIFF
--- a/src/app/api/groups/[groupDid]/profile/__tests__/profile-absent-200.test.ts
+++ b/src/app/api/groups/[groupDid]/profile/__tests__/profile-absent-200.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+/**
+ * GET /api/groups/[groupDid]/profile — absent-profile contract (issue #156).
+ *
+ * Several feed/list rows reference group DIDs whose
+ * `app.certified.actor.profile` record is gone (deleted / never-published)
+ * or whose DID no longer resolves to a PDS. Those are EXPECTED absent
+ * cases, not failures. The route must answer them with HTTP 200 + a null
+ * body — NOT 404 — so the browser doesn't log a red
+ * "Failed to load resource: 404" for every gone-group row in the feed.
+ *
+ * A genuine PDS failure (5xx / network) must stay distinguishable: it
+ * still surfaces as a 500 so "absent" and "broken" don't collapse into
+ * the same signal.
+ *
+ * The route pulls in server-only deps (proxy-agent, CSRF) at import time,
+ * so we mock those alongside the DID resolver and drive the GET handler.
+ */
+
+vi.mock("@/lib/groups/proxy-agent", () => ({
+  getAuthenticatedAgent: vi.fn(),
+  createGroupAgent: vi.fn(),
+}))
+vi.mock("@/lib/auth/csrf", () => ({ checkCsrf: vi.fn(() => null) }))
+vi.mock("@/lib/atproto/did", () => ({
+  resolvePdsUrl: vi.fn(),
+}))
+
+import { resolvePdsUrl } from "@/lib/atproto/did"
+
+const GROUP_DID = "did:plc:crmpwlowxpowweitlain3af5"
+
+function makeParams(did: string) {
+  return { params: Promise.resolve({ groupDid: did }) }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("GET /api/groups/[groupDid]/profile — absent profile (issue #156)", () => {
+  it("returns 200 + null when the group DID no longer resolves to a PDS", async () => {
+    vi.mocked(resolvePdsUrl).mockResolvedValue(null)
+
+    const { GET } = await import("../route")
+    const res = await GET(
+      new Request(`https://x.test/api/groups/${GROUP_DID}/profile`) as never,
+      makeParams(GROUP_DID),
+    )
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toBeNull()
+  })
+
+  it("returns 200 + null when the PDS reports the record absent (404)", async () => {
+    vi.mocked(resolvePdsUrl).mockResolvedValue("https://pds.test")
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("not found", { status: 404 }))
+
+    const { GET } = await import("../route")
+    const res = await GET(
+      new Request(`https://x.test/api/groups/${GROUP_DID}/profile`) as never,
+      makeParams(GROUP_DID),
+    )
+
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    expect(res.status).toBe(200)
+    expect(await res.json()).toBeNull()
+  })
+
+  it("returns 200 + null when the PDS rejects the record key (400)", async () => {
+    vi.mocked(resolvePdsUrl).mockResolvedValue("https://pds.test")
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("bad request", { status: 400 }),
+    )
+
+    const { GET } = await import("../route")
+    const res = await GET(
+      new Request(`https://x.test/api/groups/${GROUP_DID}/profile`) as never,
+      makeParams(GROUP_DID),
+    )
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toBeNull()
+  })
+
+  it("still surfaces a genuine PDS failure (5xx) as 500, not 200", async () => {
+    vi.mocked(resolvePdsUrl).mockResolvedValue("https://pds.test")
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("upstream down", { status: 503 }),
+    )
+    // The catch logs via logSafe (console.error) — swallow it so the
+    // expected-failure path doesn't pollute test output.
+    vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    const { GET } = await import("../route")
+    const res = await GET(
+      new Request(`https://x.test/api/groups/${GROUP_DID}/profile`) as never,
+      makeParams(GROUP_DID),
+    )
+
+    expect(res.status).toBe(500)
+  })
+
+  it("returns the profile record value verbatim on a hit", async () => {
+    vi.mocked(resolvePdsUrl).mockResolvedValue("https://pds.test")
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ value: { displayName: "Acme Org" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+
+    const { GET } = await import("../route")
+    const res = await GET(
+      new Request(`https://x.test/api/groups/${GROUP_DID}/profile`) as never,
+      makeParams(GROUP_DID),
+    )
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ displayName: "Acme Org" })
+  })
+
+  it("rejects an invalid DID with 400 (unchanged)", async () => {
+    const { GET } = await import("../route")
+    const res = await GET(
+      new Request("https://x.test/api/groups/not-a-did/profile") as never,
+      makeParams("not-a-did"),
+    )
+
+    expect(res.status).toBe(400)
+  })
+})

--- a/src/app/api/groups/[groupDid]/profile/route.ts
+++ b/src/app/api/groups/[groupDid]/profile/route.ts
@@ -26,10 +26,19 @@ export async function GET(
       return NextResponse.json({ error: "Invalid group DID" }, { status: 400 })
     }
 
-    // Resolve the group's PDS URL from the DID document
+    // Resolve the group's PDS URL from the DID document. A DID that no
+    // longer resolves (deleted / tombstoned / never-published) is an
+    // EXPECTED absent-profile case — many feed/list rows reference group
+    // DIDs whose profile record is simply gone (issue #156). Return 200
+    // with a null body rather than 404 so the browser doesn't log a red
+    // "Failed to load resource: 404" for every such row. Callers already
+    // coerce a missing profile to null, so this is behaviourally identical
+    // for them while removing the console noise. A genuine PDS failure
+    // (5xx / network error) below still throws → 500, so "absent" and
+    // "broken" stay distinguishable.
     const pdsUrl = await resolvePdsUrl(groupDid)
     if (!pdsUrl) {
-      return NextResponse.json({ error: "Could not resolve group PDS" }, { status: 404 })
+      return NextResponse.json(null, { status: 200 })
     }
 
     // Fetch directly from the group's PDS (unauthenticated — reads are public)
@@ -39,8 +48,11 @@ export async function GET(
     )
 
     if (!res.ok) {
+      // 400/404 from the PDS = the `app.certified.actor.profile` record
+      // doesn't exist (RecordNotFound) — the expected absent case, same
+      // as an unresolvable PDS above. 200 + null, not 404.
       if (res.status === 400 || res.status === 404) {
-        return NextResponse.json({ error: "Not found" }, { status: 404 })
+        return NextResponse.json(null, { status: 200 })
       }
       throw new Error(`PDS returned ${res.status}`)
     }

--- a/src/components/dev/mock-fetch-provider.tsx
+++ b/src/components/dev/mock-fetch-provider.tsx
@@ -434,13 +434,15 @@ function installMockFetch(
       if (managed && /^\/api\/groups\/[^/]+\/profile$/.test(path)) {
         // Per-group org profile (`getOrgProfile`) — drives `displayName`
         // on the resolved groups. The DID segment is URL-encoded; decode
-        // it back to `did:plc:…`. A 404-shaped miss for an unknown DID
-        // lets `resolveGroups` fall back to the handle.
+        // it back to `did:plc:…`. An absent profile resolves to 200 + null
+        // (mirrors the real route after issue #156 — no red 404 in the
+        // console for gone groups); `resolveGroups` falls back to the
+        // handle on the null body.
         const segment = path.split("/")[3] ?? ""
         const groupDid = decodeURIComponent(segment)
         const profile = managedOrgProfile(groupDid)
         if (profile) return json(profile)
-        return json({ error: "NotFound" }, 404)
+        return json(null)
       }
       if (path === "/api/notifications") {
         // The notifications client (`lib/atproto/notifications.ts`) POSTs

--- a/src/lib/groups/api.ts
+++ b/src/lib/groups/api.ts
@@ -200,10 +200,16 @@ export async function getOrgProfile(
     { signal }
   )
   if (!res.ok) {
+    // 404 retained for backward compatibility (older route revisions and
+    // the dev mock). The route now returns 200 + null for an absent
+    // profile (issue #156) so the browser doesn't log a red 404 for every
+    // gone-group row; both shapes coerce to null here.
     if (res.status === 404) return null
     throw new Error("Failed to fetch org profile")
   }
-  return res.json()
+  // 200 body is the bare profile record, or `null` when the record is
+  // absent / the group's PDS no longer resolves.
+  return (await res.json()) as OrgProfile | null
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #156.

Several group DIDs (`crmpwlowxpowweitlain3af5`, `rweujsefszwkyc4au2fszlck`, `bcty2ujkhj3ahywbbxm6lndy`, `c6s2adqxmn4otyhlowpv72pp`) have no `app.certified.actor.profile` record (deleted / never-published) or no longer resolve to a PDS, so `GET /api/groups/<did>/profile` answered with **HTTP 404** — and the browser network panel logged a red `Failed to load resource: 404` for every gone-group row (~108 each in the staging audit).

## What I verified first (the issue's framing was only partly accurate)

- **(a) Does the feed already degrade gracefully?** Yes, fully. Every avatar/byline in the feed + list path (`HomeFeedRow`, `EndorsementGroupRow`, `ActivityAuthor`, `OwnerByline`, `EvaluatorOption`) renders `<Avatar fallbackInitials={getInitials(displayName, did)}>`, which falls back to a DID-derived monogram (`did.slice(4,6)` → `?`). Every profile fetch is `.catch(() => null)` / `Promise.allSettled`. A null group profile produces a monogram, never an error. **No rendering change was needed.**
- **(b) Was there an app-level `console.error`/`console.warn` for the expected 404?** No. The route's 404 was an **early return** that never reached the `logSafe` catch; `logSafe` only fires for genuine PDS 5xx / network failures. The client (`authFetch`, `getOrgProfile`) doesn't log either. Matches the conclusion of sibling PR #152. **Nothing app-level to suppress.**
- **(c) Is the fetch redundant?** The **home feed** never even calls this route — feed authors resolve via the resolve-did batch. The route is hit by `useOrgProfile` (active org) and `resolveGroups` (the viewer's own managed groups), once per group. That's the real source of the 404s.

## The one genuine lever

The remaining symptom is the **browser-level** 404 network log, which **JavaScript cannot suppress** — it is emitted purely because the response status is 404. The only app-level fix is to stop returning 404 for the *expected* absent case. So:

- **route** — `GET /api/groups/[groupDid]/profile` now returns **HTTP 200 with a `null` body** when the profile record is absent (PDS 400/404) or the group's PDS no longer resolves. A genuine PDS failure (5xx / network) still throws → **500**, so "absent" and "broken" stay distinguishable.
- **`getOrgProfile`** — handles the 200-null body; the `404 → null` branch is kept for back-compat (older route revisions / dev mock).
- **dev mock** — mirrors the 200-null absent contract so dev console matches prod.

All `getOrgProfile`-style callers already coerce a missing org profile to `null`, so this is behaviourally identical for them while removing the console noise.

### Honesty note
This does not touch feed rendering (already correct) and does not suppress any app-level log (none existed). It removes the browser 404 entries by changing the expected-absent response status from 404 to 200-null — the only thing actually under our control. The optional indexer `isActive` signal (magic-indexer#200) and hiding gone groups entirely were left out of scope.

## Test plan

- [x] `npm run lint` — 0 errors, 66 warnings (unchanged vs. staging; none in changed files)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run typecheck:test` — clean
- [x] `npm test` — 621 passed (86 files), including 6 new route tests:
  - unresolvable PDS → 200 + null
  - PDS 404 → 200 + null
  - PDS 400 → 200 + null
  - PDS 5xx → 500 (still surfaced as a failure)
  - hit → record value verbatim
  - invalid DID → 400 (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)