### PR TITLE
Welcome-page navbar for signed-out viewers + certs.social-style home feed

### DIFF
--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -361,7 +361,13 @@
   background: var(--bg-elevated);
 }
 
-/* ---------- Activity timeline (GitHub-style) ---------- */
+/* ---------- Activity feed (certs.social-style social cards) ----------
+   Each entry is a full-width card separated by hairline dividers:
+   author byline (avatar + name + @handle + relative time) with the
+   event verb as a muted second line, then — for record creates — the
+   record body: full-width image, serif headline title, clamped short
+   description and a dot-separated muted meta row. Mirrors the
+   feed-card layout shipped on certs.social. */
 
 .home-feed {
   list-style: none;
@@ -376,28 +382,31 @@
   border-bottom: 1px solid var(--border-subtle);
 }
 
-/* Three columns: 32px avatar gutter · flexible content · right-anchored
-   relative time. The avatar column is sized to the Avatar component's
-   "sm" intrinsic (32px) so the actor icon renders at the same diameter
-   on every row regardless of whether the upstream profile lookup has
-   resolved yet. */
-.home-feed__row {
-  display: grid;
-  /* Date column is a fixed 84px track (same as the explore list's
-     `.cert-list-row__time`) so a relative "2d ago" reserves the same
-     box as an absolute "2026-05-20" — the dates line up in a single
-     column across every row instead of each row sizing to its own
-     content. 84px comfortably fits the YYYY-MM-DD fallback at 0.75rem. */
-  grid-template-columns: 32px minmax(0, 1fr) 84px;
-  align-items: start;
+.home-feed__item:last-child {
+  border-bottom: none;
+}
+
+/* ---- Card ---- */
+
+.home-feed__card {
+  display: flex;
+  flex-direction: column;
   gap: 12px;
-  padding: 12px 6px;
+  padding: 20px 0;
   font-size: 0.875rem;
   color: var(--fg-primary);
 }
 
-.home-feed__row:hover {
-  background: var(--bg-sunken);
+/* ---- Head: avatar + byline + verb sentence ---- */
+
+.home-feed__card-head {
+  display: grid;
+  /* Avatar column sized to the Avatar component's "sm" intrinsic
+     (32px) so the actor icon renders at the same diameter on every
+     card regardless of whether the profile lookup has resolved yet. */
+  grid-template-columns: 32px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
 }
 
 .home-feed__avatar {
@@ -406,22 +415,63 @@
   display: inline-flex;
   text-decoration: none;
   flex-shrink: 0;
-  /* Vertically align the avatar with the first line of the sentence
-     (which starts at the row's top after the 12px row padding). */
-  margin-top: 1px;
 }
 
-.home-feed__content {
+.home-feed__card-head-meta {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 1px;
   min-width: 0;
-  padding-top: 1px;
 }
 
+/* Name + @handle on one baseline, relative time pinned right. */
+.home-feed__byline {
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+}
+
+.home-feed__actor {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--fg-primary);
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.home-feed__actor:hover {
+  text-decoration: underline;
+}
+
+.home-feed__handle {
+  font-size: 0.8125rem;
+  color: var(--fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.home-feed__time {
+  margin-left: auto;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Verb sentence — muted second line under the name; carries its own
+   links (target cert / project / account names). */
 .home-feed__sentence {
   margin: 0;
+  font-size: 0.8125rem;
   line-height: 1.35;
+  color: var(--fg-secondary);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -429,16 +479,6 @@
   -webkit-line-clamp: 2;
   line-clamp: 2;
   -webkit-box-orient: vertical;
-}
-
-.home-feed__actor {
-  font-weight: 600;
-  color: var(--fg-primary);
-  text-decoration: none;
-}
-
-.home-feed__actor:hover {
-  text-decoration: underline;
 }
 
 .home-feed__target {
@@ -452,20 +492,9 @@
   border-bottom-color: var(--fg-primary);
 }
 
-.home-feed__time {
-  font-size: 0.75rem;
-  font-variant-numeric: tabular-nums;
-  color: var(--fg-secondary);
-  white-space: nowrap;
-  padding-top: 2px;
-  /* Right-align inside the fixed date track so every row's date ends at
-     the same edge (matches the explore list's time column). */
-  text-align: right;
-}
-
 /* The "Show all / Show fewer" toggle is a <Button variant="ghost"
-   size="sm">; keep it sized to its label inside the flex-column row
-   content (the primitive is inline-flex and would otherwise stretch). */
+   size="sm">; keep it sized to its label inside the flex-column card
+   (the primitive is inline-flex and would otherwise stretch). */
 .home-feed__group-toggle {
   align-self: flex-start;
 }
@@ -476,66 +505,42 @@
   padding: 48px 0;
 }
 
-/* ---- Preview card (cert + project creates) ---- */
+/* ---- Body: record image + headline + description + meta ---- */
 
-.home-feed__preview {
-  display: grid;
-  grid-template-columns: 56px minmax(0, 1fr);
-  gap: 12px;
-  padding: 10px 12px;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius);
-  background: var(--bg-elevated);
-  text-decoration: none;
-  color: inherit;
-  transition: border-color var(--transition-fast), background var(--transition-fast);
-}
-
-/* Image missing — drop the thumb track entirely so the body left-
-   aligns with the card's left padding (no ghost gutter). */
-.home-feed__preview--no-image {
-  grid-template-columns: minmax(0, 1fr);
-}
-
-a.home-feed__preview:hover {
-  border-color: var(--fg-secondary);
-  background: var(--bg-sunken);
-}
-
-.home-feed__preview-thumb {
-  width: 56px;
-  height: 56px;
-  border-radius: var(--radius);
-  overflow: hidden;
-  background: var(--bg-sunken);
+/* The whole record body is one Link to the detail page. Keep it
+   visually invisible — no underline, no color shift — so the card
+   still reads as a card; only the title underlines on hover. */
+.home-feed__card-body {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--fg-secondary);
-  flex-shrink: 0;
+  flex-direction: column;
+  gap: 8px;
+  color: inherit;
+  text-decoration: none;
+  min-width: 0;
 }
 
-.home-feed__preview-thumb img {
+a.home-feed__card-body:hover .home-feed__card-title {
+  text-decoration: underline;
+  text-decoration-color: var(--fg-muted);
+  text-underline-offset: 3px;
+}
+
+.home-feed__card-image {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+}
+
+.home-feed__card-image img {
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
 }
 
-.home-feed__preview-thumb--placeholder {
-  /* Center the lucide icon in the placeholder thumb when the record
-     has no image yet. */
-  color: var(--fg-secondary);
-}
-
-.home-feed__preview-body {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-}
-
-.home-feed__preview-title-row {
+.home-feed__card-title-row {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
@@ -543,65 +548,79 @@ a.home-feed__preview:hover {
   min-width: 0;
 }
 
-.home-feed__preview-title {
-  font-size: 0.9rem;
-  font-weight: 600;
+.home-feed__card-title {
+  font-family: var(--font-headline), "Noto Serif", Georgia, serif;
+  font-size: 1.125rem;
+  font-weight: 700;
   color: var(--fg-primary);
   line-height: 1.3;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
+  white-space: nowrap;
 }
 
-.home-feed__preview-desc {
-  font-size: 0.8rem;
+.home-feed__card-desc {
+  font-size: 0.875rem;
+  line-height: 1.6;
   color: var(--fg-secondary);
-  line-height: 1.4;
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
   -webkit-box-orient: vertical;
 }
 
-.home-feed__preview-meta {
-  display: inline-flex;
-  flex-wrap: wrap;
+.home-feed__card-meta {
+  display: flex;
   align-items: center;
-  gap: 4px 10px;
-  margin-top: 2px;
-  font-size: 0.72rem;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.75rem;
   color: var(--fg-muted);
 }
 
-.home-feed__preview-meta-item {
+.home-feed__card-meta-item {
   display: inline-flex;
   align-items: center;
   gap: 4px;
   white-space: nowrap;
 }
 
-@media (max-width: 799px) {
-  /* ---- Mobile feed: a clean, native-feeling social timeline ----
-     The page is just the feed at this width, so it gets to breathe.
-     Two columns — a 32px avatar gutter + flexible content — with the
-     relative time reflowed under the content as a muted timestamp
-     footer, the preview cards sized for thumb-reach, and a generous,
-     evenly-rhythmed row separated by clear dividers. */
+/* Dot separator between meta items (certs.social meta row). */
+.home-feed__card-meta-item + .home-feed__card-meta-item::before {
+  content: "";
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--fg-muted);
+  margin-right: 8px;
+  flex-shrink: 0;
+}
 
+/* ---- Desktop enhancements ---- */
+
+@media (min-width: 800px) {
+  .home-feed__card {
+    padding: 24px 0;
+  }
+
+  .home-feed__card-title {
+    font-size: 1.25rem;
+  }
+}
+
+@media (max-width: 799px) {
   .home-feed {
-    /* Drop the hairline top rule on mobile — the first row's own
+    /* Drop the hairline top rule on mobile — the first card's own
        padding gives enough separation from the header. */
     border-top: 0;
   }
 
   .home-feed__item {
-    /* Slightly stronger divider than the desktop subtle line so rows
-       read as distinct cards in a thumb-scrolled timeline. */
+    /* Slightly stronger divider than the desktop subtle line so cards
+       read as distinct entries in a thumb-scrolled timeline. */
     border-bottom: 1px solid var(--border-default);
   }
 
@@ -609,71 +628,8 @@ a.home-feed__preview:hover {
     border-bottom: 0;
   }
 
-  .home-feed__row {
-    grid-template-columns: 32px minmax(0, 1fr);
-    gap: 12px;
-    /* Roomier vertical rhythm; the row's own border-radius lets the
-       hover/press background round cleanly inside the divided list. */
-    padding: 16px 4px;
-    margin: 0;
-    font-size: 0.9375rem;
-    line-height: 1.4;
-    border-radius: var(--radius);
-  }
-
-  .home-feed__avatar {
-    /* Pin the avatar to the first text line of the sentence. */
-    margin-top: 1px;
-  }
-
-  .home-feed__content {
-    gap: 10px;
-    padding-top: 2px;
-  }
-
-  .home-feed__sentence {
-    /* Roomier sentence — let it run to three lines before clamping. */
-    -webkit-line-clamp: 3;
-    line-clamp: 3;
-  }
-
-  .home-feed__time {
-    grid-column: 2 / 3;
-    grid-row: 2;
-    padding-top: 0;
-    align-self: start;
-    /* Reflowed under the content on mobile — left-align it there
-       (the desktop right-align only makes sense in the fixed column)
-       and tint it muted so it reads as a quiet timestamp footer. */
-    text-align: left;
-    font-size: 0.78rem;
-    color: var(--fg-muted);
-  }
-
-  /* Crisper preview cards at phone widths: a roomier thumb, a hair more
-     padding, and a soft shadow so the card lifts off the row. */
-  .home-feed__preview {
-    grid-template-columns: 52px minmax(0, 1fr);
-    gap: 12px;
-    padding: 12px;
-    box-shadow: var(--shadow-sm);
-  }
-
-  .home-feed__preview-thumb {
-    width: 52px;
-    height: 52px;
-  }
-
-  .home-feed__preview-title {
-    font-size: 0.9375rem;
-  }
-
-  .home-feed__preview-desc {
-    font-size: 0.85rem;
-  }
-
-  .home-feed__preview-meta {
-    font-size: 0.75rem;
+  .home-feed__card {
+    padding: 16px 0;
   }
 
   /* Header heading + the load-more button get a touch more room. */

--- a/src/app/welcome/layout.tsx
+++ b/src/app/welcome/layout.tsx
@@ -1,34 +1,24 @@
 "use client";
 
-import { useProfileNavbar } from "@/lib/navbar-context";
-import { useAuth } from "@/lib/auth/auth-context";
 import SiteFooter from "@/components/layout/site-footer";
 
 /**
- * Welcome-page chrome — opts the page into the same transparent /
- * fullbleed treatment profile pages use, so the hero / bento /
- * pattern sections render edge-to-edge instead of being capped by
- * the global `.app-shell__content` reading column.
+ * Welcome-page chrome — the page renders edge-to-edge (the app-shell
+ * short-circuits its reading column on /welcome) under the regular
+ * top navbar. Signed-out viewers get the same chrome as everywhere
+ * else: hamburger + brandmark + sign-in on mobile, wordmark + search +
+ * Explore/Apps/Help + sign-in on desktop. The hero already offsets
+ * itself by --navbar-height, so the fixed mobile bar floats above it.
  *
  * Renders the global SiteFooter directly (the app-shell short-circuit
  * skips it on /welcome), full-bleed so the footer bar (border-top +
  * off-white band) spans the full viewport width like every other page.
- *
- * NOTE: this branch ships the local `useProfileNavbar` hook for
- * the transparent variant instead of main's `useNavbarVariant`;
- * the layout was adapted to match. Same intent on both sides.
  */
 export default function WelcomeLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  // Logged-out viewers get the transparent overlay navbar so the
-  // marketing hero reads edge-to-edge. Signed-in viewers instead get the
-  // normal mobile top bar (hamburger → left sidebar, brandmark, account
-  // switcher) so they can navigate out of the welcome page.
-  const { isAuthenticated } = useAuth();
-  useProfileNavbar(!isAuthenticated);
   return (
     <>
       {children}

--- a/src/components/home/home-feed.tsx
+++ b/src/components/home/home-feed.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type SyntheticEvent,
+} from "react"
 import { profileUrl, recordUrl } from "@/lib/urls"
 import Link from "next/link"
 import { Filter as FilterIcon, Inbox, MapPin, UserCheck, Users } from "lucide-react"
@@ -24,6 +31,7 @@ import {
 } from "@/lib/utils/group-feed"
 import { useFollowing } from "@/hooks/use-following"
 import { formatRelativeTime, resolveActivityImageUrl } from "@/lib/atproto/activity"
+import type { FeedActor } from "@/lib/atproto/follower-events"
 import { parseAtUri } from "@/lib/atproto/activity-uri"
 import { formatShortDate } from "@/lib/utils/format-date"
 import { hideBrokenThumb } from "@/lib/utils/image-fallback"
@@ -69,13 +77,15 @@ const MIN_VISIBLE_ITEMS = 10
 const MAX_AUTO_LOADS = 25
 
 /**
- * GitHub-style activity timeline for the home page. Each entry is
- * an actor byline + verb sentence on top; cert and project creates
- * also render a compact preview card underneath with the record's
- * thumbnail, description, and key meta (period + location count for
- * certs, item count for projects). Endorsement events keep to the
- * single-line treatment since the sentence already names both ends
- * of the action.
+ * Social-card activity feed for the home page, modeled on the
+ * certs.social feed design. Each entry is an author byline (avatar +
+ * display name + @handle + relative time) with the event verb as a
+ * muted second line; cert / project / update creates also render a
+ * full-card body underneath — full-width image, serif headline title,
+ * short description and a dot-separated meta row (period + location
+ * count for certs, item count for projects). Endorsement events keep
+ * to the byline-only treatment since the sentence already names both
+ * ends of the action.
  *
  * A `<header>` above the list carries the "Feed" heading on the
  * left and a per-tier filter popover (Hyperlabel quality tiers) on
@@ -517,33 +527,50 @@ function EvaluatorOption({
   )
 }
 
-function HomeFeedRow({ event }: { event: HomeFeedEvent }) {
-  // The indexer's denormalised `actorProfile` is empty in practice
-  // today (magic-indexer#130 — profile ingestion not enabled on
-  // prod). `useAuthorInfo` does the per-actor PDS resolve and caches
-  // at module scope. Prefer its data; treat the indexer's
-  // actorProfile as a first-paint hint when present.
-  const { info: lookup } = useAuthorInfo(event.actor)
-  const indexer = event.actorProfile
+/**
+ * Card head shared by single-event and grouped rows — the certs.social
+ * author byline: avatar + display name + @handle linking to the actor's
+ * profile, relative time pinned to the right edge, and the event verb
+ * sentence as a muted second line. The sentence renders OUTSIDE the
+ * byline link because it carries its own links (target cert / project /
+ * account names) — nested anchors are invalid HTML.
+ *
+ * The indexer's denormalised `actorProfile` is empty in practice today
+ * (magic-indexer#130 — profile ingestion not enabled on prod).
+ * `useAuthorInfo` does the per-actor PDS resolve and caches at module
+ * scope. Prefer its data; treat the indexer's actorProfile as a
+ * first-paint hint when present.
+ */
+function FeedCardHead({
+  actor,
+  actorProfile,
+  action,
+  createdAt,
+}: {
+  actor: string
+  actorProfile: FeedActor
+  action: ReactNode
+  createdAt: string
+}) {
+  const { info: lookup } = useAuthorInfo(actor)
   const actorName =
     lookup?.displayName ||
-    indexer.displayName ||
+    actorProfile.displayName ||
     lookup?.handle ||
-    indexer.handle ||
-    event.actor.slice(0, 16)
+    actorProfile.handle ||
+    actor.slice(0, 16)
+  const actorHandle = lookup?.handle || actorProfile.handle || null
   const actorAvatar =
     lookup?.avatarUrl ||
-    buildAvatarUrlFromCid(indexer.did, indexer.avatarCid)
+    buildAvatarUrlFromCid(actorProfile.did, actorProfile.avatarCid)
   const actorInitials = getInitials(
-    lookup?.displayName ?? indexer.displayName,
-    event.actor,
+    lookup?.displayName ?? actorProfile.displayName,
+    actor,
   )
-  const profileHref = profileUrl(
-    lookup?.handle || indexer.handle || event.actor,
-  )
+  const profileHref = profileUrl(actorHandle || actor)
 
   return (
-    <article className="home-feed__row">
+    <header className="home-feed__card-head">
       <Link
         href={profileHref}
         className="home-feed__avatar"
@@ -556,36 +583,52 @@ function HomeFeedRow({ event }: { event: HomeFeedEvent }) {
           fallbackInitials={actorInitials}
         />
       </Link>
-      <div className="home-feed__content">
-        <p className="home-feed__sentence">
+      <div className="home-feed__card-head-meta">
+        <p className="home-feed__byline">
           <Link href={profileHref} className="home-feed__actor">
             {actorName}
-          </Link>{" "}
-          <EventSentence event={event} />
+          </Link>
+          {actorHandle ? (
+            <span className="home-feed__handle">@{actorHandle}</span>
+          ) : null}
+          <time
+            className="home-feed__time"
+            dateTime={createdAt}
+            title={createdAt}
+          >
+            {formatRelativeTime(createdAt)}
+          </time>
         </p>
-        {event.kind === "cert.create" ? (
-          <CertPreview record={event.record} uri={event.uri} labels={event.labels} />
-        ) : null}
-        {event.kind === "collection.create" ||
-        event.kind === "project.created_with_cert" ? (
-          <CollectionPreview record={event.record} uri={event.uri} />
-        ) : null}
-        {event.kind === "update.create" ? (
-          <UpdatePreview
-            title={event.title}
-            shortDescription={event.shortDescription}
-            targetUri={event.targetUri}
-            imageUrl={event.imageUrl}
-          />
-        ) : null}
+        <p className="home-feed__sentence">{action}</p>
       </div>
-      <time
-        className="home-feed__time"
-        dateTime={event.createdAt}
-        title={event.createdAt}
-      >
-        {formatRelativeTime(event.createdAt)}
-      </time>
+    </header>
+  )
+}
+
+function HomeFeedRow({ event }: { event: HomeFeedEvent }) {
+  return (
+    <article className="home-feed__card">
+      <FeedCardHead
+        actor={event.actor}
+        actorProfile={event.actorProfile}
+        action={<EventSentence event={event} />}
+        createdAt={event.createdAt}
+      />
+      {event.kind === "cert.create" ? (
+        <CertPreview record={event.record} uri={event.uri} labels={event.labels} />
+      ) : null}
+      {event.kind === "collection.create" ||
+      event.kind === "project.created_with_cert" ? (
+        <CollectionPreview record={event.record} uri={event.uri} />
+      ) : null}
+      {event.kind === "update.create" ? (
+        <UpdatePreview
+          title={event.title}
+          shortDescription={event.shortDescription}
+          targetUri={event.targetUri}
+          imageUrl={event.imageUrl}
+        />
+      ) : null}
     </article>
   )
 }
@@ -594,87 +637,51 @@ function HomeFeedRow({ event }: { event: HomeFeedEvent }) {
  * Grouped row: "<actor> endorsed <first> and N others" with a "Show
  * all" toggle that expands an inline list of every endorsed account.
  *
- * Time + avatar follow the same layout as the single-event HomeFeedRow
- * so the visual rhythm of the feed stays consistent across mixed
- * single + grouped rows. The first-subject sentence is the row's
+ * The head follows the same byline layout as the single-event
+ * HomeFeedRow so the visual rhythm of the feed stays consistent across
+ * mixed single + grouped rows. The first-subject sentence is the row's
  * primary identity, since subjectDids[0] is the most recent
  * endorsement in the burst.
  */
 function EndorsementGroupRow({ group }: { group: EndorsementGroupItem }) {
-  const { info: lookup } = useAuthorInfo(group.actor)
-  const indexer = group.actorProfile
-  const actorName =
-    lookup?.displayName ||
-    indexer.displayName ||
-    lookup?.handle ||
-    indexer.handle ||
-    group.actor.slice(0, 16)
-  const actorAvatar =
-    lookup?.avatarUrl ||
-    buildAvatarUrlFromCid(indexer.did, indexer.avatarCid)
-  const actorInitials = getInitials(
-    lookup?.displayName ?? indexer.displayName,
-    group.actor,
-  )
-  const profileHref = profileUrl(
-    lookup?.handle || indexer.handle || group.actor,
-  )
-
   const othersCount = group.subjectDids.length - 1
   const [expanded, setExpanded] = useState(false)
 
   return (
-    <article className="home-feed__row">
-      <Link
-        href={profileHref}
-        className="home-feed__avatar"
-        aria-label={`${actorName}'s profile`}
+    <article className="home-feed__card">
+      <FeedCardHead
+        actor={group.actor}
+        actorProfile={group.actorProfile}
+        createdAt={group.createdAt}
+        action={
+          <>
+            endorsed{" "}
+            <EndorsementGroupSummary
+              firstDid={group.subjectDids[0]}
+              othersCount={othersCount}
+            />
+          </>
+        }
+      />
+      <Button
+        variant="ghost"
+        size="sm"
+        pressed={expanded}
+        aria-expanded={expanded}
+        className="home-feed__group-toggle"
+        onClick={() => setExpanded((v) => !v)}
       >
-        <Avatar
-          size="sm"
-          src={actorAvatar ?? undefined}
-          alt=""
-          fallbackInitials={actorInitials}
-        />
-      </Link>
-      <div className="home-feed__content">
-        <p className="home-feed__sentence">
-          <Link href={profileHref} className="home-feed__actor">
-            {actorName}
-          </Link>{" "}
-          endorsed{" "}
-          <EndorsementGroupSummary
-            firstDid={group.subjectDids[0]}
-            othersCount={othersCount}
-          />
-        </p>
-        <Button
-          variant="ghost"
-          size="sm"
-          pressed={expanded}
-          aria-expanded={expanded}
-          className="home-feed__group-toggle"
-          onClick={() => setExpanded((v) => !v)}
-        >
-          {expanded ? "Show fewer" : "Show all"}
-        </Button>
-        {expanded ? (
-          <ul className="home-feed__group-list">
-            {group.subjectDids.map((did) => (
-              <li key={did} className="home-feed__group-list-item">
-                <EndorsedAccountLink did={did} />
-              </li>
-            ))}
-          </ul>
-        ) : null}
-      </div>
-      <time
-        className="home-feed__time"
-        dateTime={group.createdAt}
-        title={group.createdAt}
-      >
-        {formatRelativeTime(group.createdAt)}
-      </time>
+        {expanded ? "Show fewer" : "Show all"}
+      </Button>
+      {expanded ? (
+        <ul className="home-feed__group-list">
+          {group.subjectDids.map((did) => (
+            <li key={did} className="home-feed__group-list-item">
+              <EndorsedAccountLink did={did} />
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </article>
   )
 }
@@ -1106,8 +1113,31 @@ function UpdatePreview({
   )
 }
 
-// ---------------------------------- Card shell ------------------------------
+// ---------------------------------- Card body ------------------------------
 
+/**
+ * Hide the full-width image block entirely when the blob 404s — the
+ * generic `hideBrokenThumb` only hides the `<img>`, which would leave
+ * the empty aspect-square container dominating the card.
+ */
+function hideBrokenCardImage(
+  event: SyntheticEvent<HTMLImageElement>,
+): void {
+  const wrap = event.currentTarget.closest<HTMLElement>(
+    ".home-feed__card-image",
+  )
+  if (wrap) wrap.style.display = "none"
+  else hideBrokenThumb(event)
+}
+
+/**
+ * Record body below the byline — the certs.social feed-card layout:
+ * full-width square image (when the record has one), serif headline
+ * title (plus quality tags), 3-line-clamped short description, and a
+ * dot-separated muted meta row. The whole body links to the record's
+ * detail page; only the title underlines on hover so the card still
+ * reads as a card.
+ */
 function PreviewCard({
   href,
   title,
@@ -1126,56 +1156,47 @@ function PreviewCard({
   const body = (
     <>
       {imageUrl ? (
-        <span className="home-feed__preview-thumb">
+        <span className="home-feed__card-image">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={imageUrl}
-            alt={title ? `Thumbnail for ${title}` : ""}
+            alt={title ? `Image for ${title}` : ""}
             loading="lazy"
-            onError={hideBrokenThumb}
+            onError={hideBrokenCardImage}
           />
         </span>
       ) : null}
-      <span className="home-feed__preview-body">
-        <span className="home-feed__preview-title-row">
-          <span className="home-feed__preview-title">{title}</span>
-          {tags?.map((t) => (
-            <Badge key={t.key} variant="tag" shape="square" tone={t.tone}>
-              {t.label}
-            </Badge>
+      <span className="home-feed__card-title-row">
+        <span className="home-feed__card-title">{title}</span>
+        {tags?.map((t) => (
+          <Badge key={t.key} variant="tag" shape="square" tone={t.tone}>
+            {t.label}
+          </Badge>
+        ))}
+      </span>
+      {description ? (
+        <span className="home-feed__card-desc">{description}</span>
+      ) : null}
+      {meta.length > 0 ? (
+        <span className="home-feed__card-meta">
+          {meta.map((m, i) => (
+            <span key={i} className="home-feed__card-meta-item">
+              {m}
+            </span>
           ))}
         </span>
-        {description ? (
-          <span className="home-feed__preview-desc">{description}</span>
-        ) : null}
-        {meta.length > 0 ? (
-          <span className="home-feed__preview-meta">
-            {meta.map((m, i) => (
-              <span key={i} className="home-feed__preview-meta-item">
-                {m}
-              </span>
-            ))}
-          </span>
-        ) : null}
-      </span>
+      ) : null}
     </>
   )
 
-  // When there's no image, drop the 56px thumb column entirely so
-  // the body flows to the card's left edge instead of sitting in a
-  // ghosted gutter next to an empty placeholder.
-  const cardClass = imageUrl
-    ? "home-feed__preview"
-    : "home-feed__preview home-feed__preview--no-image"
-
   if (href) {
     return (
-      <Link href={href} className={cardClass}>
+      <Link href={href} className="home-feed__card-body">
         {body}
       </Link>
     )
   }
-  return <div className={cardClass}>{body}</div>
+  return <div className="home-feed__card-body">{body}</div>
 }
 
 function formatPeriod(

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -350,15 +350,6 @@ export default function DesktopTopBar() {
 
   if (isLoading) return null;
 
-  // Marketing landing (/welcome), signed out: the page is self-contained —
-  // it owns its own hero "Sign in with Certified" CTA and the footer. The
-  // full app chrome here (global search + Explore/Apps/Help icon nav + a
-  // second top-right "Sign in") is redundant against that hero CTA, so the
-  // top bar drops out entirely. Signed-in viewers keep the bar so they can
-  // navigate back out of the marketing page. (The mobile <Navbar> already
-  // renders /welcome as a transparent overlay for signed-out viewers.)
-  if (pathname === "/welcome" && !isAuthenticated) return null;
-
   const tabHref = (tab: ProfileTab) => {
     if (tab.href) return tab.href;
     if (!pathname) return "#";

--- a/src/components/layout/mobile-sidebar.tsx
+++ b/src/components/layout/mobile-sidebar.tsx
@@ -69,15 +69,24 @@ export default function MobileSidebar({ isOpen, onClose }: MobileSidebarProps) {
     ? profileUrl(displayHandle)
     : "/profile";
 
-  const navLinks = [
-    { href: "/home", label: "Home", icon: Home },
-    { href: "/explore", label: "Explore", icon: Search },
-    { href: "/apps", label: "Apps", icon: LayoutGrid },
-    { href: profileHref, label: "Profile", icon: User },
-    { href: "/settings", label: "Settings", icon: Settings },
-    { key: "feedback", label: "Feedback", icon: MessageSquare, onClick: handleFeedbackClick },
-    { href: "/help", label: "Help", icon: HelpCircle },
-  ];
+  // Signed-out viewers get the public destinations only — Explore,
+  // Apps and Help. Everything else (Home, Profile, Settings, Feedback)
+  // requires a session, so those entries only render once signed in.
+  const navLinks = isAuthenticated
+    ? [
+        { href: "/home", label: "Home", icon: Home },
+        { href: "/explore", label: "Explore", icon: Search },
+        { href: "/apps", label: "Apps", icon: LayoutGrid },
+        { href: profileHref, label: "Profile", icon: User },
+        { href: "/settings", label: "Settings", icon: Settings },
+        { key: "feedback", label: "Feedback", icon: MessageSquare, onClick: handleFeedbackClick },
+        { href: "/help", label: "Help", icon: HelpCircle },
+      ]
+    : [
+        { href: "/explore", label: "Explore", icon: Search },
+        { href: "/apps", label: "Apps", icon: LayoutGrid },
+        { href: "/help", label: "Help", icon: HelpCircle },
+      ];
 
   const legalLinks = [
     { href: "/about", label: "About" },

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -17,7 +17,6 @@ import { Menu, X, ChevronDown, ArrowLeft } from "lucide-react";
 import MobileSidebar from "./mobile-sidebar";
 import AccountSwitcherList from "./account-switcher-list";
 import Brandmark from "@/components/ui/brandmark";
-import ThemeToggle from "@/components/ui/theme-toggle";
 import BottomSheet from "@/components/ui/bottom-sheet";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import Tooltip from "@/components/ui/tooltip";
@@ -197,10 +196,12 @@ const Navbar: React.FC = () => {
   // mobile left sidebar unreachable and hiding the sign-in button.
   const isRootLevel = !breadcrumb && ROOT_PATHS.has(pathname);
 
-  // Left control for the default + root-level layouts: hamburger (opens
-  // the mobile sidebar) when signed in, theme toggle when signed out —
-  // mirroring the certs.social mobile top bar.
-  const leftControl = isAuthenticated ? (
+  // Left control for the default + root-level layouts: the hamburger
+  // (opens the mobile sidebar) for signed-in AND signed-out viewers.
+  // Signed-out viewers get a slimmed-down sidebar (Explore / Apps /
+  // Help) so the app is still navigable before signing in; the theme
+  // toggle lives inside the sidebar in both states.
+  const leftControl = (
     <Tooltip label={dropdownOpen ? "Close menu" : "Open menu"}>
       <button
         className="navbar__hamburger"
@@ -212,14 +213,12 @@ const Navbar: React.FC = () => {
         {dropdownOpen ? <X size={22} /> : <Menu size={22} />}
       </button>
     </Tooltip>
-  ) : (
-    <ThemeToggle variant="cycle" />
   );
 
   // Right cluster for the default + root-level layouts: account switcher
   // (signed in) or the sign-in button (signed out), plus the portaled
   // bottom sheet + sidebar those controls drive.
-  const rightCluster = isAuthenticated ? (
+  const accountCluster = isAuthenticated ? (
     <>
       <div className="account-switcher" ref={switcherRef}>
         {isDesktop ? (
@@ -302,10 +301,6 @@ const Navbar: React.FC = () => {
           }}
         />
       </BottomSheet>
-
-      {/* Mobile sidebar (hamburger menu). The early-return at the top
-          of this component already guarantees we're on mobile here. */}
-      <MobileSidebar isOpen={dropdownOpen} onClose={() => setDropdownOpen(false)} />
     </>
   ) : (
     <Tooltip label="Sign in">
@@ -323,6 +318,17 @@ const Navbar: React.FC = () => {
         />
       </button>
     </Tooltip>
+  );
+
+  const rightCluster = (
+    <>
+      {accountCluster}
+      {/* Mobile sidebar (hamburger menu) — mounted for signed-in and
+          signed-out viewers alike, since the hamburger is the left
+          control in both states. The early-return at the top of this
+          component already guarantees we're on mobile here. */}
+      <MobileSidebar isOpen={dropdownOpen} onClose={() => setDropdownOpen(false)} />
+    </>
   );
 
   // Profile overlay layout: transparent background, back arrow only (no


### PR DESCRIPTION
## Summary

### 1. Top navbar on /welcome for signed-out viewers
Signed-out viewers on /welcome previously got a transparent overlay navbar (back arrow only) on mobile and no top bar at all on desktop.

- **Mobile:** the regular fixed top bar now renders — hamburger menu on the left, brandmark in the middle, sign-in button on the right. The hamburger opens the sidebar slimmed down to the public destinations: **Explore, Apps, Help** (plus the legal links and the theme toggle inside the sidebar).
- **Desktop:** the top bar no longer drops out on /welcome when signed out — Certified wordmark on the left, global search, Explore / Apps / Help buttons and the sign-in button, same as every other page.
- The landing hero already offsets itself by `--navbar-height`, so no layout compensation was needed.

### 2. Home feed redesigned after certs.social
The home-page feed swaps the GitHub-style three-column timeline for the feed-card design from [hypercerts-org/certs-social](https://github.com/hypercerts-org/certs-social):

- Author byline head — avatar + display name + @handle (links to the profile), relative time pinned right, event verb as a muted second line.
- Record body for cert / project / update creates — full-width square image, serif headline title (`font-headline`) with quality tags, 3-line-clamped description, dot-separated muted meta row (period, locations, item counts). The body links to the detail page; only the title underlines on hover.
- Cards separated by hairline dividers with the certs.social 20/24px vertical rhythm; grouped endorsement rows keep their Show all / Show fewer expansion.
- Data plumbing (useHomeFeed, evaluator/quality filters, endorsement grouping, auto-pagination) is unchanged.

## Verification
- `npx tsc --noEmit` — clean for `src/` (remaining errors are stale `.next` artifacts from another branch's routes).
- `npm run lint` — 63 warnings, identical to the clean-staging baseline (0 added).
- `npx vitest run` — 592 passed; the 29 failures in `recently-viewed.test.ts` / `swap-drafts.test.ts` also fail on clean staging (pre-existing).
- All four CLAUDE.md UI greps (radii, breakpoints, headings, modal backdrops) are silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)