### PR TITLE
chore(component-library): #130 follow-ups — dead-CSS prune (#132), link-tab nav props (#133), combobox autoHighlight opt-out (#134)

### DIFF
--- a/src/app/styles/feed.css
+++ b/src/app/styles/feed.css
@@ -909,34 +909,6 @@
   margin-bottom: 16px;
 }
 
-.page-tabs {
-  display: flex;
-  gap: 4px;
-  align-self: flex-end;
-}
-
-.page-tabs__tab {
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--fg-muted);
-  cursor: pointer;
-  font-size: 0.875rem;
-  font-weight: 500;
-  padding: 10px 16px;
-  margin-bottom: -1px;
-  transition: color 0.15s ease, border-color 0.15s ease;
-}
-
-.page-tabs__tab:hover {
-  color: var(--fg-primary);
-}
-
-.page-tabs__tab--active {
-  color: var(--fg-primary);
-  border-bottom-color: var(--fg-primary);
-}
-
 /* Generic "+ New X" toolbar button used in the tab-bar pattern
    (endorsements, groups). Subtle text-button styling so it doesn't
    compete with primary content actions further down the page. */
@@ -1547,12 +1519,7 @@
     min-height: 44px;
     padding: 10px;
   }
-  /* Tab-bar tabs + "New" buttons (endorsements, groups) → 44px tall. */
-  .page-tabs__tab {
-    display: inline-flex;
-    align-items: center;
-    min-height: 44px;
-  }
+  /* Tab-bar "New" buttons (endorsements, groups) → 44px tall. */
   .page-tabs-bar__new,
   .endorsements-new-btn {
     min-height: 44px;

--- a/src/app/styles/profile-inline-edit.css
+++ b/src/app/styles/profile-inline-edit.css
@@ -78,39 +78,6 @@
   gap: 8px;
 }
 
-/* Shared visual treatment for all inline-edit inputs (display name,
-   about, website). A clearly-visible border + light bg signals that
-   the field is editable — same affordance for every text input. */
-.profile-sidebar__website-input,
-.profile-sidebar__name-input {
-  width: 100%;
-  font: inherit;
-  color: var(--fg-primary);
-  background: var(--bg-elevated);
-  border: 1.5px solid var(--border-hover);
-  border-radius: var(--radius);
-  padding: 6px 10px;
-}
-
-.profile-sidebar__website-input {
-  flex: 1;
-  min-width: 0;
-  font-size: 0.875rem;
-}
-
-.profile-sidebar__name-input {
-  font-size: inherit;
-  font-weight: inherit;
-  line-height: inherit;
-}
-
-.profile-sidebar__website-input:focus,
-.profile-sidebar__name-input:focus {
-  outline: none;
-  border-color: var(--fg-primary);
-  box-shadow: 0 0 0 2px var(--overlay-weak);
-}
-
 /* --- Page-level edit banner -----------------------------------------
 
    Rendered ABOVE the two-column page layout when the user is in
@@ -352,24 +319,6 @@
   margin-top: 0;
 }
 
-.profile-sidebar__org-input {
-  flex: 1;
-  min-width: 0;
-  font: inherit;
-  font-size: 0.875rem;
-  color: var(--fg-primary);
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius);
-  padding: 6px 10px;
-}
-
-.profile-sidebar__org-input:focus {
-  outline: none;
-  border-color: var(--fg-primary);
-  box-shadow: 0 0 0 2px var(--overlay-weak);
-}
-
 /* --- Sidebar additional-URL list editor ----------------------------- */
 
 /* One row per additional URL. The icon stays on the left to match the
@@ -470,26 +419,6 @@
   /* Preserve in-text newlines so the multi-line content reads as the
      author wrote it. We don't sanitise HTML — the field is plain text. */
   white-space: pre-wrap;
-}
-
-/* --- Overview Website input ---------------------------------------- */
-
-.profile-overview__website-input {
-  width: 100%;
-  font: inherit;
-  font-size: 14px;
-  color: var(--fg-primary);
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius);
-  padding: 8px 12px;
-  margin-top: 8px;
-}
-
-.profile-overview__website-input:focus {
-  outline: none;
-  border-color: var(--focus-ring);
-  box-shadow: 0 0 0 2px var(--focus-ring);
 }
 
 .profile-overview__website-label {

--- a/src/components/create/contributor-identity-field.tsx
+++ b/src/components/create/contributor-identity-field.tsx
@@ -218,6 +218,11 @@ export function ContributorIdentityField({
       onSelect={handleSelect}
       onSubmitNoMatch={handleSubmitNoMatch}
       enableHomeEnd={false}
+      // Don't auto-select the first result: bare Enter commits the typed
+      // handle via onSubmitNoMatch even when prefix-match results are
+      // visible (matches pre-#130 behaviour). Arrowing into a row still
+      // selects it.
+      autoHighlight={false}
       escapeStage="close-only"
       liveStatus={null}
       listboxClassName="create-cert__contrib-id-dropdown"

--- a/src/components/groups/handle-search.tsx
+++ b/src/components/groups/handle-search.tsx
@@ -163,6 +163,9 @@ export default function HandleSearch({
       inputRef={inputRef}
       listboxClassName="handle-search__dropdown"
       enableHomeEnd={false}
+      // Don't auto-select the first result: Enter on a visible but
+      // un-navigated list should do nothing (matches pre-#130 behaviour).
+      autoHighlight={false}
       escapeStage="close-only"
       liveStatus={null}
       inputProps={{

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -662,23 +662,25 @@ export default function DesktopTopBar() {
                  (searchParams?.get("tab") ?? "overview"))
               : (searchParams?.get("tab") ?? "overview")
             return (
-              // Detail strip — canonical <Tabs> (underline). onChange
-              // REPLACES (not pushes) so switching tabs on the same cert /
-              // project doesn't pollute history; scroll:false keeps the
-              // scroll position. The row wrapper owns the bottom border.
-              <Tabs
-                value={activeDetailTab}
-                onChange={(next) => {
-                  const t = detailTabs.find((tab) => tab.key === next)
-                  if (t) router.replace(hrefFor(t), { scroll: false })
-                }}
-              >
+              // Detail strip — canonical <Tabs> rendered as real link tabs
+              // (each <Tab href> is an anchor, so middle-click / open-in-new-
+              // tab work). `linkProps` REPLACES (not pushes) so switching tabs
+              // on the same cert / project doesn't pollute history; scroll:false
+              // keeps the scroll position. `value` is derived from the URL, so
+              // onChange is a no-op — the link drives navigation. The row
+              // wrapper owns the bottom border.
+              <Tabs value={activeDetailTab} onChange={() => {}}>
                 <TabList
                   aria-label={isOnCertDetail ? "Activity sections" : "Project sections"}
                   className="border-0"
                 >
                   {detailTabs.map((t) => (
-                    <Tab key={t.key} value={t.key}>
+                    <Tab
+                      key={t.key}
+                      value={t.key}
+                      href={hrefFor(t)}
+                      linkProps={{ replace: true, scroll: false }}
+                    >
                       {t.label}
                     </Tab>
                   ))}

--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -240,9 +240,9 @@ export default function ProfileSidebar({
         {isEditing && hasInline ? (
           // Bare Input inside the H1 context so it inherits the serif H1
           // scale (font/size/weight/leading cascade from
-          // `.profile-sidebar__name`). `borderWeight="hover"` reproduces the
+          // `.profile-sidebar__name`). `borderWeight="hover"` gives the
           // 1.5px --border-hover resting / --fg-primary + --overlay-weak focus
-          // chrome the legacy `.profile-sidebar__name-input` used.
+          // chrome expected for an inline-edit field.
           <h1 className="profile-sidebar__name">
             <Input
               size="bare"
@@ -405,9 +405,8 @@ export default function ProfileSidebar({
             <li className="profile-sidebar__website-edit">
               <LinkIcon size={16} strokeWidth={1.75} aria-hidden />
               {/* flex:1 bare Input beside the icon. `borderWeight="hover"`
-                  matches the legacy `.profile-sidebar__website-input`
-                  1.5px --border-hover resting / --fg-primary focus chrome;
-                  font-size cascades from `.profile-sidebar__details li`
+                  gives the 1.5px --border-hover resting / --fg-primary focus
+                  chrome; font-size cascades from `.profile-sidebar__details li`
                   (0.875rem). */}
               <Input
                 size="bare"
@@ -458,9 +457,9 @@ export default function ProfileSidebar({
           <li className="profile-sidebar__org-field-edit">
             <Calendar size={16} strokeWidth={1.75} aria-hidden />
             <span className="profile-sidebar__org-field-label">Founded</span>
-            {/* flex:1 bare Input. `borderWeight="default"` matches the legacy
-                `.profile-sidebar__org-input` 1px --border-default resting
-                border; font-size cascades from the details-list row. */}
+            {/* flex:1 bare Input. `borderWeight="default"` gives the 1px
+                --border-default resting border; font-size cascades from the
+                details-list row. */}
             <Input
               size="bare"
               flush
@@ -572,8 +571,7 @@ function OrgUrlListEditor({ rows, onChange }: OrgUrlListEditorProps) {
           <li key={row.id} className="profile-sidebar__org-url-edit">
             <LinkIcon size={16} strokeWidth={1.75} aria-hidden />
             {/* flex:1 bare Input beside the icon. `borderWeight="default"`
-                matches the legacy `.profile-sidebar__org-input` 1px
-                --border-default resting border. */}
+                gives the 1px --border-default resting border. */}
             <Input
               size="bare"
               flush

--- a/src/components/ui/__tests__/combobox.test.tsx
+++ b/src/components/ui/__tests__/combobox.test.tsx
@@ -34,6 +34,7 @@ interface HarnessProps {
   onSubmit?: (raw: string) => void;
   escapeStage?: "two-stage" | "close-only";
   enableHomeEnd?: boolean;
+  autoHighlight?: boolean;
   withLiveStatus?: boolean;
 }
 
@@ -50,6 +51,7 @@ function Harness({
   onSubmit,
   escapeStage = "two-stage",
   enableHomeEnd = true,
+  autoHighlight = true,
   withLiveStatus = false,
 }: HarnessProps) {
   const [value, setValue] = useState("a");
@@ -68,6 +70,7 @@ function Harness({
       onSubmit={onSubmit}
       escapeStage={escapeStage}
       enableHomeEnd={enableHomeEnd}
+      autoHighlight={autoHighlight}
       inputProps={{ "aria-label": "Search", placeholder: "Search" }}
       liveStatus={
         withLiveStatus
@@ -259,6 +262,50 @@ describe("Combobox — keyboard", () => {
     render(<Harness />);
     fireEvent.mouseEnter(screen.getByText("Charlie"));
     expect(highlightedLabel()).toBe("Charlie");
+  });
+});
+
+describe("Combobox — autoHighlight={false} (opt-out, #134)", () => {
+  it("does not highlight the first row on mount when items are present", () => {
+    render(<Harness autoHighlight={false} />);
+    expect(highlightedLabel()).toBeNull();
+    // No row → aria-activedescendant must be absent.
+    expect(getInput().getAttribute("aria-activedescendant")).toBeNull();
+  });
+
+  it("Enter on a visible-but-un-navigated list does nothing when no onSubmitNoMatch (handle-search)", () => {
+    const onSelect = vi.fn();
+    render(<Harness autoHighlight={false} onSelect={onSelect} />);
+    fireEvent.keyDown(getInput(), { key: "Enter" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("Enter commits the typed value via onSubmitNoMatch even with results visible (contributor field)", () => {
+    const onSelect = vi.fn();
+    const onSubmitNoMatch = vi.fn();
+    render(
+      <Harness
+        autoHighlight={false}
+        onSelect={onSelect}
+        onSubmitNoMatch={onSubmitNoMatch}
+      />,
+    );
+    const input = getInput();
+    fireEvent.change(input, { target: { value: "alice.social" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onSubmitNoMatch).toHaveBeenCalledWith("alice.social");
+  });
+
+  it("arrowing into a row still highlights and Enter commits it", () => {
+    const onSelect = vi.fn();
+    render(<Harness autoHighlight={false} onSelect={onSelect} />);
+    const input = getInput();
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // -1 → row 0 (Alpha)
+    expect(highlightedLabel()).toBe("Alpha");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][1]).toBe(0);
   });
 });
 

--- a/src/components/ui/__tests__/tabs-link-props.test.tsx
+++ b/src/components/ui/__tests__/tabs-link-props.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+// tabs-133: `<Tab href>` link tabs can now forward Next navigation props
+// (`scroll` / `replace` / `prefetch`) to the underlying <Link> via the
+// scoped `linkProps`. Before this, TabProps only extended
+// ButtonHTMLAttributes, so those router props could not flow through and
+// URL-router strips had to fall back to button tabs driving the router
+// from `onChange`.
+//
+// next/link is stubbed with an anchor that reflects the nav props it
+// receives as data-* attributes, so we can assert they reached <Link>
+// (Link consumes them, so they never appear on the real DOM <a>).
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    replace,
+    scroll,
+    prefetch,
+    children,
+    ...rest
+  }: {
+    href: string | { toString(): string }
+    replace?: boolean
+    scroll?: boolean
+    prefetch?: boolean
+    children: React.ReactNode
+  } & Record<string, unknown>) => (
+    <a
+      href={typeof href === "string" ? href : String(href)}
+      data-replace={String(replace)}
+      data-scroll={String(scroll)}
+      data-prefetch={String(prefetch)}
+      {...rest}
+    >
+      {children}
+    </a>
+  ),
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("Tab href forwards Next navigation linkProps", () => {
+  it("renders an anchor and forwards replace + scroll to <Link>", async () => {
+    const { Tabs, TabList, Tab } = await import("../tabs")
+    render(
+      <Tabs value="a" onChange={() => {}}>
+        <TabList aria-label="Sections">
+          <Tab
+            value="a"
+            href="/x?tab=a"
+            linkProps={{ replace: true, scroll: false }}
+          >
+            A
+          </Tab>
+          <Tab
+            value="b"
+            href="/x?tab=b"
+            linkProps={{ replace: true, scroll: false }}
+          >
+            B
+          </Tab>
+        </TabList>
+      </Tabs>,
+    )
+
+    const tabA = screen.getByRole("tab", { name: "A" })
+    expect(tabA.tagName).toBe("A")
+    expect(tabA.getAttribute("href")).toBe("/x?tab=a")
+    expect(tabA.getAttribute("data-replace")).toBe("true")
+    expect(tabA.getAttribute("data-scroll")).toBe("false")
+
+    // The ARIA + roving-tabindex contract is unchanged on the link tab.
+    expect(tabA.getAttribute("aria-selected")).toBe("true")
+    expect(tabA.getAttribute("tabindex")).toBe("0")
+    const tabB = screen.getByRole("tab", { name: "B" })
+    expect(tabB.getAttribute("aria-selected")).toBe("false")
+    expect(tabB.getAttribute("tabindex")).toBe("-1")
+  })
+
+  it("does not leak linkProps / anchor props onto button tabs", async () => {
+    const { Tabs, TabList, Tab } = await import("../tabs")
+    render(
+      <Tabs value="a" onChange={() => {}}>
+        <TabList aria-label="Sections">
+          <Tab value="a">A</Tab>
+        </TabList>
+      </Tabs>,
+    )
+
+    const tabA = screen.getByRole("tab", { name: "A" })
+    expect(tabA.tagName).toBe("BUTTON")
+    expect(tabA.getAttribute("data-replace")).toBeNull()
+    expect(tabA.getAttribute("href")).toBeNull()
+  })
+})

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -173,6 +173,22 @@ export interface ComboboxProps<T> {
   /** Enable Home/End jump-to-edge keys. Default true. */
   enableHomeEnd?: boolean;
   /**
+   * Auto-highlight the first row whenever the item set is non-empty, so
+   * Enter commits a result even before the user arrows into the list.
+   * Default `true` (the standard typeahead behaviour shared by the
+   * search surfaces).
+   *
+   * Set `false` for surfaces whose Enter must not pick a row the user
+   * never navigated to:
+   *  - with `onSubmitNoMatch`, an un-highlighted Enter commits the typed
+   *    value via that handler even when results are visible (e.g. the
+   *    contributor field, where you may be entering a handle that merely
+   *    *prefix-matches* existing rows);
+   *  - without it, an un-highlighted Enter does nothing (e.g. handle
+   *    search). Arrow / Home / End still highlight and commit normally.
+   */
+  autoHighlight?: boolean;
+  /**
    * Escape behaviour:
    *  - 'two-stage' (default, WAI-ARIA): first Escape closes the
    *    listbox; a second Escape (already closed) clears the input,
@@ -217,6 +233,7 @@ function Combobox<T>({
   listboxClassName = "",
   role,
   enableHomeEnd = true,
+  autoHighlight = true,
   escapeStage = "two-stage",
   liveStatus,
 }: ComboboxProps<T>) {
@@ -234,12 +251,12 @@ function Combobox<T>({
   const count = items.length;
 
   // Reset the highlight whenever the item set changes: first row when
-  // the list is non-empty, -1 when it's empty. Keying off `count` (not
-  // the array identity) keeps this stable when a parent passes a fresh
-  // array each render with the same contents.
+  // the list is non-empty (and auto-highlight is on), -1 otherwise.
+  // Keying off `count` (not the array identity) keeps this stable when a
+  // parent passes a fresh array each render with the same contents.
   useEffect(() => {
-    setHighlight(count > 0 ? 0 : -1);
-  }, [count]);
+    setHighlight(count > 0 && autoHighlight ? 0 : -1);
+  }, [count, autoHighlight]);
 
   // Close on outside click.
   useEffect(() => {
@@ -278,22 +295,28 @@ function Combobox<T>({
   );
 
   const commitHighlighted = useCallback(() => {
-    // Enter: select the highlighted row, falling back to the first row
-    // when the list has items but nothing is highlighted yet. If there
-    // are no items, hand control to `onSubmitNoMatch` (typed-but-
-    // unmatched commit). When highlight is -1 *with* items present we
-    // also treat that as "no highlighted match" for onSubmitNoMatch
-    // semantics — but only if the caller opted in AND the list is
-    // empty; with items we default to the first row to preserve the
-    // existing surfaces' "Enter picks first result" behaviour.
-    if (count > 0) {
-      const index = highlight >= 0 ? highlight : 0;
-      const item = items[index];
-      if (item !== undefined) onSelect(item, index);
+    // Enter commits in priority order:
+    //  1. an explicitly highlighted row (arrow / Home / End, or the
+    //     auto-highlighted first row);
+    //  2. with `autoHighlight`, the first row as a fallback when items
+    //     exist but nothing is highlighted yet — preserves the search
+    //     surfaces' "Enter picks first result" behaviour;
+    //  3. otherwise hand control to `onSubmitNoMatch` (typed-value
+    //     commit). With `autoHighlight` off this is how the contributor
+    //     field commits a typed handle even while results are visible;
+    //     handle-search (no `onSubmitNoMatch`) simply does nothing.
+    if (highlight >= 0) {
+      const item = items[highlight];
+      if (item !== undefined) onSelect(item, highlight);
+      return;
+    }
+    if (autoHighlight && count > 0) {
+      const item = items[0];
+      if (item !== undefined) onSelect(item, 0);
       return;
     }
     onSubmitNoMatch?.(value);
-  }, [count, highlight, items, onSelect, onSubmitNoMatch, value]);
+  }, [autoHighlight, count, highlight, items, onSelect, onSubmitNoMatch, value]);
 
   const handleEscape = useCallback(() => {
     if (open) {
@@ -335,9 +358,14 @@ function Combobox<T>({
           // Enter commits. Always preventDefault when there's anything
           // to commit (a row, or a no-match handler with a typed value)
           // so the surrounding form doesn't submit out from under us.
-          const hasNoMatchTarget =
-            count === 0 && onSubmitNoMatch && value.trim().length > 0;
-          if (count === 0 && !hasNoMatchTarget) return;
+          // A row commits when one is highlighted, or — with
+          // autoHighlight — when items exist and we fall back to row 0.
+          const willCommitRow = highlight >= 0 || (autoHighlight && count > 0);
+          const willSubmitNoMatch =
+            !willCommitRow && !!onSubmitNoMatch && value.trim().length > 0;
+          // Nothing to commit (e.g. handle-search with autoHighlight off
+          // and no row navigated to): let Enter through untouched.
+          if (!willCommitRow && !willSubmitNoMatch) return;
           e.preventDefault();
           commitHighlighted();
           return;
@@ -361,8 +389,10 @@ function Combobox<T>({
       }
     },
     [
+      autoHighlight,
       count,
       enableHomeEnd,
+      highlight,
       moveHighlight,
       commitHighlighted,
       handleEscape,

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import Link, { type LinkProps } from "next/link";
 import React, {
   createContext,
   useCallback,
@@ -190,6 +190,12 @@ export interface TabProps
    *  activation so controlled `value` stays in sync; navigation is left to the
    *  router. Ignored when `disabled`. */
   href?: string;
+  /** Next navigation props forwarded to the underlying `<Link>` — only when
+   *  the tab renders as a link (`href` set and not `disabled`). Lets a
+   *  URL-router tab strip request `replace` + `scroll={false}` (and optionally
+   *  `prefetch`) semantics instead of falling back to a button tab that drives
+   *  the router from `onChange`. No effect on button tabs. */
+  linkProps?: Pick<LinkProps, "scroll" | "replace" | "prefetch">;
 }
 
 export function Tab({
@@ -198,6 +204,7 @@ export function Tab({
   disabled = false,
   count,
   href,
+  linkProps,
   className = "",
   ...props
 }: TabProps) {
@@ -328,6 +335,7 @@ export function Tab({
         href={href}
         // Keep the controlled `value` in sync; the router handles navigation.
         onClick={() => ctx.onChange(value)}
+        {...linkProps}
         {...sharedProps}
         {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
       >


### PR DESCRIPTION
Two non-blocking follow-ups auto-filed from PR #130 (component-library completion).

## closes #132 — prune dead inline-edit / page-tabs CSS

After #130 moved these surfaces onto the shared `Input` primitive and the `Tabs` component, the old CSS was orphaned (verified 0 `className=` usages via grep):

- **`profile-inline-edit.css`**: removed `.profile-sidebar__website-input`, `.profile-sidebar__name-input` (shared rule + singles + `:focus`), `.profile-sidebar__org-input` (+ `:focus`), `.profile-overview__website-input` (+ `:focus`).
- **`feed.css`**: removed the standalone `.page-tabs` / `.page-tabs__tab` (+ `:hover` / `--active`) block and its 44px tap-target media rule. TSX uses only `.page-tabs-bar` / `.page-tabs-bar__new`, which are untouched.
- **`profile-sidebar.tsx`**: trimmed the four stale migration comments that referenced the deleted selectors (kept the `borderWeight` rationale).

Acceptance grep is clean:
```
grep -rn "profile-sidebar__website-input\|profile-sidebar__name-input\|profile-sidebar__org-input\|profile-overview__website-input\|page-tabs__tab\|\.page-tabs " src/   # → nothing
```
The "do NOT remove" keep-list from the issue (`.cert-detail__*-input`, `.project-detail__title-input`, `.page-tabs-bar*`, etc.) is untouched.

## closes #133 — `<Tab href>` link tabs forward Next navigation props

`TabProps` only extended `ButtonHTMLAttributes`, so link tabs couldn't carry `scroll` / `replace` / `prefetch` — URL-router strips fell back to button tabs driving the router from `onChange`.

- **`tabs.tsx`**: added `linkProps?: Pick<LinkProps, "scroll" | "replace" | "prefetch">`, spread onto `<Link>` **only** on the link path. Button tabs' type surface is unchanged.
- **`desktop-top-bar.tsx`** (worked example): migrated the cert/project detail strip to `<Tab href={hrefFor(t)} linkProps={{ replace: true, scroll: false }}>`, dropping the `onChange`→`router.replace` workaround. Tabs are now real anchors (middle-click / open-in-new-tab work) while preserving `replace` + `scroll:false`; `value` derives from the URL so `onChange` is a no-op.
- **test**: `tabs-link-props.test.tsx` asserts a link tab forwards `replace`/`scroll` to `<Link>` and keeps `role="tab"` / `aria-selected` / roving `tabIndex`, and that button tabs don't gain anchor props.

## Verification
- `npx tsc --noEmit` — clean on source
- `npm run lint` — 0 errors, 66 warnings (== staging baseline, no new warnings)
- `npx vitest run` — green except the two pre-existing `localStorage`-mock failures (`swap-drafts`, `recently-viewed`) that also fail on clean `staging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)