### PR TITLE
Mobile polish: quieter chrome, certs.social feed tabs + filters, tighter gutters

### DIFF
--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -12,11 +12,11 @@ export default function AppsPage() {
 
   return (
     <div className="apps-store">
+      {/* The navbar already carries the "Apps" page title — no eyebrow /
+          h1 repeat here, just the one-line intro. */}
       <header className="apps-store__header">
-        <span className="apps-store__eyebrow">Ecosystem</span>
-        <h1 className="apps-store__title">Apps</h1>
         <p className="apps-store__intro">
-          Apps built on the AT Protocol. One Certified identity, every app.
+          Apps built with Certified on AT Protocol.
         </p>
       </header>
 

--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -7,12 +7,23 @@
    styling only. */
 
 .explore-page {
-  padding: 24px 16px 64px;
+  padding: 24px 8px 64px;
 }
 
 @media (min-width: 800px) {
   .explore-page {
     padding: 0;
+  }
+}
+
+@media (max-width: 799px) {
+  /* Zero the shell's 16px reading gutter — the page carries its own
+     small (8px) gutter above so list rows run nearly edge-to-edge,
+     matching the /home feed treatment. Specificity (three classes via
+     :has) beats the components.css mobile gutter rule. */
+  .app-shell:has(.explore-page) .app-shell__content {
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -690,16 +701,62 @@
   text-align: right;
 }
 
+/* Phone: list rows pick up the /home feed-card treatment — the boxed
+   list flattens to hairline-divided full-width cards, the author
+   byline moves on top with the relative time pinned right, and titles
+   speak in the serif headline voice. */
 @media (max-width: 799px) {
-  .cert-list-row {
-    grid-template-columns: 1fr;
-    padding: 10px 12px;
-    gap: 8px;
+  .explore__list {
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    overflow: visible;
   }
-  .cert-list-row__author-col,
+
+  .explore__list > li + li .cert-list-row,
+  .explore__list > li + li .account-list-row {
+    border-top: 1px solid var(--border-default);
+  }
+
+  .cert-list-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+      "author time"
+      "link link";
+    gap: 10px 12px;
+    padding: 16px 0;
+  }
+
+  .cert-list-row:hover {
+    background: transparent;
+  }
+
+  .cert-list-row__author-col {
+    grid-area: author;
+  }
+
   .cert-list-row__time {
-    justify-self: start;
-    text-align: left;
+    grid-area: time;
+    color: var(--fg-muted);
+  }
+
+  .cert-list-row__link {
+    grid-area: link;
+    align-items: flex-start;
+  }
+
+  .cert-list-row__body {
+    gap: 4px;
+  }
+
+  .cert-list-row__title {
+    font-family: var(--font-headline), "Noto Serif", Georgia, serif;
+    font-size: 1.0625rem;
+    font-weight: 700;
+  }
+
+  .cert-list-row__meta {
+    color: var(--fg-muted);
   }
 }
 
@@ -912,9 +969,16 @@
 }
 
 @media (max-width: 799px) {
+  /* Account rows share the flattened feed treatment: full-width rows
+     between hairline dividers (set in the cert-list-row mobile block),
+     no boxed hover wash. */
   .account-list-row {
     grid-template-columns: minmax(0, 1fr);
     gap: 6px;
+    padding: 14px 0;
+  }
+  .account-list-row:hover {
+    background: transparent;
   }
   .account-list-row__badge,
   .account-list-row__joined {

--- a/src/app/styles/feed.css
+++ b/src/app/styles/feed.css
@@ -235,6 +235,46 @@
   padding: 10px 16px 8px;
 }
 
+/* Section heading inside the panel ("Activity quality", …) — same
+   register as the create-form field labels. */
+.feed-evaluator-panel__heading {
+  margin: 8px 0 6px;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-muted);
+}
+
+.feed-evaluator-panel__heading:first-child {
+  margin-top: 2px;
+}
+
+/* Quiet text button at the panel's bottom. */
+.feed-evaluator-panel__reset {
+  display: block;
+  margin: 2px 0 4px;
+  padding: 6px 0;
+  border: none;
+  background: transparent;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.feed-evaluator-panel__reset:hover:not(:disabled) {
+  color: var(--fg-primary);
+}
+
+.feed-evaluator-panel__reset:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .feed-evaluators {
   background: var(--bg-canvas);
   padding: 10px 16px 8px;

--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -288,10 +288,17 @@
 }
 
 @media (max-width: 799px) {
+  /* Zero the shell's 16px reading gutter for the home page — the feed
+     carries its own (small) gutter below, so cards run nearly
+     edge-to-edge like a native social timeline. Specificity (three
+     classes via :has) beats the components.css mobile gutter rule. */
+  .app-shell:has(.home-page) .app-shell__content {
+    padding-left: 0;
+    padding-right: 0;
+  }
   .home__main {
-    /* Slightly tighter side gutters on a phone so the feed gets room,
-       with a touch more top breathing space below the navbar. */
-    padding: 12px 14px 32px;
+    /* Just a small side gutter on a phone so the feed gets the room. */
+    padding: 12px 8px 32px;
   }
 }
 
@@ -323,29 +330,6 @@
   min-width: 0;
 }
 
-.home-feed__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  margin: 0 0 12px;
-}
-
-.home-feed__header-actions {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.home-feed__heading {
-  margin: 0;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--fg-secondary);
-}
-
 .home__news {
   min-width: 0;
   /* Match the .right-rail surface used elsewhere — light card on
@@ -369,13 +353,14 @@
    description and a dot-separated muted meta row. Mirrors the
    feed-card layout shipped on certs.social. */
 
+/* No border-top — the tab strip above (.feed-tabs) carries the
+   dividing rule, exactly like the certs.social feed surface. */
 .home-feed {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  border-top: 1px solid var(--border-subtle);
 }
 
 .home-feed__item {
@@ -612,12 +597,6 @@ a.home-feed__card-body:hover .home-feed__card-title {
 }
 
 @media (max-width: 799px) {
-  .home-feed {
-    /* Drop the hairline top rule on mobile — the first card's own
-       padding gives enough separation from the header. */
-    border-top: 0;
-  }
-
   .home-feed__item {
     /* Slightly stronger divider than the desktop subtle line so cards
        read as distinct entries in a thumb-scrolled timeline. */
@@ -630,11 +609,6 @@ a.home-feed__card-body:hover .home-feed__card-title {
 
   .home-feed__card {
     padding: 16px 0;
-  }
-
-  /* Header heading + the load-more button get a touch more room. */
-  .home-feed__header {
-    margin-bottom: 8px;
   }
 
   .home-feed__load-more {
@@ -667,209 +641,15 @@ a.home-feed__card-body:hover .home-feed__card-title {
   padding: 0 16px;
 }
 
-/* ---------- Quality filter popover (right side of feed header) ---------- */
+/* The feed's tab strip + inline filter panel reuse the certs.social
+   classes in feed.css (.feed-tabs, .feed-evaluator-panel,
+   .feed-evaluators__*) — no home-specific chrome styles needed. */
 
-.home-feed__filter {
-  position: relative;
-}
-
-.home-feed__filter-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  padding: 0;
-  border: 1px solid transparent;
-  border-radius: var(--radius);
-  background: transparent;
-  color: var(--fg-secondary);
-  cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
-}
-
-.home-feed__filter-btn:hover {
-  background: var(--bg-sunken);
-  color: var(--fg-primary);
-}
-
-.home-feed__filter-btn:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--focus-ring);
-}
-
-/* When any tier is excluded, give the trigger a subtle filled state
-   so the filter doesn't look idle. */
-.home-feed__filter-btn--active {
-  color: var(--fg-primary);
-  border-color: var(--border-medium);
-  background: var(--bg-sunken);
-}
-
-/* Mobile: 44px tap targets for the feed filter trigger and sidebar/list
-   rows, roomier checkbox rows, and a viewport-constrained popover so the
-   right-anchored menu can't overflow off a narrow screen. */
+/* Mobile: comfortable tap height for the home sidebar/list rows. */
 @media (max-width: 799px) {
-  .home-feed__filter-btn {
-    width: 44px;
-    height: 44px;
-  }
-  .home-feed__filter-pop {
-    max-width: calc(100vw - 32px);
-  }
-  .home-feed__filter-item {
-    padding: 10px 8px;
-  }
   .home-row {
     min-height: 44px;
   }
-}
-
-.home-feed__filter-pop {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  z-index: var(--z-popover);
-  min-width: 184px;
-  padding: 10px 8px 8px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-medium);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow-md);
-}
-
-.home-feed__filter-title {
-  margin: 0 4px 6px;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: var(--fg-secondary);
-}
-
-.home-feed__filter-help {
-  margin: 0 4px 8px;
-  font-size: 0.75rem;
-  line-height: 1.4;
-  color: var(--fg-secondary);
-}
-
-.home-feed__filter-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.home-feed__filter-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  border-radius: var(--radius);
-  font-size: 0.8125rem;
-  color: var(--fg-primary);
-  cursor: pointer;
-  user-select: none;
-  transition: background var(--transition-fast);
-}
-
-.home-feed__filter-item:hover {
-  background: var(--bg-sunken);
-}
-
-.home-feed__filter-item input {
-  width: 14px;
-  height: 14px;
-  accent-color: var(--fg-primary);
-  cursor: pointer;
-  flex-shrink: 0;
-}
-
-/* "Reset to default" link at the bottom of each filter popover.
-   Quiet text-button styling so it doesn't compete with the active
-   selection above; disabled state when already at default keeps it
-   visible but inert. Mirrors `.popover__reset-btn` in explore.css. */
-.home-feed__filter-reset {
-  display: block;
-  width: calc(100% - 8px);
-  margin: 8px 4px 0;
-  padding: 6px 8px;
-  border: 0;
-  border-top: 1px solid var(--border-subtle);
-  border-radius: 0;
-  background: none;
-  text-align: left;
-  font-family: var(--font-inter), system-ui, sans-serif;
-  font-size: 0.78rem;
-  font-weight: 500;
-  color: var(--fg-secondary);
-  cursor: pointer;
-  transition: background var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.home-feed__filter-reset:hover:not(:disabled) {
-  background: var(--bg-sunken);
-  color: var(--fg-primary);
-}
-
-.home-feed__filter-reset:disabled {
-  color: var(--fg-muted);
-  cursor: default;
-}
-
-/* ---------- Trusted-evaluator popover overrides ---------- */
-
-.home-feed__filter-pop--evaluators {
-  min-width: 248px;
-}
-
-.home-feed__evaluator-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 4px 6px 4px 8px;
-  border-radius: var(--radius);
-}
-
-.home-feed__evaluator-check {
-  width: 14px;
-  height: 14px;
-  accent-color: var(--fg-primary);
-  cursor: pointer;
-  flex-shrink: 0;
-}
-
-.home-feed__evaluator-link {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex: 1;
-  min-width: 0;
-  padding: 4px 6px;
-  border-radius: var(--radius);
-  color: var(--fg-primary);
-  text-decoration: none;
-  transition: background var(--transition-fast);
-}
-
-.home-feed__evaluator-link:hover {
-  background: var(--bg-sunken);
-}
-
-.home-feed__evaluator-link:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--focus-ring);
-}
-
-.home-feed__evaluator-name {
-  font-size: 0.8125rem;
-  line-height: 1.3;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
 }
 
 /* ---------- Activity timeline load-more sentinel ---------- */

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -299,39 +299,6 @@ html[data-theme="dark"] .signin-mark__img--light {
   gap: 16px;
 }
 
-.navbar__signin-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 4px 8px;
-  background: none;
-  border: none;
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: opacity var(--transition-fast), transform var(--transition-fast);
-}
-
-.navbar__signin-btn:hover {
-  opacity: 0.85;
-}
-
-.navbar__signin-btn:active {
-  transform: scale(0.97);
-}
-
-.navbar__signin-btn:focus-visible {
-  outline: 2px solid var(--focus-ring);
-  outline-offset: 2px;
-}
-
-.navbar__signin-img {
-  height: 26px;
-  width: auto;
-  display: block;
-}
-
-
-
 /* ========== App Top Nav (authenticated) ========== */
 .navbar__app-links {
   display: flex;
@@ -532,11 +499,39 @@ html[data-theme="dark"] .signin-mark__img--light {
    inner-content classes below (sections, profile, links, badges) are
    still rendered by MobileSidebar and styled here. */
 
-.mobile-sidebar__section--profile {
+/* Brand row pinned to the drawer's top: wordmark top-left, theme
+   toggle top-right. Sits above the (signed-in-only) profile block. */
+.mobile-sidebar__section--brand {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
+}
+
+.mobile-sidebar__wordmark {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius);
+}
+
+.mobile-sidebar__wordmark-img {
+  height: 18px;
+  width: auto;
+  display: block;
+}
+
+/* Source SVG is pure black; flip via CSS filter in dark mode (mirrors
+   .desktop-top-bar__wordmark / .site-footer__wordmark). */
+:root[data-theme="dark"] .mobile-sidebar__wordmark-img {
+  filter: invert(1);
+}
+
+/* Brand row on top, profile block (signed-in only) stacked below. */
+.mobile-sidebar__section--profile {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 16px;
 }
 
 .mobile-sidebar__profile {

--- a/src/app/styles/pages.css
+++ b/src/app/styles/pages.css
@@ -827,28 +827,10 @@
   padding-top: 8px;
 }
 
+/* The navbar carries the "Apps" page title; the header is just the
+   one-line intro now. */
 .apps-store__header {
   margin-bottom: 24px;
-}
-
-.apps-store__eyebrow {
-  display: inline-block;
-  font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--fg-muted);
-  margin-bottom: 8px;
-}
-
-.apps-store__title {
-  font-family: var(--font-headline), "Noto Serif", serif;
-  font-size: clamp(2rem, 3vw + 0.5rem, 2.75rem);
-  font-weight: 700;
-  line-height: 1.05;
-  letter-spacing: -0.02em;
-  color: var(--fg-primary);
-  margin: 0 0 10px;
 }
 
 .apps-store__intro {

--- a/src/app/styles/settings-page.css
+++ b/src/app/styles/settings-page.css
@@ -109,19 +109,14 @@
   overflow-y: auto;
 }
 
-/* On mobile the page-layout grid collapses to a single column —
-   sticky behaviour stops making sense (the rail sits above the
-   panel, not beside it), so unpin it. */
+/* On mobile the page-layout grid collapses to a single column and the
+   section nav would just stack above the panel — drop it entirely; the
+   sections themselves are a short scroll and carry their own headings.
+   Deep links (#section) still work since the anchors live on the
+   sections, not the menu. */
 @media (max-width: 799px) {
   .sx__menu {
-    position: static;
-    max-height: none;
-    overflow: visible;
-  }
-  /* Settings menu items meet the 44px tap target on mobile (the compact
-     ~32px desktop padding is too small to tap reliably). */
-  .sx-menu__item {
-    min-height: 44px;
+    display: none;
   }
 }
 

--- a/src/components/home/home-feed.tsx
+++ b/src/components/home/home-feed.tsx
@@ -10,12 +10,11 @@ import {
 } from "react"
 import { profileUrl, recordUrl } from "@/lib/urls"
 import Link from "next/link"
-import { Filter as FilterIcon, Inbox, MapPin, UserCheck, Users } from "lucide-react"
+import { ChevronDown, Inbox, MapPin, Users } from "lucide-react"
 import Avatar from "@/components/ui/avatar"
 import Badge, { type BadgeTone } from "@/components/ui/badge"
 import Banner from "@/components/ui/banner"
 import Button from "@/components/ui/button"
-import Tooltip from "@/components/ui/tooltip"
 import EmptyState from "@/components/ui/empty-state"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import LoadMoreSentinel from "@/components/ui/load-more-sentinel"
@@ -39,11 +38,15 @@ import { getInitials } from "@/lib/utils/initials"
 import { buildAvatarUrlFromCid } from "@/lib/atproto/profile"
 import {
   DEFAULT_HIDDEN_CERT_LABELS,
+  DEFAULT_HIDDEN_ORG_LABELS,
   HYPERLABEL_DISPLAY_LABELS,
   HYPERLABEL_DISPLAY_ORDER,
   HYPERLABEL_TIERS,
+  ORGLABEL_TIERS,
   type HyperlabelTier,
+  type OrglabelTier,
 } from "@/lib/atproto/labels"
+import { fetchOrgDidsByLabel } from "@/lib/atproto/workspace"
 import { TRUSTED_EVALUATOR_DIDS } from "@/lib/atproto/trusted-evaluators"
 import type { ActivityRecord } from "@/lib/atproto/activity-types"
 import type { CollectionRecord } from "@/lib/atproto/collection"
@@ -60,6 +63,27 @@ const DEFAULT_INCLUDED_TIERS: ReadonlySet<HyperlabelTier> = new Set(
 const UNLABELED_SLUG = "unlabeled" as const
 type UnlabeledSlug = typeof UNLABELED_SLUG
 type QualityFilterValue = HyperlabelTier | UnlabeledSlug
+type OrgQualityValue = OrglabelTier | UnlabeledSlug
+
+/** Default org-quality set — everything except the labels in
+ *  DEFAULT_HIDDEN_ORG_LABELS (today only "likely-test"). Matches the
+ *  explore page's Account-quality default. */
+const DEFAULT_INCLUDED_ORG_TIERS: ReadonlySet<OrglabelTier> = new Set(
+  ORGLABEL_TIERS.filter((t) => !DEFAULT_HIDDEN_ORG_LABELS.includes(t)),
+)
+
+/** Highest tier first — same order the explore Account-quality
+ *  popover lists them in. */
+const ORGLABEL_DISPLAY_ORDER: readonly OrglabelTier[] = [
+  "high-quality",
+  "standard",
+  "likely-test",
+]
+const ORGLABEL_DISPLAY_LABELS: Record<OrglabelTier, string> = {
+  "high-quality": "High quality",
+  standard: "Standard",
+  "likely-test": "Likely test",
+}
 
 /** Visible-row threshold below which the feed auto-paginates. Sized
  *  to "more than fits in one screen on a tall viewport" so a user
@@ -116,6 +140,25 @@ export default function HomeFeed({ activeDid }: { activeDid: string }) {
   const [selectedEvaluators, setSelectedEvaluators] = useState<Set<string>>(
     () => new Set(TRUSTED_EVALUATOR_DIDS),
   )
+  // Organization-quality filter (Orglabeler tiers) — applied to the
+  // event ACTOR rather than the record, by adjusting the author DID
+  // set handed to useHomeFeed (see effectiveFollows below).
+  const [includedOrgTiers, setIncludedOrgTiers] = useState<Set<OrgQualityValue>>(
+    () => new Set<OrgQualityValue>([...DEFAULT_INCLUDED_ORG_TIERS, UNLABELED_SLUG]),
+  )
+  // Inline filter panel under the "For you" tab (certs.social pattern:
+  // clicking the active tab toggles the disclosure).
+  const [filterOpen, setFilterOpen] = useState(false)
+  const filterWrapRef = useRef<HTMLDivElement>(null)
+  useClickOutsideClose(filterOpen, filterWrapRef, () => setFilterOpen(false))
+  useEffect(() => {
+    if (!filterOpen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFilterOpen(false)
+    }
+    document.addEventListener("keydown", onKey)
+    return () => document.removeEventListener("keydown", onKey)
+  }, [filterOpen])
   // Two filter modes, mirroring the explore page (see the
   // `certIncludeUnlabeled` comment block there for the full rationale):
   //   - Unlabeled INCLUDED → use `excludeCertLabels` (drop specific
@@ -143,24 +186,36 @@ export default function HomeFeed({ activeDid }: { activeDid: string }) {
   )
   const { endorsedDids, isLoading: endorsementsLoading } =
     useEvaluatorEndorsements(selectedEvaluators)
-  // Direct follows ∪ DIDs endorsed by any selected trusted evaluator.
-  // The viewer's own DID is excluded so the feed doesn't show the
-  // viewer's own activity (matches the prior behaviour — direct
-  // follows never include self).
+  const orgFilter = useOrgQualityFilter(includedOrgTiers)
+  // Direct follows ∪ DIDs endorsed by any selected trusted evaluator,
+  // then narrowed by the organization-quality filter. The viewer's own
+  // DID is excluded so the feed doesn't show the viewer's own activity
+  // (matches the prior behaviour — direct follows never include self).
   const effectiveFollows = useMemo(() => {
     const out = new Set<string>(followedDids)
     for (const did of endorsedDids) {
       if (did !== activeDid) out.add(did)
     }
+    if (orgFilter.dids) {
+      if (orgFilter.mode === "exclude") {
+        // Unlabeled INCLUDED: drop actors carrying an excluded tier.
+        for (const did of orgFilter.dids) out.delete(did)
+      } else if (orgFilter.mode === "include-only") {
+        // Unlabeled EXCLUDED: keep only actors carrying a checked tier.
+        for (const did of [...out]) {
+          if (!orgFilter.dids.has(did)) out.delete(did)
+        }
+      }
+    }
     return out
-  }, [followedDids, endorsedDids, activeDid])
-  // Gate the feed fetch on BOTH author sources being resolved so the
-  // feed renders in a single frame instead of flashing direct-follows
-  // first and then a second pass with the evaluator-endorsed union.
-  // useEvaluatorEndorsements caches its result at module scope, so
-  // after the first /home visit `ready` flips effectively-synchronously
-  // on the next visit — only the cold first paint waits.
-  const ready = !followsLoading && !endorsementsLoading
+  }, [followedDids, endorsedDids, activeDid, orgFilter.mode, orgFilter.dids])
+  // Gate the feed fetch on every author source being resolved (follows,
+  // evaluator endorsements, org-label DID set) so the feed renders in a
+  // single frame instead of flashing direct-follows first and then a
+  // second pass with the narrowed union. All three fetches cache at
+  // module scope, so after the first /home visit `ready` flips
+  // effectively-synchronously — only the cold first paint waits.
+  const ready = !followsLoading && !endorsementsLoading && !orgFilter.isLoading
   const { events, isLoading, isLoadingMore, hasMore, loadMore, error } =
     useHomeFeed(effectiveFollows, {
       excludeCertLabels,
@@ -168,21 +223,61 @@ export default function HomeFeed({ activeDid }: { activeDid: string }) {
       ready,
     })
 
+  // "For you" flips to "Custom" once any filter diverges from the
+  // defaults — same affordance certs.social uses on its feed tabs.
+  const isDefaultFilters =
+    isQualityDefault(includedTiers) &&
+    isOrgQualityDefault(includedOrgTiers) &&
+    selectedEvaluators.size === TRUSTED_EVALUATOR_DIDS.length
+
+  const resetFilters = () => {
+    setIncludedTiers(
+      new Set<QualityFilterValue>([...DEFAULT_INCLUDED_TIERS, UNLABELED_SLUG]),
+    )
+    setIncludedOrgTiers(
+      new Set<OrgQualityValue>([...DEFAULT_INCLUDED_ORG_TIERS, UNLABELED_SLUG]),
+    )
+    setSelectedEvaluators(new Set(TRUSTED_EVALUATOR_DIDS))
+  }
+
   return (
     <>
-      <header className="home-feed__header">
-        <h2 className="home-feed__heading">Feed</h2>
-        <div className="home-feed__header-actions">
-          <EvaluatorFilter
-            selected={selectedEvaluators}
-            onChange={setSelectedEvaluators}
-          />
-          <QualityFilter
-            included={includedTiers}
-            onChange={setIncludedTiers}
-          />
+      {/* certs.social-style tab strip. One tab for now ("For you");
+          clicking the active tab toggles the inline filter panel. */}
+      <div ref={filterWrapRef}>
+        <div className="feed-tabs" role="tablist" aria-label="Feed">
+          <div className="feed-tabs__tab-wrapper">
+            <button
+              type="button"
+              className="feed-tabs__tab feed-tabs__tab--active"
+              role="tab"
+              aria-selected="true"
+              aria-haspopup="dialog"
+              aria-expanded={filterOpen}
+              onClick={() => setFilterOpen((v) => !v)}
+            >
+              {isDefaultFilters ? "For you" : "Custom"}
+              <ChevronDown
+                size={14}
+                aria-hidden
+                className={`feed-tabs__chevron${filterOpen ? " feed-tabs__chevron--open" : ""}`}
+              />
+            </button>
+          </div>
         </div>
-      </header>
+        {filterOpen ? (
+          <FeedFilterPanel
+            selectedEvaluators={selectedEvaluators}
+            onEvaluatorsChange={setSelectedEvaluators}
+            includedTiers={includedTiers}
+            onTiersChange={setIncludedTiers}
+            includedOrgTiers={includedOrgTiers}
+            onOrgTiersChange={setIncludedOrgTiers}
+            isDefault={isDefaultFilters}
+            onReset={resetFilters}
+          />
+        ) : null}
+      </div>
       <HomeFeedBody
         followsLoading={followsLoading}
         followsError={!!followsError}
@@ -315,96 +410,6 @@ function HomeFeedBody({
   )
 }
 
-/**
- * Right-aligned icon button next to the "Feed" heading. Opens a
- * popover with one checkbox per Hyperlabel tier. The selected set
- * drives `excludeCertLabels` at the hydration round-trip — anything
- * unchecked is filtered out before reaching the timeline.
- */
-function QualityFilter({
-  included,
-  onChange,
-}: {
-  included: Set<QualityFilterValue>
-  onChange: (next: Set<QualityFilterValue>) => void
-}) {
-  const [open, setOpen] = useState(false)
-  const wrapRef = useRef<HTMLDivElement>(null)
-
-  useClickOutsideClose(open, wrapRef, () => setOpen(false))
-
-  const toggle = (value: QualityFilterValue) => {
-    const next = new Set(included)
-    if (next.has(value)) next.delete(value)
-    else next.add(value)
-    onChange(next)
-  }
-
-  const resetToDefault = () => {
-    onChange(new Set<QualityFilterValue>([...DEFAULT_INCLUDED_TIERS, UNLABELED_SLUG]))
-  }
-
-  // "Filtered" badge highlights the button when the popover state
-  // diverges from the default (every visible tier + unlabeled).
-  // Total filter slots = number of Hyperlabel tiers + 1 for unlabeled.
-  const filtered = included.size !== HYPERLABEL_TIERS.length + 1
-  const isDefault = isQualityDefault(included)
-
-  return (
-    <div className="home-feed__filter" ref={wrapRef}>
-      <Tooltip label="Filter by activity quality">
-        <button
-          type="button"
-          className={`home-feed__filter-btn${filtered ? " home-feed__filter-btn--active" : ""}`}
-          onClick={() => setOpen((v) => !v)}
-          aria-haspopup="true"
-          aria-expanded={open}
-          aria-label="Filter feed by activity quality"
-        >
-          <FilterIcon size={14} strokeWidth={1.75} aria-hidden />
-        </button>
-      </Tooltip>
-      {open ? (
-        <div className="home-feed__filter-pop" role="dialog" aria-label="Activity quality filters">
-          <p className="home-feed__filter-title">Activities quality</p>
-          <ul className="home-feed__filter-list">
-            {HYPERLABEL_DISPLAY_ORDER.map((tier) => (
-              <li key={tier}>
-                <label className="home-feed__filter-item">
-                  <input
-                    type="checkbox"
-                    checked={included.has(tier)}
-                    onChange={() => toggle(tier)}
-                  />
-                  <span>{HYPERLABEL_DISPLAY_LABELS[tier]}</span>
-                </label>
-              </li>
-            ))}
-            <li>
-              <label className="home-feed__filter-item">
-                <input
-                  type="checkbox"
-                  checked={included.has(UNLABELED_SLUG)}
-                  onChange={() => toggle(UNLABELED_SLUG)}
-                />
-                <span>Not labeled yet</span>
-              </label>
-            </li>
-          </ul>
-          <button
-            type="button"
-            className="home-feed__filter-reset"
-            onClick={resetToDefault}
-            disabled={isDefault}
-          >
-            Reset to default
-          </button>
-        </div>
-      ) : null}
-    </div>
-  )
-}
-
 function isQualityDefault(included: Set<QualityFilterValue>): boolean {
   // Default = every tier in DEFAULT_INCLUDED_TIERS, plus unlabeled.
   if (included.size !== DEFAULT_INCLUDED_TIERS.size + 1) return false
@@ -413,85 +418,200 @@ function isQualityDefault(included: Set<QualityFilterValue>): boolean {
   return true
 }
 
+function isOrgQualityDefault(included: Set<OrgQualityValue>): boolean {
+  if (included.size !== DEFAULT_INCLUDED_ORG_TIERS.size + 1) return false
+  if (!included.has(UNLABELED_SLUG)) return false
+  for (const t of DEFAULT_INCLUDED_ORG_TIERS) if (!included.has(t)) return false
+  return true
+}
+
 /**
- * Trusted-evaluator settings popover (left of the quality filter).
- * Each checkbox represents one curated evaluator account; selecting
- * an evaluator pulls every DID they've endorsed into the effective
- * follow set, so the feed shows transitively-vouched activity. The
- * popover lists evaluators by display name / handle resolved via
- * `useAuthorInfo` — the underlying DID is hidden behind the friendly
- * label.
+ * Resolve the organization-quality checkboxes into a DID set + how to
+ * apply it to the feed's author set. Two modes, mirroring the cert
+ * quality filter's polarity logic:
+ *   - Unlabeled INCLUDED → "exclude": fetch the DIDs carrying any
+ *     UNchecked tier and subtract them (unlabeled actors pass).
+ *   - Unlabeled EXCLUDED → "include-only": fetch the DIDs carrying a
+ *     checked tier and intersect (unlabeled actors drop).
+ * `fetchOrgDidsByLabel` caches per label tuple at module scope, so the
+ * default exclusion costs one request per session. On fetch failure the
+ * filter degrades to unfiltered (`dids: null`) rather than blanking the
+ * feed.
  */
-function EvaluatorFilter({
-  selected,
-  onChange,
+function useOrgQualityFilter(included: Set<OrgQualityValue>): {
+  mode: "none" | "exclude" | "include-only"
+  dids: Set<string> | null
+  isLoading: boolean
+} {
+  const includeUnlabeled = included.has(UNLABELED_SLUG)
+  const labels = useMemo(
+    () =>
+      includeUnlabeled
+        ? ORGLABEL_TIERS.filter((t) => !included.has(t))
+        : ORGLABEL_TIERS.filter((t) => included.has(t)),
+    [included, includeUnlabeled],
+  )
+  const mode = includeUnlabeled
+    ? labels.length === 0
+      ? ("none" as const)
+      : ("exclude" as const)
+    : ("include-only" as const)
+  const key = mode === "none" ? "none" : `${mode}:${labels.join(",")}`
+  const [state, setState] = useState<{ key: string; dids: Set<string> | null }>(
+    { key: "none", dids: null },
+  )
+  useEffect(() => {
+    if (mode === "none") return
+    let cancelled = false
+    fetchOrgDidsByLabel({ labels })
+      .then((dids) => {
+        if (!cancelled) setState({ key, dids })
+      })
+      .catch(() => {
+        if (!cancelled) setState({ key, dids: null })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, mode, labels])
+  if (mode === "none") return { mode, dids: null, isLoading: false }
+  const fresh = state.key === key
+  return { mode, dids: fresh ? state.dids : null, isLoading: !fresh }
+}
+
+/**
+ * Inline filter panel under the "For you" tab — the certs.social
+ * evaluator-panel pattern (`.feed-evaluator-panel` / `.feed-evaluators`
+ * styles), extended with three sections: trusted evaluators, activity
+ * quality (Hyperlabel tiers) and organization quality (Orglabeler
+ * tiers), plus a reset row.
+ */
+function FeedFilterPanel({
+  selectedEvaluators,
+  onEvaluatorsChange,
+  includedTiers,
+  onTiersChange,
+  includedOrgTiers,
+  onOrgTiersChange,
+  isDefault,
+  onReset,
 }: {
-  selected: Set<string>
-  onChange: (next: Set<string>) => void
+  selectedEvaluators: Set<string>
+  onEvaluatorsChange: (next: Set<string>) => void
+  includedTiers: Set<QualityFilterValue>
+  onTiersChange: (next: Set<QualityFilterValue>) => void
+  includedOrgTiers: Set<OrgQualityValue>
+  onOrgTiersChange: (next: Set<OrgQualityValue>) => void
+  isDefault: boolean
+  onReset: () => void
 }) {
-  const [open, setOpen] = useState(false)
-  const wrapRef = useRef<HTMLDivElement>(null)
-
-  useClickOutsideClose(open, wrapRef, () => setOpen(false))
-
-  const toggle = (did: string) => {
-    const next = new Set(selected)
-    if (next.has(did)) next.delete(did)
-    else next.add(did)
-    onChange(next)
+  function toggled<T>(set: Set<T>, value: T): Set<T> {
+    const next = new Set(set)
+    if (next.has(value)) next.delete(value)
+    else next.add(value)
+    return next
   }
-
-  const resetToDefault = () => {
-    onChange(new Set(TRUSTED_EVALUATOR_DIDS))
-  }
-
-  const partial = selected.size !== TRUSTED_EVALUATOR_DIDS.length
 
   return (
-    <div className="home-feed__filter" ref={wrapRef}>
-      <Tooltip label="Trusted-evaluator settings">
-        <button
-          type="button"
-          className={`home-feed__filter-btn${partial ? " home-feed__filter-btn--active" : ""}`}
-          onClick={() => setOpen((v) => !v)}
-          aria-haspopup="true"
-          aria-expanded={open}
-          aria-label="Trusted-evaluator settings"
-        >
-          <UserCheck size={14} strokeWidth={1.75} aria-hidden />
-        </button>
-      </Tooltip>
-      {open ? (
-        <div className="home-feed__filter-pop home-feed__filter-pop--evaluators" role="dialog" aria-label="Trusted evaluators">
-          <p className="home-feed__filter-help">
-            Show activities from accounts that are endorsed by:
-          </p>
-          <ul className="home-feed__filter-list">
-            {TRUSTED_EVALUATOR_DIDS.map((did) => (
-              <li key={did}>
-                <EvaluatorOption
-                  did={did}
-                  checked={selected.has(did)}
-                  onToggle={() => toggle(did)}
-                />
-              </li>
-            ))}
-          </ul>
-          <button
-            type="button"
-            className="home-feed__filter-reset"
-            onClick={resetToDefault}
-            disabled={!partial}
-          >
-            Reset to default
-          </button>
-        </div>
-      ) : null}
+    <div
+      className="feed-evaluator-panel"
+      role="region"
+      aria-label="Feed filters"
+    >
+      <p className="feed-evaluator-panel__heading">
+        Show activities from accounts that are endorsed by:
+      </p>
+      <div className="feed-evaluators__list">
+        {TRUSTED_EVALUATOR_DIDS.map((did) => (
+          <EvaluatorRow
+            key={did}
+            did={did}
+            checked={selectedEvaluators.has(did)}
+            onToggle={() =>
+              onEvaluatorsChange(toggled(selectedEvaluators, did))
+            }
+          />
+        ))}
+      </div>
+      <div className="feed-evaluators__separator" aria-hidden="true" />
+      <p className="feed-evaluator-panel__heading">Activity quality</p>
+      <div className="feed-evaluators__list">
+        {HYPERLABEL_DISPLAY_ORDER.map((tier) => (
+          <FilterCheckRow
+            key={tier}
+            label={HYPERLABEL_DISPLAY_LABELS[tier]}
+            checked={includedTiers.has(tier)}
+            onToggle={() => onTiersChange(toggled(includedTiers, tier))}
+          />
+        ))}
+        <FilterCheckRow
+          label="Not labeled yet"
+          checked={includedTiers.has(UNLABELED_SLUG)}
+          onToggle={() => onTiersChange(toggled(includedTiers, UNLABELED_SLUG))}
+        />
+      </div>
+      <div className="feed-evaluators__separator" aria-hidden="true" />
+      <p className="feed-evaluator-panel__heading">Organization quality</p>
+      <div className="feed-evaluators__list">
+        {ORGLABEL_DISPLAY_ORDER.map((tier) => (
+          <FilterCheckRow
+            key={tier}
+            label={ORGLABEL_DISPLAY_LABELS[tier]}
+            checked={includedOrgTiers.has(tier)}
+            onToggle={() => onOrgTiersChange(toggled(includedOrgTiers, tier))}
+          />
+        ))}
+        <FilterCheckRow
+          label="Not labeled yet"
+          checked={includedOrgTiers.has(UNLABELED_SLUG)}
+          onToggle={() =>
+            onOrgTiersChange(toggled(includedOrgTiers, UNLABELED_SLUG))
+          }
+        />
+      </div>
+      <div className="feed-evaluators__separator" aria-hidden="true" />
+      <button
+        type="button"
+        className="feed-evaluator-panel__reset"
+        onClick={onReset}
+        disabled={isDefault}
+      >
+        Reset to default
+      </button>
     </div>
   )
 }
 
-function EvaluatorOption({
+function FilterCheckRow({
+  label,
+  checked,
+  onToggle,
+}: {
+  label: string
+  checked: boolean
+  onToggle: () => void
+}) {
+  return (
+    <label className="feed-evaluators__row">
+      <input
+        type="checkbox"
+        className="feed-evaluators__checkbox"
+        checked={checked}
+        onChange={onToggle}
+      />
+      <span className="feed-evaluators__name">{label}</span>
+    </label>
+  )
+}
+
+/**
+ * One trusted-evaluator row — checkbox + avatar + display name +
+ * @handle, the whole row a click-to-toggle label (certs.social's
+ * EvaluatorCheckbox layout). Selecting an evaluator pulls every DID
+ * they've endorsed into the effective follow set, so the feed shows
+ * transitively-vouched activity.
+ */
+function EvaluatorRow({
   did,
   checked,
   onToggle,
@@ -501,29 +621,36 @@ function EvaluatorOption({
   onToggle: () => void
 }) {
   const { info } = useAuthorInfo(did)
-  const label = info?.displayName || (info?.handle ? `@${info.handle}` : did.slice(0, 14) + "…")
-  const initials = getInitials(info?.displayName, did)
-  const profileHref = profileUrl(info?.handle || did)
+  const label =
+    info?.displayName ||
+    (info?.handle ? `@${info.handle}` : did.slice(0, 14) + "…")
   return (
-    <div className="home-feed__evaluator-row">
+    <label className="feed-evaluators__row">
       <input
-        id={`eval-${did}`}
         type="checkbox"
-        className="home-feed__evaluator-check"
+        className="feed-evaluators__checkbox"
         checked={checked}
         onChange={onToggle}
         aria-label={`Include endorsements by ${label}`}
       />
-      <Link href={profileHref} className="home-feed__evaluator-link">
-        <Avatar
-          size="sm"
-          src={info?.avatarUrl ?? undefined}
+      {info?.avatarUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={info.avatarUrl}
           alt=""
-          fallbackInitials={initials}
+          className="feed-evaluators__avatar"
+          width={24}
+          height={24}
+          onError={hideBrokenThumb}
         />
-        <span className="home-feed__evaluator-name">{label}</span>
-      </Link>
-    </div>
+      ) : (
+        <span className="feed-evaluators__avatar feed-evaluators__avatar--placeholder" />
+      )}
+      <span className="feed-evaluators__name">{label}</span>
+      {info?.displayName && info?.handle ? (
+        <span className="feed-evaluators__handle">@{info.handle}</span>
+      ) : null}
+    </label>
   )
 }
 

--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -52,7 +52,9 @@ const SIDEBAR_PREVIEW_LIMIT = 5
  * the hard-coded news DID.
  */
 export default function Home() {
-  usePageTitle("Home")
+  // The navbar carries the page title; the feed itself no longer
+  // renders its own "Feed" heading (the tab strip took its place).
+  usePageTitle("Feed")
   const router = useRouter()
   const { isLoading: authLoading, isAuthenticated, did: personalDid } = useAuth()
   const { activeOrg } = useOrg()

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
-import { Newspaper, Search, PlusCircle, MessageSquare } from "lucide-react";
+import { LayoutGrid, Newspaper, Search, PlusCircle, MessageSquare } from "lucide-react";
 import { useFeedback } from "@/lib/feedback-context";
 import { useOrg } from "@/lib/groups/org-context";
 import { isRouteVisibleToActor } from "@/lib/groups/personal-only";
@@ -36,6 +36,7 @@ export default function BottomNav() {
     ...(showCreate
       ? [{ key: "create", label: "Create", icon: PlusCircle, onClick: () => router.push("/create"), active: pathname === "/create" }]
       : []),
+    { key: "apps", label: "Apps", icon: LayoutGrid, onClick: () => router.push("/apps"), active: pathname === "/apps" },
     { key: "feedback", label: "Feedback", icon: MessageSquare, onClick: openFeedback, active: false },
   ];
 

--- a/src/components/layout/mobile-sidebar.tsx
+++ b/src/components/layout/mobile-sidebar.tsx
@@ -97,9 +97,25 @@ export default function MobileSidebar({ isOpen, onClose }: MobileSidebarProps) {
 
   return (
     <Drawer open={isOpen} onClose={onClose} side="left" ariaLabel="Navigation menu">
-        {/* Section 1: Profile (top-left, taps through to user profile) +
-            theme toggle (top-right) */}
+        {/* Section 1: Certified wordmark (top-left) + theme toggle
+            (top-right), with the profile block (signed-in only)
+            underneath. */}
         <div className="mobile-sidebar__section mobile-sidebar__section--profile">
+          <div className="mobile-sidebar__section--brand">
+            <Link
+              href={isAuthenticated ? "/home" : "/welcome"}
+              className="mobile-sidebar__wordmark"
+              onClick={onClose}
+              aria-label="Certified home"
+            >
+              <img
+                src="/brand/wordmark/certified_wordmark_black.svg"
+                alt="Certified"
+                className="mobile-sidebar__wordmark-img"
+              />
+            </Link>
+            <ThemeToggle variant="cycle" className="mobile-sidebar__theme" />
+          </div>
           {isAuthenticated ? (
             <Link
               href={profileHref}
@@ -119,10 +135,7 @@ export default function MobileSidebar({ isOpen, onClose }: MobileSidebarProps) {
                 <p className="mobile-sidebar__handle">@{displayHandle}</p>
               ) : null}
             </Link>
-          ) : (
-            <div className="mobile-sidebar__profile" />
-          )}
-          <ThemeToggle variant="cycle" className="mobile-sidebar__theme" />
+          ) : null}
         </div>
 
         {/* Section 2: Navigation */}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -8,6 +8,7 @@ import { useNavbarContext } from "@/lib/navbar-context";
 import { useProfile } from "@/hooks/use-profile";
 import { useSession } from "@/hooks/use-session";
 import Avatar from "@/components/ui/avatar";
+import Button from "@/components/ui/button";
 import { getInitials } from "@/lib/utils/initials";
 import { useOrg } from "@/lib/groups/org-context";
 import { routeForActorSwitch } from "@/lib/groups/navigation";
@@ -200,19 +201,19 @@ const Navbar: React.FC = () => {
   // (opens the mobile sidebar) for signed-in AND signed-out viewers.
   // Signed-out viewers get a slimmed-down sidebar (Explore / Apps /
   // Help) so the app is still navigable before signing in; the theme
-  // toggle lives inside the sidebar in both states.
+  // toggle lives inside the sidebar in both states. No Tooltip — this
+  // bar only renders <800px, where a tap surfaces the tooltip bubble
+  // as a stray tag instead of hover help.
   const leftControl = (
-    <Tooltip label={dropdownOpen ? "Close menu" : "Open menu"}>
-      <button
-        className="navbar__hamburger"
-        onClick={() => { setDropdownOpen(!dropdownOpen); setSwitcherOpen(false); }}
-        aria-label={dropdownOpen ? "Close menu" : "Open menu"}
-        aria-haspopup="menu"
-        aria-expanded={dropdownOpen}
-      >
-        {dropdownOpen ? <X size={22} /> : <Menu size={22} />}
-      </button>
-    </Tooltip>
+    <button
+      className="navbar__hamburger"
+      onClick={() => { setDropdownOpen(!dropdownOpen); setSwitcherOpen(false); }}
+      aria-label={dropdownOpen ? "Close menu" : "Open menu"}
+      aria-haspopup="menu"
+      aria-expanded={dropdownOpen}
+    >
+      {dropdownOpen ? <X size={22} /> : <Menu size={22} />}
+    </button>
   );
 
   // Right cluster for the default + root-level layouts: account switcher
@@ -260,18 +261,16 @@ const Navbar: React.FC = () => {
             </PopoverContent>
           </Popover>
         ) : (
-          <Tooltip label="Switch account">
-            <button
-              className="account-switcher__trigger"
-              onClick={() => { setSwitcherOpen(!switcherOpen); setDropdownOpen(false); }}
-              aria-label="Switch account"
-              aria-haspopup="menu"
-              aria-expanded={switcherOpen}
-            >
-              <Avatar size="sm" src={displayAvatarUrl} fallbackInitials={avatarInitials} />
-              <ChevronDown size={14} className="navbar__chevron-desktop" />
-            </button>
-          </Tooltip>
+          <button
+            className="account-switcher__trigger"
+            onClick={() => { setSwitcherOpen(!switcherOpen); setDropdownOpen(false); }}
+            aria-label="Switch account"
+            aria-haspopup="menu"
+            aria-expanded={switcherOpen}
+          >
+            <Avatar size="sm" src={displayAvatarUrl} fallbackInitials={avatarInitials} />
+            <ChevronDown size={14} className="navbar__chevron-desktop" />
+          </button>
         )}
       </div>
 
@@ -303,21 +302,12 @@ const Navbar: React.FC = () => {
       </BottomSheet>
     </>
   ) : (
-    <Tooltip label="Sign in">
-      <button
-        type="button"
-        onClick={openSignIn}
-        className="navbar__signin-btn"
-        aria-label="Sign in"
-      >
-        <img
-          src="/brand/signin/certified_signin_black.svg"
-          alt=""
-          aria-hidden
-          className="navbar__signin-img"
-        />
-      </button>
-    </Tooltip>
+    // Quiet outline button rather than the filled black sign-in lockup —
+    // a second solid-black element reads heavy next to the (black)
+    // brandmark in the bar's center slot.
+    <Button variant="secondary" size="sm" onClick={openSignIn}>
+      Sign in
+    </Button>
   );
 
   const rightCluster = (

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -36,6 +36,11 @@ import { useMounted } from "@/hooks/use-mounted";
  *
  * When `label` is empty the children render unwrapped — no tooltip, no
  * extra DOM — so callers can pass a possibly-empty string without guarding.
+ *
+ * Touch devices render the children unwrapped too: a tap fires focus +
+ * a synthetic mouseenter, which made the bubble pop up as a stray tag
+ * after every tap. Tooltips are a hover affordance — on a coarse
+ * pointer there is no hover, so there is no tooltip.
  */
 export interface TooltipProps {
   /** The text shown in the bubble. Empty string disables the tooltip. */
@@ -57,6 +62,24 @@ interface Coords {
 
 const GAP = 8;
 const PADDING = 8;
+
+/**
+ * True once we know the primary pointer can actually hover (mouse /
+ * trackpad). Starts false — matching the SSR markup — and flips in an
+ * effect, so touch devices never mount the hover listeners at all.
+ */
+function useHoverCapable(): boolean {
+  const [capable, setCapable] = useState(false);
+  useEffect(() => {
+    const mq = globalThis.matchMedia?.("(hover: hover) and (pointer: fine)");
+    if (!mq) return;
+    setCapable(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => setCapable(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return capable;
+}
 
 function computeCoords(
   rect: DOMRect,
@@ -98,6 +121,7 @@ export default function Tooltip({
   className = "",
 }: TooltipProps) {
   const mounted = useMounted();
+  const hoverCapable = useHoverCapable();
   const wrapRef = useRef<HTMLSpanElement | null>(null);
   const bubbleRef = useRef<HTMLDivElement | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -154,7 +178,7 @@ export default function Tooltip({
     };
   }, [open, side, hide]);
 
-  if (!label) return children;
+  if (!label || !hoverCapable) return children;
 
   const trigger = cloneElement(children, {
     "aria-describedby": open


### PR DESCRIPTION
## Summary

Follow-up to #162 — a batch of mobile refinements plus the certs.social-style feed tab/filter chrome.

### Mobile chrome
- **Sign-in button (top navbar):** the filled-black brand lockup is replaced with the secondary (outline) `Button` — a second solid-black element read heavy next to the black brandmark. Dead `.navbar__signin-*` CSS removed.
- **Tooltips never show on touch:** a tap fires focus + a synthetic mouseenter, so bubbles like "Open menu" popped up as stray tags after every tap (hamburger, bottom-nav items, account switcher, …). The `Tooltip` primitive now renders children unwrapped unless the primary pointer can hover (`(hover: hover) and (pointer: fine)`), fixing this for every tooltip in the app.
- **Mobile sidebar:** the Certified wordmark sits top-left (dark-mode inverted like other wordmark surfaces), theme toggle top-right, profile block below for signed-in viewers.
- **Bottom nav:** new **Apps** item between Create and Feedback.

### Feed (home page)
- The "Feed" heading + two filter popovers are replaced by the **certs.social tab strip**: one "For you" tab; clicking it again toggles an inline filter panel (the ported `.feed-tabs` / `.feed-evaluator-panel` styles in feed.css, revived). The tab label flips to "Custom" when filters diverge from defaults.
- The panel hosts three sections: **trusted evaluators** ("Show activities from accounts that are endorsed by:"), **activity quality**, and a new **organization quality** filter (Orglabeler tiers + "Not labeled yet"). The org filter narrows the feed's author DID set via the cached `fetchOrgDidsByLabel` lookup — subtract-mode when unlabeled accounts are included, intersect-mode when they're not; defaults hide `likely-test` orgs (matching /explore), and it degrades to unfiltered if the lookup fails.
- The navbar title becomes **Feed** (`usePageTitle`).

### Page polish (mobile)
- **/home and /explore gutters:** the app-shell's 16px reading gutter is zeroed on phones; the pages carry their own small 8px gutter so content runs nearly edge-to-edge.
- **/explore list rows** pick up the feed-card treatment on phones: un-boxed hairline-divided rows, author byline on top with relative time pinned right, serif headline titles. Desktop keeps the dense table rows.
- **/settings** drops the section nav on phones (sections carry their own headings; `#section` deep links still work).
- **/apps** drops the "Ecosystem" eyebrow + "Apps" h1 in favour of the single line "Apps built with Certified on AT Protocol."

## Verification
- `npx tsc --noEmit` clean for `src/`; `npm run lint` at the staging baseline (63 warnings, 0 added).
- `npx vitest run`: 592 passed; the 29 failures in `recently-viewed` / `swap-drafts` are pre-existing on staging.
- CLAUDE.md UI greps (radii / breakpoints / headings / modal backdrops) all silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)