### PR TITLE
feat: mobile detail-page redesign, navbar record menu, explore account search

### DIFF
--- a/src/app/api/indexer/route.ts
+++ b/src/app/api/indexer/route.ts
@@ -315,8 +315,8 @@ ${ACTIVITY_NODE_SELECTION}
   // most-recently-indexed profiles so the actor switcher has
   // something to show even before the user has interacted.
   NetworkActors: `
-    query NetworkActors($first: Int!, $after: String) {
-      appCertifiedActorProfile(first: $first, after: $after) {
+    query NetworkActors($first: Int!, $after: String, $search: String) {
+      appCertifiedActorProfile(first: $first, after: $after, search: $search) {
         totalCount
         edges {
           cursor
@@ -359,10 +359,12 @@ ${ACTIVITY_NODE_SELECTION}
       $first: Int!
       $after: String
       $isOrganization: Boolean!
+      $search: String
     ) {
       appCertifiedActorProfile(
         first: $first
         after: $after
+        search: $search
         where: { isOrganization: { eq: $isOrganization } }
       ) {
         totalCount
@@ -1246,7 +1248,13 @@ function buildVariables(
         search: readString(vars.search, MAX_SEARCH_LEN),
       }
     }
-    case "NetworkActors":
+    case "NetworkActors": {
+      return {
+        first: clampFirst(vars.first, MAX_FIRST, 20),
+        after: readString(vars.after, MAX_AFTER_LEN),
+        search: readString(vars.search, MAX_SEARCH_LEN),
+      }
+    }
     case "OrganizationDids": {
       return {
         first: clampFirst(vars.first, MAX_FIRST, 20),
@@ -1262,6 +1270,7 @@ function buildVariables(
         first: clampFirst(vars.first, MAX_FIRST, 20),
         after: readString(vars.after, MAX_AFTER_LEN),
         isOrganization: vars.isOrganization,
+        search: readString(vars.search, MAX_SEARCH_LEN),
       }
     }
     case "OrganizationDidsByLabel": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,7 @@
 @import "./styles/settings-page.css";
 @import "./styles/leaflet.css";
 @import "./styles/landing.css";
+@import "./styles/view-transitions.css";
 
 @tailwind base;
 @tailwind components;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter, Noto_Serif } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/lib/auth/auth-context";
 import { NavbarProvider } from "@/lib/navbar-context";
+import { ViewTransitionProvider } from "@/lib/view-transitions";
 import Navbar from "@/components/layout/navbar";
 import DesktopTopBar from "@/components/layout/desktop-top-bar";
 import { Providers } from "@/lib/providers";
@@ -158,6 +159,7 @@ export default function RootLayout({
               <OnboardingProvider>
               <NavbarProvider>
                 <FeedbackProvider>
+                <ViewTransitionProvider>
                 <a href="#main-content" className="skip-nav">Skip to main content</a>
                 <ActingAsBar />
                 <Navbar />
@@ -176,6 +178,7 @@ export default function RootLayout({
                 <PwaInstallGuard />
                 <FeedbackModal />
                 <OnboardingModal />
+                </ViewTransitionProvider>
                 </FeedbackProvider>
               </NavbarProvider>
               </OnboardingProvider>

--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -30,6 +30,15 @@
   padding: 0;
 }
 
+/* On phones the navbar is a fixed overlay, so the zeroed content slot
+   would let the title slide under it. Re-add the navbar-height top
+   offset (the inner .page-layout's 24px provides the gap below it). */
+@media (max-width: 799px) {
+  .app-shell:has(.cert-detail--wide) .app-shell__content {
+    padding-top: var(--navbar-height);
+  }
+}
+
 @media (min-width: 800px) {
   /* Cap the cert-detail two-pane layout so its total content width
      matches the single-pane project page (.project-detail max-width
@@ -68,6 +77,107 @@
   .cert-detail--wide.page-layout > .cert-detail__main {
     grid-column: 1;
     grid-row: 1;
+  }
+}
+
+/* ---------- Mobile reading reorder (single column) ----------
+   On phones the two-column reading view collapses into one prescribed
+   vertical order. The DOM keeps its desktop structure; `display:
+   contents` dissolves the aside / main / meta wrappers so their leaf
+   blocks become direct items of the single-column `.page-layout` grid,
+   and `order` sequences them:
+
+     1 title + byline   2 image          3 time period (+ menu)
+     4 work scope       5 contributors   6 rights
+     7 summary          8 updates        9 locations
+
+   Scoped to the reading view (`:not(.cert-detail--editing)`) so the
+   inline edit form keeps its own DOM-order layout. */
+@media (max-width: 799px) {
+  /* Single-column grid with a 0-floored track so promoted leaves can
+     never push the page wider than the viewport. (The default implicit
+     `auto` track sizes to content and overflows on wide items.) */
+  .cert-detail--wide:not(.cert-detail--editing) {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cert-detail--wide:not(.cert-detail--editing) > .cert-detail__aside,
+  .cert-detail--wide:not(.cert-detail--editing) > .cert-detail__main,
+  .cert-detail--wide:not(.cert-detail--editing) .cert-detail__meta {
+    display: contents;
+  }
+
+  .cert-detail--wide:not(.cert-detail--editing) .cert-detail__headline {
+    order: 1;
+  }
+  .cert-detail--wide:not(.cert-detail--editing) .cert-detail__image {
+    order: 2;
+  }
+  .cert-detail--wide:not(.cert-detail--editing)
+    .cert-detail__meta-row--timeperiod {
+    order: 3;
+  }
+  .cert-detail--wide:not(.cert-detail--editing)
+    .cert-detail__meta-row--workscope {
+    order: 4;
+  }
+  .cert-detail--wide:not(.cert-detail--editing)
+    .cert-detail__meta-row--contributors {
+    order: 5;
+  }
+  .cert-detail--wide:not(.cert-detail--editing) .cert-detail__meta-row--rights {
+    order: 6;
+  }
+  .cert-detail--wide:not(.cert-detail--editing) .cert-detail__section--summary {
+    order: 7;
+  }
+  .cert-detail--wide:not(.cert-detail--editing) .context-updates {
+    order: 8;
+  }
+  .cert-detail--wide:not(.cert-detail--editing)
+    .cert-detail__section--locations {
+    order: 9;
+  }
+
+  /* The single-column grid already provides a uniform 24px row gap
+     between every promoted leaf (headline, image, each meta-row).
+     The promoted `.cert-detail__section` blocks (Summary, Locations)
+     carry their own `margin-top: 4px` + `padding-top: 24px` from the
+     desktop two-column layout, which stacked extra space on top of the
+     grid gap and made those sections sit noticeably farther from the
+     preceding element than the meta-rows do. Zero them so the grid gap
+     is the only spacing — every element is then a consistent 24px apart. */
+  .cert-detail--wide:not(.cert-detail--editing) .cert-detail__section,
+  .cert-detail--wide:not(.cert-detail--editing) .context-updates {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: none;
+  }
+
+  /* Description / Contributors tabs: show only the tab content. Hide the
+     headline, image, and meta rows (the tab name + count live in the
+     navbar; the navbar Back button returns). */
+  .cert-detail--tab-description .cert-detail__headline,
+  .cert-detail--tab-contributors .cert-detail__headline,
+  .cert-detail--tab-description .cert-detail__image,
+  .cert-detail--tab-contributors .cert-detail__image,
+  .cert-detail--tab-description .cert-detail__meta-row,
+  .cert-detail--tab-contributors .cert-detail__meta-row {
+    display: none;
+  }
+
+  /* Contributors tab: title + count live in the navbar — drop the
+     in-main section header. */
+  .cert-detail--tab-contributors .cert-detail__section-header {
+    display: none;
+  }
+
+  /* "Read full description" centers on phones (both the activity and
+     project detail pages use this class). Ancestor-scoped to beat the
+     base `align-self: flex-start`. */
+  .cert-detail--wide .cert-detail__read-more,
+  .project-detail .cert-detail__read-more {
+    align-self: center;
   }
 }
 
@@ -365,6 +475,87 @@
   gap: 12px;
 }
 
+/* "Activity" eyebrow + date row above the title — mirrors the project
+   page's "Project" eyebrow. Hidden on desktop (the date lives in the
+   headline columns there). */
+.cert-detail__eyebrow-row {
+  display: none;
+}
+
+.cert-detail__eyebrow {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-muted);
+  line-height: 1.2;
+}
+
+.cert-detail__eyebrow-date {
+  display: none;
+}
+
+/* Three-dot menu on the author row — mobile only (desktop keeps it in
+   the Time period row). */
+.cert-detail__headline-action {
+  display: none;
+}
+
+@media (max-width: 799px) {
+  .cert-detail__eyebrow-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    /* Cancel the headline's 12px gap so the eyebrow sits tight to the
+       title, matching the project page. */
+    margin-bottom: -12px;
+  }
+  .cert-detail__headline-action {
+    display: inline-flex;
+    margin-left: auto;
+    align-self: flex-start;
+    flex: none;
+  }
+  .cert-detail__headline-action button[aria-label="Open list actions"] {
+    height: 32px;
+    width: 32px;
+  }
+  .cert-detail__meta-menu {
+    display: none;
+  }
+  /* Author fills the first line minus the menu (basis 0 + grow) and
+     truncates, so the menu never wraps to the next row. */
+  .cert-detail__headline-col--author {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+  .cert-detail__headline-author {
+    min-width: 0;
+  }
+
+  /* Summary reads at the same size as the meta values (e.g. work scope).
+     Scoped via the section to beat the base 1rem rule. */
+  .cert-detail__section--summary .cert-detail__short-desc {
+    font-size: 0.875rem;
+  }
+  .cert-detail__eyebrow-date {
+    display: inline;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: var(--fg-muted);
+    white-space: nowrap;
+  }
+  /* Date now lives in the eyebrow row; the "Author" label is dropped.
+     Ancestor-scoped to beat the base `.cert-detail__headline-col`. */
+  .cert-detail__headline-cols .cert-detail__headline-col--date {
+    display: none;
+  }
+  .cert-detail__headline-col--author .cert-detail__meta-label {
+    display: none;
+  }
+}
+
 .cert-detail__title {
   font-family: var(--font-headline), "Noto Serif", serif;
   font-size: 1.875rem;
@@ -501,8 +692,17 @@
   font-size: 0.8125rem;
   font-weight: 500;
   text-decoration: none;
+  /* Works as both <a> (desktop, tab link) and <button> (mobile,
+     inline disclosure) — reset the UA button font + cursor. */
+  font-family: inherit;
+  cursor: pointer;
   transition: background var(--transition-fast),
     border-color var(--transition-fast);
+}
+
+/* Full description expanded in place on mobile, below the summary. */
+.cert-detail__inline-description {
+  margin-top: 12px;
 }
 
 .cert-detail__read-more:hover {
@@ -660,12 +860,16 @@
   font-weight: 500;
   color: var(--fg-primary);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .cert-detail__headline-handle {
   font-size: 0.75rem;
   color: var(--fg-muted);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Skeletons */
@@ -836,12 +1040,24 @@
   margin-right: 0;
 }
 
+/* Summary heading row: label left, "Read full description" link right. */
+.cert-detail__summary-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
 .cert-detail__section-see-all {
   margin-left: auto;
   font-size: 0.75rem;
   font-weight: 500;
   color: var(--fg-secondary);
   text-decoration: none;
+  /* Sits inside the uppercase `.cert-detail__meta-label` <dt> on the
+     contributors row, so it would inherit text-transform: uppercase.
+     Match the Updates "See all" (sentence case) explicitly. */
+  text-transform: none;
+  letter-spacing: normal;
   transition: color var(--transition-fast);
 }
 
@@ -956,6 +1172,13 @@
   color: var(--fg-secondary);
   text-decoration: none;
   border-radius: var(--radius);
+  /* Works as both <a> (desktop) and <button> (mobile inline toggle) —
+     strip the UA button chrome and inherit the surrounding font. */
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
   transition: background var(--transition-fast),
     color var(--transition-fast);
 }
@@ -1446,9 +1669,20 @@
    with a missing value). Stack the labelled columns vertically and
    keep the author avatar + meta on one line. */
 @media (max-width: 799px) {
+  /* Author + Date created share the first row; Project wraps to its
+     own full-width row below them (matches the mobile reading order). */
   .cert-detail__headline-cols {
-    flex-direction: column;
-    gap: 12px;
+    flex-direction: row;
+    flex-wrap: wrap;
+    /* Row gap separates the author row from the Project block below
+       it (the author takes the full row, so Project wraps under). 8px
+       read as cramped against the labelled Project block — 16px gives
+       it clear breathing room, just above the title→author gap. */
+    gap: 16px 24px;
+  }
+
+  .cert-detail__headline-col:nth-child(3) {
+    flex: 1 1 100%;
   }
 
   .cert-detail__headline-author {

--- a/src/app/styles/context-updates.css
+++ b/src/app/styles/context-updates.css
@@ -71,17 +71,49 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  /* Spacing between updates comes from the per-item divider below. */
+  gap: 0;
 }
 
+/* No card box around updates — plain stacked rows. */
 .context-updates__item {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 14px;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius);
-  background: var(--bg-elevated);
+}
+
+/* Light divider + generous spacing between consecutive updates. */
+.context-updates__item + .context-updates__item {
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 24px;
+  padding-top: 24px;
+}
+
+/* "Update N" label + date on one row, numbering each card on the
+   Updates tab. Same small uppercase muted style as the section headings. */
+.context-updates__item-number-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.context-updates__item-number {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  line-height: 1;
+}
+
+/* Date trailing the "Update N" label, right-aligned, same size + weight. */
+.context-updates__item-number-date {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--fg-muted);
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .context-updates__item-head {
@@ -130,7 +162,9 @@
   position: relative;
 }
 
-.context-updates__doc-wrap--clamped::after {
+/* Fade-out only when the body is actually truncated (i.e. a "Read more"
+   is offered). Fully-visible content gets no fade. */
+.context-updates__doc-wrap--truncated::after {
   content: "";
   position: absolute;
   inset: auto 0 0 0;
@@ -343,7 +377,7 @@
 
 @media (max-width: 799px) {
   .context-updates__item {
-    padding: 12px;
+    padding: 0;
   }
   .context-updates__attachment--image .context-updates__attachment-link {
     width: 72px;

--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -314,24 +314,29 @@
     flex: 1 0 100%;
     min-width: 0;
   }
-  /* Second row: dropdown on the left, action cluster pushed to the right. */
+  /* Second row: dropdown on the left, action cluster pushed to the right.
+     Stretch the cluster to the row height so its icon buttons can match
+     the category pills (which set the line height). */
   .explore__chrome-actions {
     margin-left: auto;
     gap: 8px;
+    align-self: stretch;
   }
   .explore__chrome-btn {
     min-height: 44px;
     padding-top: 10px;
     padding-bottom: 10px;
   }
-  /* Mobile icon buttons: stretch to match the pill row height and
-     use aspect-ratio to stay square. Reset padding to avoid the
-     extra top/bottom from .explore__chrome-btn inflating the height. */
+  /* Mobile icon buttons (sort + filter): match the category pill's
+     height and stay square. Dropping the inherited 44px min-height lets
+     the cluster size to the pills (~30px); stretching to the cluster +
+     aspect-ratio then makes each icon a pill-height square. */
   .explore__chrome-btn--icon {
     align-self: stretch;
     aspect-ratio: 1 / 1;
     width: auto;
     height: auto;
+    min-height: 0;
     padding: 0;
   }
   /* The type dropdown trigger matches the 44px control height too. */
@@ -696,6 +701,17 @@
   background: var(--bg-sunken);
 }
 
+/* Compact variant (image + title/meta only, no author/date columns).
+   Compound selector so it beats both the base and the mobile
+   `.cert-list-row` grid rules regardless of source order. */
+.cert-list-row.cert-list-row--compact {
+  grid-template-columns: 1fr;
+  grid-template-areas: none;
+}
+.cert-list-row.cert-list-row--compact .cert-list-row__link {
+  grid-area: auto;
+}
+
 .cert-list-row__link {
   display: flex;
   align-items: center;
@@ -745,24 +761,22 @@
 
 .cert-list-row__meta {
   margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
+  /* Single line: time period · work scope, truncated with an ellipsis
+     when the work scope doesn't fit (no wrapping to a second line). */
   font-size: 0.75rem;
   color: var(--fg-secondary);
   line-height: 1.3;
+  white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .cert-list-row__meta-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  white-space: nowrap;
+  display: inline;
 }
 
 .cert-list-row__meta-sep {
+  margin: 0 5px;
   color: var(--fg-muted);
 }
 
@@ -885,6 +899,17 @@
   .explore__grid--projects,
   .explore__grid--certs {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  /* On phones, drop the whole image *placeholder* box for
+     projects/activities that have no real image — including the grey
+     aspect-ratio wrapper that reserves the space, not just the icon.
+     Scoped to the explore grids so the shared activity card keeps its
+     placeholder on the home feed. Cards with a real image are untouched. */
+  .explore__grid--projects
+    .explore-project-card__image-wrap:has(.explore-project-card__image--placeholder),
+  .explore__grid--certs .feed-card__image-wrap--placeholder {
+    display: none;
   }
 }
 

--- a/src/app/styles/landing.css
+++ b/src/app/styles/landing.css
@@ -293,6 +293,11 @@
   }
 }
 
+.lp-topbar__home {
+  display: inline-flex;
+  align-items: center;
+}
+
 .lp-topbar__wordmark {
   display: block;
   height: 22px;
@@ -335,6 +340,17 @@
   .lp-topbar__btn:hover {
     color: var(--color-navy);
     border-color: var(--color-mid-gray);
+  }
+
+  /* Account variant: avatar + label, tighter left padding so the
+     avatar reads as the leading element. */
+  .lp-topbar__btn--account {
+    gap: 8px;
+    padding-left: 8px;
+  }
+
+  .lp-topbar__avatar {
+    flex: none;
   }
 }
 
@@ -1022,6 +1038,74 @@
     border-top: 1px solid var(--color-light-gray);
   }
   .lp-trust__col:first-child {
+    padding-top: 0;
+  }
+}
+
+/* ---------- AI world ---------- */
+
+.lp-ai__lede {
+  font-size: 1.0625rem;
+  line-height: 1.6;
+  color: var(--color-mid-gray);
+  max-width: 56ch;
+  margin: 20px 0 0;
+}
+
+.lp-ai {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 32px;
+}
+
+.lp-ai__col {
+  border-left: 1px solid var(--color-light-gray);
+  padding-left: 32px;
+  transition:
+    opacity 600ms cubic-bezier(0.16, 1, 0.3, 1),
+    transform 600ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.lp-ai__col:first-child {
+  border-left: 0;
+  padding-left: 0;
+}
+
+/* Reveal: armed hides the columns, shown releases them. The second
+   column trails the first for a left-then-right fade-up. */
+.lp-ai[data-anim="armed"] .lp-ai__col {
+  opacity: 0;
+  transform: translateY(28px);
+}
+
+.lp-ai[data-anim="shown"] .lp-ai__col {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.lp-ai__col:nth-child(2) {
+  transition-delay: 140ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lp-ai__col {
+    transition: none;
+  }
+}
+
+@media (max-width: 799px) {
+  .lp-ai {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+  .lp-ai__col {
+    border-left: 0;
+    padding: 28px 0;
+  }
+  .lp-ai__col + .lp-ai__col {
+    border-top: 1px solid var(--color-light-gray);
+  }
+  .lp-ai__col:first-child {
     padding-top: 0;
   }
 }

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -306,6 +306,15 @@ html[data-theme="dark"] .signin-mark__img--light {
   min-height: 32px;
 }
 
+/* Record-level overflow menu (Share / Add to list / Copy AT URI) in the
+   titled navbar's right slot on detail pages. Right-aligned to mirror the
+   back button on the left; the ghost icon trigger keeps its own sizing. */
+.navbar__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
 /* ========== App Top Nav (authenticated) ========== */
 .navbar__app-links {
   display: flex;

--- a/src/app/styles/project-detail.css
+++ b/src/app/styles/project-detail.css
@@ -253,6 +253,10 @@
   .project-detail__head-bar {
     flex-direction: column;
     align-items: flex-start;
+    /* Tighter than the desktop 16px gap / 20px margin so the author
+       (in the byline below) sits closer to the title. */
+    gap: 8px;
+    margin-bottom: 8px;
   }
 
   .project-detail__head-actions {
@@ -264,6 +268,285 @@
     overflow: visible;
     text-overflow: clip;
     overflow-wrap: anywhere;
+  }
+}
+
+/* ---------- Mobile byline (author) ---------- */
+
+/* Hidden on desktop — the author lives in the head bar. Shown on mobile
+   (reading view) right under the title. */
+.project-detail__byline {
+  display: none;
+}
+
+/* Date created trailing the "Project" eyebrow on mobile (right-aligned,
+   label-less). Hidden on desktop, where the date shows in the
+   inline-created row below the hero. */
+.project-detail__eyebrow-date {
+  display: none;
+}
+
+/* "Description" heading on the description tab. Hidden on desktop, where
+   the head bar still carries the project title; shown on mobile, where
+   the head bar is hidden on this tab. */
+.project-detail__tab-title {
+  display: none;
+}
+
+/* Location section — same shape as the activity Locations section. */
+.project-detail__location-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Mobile activities preview as full-width list rows (no card grid, no
+   extra side margins — the rows fill the content width). */
+.project-detail__certs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* ---------- Mobile reading reorder (single column) ----------
+   Phones present a prescribed vertical order:
+     1 title (+ eyebrow date)   2 author   3 image
+     4 short description (+ menu)   5 read more   6 location
+     7 time period / contributors   8 updates   9 activities
+   Scoped to the reading view (`:not(.project-detail--editing)`) so the
+   inline edit form keeps its own layout. The page is already a single
+   flex column, so `order` on the direct children is enough. */
+@media (max-width: 799px) {
+  /* Drop the article's own side padding so the only gutter is the
+     app-shell content's 16px — matching the activity detail page (which
+     zeroes the shell padding and gets its 16px from .page-layout). */
+  .project-detail {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  /* "Project" eyebrow + date created on one row, date pushed to the far
+     right. The title group must span the full width for space-between to
+     reach the content edge (it's content-width by default). */
+  .project-detail__head-title-group {
+    width: 100%;
+  }
+  .project-detail__eyebrow-row {
+    display: flex;
+    width: 100%;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .project-detail__eyebrow-date {
+    display: inline;
+    /* Match the "PROJECT" eyebrow: size + weight. */
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: var(--fg-muted);
+    white-space: nowrap;
+  }
+
+  /* Summary reads as normal body text on mobile — not italic, and the
+     same size/weight as the "Read full description" control. (Scoped
+     via the row for specificity over the base rule.) */
+  .project-detail__lead-row .project-detail__lead {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 0.8125rem;
+  }
+
+  /* Section headings (Summary, Activities) match the "Updates" heading:
+     a small uppercase muted label rather than the serif section title.
+     Ancestor-scoped to beat the base `.project-detail__certs-title`
+     (defined later in the file at equal specificity). */
+  .project-detail .project-detail__certs-title {
+    font-family: inherit;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-muted);
+    line-height: 1;
+  }
+
+  /* "Description" heading stands in for the (hidden) title on the
+     description tab. order:0 keeps it above the prose. */
+  .project-detail__tab-title {
+    display: block;
+    order: 0;
+    font-family: var(--font-headline), "Noto Serif", serif;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--fg-primary);
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+    margin: 0 0 4px;
+  }
+
+  .project-detail:not(.project-detail--editing) .project-detail__byline {
+    display: flex;
+    align-items: center;
+    /* Keep the author + menu on one row; the author truncates rather
+       than pushing the menu to the next line. */
+    flex-wrap: nowrap;
+    margin: 2px 0 8px;
+  }
+
+  /* Author shrinks + truncates instead of wrapping the menu. */
+  .project-detail__byline .feed-card__author {
+    min-width: 0;
+  }
+  .project-detail__byline .feed-card__author-meta {
+    min-width: 0;
+  }
+  .project-detail__byline .feed-card__author-name,
+  .project-detail__byline .feed-card__author-handle {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* Three-dot menu sits at the trailing edge of the author row,
+     top-aligned; its desktop copy in the lead row is hidden here. */
+  .project-detail__byline-menu {
+    margin-left: auto;
+    flex: none;
+    display: inline-flex;
+    align-items: flex-start;
+    align-self: flex-start;
+  }
+
+  /* Smaller square trigger than the default 44px icon button. Scoped to
+     the trigger only (not the popover's menu-item buttons). */
+  .project-detail__byline-menu button[aria-label="Open list actions"] {
+    height: 32px;
+    width: 32px;
+  }
+  .project-detail__lead-menu {
+    display: none;
+  }
+
+  /* Author + date now live in the byline / eyebrow row — hide the
+     desktop copies. */
+  .project-detail:not(.project-detail--editing) .project-detail__head-author,
+  .project-detail:not(.project-detail--editing)
+    .project-detail__inline-created {
+    display: none;
+  }
+
+  .project-detail:not(.project-detail--editing) .project-detail__head-bar {
+    order: 1;
+  }
+  .project-detail:not(.project-detail--editing) .project-detail__byline {
+    order: 2;
+  }
+  .project-detail:not(.project-detail--editing) .project-detail__hero {
+    order: 3;
+  }
+  .project-detail:not(.project-detail--editing) .project-detail__summary {
+    order: 4;
+  }
+  .project-detail:not(.project-detail--editing) .project-detail__meta {
+    order: 7;
+  }
+  .project-detail:not(.project-detail--editing) .context-updates {
+    order: 8;
+  }
+  .project-detail:not(.project-detail--editing)
+    .project-detail__certs--preview {
+    order: 9;
+  }
+  /* Location sits at the very bottom of the overview. */
+  .project-detail:not(.project-detail--editing)
+    .project-detail__location-section {
+    order: 11;
+  }
+
+  /* Standardized 24px gap between the overview's content sections
+     (summary → location → details → updates → activities). Applied as a
+     top margin on each section after the summary; the hero already
+     provides the 24px above the summary itself. The updates section
+     drops its own divider + top padding so it matches the rest. */
+  .project-detail:not(.project-detail--editing)
+    .project-detail__location-section,
+  .project-detail:not(.project-detail--editing) .project-detail__meta,
+  .project-detail:not(.project-detail--editing) .context-updates,
+  .project-detail:not(.project-detail--editing)
+    .project-detail__certs--preview {
+    margin-top: 24px;
+  }
+  .project-detail:not(.project-detail--editing) .context-updates {
+    padding-top: 0;
+    border-top: none;
+  }
+
+  /* Sub-tab content (full description / full activities list) and the
+     empty-state line carry no explicit order; without this they'd
+     default to 0 and render above the title + byline. Park them last. */
+  .project-detail:not(.project-detail--editing) .project-detail__prose,
+  .project-detail:not(.project-detail--editing)
+    .project-detail__certs:not(.project-detail__certs--preview),
+  .project-detail:not(.project-detail--editing) .project-detail__tab-empty {
+    order: 10;
+  }
+
+  /* Description / Updates / Activities tabs: show only the tab content —
+     hide the title bar and byline (the tab name lives in the navbar;
+     Back returns). */
+  .project-detail--tab-description .project-detail__head-bar,
+  .project-detail--tab-updates .project-detail__head-bar,
+  .project-detail--tab-activities .project-detail__head-bar,
+  .project-detail--tab-description:not(.project-detail--editing)
+    .project-detail__byline,
+  .project-detail--tab-updates:not(.project-detail--editing)
+    .project-detail__byline,
+  .project-detail--tab-activities:not(.project-detail--editing)
+    .project-detail__byline {
+    display: none;
+  }
+
+  /* Activities tab (view mode): the title + count live in the navbar,
+     so drop the in-main section header — just the gallery. */
+  .project-detail--tab-activities:not(.project-detail--editing)
+    .project-detail__certs-header {
+    display: none;
+  }
+
+  /* Updates tab: the title + count live in the navbar, so drop the
+     whole in-main header (heading + count) and the section's top
+     divider/padding so the first update sits right at the top. The
+     compound selector beats the standardized 24px section margin. */
+  .project-detail--tab-updates .context-updates__head {
+    display: none;
+  }
+  .project-detail.project-detail--tab-updates:not(.project-detail--editing)
+    .context-updates {
+    border-top: none;
+    margin-top: 0;
+    padding-top: 0;
+  }
+  /* Tighten the gap between the navbar and the first update / activity. */
+  .project-detail--tab-updates,
+  .project-detail--tab-activities {
+    margin-top: 4px;
+  }
+
+  /* Activities tab: drop the section's top divider + padding so the
+     gallery sits at the same distance from the navbar as the updates. */
+  .project-detail--tab-activities .project-detail__certs {
+    border-top: none;
+    margin-top: 0;
+    padding-top: 0;
+  }
+
+
+  /* First activity row sits the same distance below its heading as the
+     first update sits below "Updates" — header gap only, no extra top
+     padding (updates now have no card padding either). */
+  .project-detail__certs--preview .cert-list-row:first-child {
+    padding-top: 0;
   }
 }
 
@@ -434,18 +717,20 @@
   background: var(--overlay-weak);
 }
 
-/* "See all →" link in the Overview tab's certs preview header.
-   Pushed to the right edge of the flex header next to the count
-   chip; navigates to the dedicated Certs tab. */
+/* Section-header action link ("Read full description →", "Show all
+   activities →"). Matches the Updates section's "See all →" exactly:
+   same size, weight, colour, and hover. */
 .project-detail__see-all {
   margin-left: auto;
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
   font-weight: 500;
-  color: var(--fg-primary);
+  color: var(--fg-secondary);
   text-decoration: none;
+  transition: color var(--transition-fast);
 }
 
 .project-detail__see-all:hover {
+  color: var(--fg-primary);
   text-decoration: underline;
   text-underline-offset: 2px;
 }

--- a/src/app/styles/view-transitions.css
+++ b/src/app/styles/view-transitions.css
@@ -1,0 +1,59 @@
+/* Directional page-slide for in-app tab navigation, driven by the
+   View Transitions API. `html[data-vt-dir]` is set by the
+   ViewTransitionProvider for the duration of each transition.
+
+   Forward: the old view slides out to the left while the new view
+   slides in from the right ("moving to the right"). Back reverses it.
+   No data attribute → the browser's default root cross-fade applies
+   (e.g. ordinary navigations); reduced-motion skips it entirely since
+   the provider never starts a transition in that mode. */
+
+@keyframes vt-slide-in-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes vt-slide-out-left {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100%);
+  }
+}
+
+@keyframes vt-slide-in-left {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes vt-slide-out-right {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+html[data-vt-dir="forward"]::view-transition-old(root) {
+  animation: vt-slide-out-left 280ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+html[data-vt-dir="forward"]::view-transition-new(root) {
+  animation: vt-slide-in-right 280ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+html[data-vt-dir="back"]::view-transition-old(root) {
+  animation: vt-slide-out-right 280ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+html[data-vt-dir="back"]::view-transition-new(root) {
+  animation: vt-slide-in-left 280ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}

--- a/src/components/context/context-updates.tsx
+++ b/src/components/context/context-updates.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useLayoutEffect, useRef, useState } from "react"
-import Link from "next/link"
+import { TransitionLink } from "@/lib/view-transitions"
 import { useRouter } from "next/navigation"
 import Button from "@/components/ui/button"
 import {
@@ -184,26 +184,29 @@ export default function ContextUpdates({
         </h2>
         <span className="context-updates__count">{updates.length}</span>
         {variant === "overview" && seeAllHref ? (
-          <Link
+          <TransitionLink
             href={seeAllHref}
             replace
             scroll={false}
             className="context-updates__see-all"
           >
             See all →
-          </Link>
+          </TransitionLink>
         ) : null}
         {newButton}
       </header>
       <ul className="context-updates__list">
-        {visibleUpdates.map((u) => (
+        {visibleUpdates.map((u, i) => (
           // Clamp in both variants — the dedicated Updates subtab gets
           // the same Read more / Show less affordance as the overview
           // preview, so a single long update doesn't dominate the tab.
+          // The full (tab) variant numbers each update with a small
+          // heading; the overview preview doesn't.
           <UpdateCard
             key={u.uri}
             record={u}
             clamp
+            heading={variant === "full" ? `Update ${i + 1}` : undefined}
             base={manage ? base : null}
             viewerDid={viewerDid}
             onChanged={refetch}
@@ -220,6 +223,9 @@ interface UpdateCardProps {
   /** When true, clamp the description to a few lines and surface a
    *  "Read more" affordance if the content overflows. */
   clamp: boolean
+  /** Small label above the card (e.g. "Update 1") — used on the
+   *  dedicated Updates tab to numerate the list. */
+  heading?: string
   /** Base record URL (`/{actor}/{type}/{rkey}`) the edit route hangs
    *  off. Non-null ONLY in manage mode — when set, the card renders
    *  Edit + Delete affordances. */
@@ -237,6 +243,7 @@ interface UpdateCardProps {
 function UpdateCard({
   record,
   clamp,
+  heading,
   base = null,
   viewerDid = null,
   onChanged,
@@ -314,16 +321,32 @@ function UpdateCard({
   }, [clamp, expanded, value.description])
 
   const docClass = clamp && !expanded
-    ? "context-updates__doc-wrap context-updates__doc-wrap--clamped"
+    ? `context-updates__doc-wrap context-updates__doc-wrap--clamped${
+        isTruncated ? " context-updates__doc-wrap--truncated" : ""
+      }`
     : "context-updates__doc-wrap"
 
   return (
     <li className="context-updates__item">
+      {heading ? (
+        <div className="context-updates__item-number-row">
+          <span className="context-updates__item-number">{heading}</span>
+          {createdLabel ? (
+            <time
+              className="context-updates__item-number-date"
+              dateTime={createdAt ?? undefined}
+            >
+              {createdLabel}
+            </time>
+          ) : null}
+        </div>
+      ) : null}
       <header className="context-updates__item-head">
         {title ? (
           <h3 className="context-updates__title">{title}</h3>
         ) : null}
-        {createdLabel ? (
+        {/* Date lives in the numbered row when a heading is shown. */}
+        {!heading && createdLabel ? (
           <time
             className="context-updates__when"
             dateTime={createdAt ?? undefined}

--- a/src/components/explore-page/cert-list-row.tsx
+++ b/src/components/explore-page/cert-list-row.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { MapPin } from "lucide-react"
 import CertIcon from "@/components/ui/cert-icon"
 import type { ActivityRecord } from "@/lib/atproto/activity-types"
 import {
@@ -9,25 +8,20 @@ import {
 } from "@/lib/atproto/activity"
 import { activityDetailHref, parseActivityUri } from "@/lib/atproto/activity-uri"
 import { formatShortDate } from "@/lib/utils/format-date"
-import type { EndorsementClosureAccount } from "@/lib/atproto/indexer"
 import ExploreListRow from "./explore-list-row"
 
 /**
- * Dense single-row representation of a cert for the /explore list
- * view. Resolves cert-shaped fields (title, period, work scope,
- * location flag, author) and hands them to `<ExploreListRow>`, which
- * owns the actual JSX scaffolding shared with `<ProjectListRow>`.
+ * Dense single-row representation of a cert. Shows only the image (or a
+ * placeholder), the activity title, the time period, and the work scope
+ * — no author/date columns (the compact ExploreListRow variant), so the
+ * row spans the full width. Used by /explore and the project detail page.
  */
 export default function CertListRow({
   record,
   did,
-  endorsementMeta,
 }: {
   record: ActivityRecord
   did: string
-  /** Closure-graph metadata for the cert AUTHOR's DID, when the
-   *  active explore filter is endorsement-based (#84). */
-  endorsementMeta?: EndorsementClosureAccount
 }) {
   const { value } = record
   const imageUrl = value.image
@@ -41,23 +35,11 @@ export default function CertListRow({
 
   const period = formatTimePeriod(value.startDate ?? null, value.endDate ?? null)
   const scope = evaluateWorkScope(value.workScope)
-  const hasLocation = Array.isArray(value.locations) && value.locations.length > 0
 
-  // Meta is `[period?, scope?, locationIcon?]` joined by `·`. The
-  // location segment is just the icon — certs don't surface a
-  // location *name* in this row variant (the detail page does).
-  const metaItems = [
-    period,
-    scope,
-    hasLocation ? (
-      <MapPin
-        size={12}
-        strokeWidth={1.75}
-        aria-label="Has location"
-        className="cert-list-row__meta-icon"
-      />
-    ) : null,
-  ].filter((m): m is NonNullable<typeof m> => m !== null && m !== undefined)
+  // Time period + work scope only, joined by `·`.
+  const metaItems = [period, scope].filter(
+    (m): m is string => typeof m === "string" && m.length > 0,
+  )
 
   return (
     <ExploreListRow
@@ -73,9 +55,9 @@ export default function CertListRow({
       }
       title={value.title}
       metaItems={metaItems}
-      authorDid={did}
-      endorsementMeta={endorsementMeta}
-      timestampIso={value.createdAt}
+      authorDid={null}
+      timestampIso={null}
+      compact
     />
   )
 }

--- a/src/components/explore-page/explore-list-row.tsx
+++ b/src/components/explore-page/explore-list-row.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, type ReactNode } from "react"
+import { useEffect, useRef, useState, type ReactNode } from "react"
 import Link from "next/link"
 import ActivityAuthor from "@/components/feed/activity-author"
 import { formatRelativeTime } from "@/lib/atproto/activity"
@@ -48,6 +48,9 @@ export interface ExploreListRowProps {
   /** ISO timestamp for the right-hand "x ago" column. Null shows
    *  nothing. */
   timestampIso: string | null
+  /** Compact variant: drops the author and date columns entirely so the
+   *  thumb + title/meta block spans the full row width. */
+  compact?: boolean
 }
 
 export default function ExploreListRow({
@@ -59,9 +62,38 @@ export default function ExploreListRow({
   authorDid,
   endorsementMeta,
   timestampIso,
+  compact = false,
 }: ExploreListRowProps) {
   const [imageFailed, setImageFailed] = useState(false)
   const showImage = thumbUrl !== null && !imageFailed
+
+  // Hide the "·" separator on any meta item that wraps to a new line, so
+  // a dangling dot never sits at the start (or end) of a wrapped line.
+  const metaRef = useRef<HTMLParagraphElement>(null)
+  const [lineStarts, setLineStarts] = useState<number[]>([])
+  useEffect(() => {
+    const el = metaRef.current
+    if (!el) return
+    const measure = () => {
+      const items = Array.from(el.children) as HTMLElement[]
+      const starts: number[] = []
+      let prevTop: number | null = null
+      items.forEach((it, i) => {
+        const top = it.offsetTop
+        if (prevTop === null || top > prevTop + 1) starts.push(i)
+        prevTop = top
+      })
+      setLineStarts((prev) =>
+        prev.length === starts.length && prev.every((v, i) => v === starts[i])
+          ? prev
+          : starts,
+      )
+    }
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [metaItems])
 
   const body = (
     <>
@@ -82,10 +114,10 @@ export default function ExploreListRow({
       <div className="cert-list-row__body">
         <h3 className="cert-list-row__title">{title}</h3>
         {metaItems.length > 0 ? (
-          <p className="cert-list-row__meta">
+          <p className="cert-list-row__meta" ref={metaRef}>
             {metaItems.map((item, i) => (
               <span key={i} className="cert-list-row__meta-item">
-                {i > 0 ? (
+                {i > 0 && !lineStarts.includes(i) ? (
                   <span className="cert-list-row__meta-sep" aria-hidden>
                     ·
                   </span>
@@ -100,28 +132,34 @@ export default function ExploreListRow({
   )
 
   return (
-    <article className="cert-list-row">
+    <article
+      className={`cert-list-row${compact ? " cert-list-row--compact" : ""}`}
+    >
       {href ? (
         <Link href={href} className="cert-list-row__link">
           {body}
         </Link>
       ) : null}
 
-      <div className="cert-list-row__author-col">
-        {authorDid ? (
-          <ActivityAuthor
-            did={authorDid}
-            nameSuffix={
-              endorsementMeta ? (
-                <EndorsementRowBadge meta={endorsementMeta} />
-              ) : null
-            }
-          />
-        ) : null}
-      </div>
-      <time className="cert-list-row__time">
-        {timestampIso ? formatRelativeTime(timestampIso) : ""}
-      </time>
+      {compact ? null : (
+        <>
+          <div className="cert-list-row__author-col">
+            {authorDid ? (
+              <ActivityAuthor
+                did={authorDid}
+                nameSuffix={
+                  endorsementMeta ? (
+                    <EndorsementRowBadge meta={endorsementMeta} />
+                  ) : null
+                }
+              />
+            ) : null}
+          </div>
+          <time className="cert-list-row__time">
+            {timestampIso ? formatRelativeTime(timestampIso) : ""}
+          </time>
+        </>
+      )}
     </article>
   )
 }

--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -52,6 +52,7 @@ import {
   type SortOrder,
 } from "./explore-types"
 import { useExploreData } from "@/hooks/use-explore"
+import { useScrollRestoration } from "@/hooks/use-scroll-restoration"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useLayoutBreakpoints } from "@/hooks/use-layout-breakpoints"
 import { usePageTitle } from "@/lib/navbar-context"
@@ -630,6 +631,13 @@ function ExploreMain({
         ? quality.includeOrgLabels
         : undefined,
   })
+
+  // Restore the window scroll offset when the reader returns from a
+  // project/activity detail page (back button). Keyed by the full URL so
+  // each kind/filter/search combination restores independently; gated on
+  // the list having finished its initial load so the page is tall enough.
+  const scrollKey = `${pathname}?${searchParams?.toString() ?? ""}`
+  useScrollRestoration(scrollKey, !data.isLoading)
 
   const onDegreesChange = useCallback(
     (next: Set<Degree>) => {
@@ -1827,16 +1835,9 @@ function ResultsArea({
       <ul className="explore__list explore__list--certs">
         {certs.map((rec) => {
           const did = certDids.get(rec.uri) ?? ""
-          const meta = closure && did
-            ? closure.closureByDid.get(did)
-            : undefined
           return (
             <li key={rec.uri}>
-              <CertListRow
-                record={rec}
-                did={did}
-                endorsementMeta={meta}
-              />
+              <CertListRow record={rec} did={did} />
             </li>
           )
         })}

--- a/src/components/feed/activity-detail-route.tsx
+++ b/src/components/feed/activity-detail-route.tsx
@@ -1,13 +1,11 @@
 "use client"
 
 import { useEffect } from "react"
-import { usePageTitleBreadcrumb } from "@/lib/navbar-context"
 import { useActivity } from "@/hooks/use-activity"
 import ActivityDetail from "@/components/feed/activity-detail"
 import ErrorMessage from "@/components/ui/error-message"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import { trackRecentlyViewed } from "@/lib/utils/recently-viewed"
-import { profileUrl, recordUrl } from "@/lib/urls"
 
 /**
  * Activity (cert) detail body, rendered by the handle-forward record route
@@ -36,16 +34,6 @@ export default function ActivityDetailRoute({
     if (activity?.uri) trackRecentlyViewed("cert", activity.uri)
   }, [activity?.uri])
 
-  const certTitle = activity?.value.title ?? null
-  usePageTitleBreadcrumb(
-    handle && certTitle && rkey
-      ? {
-          left: { text: handle, href: profileUrl(handle) },
-          right: { text: certTitle, href: recordUrl(handle, "activity", rkey) },
-        }
-      : null,
-  )
-
   if (resolving || isLoading) {
     return (
       <div className="cert-detail-page">
@@ -73,6 +61,7 @@ export default function ActivityDetailRoute({
         did={activity.did}
         value={activity.value}
         cid={activity.cid}
+        handle={handle}
       />
     </div>
   )

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
 import { profileUrl, recordUrl } from "@/lib/urls"
+import { usePageTitle, usePageRecordMenu } from "@/lib/navbar-context"
 import Link from "next/link"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import DeleteRecordDialog from "@/components/ui/delete-record-dialog"
@@ -9,7 +10,6 @@ import ConfirmDialog from "@/components/ui/confirm-dialog"
 import { authFetch } from "@/lib/auth/fetch"
 import {
   Calendar,
-  ChevronRight,
   FileText,
   MapPin,
   Pencil,
@@ -40,6 +40,7 @@ import EditBanner from "@/components/ui/edit-banner"
 import Tooltip from "@/components/ui/tooltip"
 import { useCertProjects } from "@/hooks/use-cert-projects"
 import { useAuthorInfo } from "@/hooks/use-author-info"
+import { TransitionLink } from "@/lib/view-transitions"
 import LeafletDocument, {
   isRenderableDescription,
 } from "@/components/leaflet/leaflet-document"
@@ -73,6 +74,8 @@ interface ActivityDetailProps {
    *  `swapRecord` so a concurrent edit in another tab can't silently
    *  clobber this save (issue #71). */
   cid: string
+  /** Resolved handle, for the navbar breadcrumb (overview tab). */
+  handle: string | null
 }
 
 /**
@@ -159,6 +162,7 @@ export default function ActivityDetail({
   did,
   value,
   cid,
+  handle,
 }: ActivityDetailProps) {
   const baseImageUrl = value.image
     ? resolveActivityImageUrl(value.image, did)
@@ -224,6 +228,35 @@ export default function ActivityDetail({
     tabParam === "updates"
       ? tabParam
       : "overview"
+
+  // Navbar title: sub-tabs show the tab name next to the back arrow; the
+  // overview shows the activity's own name. (We deliberately don't prefix
+  // it with the author handle — the mobile bar is too narrow to show both,
+  // and the name is the useful identifier.)
+  usePageTitle(
+    activeTab === "description"
+      ? "Description"
+      : activeTab === "contributors"
+        ? contributorCount > 0
+          ? `Contributors (${contributorCount})`
+          : "Contributors"
+        : activeTab === "updates"
+          ? "Updates"
+          : value.title || "Activity",
+  )
+  // Record-level overflow menu in the mobile navbar's right slot (Share /
+  // Add to list / Copy AT URI). Reads as page-level chrome instead of an
+  // action on the author. Desktop keeps the in-body menu (time-period row).
+  usePageRecordMenu(
+    rkey
+      ? {
+          targetUri: `at://${did}/org.hypercerts.claim.activity/${rkey}`,
+          targetCid: cid,
+          targetType: LIST_CERTS_TYPE,
+          shareTab: activeTab === "overview" ? null : activeTab,
+        }
+      : null,
+  )
 
   // Edit affordance — the viewer can act on the cert when they're
   // signed in as the cert's creator. Two paths:
@@ -717,6 +750,23 @@ export default function ActivityDetail({
   // three tabs start their content at the same vertical position.
   const headline = (
     <header className="cert-detail__headline">
+      {/* Mobile: "Activity" eyebrow + date created (right-aligned) above
+          the title — mirrors the project page's "Project" eyebrow row.
+          Hidden on desktop, where the date shows in the headline columns. */}
+      <div className="cert-detail__eyebrow-row">
+        <span className="cert-detail__eyebrow" aria-hidden="true">
+          Activity
+        </span>
+        {value.createdAt ? (
+          <time
+            className="cert-detail__eyebrow-date"
+            dateTime={value.createdAt}
+            title={value.createdAt}
+          >
+            {createdAbsolute}
+          </time>
+        ) : null}
+      </div>
       <div className="cert-detail__title-row">
         {editing ? (
           // Bare/flush <Input> for the inline title edit. The detail
@@ -784,6 +834,8 @@ export default function ActivityDetail({
           </>
         ) : null}
       </div>
+      {/* No `action` here: on mobile the record menu lives in the navbar
+          (usePageRecordMenu), on desktop in the time-period row below. */}
       <CertHeadlineColumns
         did={did}
         rkey={rkey}
@@ -801,14 +853,33 @@ export default function ActivityDetail({
   // styled the same as the headline columns above (Date created /
   // Author / Project) so the section reads as another peer in the
   // overview's labelled-meta family.
-  const summaryHeading = (
-    <span className="cert-detail__meta-label">Summary</span>
+  // "Read full description" affordance — navigates to the Description
+  // tab as a real history entry, sliding the view right (Back reverses
+  // it). Styled like the project page's: a "See all"-style link on the
+  // Summary heading row, right-aligned.
+  const descriptionDisclosure =
+    showFullDescription && descriptionHref ? (
+      <TransitionLink
+        href={descriptionHref}
+        className="cert-detail__section-see-all"
+      >
+        Read full description →
+      </TransitionLink>
+    ) : null
+
+  // Summary heading row: label on the left, "Read full description" link
+  // on the right (same shape as the project page).
+  const summaryHead = (
+    <div className="cert-detail__summary-head">
+      <span className="cert-detail__meta-label">Summary</span>
+      {descriptionDisclosure}
+    </div>
   )
 
   const shortDescSection =
     activeTab !== "overview" ? null : editing ? (
-      <section className="cert-detail__section">
-        {summaryHeading}
+      <section className="cert-detail__section cert-detail__section--summary">
+        {summaryHead}
         <textarea
           className="cert-detail__short-desc-input"
           value={drafts.shortDescription}
@@ -822,40 +893,15 @@ export default function ActivityDetail({
         />
       </section>
     ) : effectiveValue.shortDescription ? (
-      <section className="cert-detail__section">
-        {summaryHeading}
+      <section className="cert-detail__section cert-detail__section--summary">
+        {summaryHead}
         <p className="cert-detail__short-desc">
           {effectiveValue.shortDescription}
         </p>
-        {/* `push`-mode link (no `replace`) so the description tab
-            becomes a real history entry — pressing the browser
-            Back button returns the viewer to the Overview tab.
-            The navbar's 2nd-row back button uses its own history
-            handler (in `lib/navbar-context`) and walks to whatever
-            page the viewer came from before the cert, not to a
-            tab within it. */}
-        {showFullDescription && descriptionHref ? (
-          <Link
-            href={descriptionHref}
-            scroll={false}
-            className="cert-detail__read-more"
-          >
-            Read full description
-            <ChevronRight size={14} strokeWidth={1.75} aria-hidden />
-          </Link>
-        ) : null}
       </section>
-    ) : showFullDescription && descriptionHref ? (
-      <section className="cert-detail__section">
-        {summaryHeading}
-        <Link
-          href={descriptionHref}
-          scroll={false}
-          className="cert-detail__read-more"
-        >
-          Read full description
-          <ChevronRight size={14} strokeWidth={1.75} aria-hidden />
-        </Link>
+    ) : descriptionDisclosure ? (
+      <section className="cert-detail__section cert-detail__section--summary">
+        {summaryHead}
       </section>
     ) : null
 
@@ -875,54 +921,65 @@ export default function ActivityDetail({
         />
       ) : null}
 
-      <article className="page-layout cert-detail--wide">
+      <article
+        className={`page-layout cert-detail--wide cert-detail--tab-${activeTab}${editing ? " cert-detail--editing" : ""}`}
+      >
       <aside className="cert-detail__aside" aria-label="Activity details">
-        <div
-          className={
-            editing
-              ? "cert-detail__image cert-detail__image--editing"
-              : "cert-detail__image"
-          }
-        >
-          {effectiveImageUrl && !imageFailed ? (
-            /* eslint-disable-next-line @next/next/no-img-element */
-            <img
-              src={effectiveImageUrl}
-              alt=""
-              className="cert-detail__image-img"
-              onError={() => setImageFailed(true)}
-            />
-          ) : (
-            <CertIcon
-              size={56}
-              strokeWidth={1.25}
-              className="cert-detail__image-placeholder-icon"
-              aria-hidden
-            />
-          )}
-          {editing ? (
-            <ImageEditOverlay
-              onFile={handleImageFile}
-              hasPending={!!pendingImageBlob}
-            />
-          ) : null}
-        </div>
+        {/* No placeholder in the read-only view: the image box renders
+            only when there's a real image (or in edit mode, where the
+            placeholder is the upload target). */}
+        {(effectiveImageUrl && !imageFailed) || editing ? (
+          <div
+            className={
+              editing
+                ? "cert-detail__image cert-detail__image--editing"
+                : "cert-detail__image"
+            }
+          >
+            {effectiveImageUrl && !imageFailed ? (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                src={effectiveImageUrl}
+                alt=""
+                className="cert-detail__image-img"
+                onError={() => setImageFailed(true)}
+              />
+            ) : (
+              <CertIcon
+                size={56}
+                strokeWidth={1.25}
+                className="cert-detail__image-placeholder-icon"
+                aria-hidden
+              />
+            )}
+            {editing ? (
+              <ImageEditOverlay
+                onFile={handleImageFile}
+                hasPending={!!pendingImageBlob}
+              />
+            ) : null}
+          </div>
+        ) : null}
 
         <dl className="cert-detail__meta">
           {/* "Created" lives in the headline byline now — no need to
               repeat it in the aside meta list. */}
-          <div className="cert-detail__meta-row">
+          <div className="cert-detail__meta-row cert-detail__meta-row--timeperiod">
             <dt className="cert-detail__meta-label cert-detail__meta-label--with-action">
               <span className="cert-detail__meta-label-text">
                 <Calendar size={11} strokeWidth={2} aria-hidden />
                 Time period
               </span>
               {rkey ? (
-                <AddToListMenu
-                  targetUri={`at://${did}/org.hypercerts.claim.activity/${rkey}`}
-                  targetCid={cid}
-                  targetType={LIST_CERTS_TYPE}
-                />
+                // Desktop only — on mobile the menu moves to the author row.
+                <span className="cert-detail__meta-menu">
+                  <AddToListMenu
+                    targetUri={`at://${did}/org.hypercerts.claim.activity/${rkey}`}
+                    targetCid={cid}
+                    targetType={LIST_CERTS_TYPE}
+                    shareTab={activeTab === "overview" ? null : activeTab}
+                  />
+                </span>
               ) : null}
             </dt>
             <dd className="cert-detail__meta-value">
@@ -968,7 +1025,7 @@ export default function ActivityDetail({
           </div>
 
           {editing || workScopeLabel ? (
-            <div className="cert-detail__meta-row">
+            <div className="cert-detail__meta-row cert-detail__meta-row--workscope">
               <dt className="cert-detail__meta-label">
                 <Target size={11} strokeWidth={2} aria-hidden />
                 Work scope
@@ -1009,41 +1066,43 @@ export default function ActivityDetail({
               top of the main column stays reserved for narrative
               content. NOT tab-gated: the aside is identical on every
               cert tab. */}
-          {contributorCount > 0 ? (
-            <div className="cert-detail__meta-row">
-              <dt className="cert-detail__meta-label">
-                <Users size={11} strokeWidth={2} aria-hidden />
-                Contributors
-                <span className="cert-detail__meta-count">
-                  {contributorCount}
-                </span>
-              </dt>
-              <dd className="cert-detail__meta-value">
-                {(() => {
-                  const ASIDE_CONTRIB_PREVIEW = 5
-                  const previewContributors = contributors.slice(
-                    0,
-                    ASIDE_CONTRIB_PREVIEW,
-                  )
-                  const hasMore = contributorCount > ASIDE_CONTRIB_PREVIEW
-                  const contributorsHref = pathname
-                    ? `${pathname}?tab=contributors`
-                    : null
-                  const hasAnyWeight = previewContributors.some(
-                    (c) => c.contributionWeight != null,
-                  )
-                  // Percentages are computed across the FULL
-                  // contributor list (not just the preview slice) so
-                  // the % column adds to 100 even when the aside
-                  // shows only the first 5 of N rows.
-                  const weightPercents = buildWeightPercents(contributors)
-                  return (
-                    <>
-                      {hasAnyWeight ? (
-                        <ContributorWeightHeader />
+          {contributorCount > 0
+            ? (() => {
+                const ASIDE_CONTRIB_PREVIEW = 5
+                const shown = contributors.slice(0, ASIDE_CONTRIB_PREVIEW)
+                const contributorsHref = pathname
+                  ? `${pathname}?tab=contributors`
+                  : null
+                const hasAnyWeight = shown.some(
+                  (c) => c.contributionWeight != null,
+                )
+                // Percentages computed across the FULL list so the %
+                // column adds to 100 even when only the first 5 show.
+                const weightPercents = buildWeightPercents(contributors)
+                return (
+                  <div className="cert-detail__meta-row cert-detail__meta-row--contributors">
+                    <dt className="cert-detail__meta-label cert-detail__meta-label--with-action">
+                      <span className="cert-detail__meta-label-text">
+                        <Users size={11} strokeWidth={2} aria-hidden />
+                        Contributors
+                        <span className="cert-detail__meta-count">
+                          {contributorCount}
+                        </span>
+                      </span>
+                      {contributorsHref ? (
+                        <TransitionLink
+                          href={contributorsHref}
+                          replace
+                          className="cert-detail__section-see-all"
+                        >
+                          See all →
+                        </TransitionLink>
                       ) : null}
+                    </dt>
+                    <dd className="cert-detail__meta-value">
+                      {hasAnyWeight ? <ContributorWeightHeader /> : null}
                       <ul className="cert-detail__contributors cert-detail__contributors--aside">
-                        {previewContributors.map((c, i) => {
+                        {shown.map((c, i) => {
                           const roleText = contributionRoleText(
                             c.contributionDetails,
                           )
@@ -1061,29 +1120,18 @@ export default function ActivityDetail({
                           )
                         })}
                       </ul>
-                      {hasMore && contributorsHref ? (
-                        <Link
-                          href={contributorsHref}
-                          scroll={false}
-                          replace
-                          className="cert-detail__aside-see-all"
-                        >
-                          Show all
-                        </Link>
-                      ) : null}
-                    </>
-                  )
-                })()}
-              </dd>
-            </div>
-          ) : null}
+                    </dd>
+                  </div>
+                )
+              })()
+            : null}
 
           {/* Rights row — sits at the bottom of the meta list. The
               other meta rows are quick scalar facts; Rights
               references an external record and reads as a
               less-frequent reference. */}
           {value.rights ? (
-            <div className="cert-detail__meta-row">
+            <div className="cert-detail__meta-row cert-detail__meta-row--rights">
               <dt className="cert-detail__meta-label">
                 <FileText size={11} strokeWidth={2} aria-hidden />
                 Rights
@@ -1139,7 +1187,7 @@ export default function ActivityDetail({
                 so the older full-width Projects section is gone — it
                 would have duplicated the headline Project column. */}
             {locations.length > 0 ? (
-              <section className="cert-detail__section">
+              <section className="cert-detail__section cert-detail__section--locations">
                 <span className="cert-detail__meta-label">
                   <MapPin size={11} strokeWidth={2} aria-hidden />
                   Locations
@@ -1474,18 +1522,22 @@ function CertHeadlineColumns({
   rkey,
   createdAt,
   formattedDate,
+  action,
 }: {
   did: string
   rkey: string | null
   createdAt: string
   formattedDate: string
+  /** Trailing control (the three-dot menu) shown on the author's row,
+   *  right-aligned, on mobile. */
+  action?: ReactNode
 }) {
   const { info, isLoading: authorLoading } = useAuthorInfo(did)
   const { projects } = useCertProjects(did, rkey)
 
   return (
     <div className="cert-detail__headline-cols">
-      <div className="cert-detail__headline-col">
+      <div className="cert-detail__headline-col cert-detail__headline-col--author">
         <span className="cert-detail__meta-label">Author</span>
         {authorLoading || !info ? (
           <span
@@ -1525,7 +1577,11 @@ function CertHeadlineColumns({
         )}
       </div>
 
-      <div className="cert-detail__headline-col">
+      {action ? (
+        <div className="cert-detail__headline-action">{action}</div>
+      ) : null}
+
+      <div className="cert-detail__headline-col cert-detail__headline-col--date">
         <span className="cert-detail__meta-label">Date created</span>
         <time
           dateTime={createdAt}

--- a/src/components/landing/landing-page.tsx
+++ b/src/components/landing/landing-page.tsx
@@ -8,6 +8,7 @@ import ExploreProfiles, {
 } from "@/components/landing/sections/explore-profiles";
 import NetworkStats from "@/components/landing/sections/network-stats";
 import Trust from "@/components/landing/sections/trust";
+import AiWorld from "@/components/landing/sections/ai-world";
 import OrganizationsStrip from "@/components/landing/sections/organizations-strip";
 import FaqSection from "@/components/landing/sections/faq-content";
 import ClosingCta from "@/components/landing/sections/closing-cta";
@@ -40,6 +41,7 @@ export default async function LandingPage() {
       <Hero />
       <WhatLivesHere />
       <MayaWalkthrough />
+      <AiWorld />
       <PartnerApps />
       <ExploreProfiles profiles={profiles} />
       <NetworkStats />

--- a/src/components/landing/landing-topbar.tsx
+++ b/src/components/landing/landing-topbar.tsx
@@ -2,25 +2,37 @@
 
 import Link from "next/link";
 import { useAuth } from "@/lib/auth/auth-context";
+import { useProfile } from "@/hooks/use-profile";
+import Avatar from "@/components/ui/avatar";
+import { getInitials } from "@/lib/utils/initials";
 
 export default function LandingTopBar() {
-  const { isLoading, isAuthenticated, openSignInModal } = useAuth();
+  const { isLoading, isAuthenticated, openSignInModal, did } = useAuth();
+  const { profile, avatarUrl } = useProfile();
 
   return (
     <>
       {/* Centered wordmark — in normal page flow, scrolls away */}
       <div className="lp-topbar">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src="/brand/wordmark/certified_wordmark_black.svg"
-          alt="Certified"
-          className="lp-topbar__wordmark"
-        />
+        <Link href="/welcome" className="lp-topbar__home" aria-label="Certified — home">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="/brand/wordmark/certified_wordmark_black.svg"
+            alt="Certified"
+            className="lp-topbar__wordmark"
+          />
+        </Link>
       </div>
       {/* Sign-in / open-app button — position: fixed, persists on scroll */}
       {!isLoading && (
         isAuthenticated ? (
-          <Link href="/home" className="lp-topbar__btn">
+          <Link href="/home" className="lp-topbar__btn lp-topbar__btn--account">
+            <Avatar
+              size="sm"
+              src={avatarUrl || undefined}
+              fallbackInitials={getInitials(profile?.displayName, did)}
+              className="lp-topbar__avatar !h-5 !w-5"
+            />
             Open app
           </Link>
         ) : (

--- a/src/components/landing/sections/ai-world.tsx
+++ b/src/components/landing/sections/ai-world.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * "Built for an AI world" — the AI positioning section. Two statements:
+ * (1) when everyone can produce a perfect narrative, presentation stops
+ * being a reliable signal and judgement shifts to a verifiable track
+ * record, and (2) that same open, machine-readable record is what AI
+ * agents read to discover, match, and vouch. Reuses the numbered
+ * lp-item pattern; two-column grid that stacks below 800px.
+ *
+ * Reveal: an IntersectionObserver arms the columns (hides them) on mount
+ * and releases them when the section scrolls into view, so the two
+ * statements fade up left-then-right. Markup is visible by default, so
+ * without JS the content still renders; reduced-motion skips straight to
+ * the shown state with no transition.
+ */
+
+const STATEMENTS = [
+  {
+    num: "01",
+    title: "When every project sounds impressive",
+    body: "With AI, anyone can produce a compelling pitch, so presentation says little about whether a project is good. Judgement shifts to what can't be performed: funding you genuinely raised, work you published, endorsements signed by partners who put their name to it. Evidence, not eloquence.",
+  },
+  {
+    num: "02",
+    title: "The trust layer agents read",
+    body: "Records are open and machine-readable on AT Protocol. As AI agents start discovering projects, matching funders, and vouching on people's behalf, your signed record is what they read. When people and AI decide together, that transparency is what keeps the outcomes sound.",
+  },
+];
+
+export default function AiWorld() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // The reveal is driven through the ref's data-anim attribute rather
+  // than React state: no extra render, and no content is hidden until
+  // JS runs (the markup ships visible, so no-JS / reduced-motion render
+  // the finished state). armed = hidden + ready; shown = released.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    el.dataset.anim = "armed";
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          el.dataset.anim = "shown";
+          io.disconnect();
+        }
+      },
+      { threshold: 0.2 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return (
+    <section className="lp-section" aria-labelledby="lp-ai-title">
+      <div className="lp-section__inner">
+        <header className="lp-section__header">
+          <span className="lp-eyebrow">Built for an AI world</span>
+          <h2 id="lp-ai-title" className="lp-h2">
+            When anything can be generated, real is the rare thing
+          </h2>
+          <p className="lp-ai__lede">
+            Certified doesn&apos;t generate trust. It records it. A verified,
+            endorsed history that both people and machines can rely on.
+          </p>
+        </header>
+        <div className="lp-ai" ref={ref}>
+          {STATEMENTS.map((s) => (
+            <div key={s.num} className="lp-ai__col lp-item">
+              <span className="lp-item__num">{s.num}</span>
+              <h3 className="lp-item__title">{s.title}</h3>
+              <p className="lp-item__body">{s.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/sections/maya-walkthrough.tsx
+++ b/src/components/landing/sections/maya-walkthrough.tsx
@@ -19,7 +19,7 @@ const STEPS = [
   {
     num: "01",
     title: "She raises funding",
-    body: "Maya raised funding on a crowdfunding app like Ma Earth. Her project page, updates, and supporters were saved to her Certified account automatically.",
+    body: "Maya raised funding for her organization on a crowdfunding app like Ma Earth. Her project page, updates, and supporters were saved to a Certified record automatically — held by her or her organization, whichever fits.",
   },
   {
     num: "02",

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -23,6 +23,7 @@ import {
 import SiteDrawer from "./site-drawer";
 import { useAuth } from "@/lib/auth/auth-context";
 import { useNavbarContext } from "@/lib/navbar-context";
+import { useViewTransition } from "@/lib/view-transitions";
 import { useProfile } from "@/hooks/use-profile";
 import { useSession } from "@/hooks/use-session";
 import { useOrg } from "@/lib/groups/org-context";
@@ -128,6 +129,7 @@ const PROJECT_DETAIL_TABS: DetailTab[] = [
 export default function DesktopTopBar() {
   const pathname = usePathname();
   const router = useRouter();
+  const { transitionBack } = useViewTransition();
   const searchParams = useSearchParams();
 
   const { isLoading, isAuthenticated, did, openSignIn, signOut } = useAuth();
@@ -629,7 +631,7 @@ export default function DesktopTopBar() {
           <button
             type="button"
             className="desktop-top-bar__back"
-            onClick={() => router.back()}
+            onClick={() => transitionBack()}
             aria-label="Go back"
           >
             <ArrowLeft size={16} strokeWidth={1.75} aria-hidden />

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth/auth-context";
 import { useNavbarContext } from "@/lib/navbar-context";
+import { useViewTransition } from "@/lib/view-transitions";
 import { useProfile } from "@/hooks/use-profile";
 import { useSession } from "@/hooks/use-session";
 import Avatar from "@/components/ui/avatar";
@@ -21,6 +22,8 @@ import Brandmark from "@/components/ui/brandmark";
 import BottomSheet from "@/components/ui/bottom-sheet";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import Tooltip from "@/components/ui/tooltip";
+import AddToListMenu from "@/components/lists/add-to-list-menu";
+import type { TypedListType } from "@/lib/atproto/typed-lists";
 import { useLayoutBreakpoints } from "@/hooks/use-layout-breakpoints";
 
 const ROLE_ORDER: Record<string, number> = { owner: 0, admin: 1, member: 2 };
@@ -46,11 +49,13 @@ const ROOT_PATHS = new Set<string>([
 
 const Navbar: React.FC = () => {
   const { isLoading, isAuthenticated, did, openSignIn, signOut } = useAuth();
-  const { pageTitle, breadcrumb, profileOverlay } = useNavbarContext();
+  const { pageTitle, breadcrumb, recordMenu, profileOverlay } =
+    useNavbarContext();
   const { profile, avatarUrl } = useProfile();
   const { handle } = useSession();
   const pathname = usePathname();
   const router = useRouter();
+  const { transitionBack } = useViewTransition();
   const { activeOrg, groups, switchOrg } = useOrg();
   const { orgAvatarUrl } = useOrgProfile();
 
@@ -133,32 +138,28 @@ const Navbar: React.FC = () => {
   //
   // NOTE: these hooks MUST sit above `if (isLoading) return null` so the
   // hook count is stable across renders (rules of hooks).
+  // In-app navigation depth. We patch history.pushState (which Next's
+  // router calls for every forward navigation, INCLUDING query-only tab
+  // navigations like `?tab=description`) to increment, and popstate to
+  // decrement. router.replace uses replaceState, so it isn't counted —
+  // the did→handle URL canonicalization can't inflate the count. When
+  // the counter is 0 the back stack would exit the app, so handleBack
+  // pushes `/` instead.
   const inAppDepthRef = useRef(0);
-  const initializedRef = useRef(false);
-  const skipNextPathnameRef = useRef(false);
-
   useEffect(() => {
-    if (!initializedRef.current) {
-      initializedRef.current = true;
-      return;
-    }
-    if (skipNextPathnameRef.current) {
-      skipNextPathnameRef.current = false;
-      return;
-    }
-    inAppDepthRef.current += 1;
-  }, [pathname]);
-
-  useEffect(() => {
+    const origPushState = history.pushState.bind(history);
+    history.pushState = (...args: Parameters<typeof origPushState>) => {
+      inAppDepthRef.current += 1;
+      return origPushState(...args);
+    };
     const onPop = () => {
-      // A browser back/forward fires popstate. The subsequent pathname
-      // effect shouldn't count this as a "new" navigation — mark it to
-      // skip — and drop the depth counter by one.
-      skipNextPathnameRef.current = true;
       inAppDepthRef.current = Math.max(0, inAppDepthRef.current - 1);
     };
     window.addEventListener("popstate", onPop);
-    return () => window.removeEventListener("popstate", onPop);
+    return () => {
+      history.pushState = origPushState;
+      window.removeEventListener("popstate", onPop);
+    };
   }, []);
 
   // Don't render navbar while auth is loading — prevents white flash.
@@ -178,16 +179,19 @@ const Navbar: React.FC = () => {
     .join(" ");
 
   const handleBack = () => {
-    if (inAppDepthRef.current > 0) {
-      // We have in-app history — safe to pop. The popstate listener
-      // above will decrement the counter.
-      router.back();
-    } else {
-      // The user entered our app on this page (direct link, external
-      // referrer, or page refresh). `router.back()` would take them
-      // outside the app — push home instead.
-      router.push("/");
-    }
+    // Reverse slide for the back gesture (see ViewTransitionProvider).
+    transitionBack(() => {
+      if (inAppDepthRef.current > 0) {
+        // We have in-app history — safe to pop. The popstate listener
+        // above will decrement the counter.
+        router.back();
+      } else {
+        // The user entered our app on this page (direct link, external
+        // referrer, or page refresh). `router.back()` would take them
+        // outside the app — push home instead.
+        router.push("/");
+      }
+    });
   };
 
   // Top-level destinations show the hamburger + account switcher / sign-in
@@ -393,7 +397,20 @@ const Navbar: React.FC = () => {
               pageTitle
             )}
           </div>
-          <div className="navbar__right">{isRootLevel ? rightCluster : null}</div>
+          <div className="navbar__right">
+            {isRootLevel ? (
+              rightCluster
+            ) : recordMenu ? (
+              <span className="navbar__action">
+                <AddToListMenu
+                  targetUri={recordMenu.targetUri}
+                  targetCid={recordMenu.targetCid}
+                  targetType={recordMenu.targetType as TypedListType}
+                  shareTab={recordMenu.shareTab}
+                />
+              </span>
+            ) : null}
+          </div>
         </div>
       </nav>
     );

--- a/src/components/lists/add-to-list-menu.tsx
+++ b/src/components/lists/add-to-list-menu.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Copy, ListPlus, MoreVertical } from "lucide-react"
+import { Copy, ListPlus, MoreVertical, Share2 } from "lucide-react"
 import AppDialog, { AppDialogHeader, AppDialogBody } from "@/components/ui/app-dialog"
 import Button from "@/components/ui/button"
 import Input from "@/components/ui/input"
@@ -13,6 +13,7 @@ import {
   PopoverItem,
 } from "@/components/ui/popover"
 import { useAuth } from "@/lib/auth/auth-context"
+import { recordUrlFromAtUri } from "@/lib/urls"
 import { useTypedLists } from "@/hooks/use-typed-lists"
 import {
   itemUriMatchesType,
@@ -35,6 +36,12 @@ interface AddToListMenuProps {
    *  saves one round-trip. */
   targetCid: string
   targetType: TypedListType
+  /** When this menu acts on the record of the page the viewer is
+   *  currently on AND that page is showing a sub-tab, pass the tab key
+   *  (e.g. "updates") so the Share link deep-links straight to that tab.
+   *  Omit / pass null on the overview or on surfaces (feed cards, the
+   *  profile sidebar) where the page tab is unrelated to this record. */
+  shareTab?: string | null
 }
 
 /**
@@ -54,31 +61,48 @@ export default function AddToListMenu({
   targetUri,
   targetCid,
   targetType,
+  shareTab = null,
 }: AddToListMenuProps) {
   const { did: viewerDid, openSignIn } = useAuth()
   const [open, setOpen] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
-  const [copied, setCopied] = useState(false)
+  const [copied, setCopied] = useState<"share" | "uri" | null>(null)
+
+  // DID-based web path for sharing — recordUrlFromAtUri maps the
+  // collection to its friendly route segment and defaults to the URI's
+  // DID, so the link survives handle changes and never breaks. Null for
+  // collections without a record page (e.g. account profiles), which
+  // scopes the Share item to activities and projects. The absolute
+  // origin is prepended at click time from window.location, so the copied
+  // link is correct in every environment (the PUBLIC_URL env isn't
+  // inlined into the client bundle).
+  const sharePath = useMemo(() => {
+    const base = recordUrlFromAtUri(targetUri)
+    if (!base) return base
+    // Deep-link the share to the tab the viewer is currently on, so the
+    // recipient lands on the same view (Updates, Activities, …).
+    return shareTab ? `${base}?tab=${encodeURIComponent(shareTab)}` : base
+  }, [targetUri, shareTab])
 
   // Reset the brief "Copied" affordance whenever the popover opens
   // again, so the previous run's feedback doesn't leak across opens.
   useEffect(() => {
-    if (open) setCopied(false)
+    if (open) setCopied(null)
   }, [open])
 
-  const handleCopy = useCallback(async () => {
+  const copyText = useCallback(async (text: string, which: "share" | "uri") => {
     try {
-      await navigator.clipboard.writeText(targetUri)
-      setCopied(true)
+      await navigator.clipboard.writeText(text)
+      setCopied(which)
       // Keep the popover open briefly so the user sees the
       // confirmation, then auto-close.
       window.setTimeout(() => {
         setOpen(false)
       }, 900)
     } catch (err) {
-      console.error("Failed to copy URI:", err)
+      console.error("Failed to copy:", err)
     }
-  }, [targetUri])
+  }, [])
 
   // Shown to logged-out viewers too: "Copy AT URI" works without auth,
   // and "Add to list" funnels them to sign-in. Only the URI→type guard
@@ -98,6 +122,16 @@ export default function AddToListMenu({
           </Button>
         </PopoverTrigger>
         <PopoverContent align="end">
+          {sharePath ? (
+            <PopoverItem
+              onClick={() =>
+                copyText(`${window.location.origin}${sharePath}`, "share")
+              }
+            >
+              <Share2 size={13} strokeWidth={1.75} aria-hidden />
+              {copied === "share" ? "Link copied" : "Share"}
+            </PopoverItem>
+          ) : null}
           <PopoverItem
             onClick={() => {
               setOpen(false)
@@ -110,9 +144,9 @@ export default function AddToListMenu({
             <ListPlus size={13} strokeWidth={1.75} aria-hidden />
             Add to list
           </PopoverItem>
-          <PopoverItem onClick={handleCopy}>
+          <PopoverItem onClick={() => copyText(targetUri, "uri")}>
             <Copy size={13} strokeWidth={1.75} aria-hidden />
-            {copied ? "Copied" : "Copy AT URI"}
+            {copied === "uri" ? "Copied" : "Copy AT URI"}
           </PopoverItem>
         </PopoverContent>
       </Popover>

--- a/src/components/project/__tests__/project-detail-location.test.tsx
+++ b/src/components/project/__tests__/project-detail-location.test.tsx
@@ -60,7 +60,15 @@ describe("ProjectDetail location strongRef", () => {
       location: { uri: LOCATION_URI, cid: "bafyloc" },
     } as unknown as CollectionValue
 
-    render(<ProjectDetail did={DID} rkey="proj1" value={value} cid="bafycid" />)
+    render(
+      <ProjectDetail
+        did={DID}
+        rkey="proj1"
+        value={value}
+        cid="bafycid"
+        handle={null}
+      />,
+    )
 
     // The resolved place name appears in a Location meta row.
     expect(await screen.findByText("Berlin")).toBeTruthy()

--- a/src/components/project/project-detail-route.tsx
+++ b/src/components/project/project-detail-route.tsx
@@ -1,12 +1,10 @@
 "use client"
 
 import { useEffect } from "react"
-import { usePageTitle, usePageTitleBreadcrumb } from "@/lib/navbar-context"
 import { useProject } from "@/hooks/use-project"
 import ProjectDetail from "@/components/project/project-detail"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import { trackRecentlyViewed } from "@/lib/utils/recently-viewed"
-import { profileUrl, recordUrl } from "@/lib/urls"
 
 /**
  * Project detail body, rendered by the handle-forward record route
@@ -27,9 +25,6 @@ export default function ProjectDetailRoute({
   rkey: string | null
   resolving: boolean
 }) {
-  // Plain-string fallback while author/project data is still resolving.
-  usePageTitle("Project")
-
   const { project, isLoading, error } = useProject(did, rkey)
 
   // Recently-viewed: record the at:// URI once the project resolves so
@@ -37,19 +32,6 @@ export default function ProjectDetailRoute({
   useEffect(() => {
     if (project?.uri) trackRecentlyViewed("project", project.uri)
   }, [project?.uri])
-
-  const projectTitle =
-    (typeof project?.value.title === "string" && project.value.title) ||
-    (typeof project?.value.name === "string" && project.value.name) ||
-    null
-  usePageTitleBreadcrumb(
-    handle && projectTitle && rkey
-      ? {
-          left: { text: handle, href: profileUrl(handle) },
-          right: { text: projectTitle, href: recordUrl(handle, "project", rkey) },
-        }
-      : null,
-  )
 
   if (resolving || isLoading) {
     return (
@@ -84,6 +66,7 @@ export default function ProjectDetailRoute({
         rkey={rkey}
         value={project.value}
         cid={project.cid}
+        handle={handle}
       />
     </div>
   )

--- a/src/components/project/project-detail.tsx
+++ b/src/components/project/project-detail.tsx
@@ -2,7 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { profileUrl, recordUrl } from "@/lib/urls"
+import { usePageTitle, usePageRecordMenu } from "@/lib/navbar-context"
 import Link from "next/link"
+import { TransitionLink } from "@/lib/view-transitions"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import DeleteRecordDialog from "@/components/ui/delete-record-dialog"
 import ConfirmDialog from "@/components/ui/confirm-dialog"
@@ -14,9 +16,9 @@ import {
 } from "@/components/ui/popover"
 import { authFetch } from "@/lib/auth/fetch"
 import {
-  ChevronRight,
   FolderGit2,
   Inbox,
+  MapPin,
   MoreVertical,
   Pencil,
   Plus,
@@ -25,7 +27,7 @@ import {
 import ActivityAuthor from "@/components/feed/activity-author"
 import ActivityCard from "@/components/feed/activity-card"
 import ActivityContributor from "@/components/feed/activity-contributor"
-import FeedLayout from "@/components/feed/feed-layout"
+import CertLocationsMap from "@/components/feed/cert-locations-map"
 import ImageEditOverlay from "@/components/feed/image-edit-overlay"
 import EditBanner from "@/components/ui/edit-banner"
 import EmptyState from "@/components/ui/empty-state"
@@ -41,6 +43,9 @@ import ContextUpdates from "@/components/context/context-updates"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useOrg } from "@/lib/groups/org-context"
 import { useProjectItems } from "@/hooks/use-project-items"
+import { useContextUpdates } from "@/hooks/use-context-updates"
+import { useLayoutBreakpoints } from "@/hooks/use-layout-breakpoints"
+import CertListRow from "@/components/explore-page/cert-list-row"
 import {
   resolveActivityImageUrl,
 } from "@/lib/atproto/activity"
@@ -49,8 +54,6 @@ import { InvalidSwapError } from "@/lib/atproto/repo-write"
 import { saveWithSwap } from "@/lib/atproto/save-with-swap"
 import { saveDraft } from "@/lib/utils/swap-drafts"
 import { uploadBlob, type UploadedBlob } from "@/lib/atproto/profile"
-import { parseAtUri } from "@/lib/atproto/activity-uri"
-import { splitLocationName } from "@/lib/atproto/location"
 import { asLinearDocument, isEmptyLongDescription } from "@/lib/leaflet/guards"
 import { formatShortDate } from "@/lib/utils/format-date"
 import type { LinearDocument } from "@/lib/leaflet/types"
@@ -68,7 +71,7 @@ import type { BlobRef } from "@atproto/api"
  *  wraps to two rows (still a compact summary). The "See all" link
  *  in the section header takes the user to the dedicated Certs tab
  *  for the full grid. */
-const OVERVIEW_CERT_PREVIEW = 3
+const OVERVIEW_CERT_PREVIEW = 10
 
 interface ProjectDetailProps {
   did: string
@@ -78,6 +81,8 @@ interface ProjectDetailProps {
    *  `swapRecord` so a concurrent edit in another tab can't silently
    *  clobber this save (issue #71). */
   cid: string
+  /** Resolved handle, for the navbar breadcrumb (overview tab). */
+  handle: string | null
 }
 
 function asString(v: unknown): string | null {
@@ -156,6 +161,7 @@ export default function ProjectDetail({
   rkey,
   value,
   cid,
+  handle,
 }: ProjectDetailProps) {
   // Edit-eligibility mirrors `activity-detail.tsx:165-184`.
   const { did: sessionDid, isAuthenticated } = useAuth()
@@ -279,6 +285,45 @@ export default function ProjectDetail({
       ? normalizedTab
       : "overview"
 
+  // Updates count for the navbar title on the Updates tab. Fetched only
+  // on that tab (null subjectUri = no fetch elsewhere).
+  const { updates: navUpdates } = useContextUpdates(
+    activeTab === "updates"
+      ? `at://${did}/org.hypercerts.collection/${rkey}`
+      : null,
+  )
+
+  // Navbar title: sub-tabs show the tab name next to the back arrow; the
+  // overview shows the project's own name. (We deliberately don't prefix
+  // it with the author handle — the mobile bar is too narrow to show both,
+  // and the name is the useful identifier.)
+  usePageTitle(
+    activeTab === "description"
+      ? "Description"
+      : activeTab === "updates"
+        ? navUpdates.length > 0
+          ? `Updates (${navUpdates.length})`
+          : "Updates"
+        : activeTab === "activities"
+          ? Array.isArray(value.items) && value.items.length > 0
+            ? `Activities (${value.items.length})`
+            : "Activities"
+          : title || "Project",
+  )
+  // Record-level overflow menu in the mobile navbar's right slot (Share /
+  // Add to list / Copy AT URI). Reads as page-level chrome instead of an
+  // action on the author. Desktop keeps the in-body menu (lead row).
+  usePageRecordMenu(
+    rkey
+      ? {
+          targetUri: `at://${did}/org.hypercerts.collection/${rkey}`,
+          targetCid: cid,
+          targetType: LIST_PROJECTS_TYPE,
+          shareTab: activeTab === "overview" ? null : activeTab,
+        }
+      : null,
+  )
+
   /** Build a URL pointing at another subtab on this page —
    *  preserves any other query params the user might be carrying
    *  (rare today; future-proof). Returns null when pathname isn't
@@ -340,11 +385,8 @@ export default function ProjectDetail({
   // `location` persists as a `com.atproto.repo.strongRef` ({ uri, cid })
   // pointing at an `app.certified.location` record (see create / edit
   // pages). `asString` returns null for that object, so the legacy
-  // string path stays inline while the strongRef is resolved to its
-  // place name in the effect below — mirroring the edit page's
-  // hydration (parse at:// → getRecord → splitLocationName). The
-  // object shape is never rendered directly, so `[object Object]` can't
-  // leak into the Location row.
+  // string path stays inline; the strongRef is handed straight to
+  // CertLocationsMap, which resolves and renders the coordinates.
   const rawLocation = (effectiveValue as Record<string, unknown>).location
   const inlineLocation = asString(rawLocation)
   const locationRef =
@@ -353,49 +395,15 @@ export default function ProjectDetail({
       : null
   const locationRefUri =
     typeof locationRef?.uri === "string" ? locationRef.uri : null
-  const [resolvedLocationName, setResolvedLocationName] = useState<
-    string | null
-  >(null)
-
-  useEffect(() => {
-    // Legacy string locations render inline; nothing to resolve.
-    if (inlineLocation || !locationRefUri) {
-      setResolvedLocationName(null)
-      return
-    }
-    const parsed = parseAtUri(locationRefUri)
-    const fallback = locationRefUri.split("/").pop() || locationRefUri
-    if (!parsed) {
-      setResolvedLocationName(fallback)
-      return
-    }
-    let aborted = false
-    const qs = new URLSearchParams({
-      repo: parsed.did,
-      collection: parsed.collection,
-      rkey: parsed.rkey,
-    })
-    authFetch(`/api/xrpc/com/atproto/repo/getRecord?${qs.toString()}`)
-      .then(async (res) => {
-        if (aborted) return
-        if (!res.ok) {
-          setResolvedLocationName(fallback)
-          return
-        }
-        const data = (await res.json()) as { value?: { name?: string } }
-        const raw = data.value?.name?.trim() ?? ""
-        const split = splitLocationName(raw)
-        setResolvedLocationName(split.name || raw || fallback)
-      })
-      .catch(() => {
-        if (!aborted) setResolvedLocationName(fallback)
-      })
-    return () => {
-      aborted = true
-    }
-  }, [inlineLocation, locationRefUri])
-
-  const location = inlineLocation ?? resolvedLocationName
+  const locationCid =
+    typeof locationRef?.cid === "string" ? locationRef.cid : ""
+  // A resolvable location record renders the SAME interactive map the
+  // activity detail page uses — CertLocationsMap takes the strongRef and
+  // resolves the coordinates itself. Legacy inline-string locations have
+  // no record to map, so they fall back to a plain text value.
+  const locationStrongRefs = locationRefUri
+    ? [{ uri: locationRefUri, cid: locationCid }]
+    : []
 
   const contributors = Array.isArray(
     (effectiveValue as Record<string, unknown>).contributors,
@@ -440,11 +448,14 @@ export default function ProjectDetail({
   }
 
   const certCount = resolutions.length
+  // Phones show the activities preview as full-width list rows (the
+  // explore list view); desktop keeps the card grid.
+  const { isDesktop } = useLayoutBreakpoints()
   // Date created lives ABOVE the meta aside now (rendered inline
   // below the head bar, no card chrome) so it isn't part of the
   // aside's empty-state check.
-  const hasAnyMeta =
-    !!timePeriodLabel || !!location || contributors.length > 0
+  const hasAnyMeta = !!timePeriodLabel || contributors.length > 0
+  const hasLocation = !!locationRefUri || !!inlineLocation
 
   const handleEditClick = useCallback(() => {
     const linear =
@@ -924,16 +935,32 @@ export default function ProjectDetail({
         />
       ) : null}
 
-      <article className="project-detail project-detail--wide">
+      <article
+        className={`project-detail project-detail--wide project-detail--tab-${activeTab}${editing ? " project-detail--editing" : ""}`}
+      >
         {/* Persistent head bar — same shape on every tab:
               Title (left) ── Byline + Edit button (right)
             Title editing lives here too (input replaces h1 while
             editing) so the user can rename from any tab. */}
         <header className="project-detail__head-bar">
           <div className="project-detail__head-title-group">
-            <span className="project-detail__eyebrow" aria-hidden="true">
-              Project
-            </span>
+            <div className="project-detail__eyebrow-row">
+              <span className="project-detail__eyebrow" aria-hidden="true">
+                Project
+              </span>
+              {/* Mobile: date created (no label) trails the eyebrow,
+                  right-aligned. Hidden on desktop, where it shows in the
+                  inline-created row below the hero. */}
+              {createdAt ? (
+                <time
+                  className="project-detail__eyebrow-date"
+                  dateTime={createdAt}
+                  title={createdAt}
+                >
+                  {formatShortDate(createdAt)}
+                </time>
+              ) : null}
+            </div>
             {editing ? (
               <input
                 ref={titleInputRef}
@@ -954,7 +981,9 @@ export default function ProjectDetail({
             )}
           </div>
           <div className="project-detail__head-actions">
-            <ActivityAuthor did={did} />
+            <span className="project-detail__head-author">
+              <ActivityAuthor did={did} />
+            </span>
             {!editing && (isOwner || editAsGroup) ? (
               <>
                 {isOwner ? (
@@ -998,6 +1027,15 @@ export default function ProjectDetail({
             ) : null}
           </div>
         </header>
+
+        {/* Mobile-only byline: author shown right under the title. (The
+            date created sits on the eyebrow row above; the record menu
+            now lives in the navbar — usePageRecordMenu.) Desktop keeps
+            the author in the head bar and the menu in the lead row, both
+            hidden on mobile via CSS. Rendered on every tab. */}
+        <div className="project-detail__byline">
+          <ActivityAuthor did={did} />
+        </div>
 
         {/* Overview-only: hero banner + short description + the
             "more" link. Hidden on Description / Certs so those tabs
@@ -1081,30 +1119,37 @@ export default function ProjectDetail({
                 }
                 rows={2}
               />
-            ) : (
-              <div className="project-detail__lead-row">
-                {shortDesc ? (
-                  <p className="project-detail__lead">{shortDesc}</p>
-                ) : (
-                  <span className="project-detail__lead project-detail__lead--empty" />
-                )}
-                <AddToListMenu
-                  targetUri={`at://${did}/org.hypercerts.collection/${rkey}`}
-                  targetCid={cid}
-                  targetType={LIST_PROJECTS_TYPE}
-                />
-              </div>
-            )}
-
-            {showFullDescription && descriptionHref ? (
-              <Link
-                href={descriptionHref}
-                scroll={false}
-                className="cert-detail__read-more"
-              >
-                Read full description
-                <ChevronRight size={14} strokeWidth={1.75} aria-hidden />
-              </Link>
+            ) : shortDesc || showFullDescription ? (
+              <section className="project-detail__summary">
+                {/* Section header in the same style as "Activities in this
+                    project" / "Updates": title left, action link right. */}
+                <div className="project-detail__certs-header">
+                  <h2 className="project-detail__certs-title">Summary</h2>
+                  {showFullDescription && descriptionHref ? (
+                    <TransitionLink
+                      href={descriptionHref}
+                      className="project-detail__see-all"
+                    >
+                      Read full description →
+                    </TransitionLink>
+                  ) : null}
+                </div>
+                <div className="project-detail__lead-row">
+                  {shortDesc ? (
+                    <p className="project-detail__lead">{shortDesc}</p>
+                  ) : (
+                    <span className="project-detail__lead project-detail__lead--empty" />
+                  )}
+                  {/* Desktop only — on mobile the menu moves to the byline. */}
+                  <span className="project-detail__lead-menu">
+                    <AddToListMenu
+                      targetUri={`at://${did}/org.hypercerts.collection/${rkey}`}
+                      targetCid={cid}
+                      targetType={LIST_PROJECTS_TYPE}
+                    />
+                  </span>
+                </div>
+              </section>
             ) : null}
           </>
         ) : null}
@@ -1127,13 +1172,6 @@ export default function ProjectDetail({
                 </div>
               ) : null}
 
-              {location ? (
-                <div className="project-detail__meta-row">
-                  <span className="project-detail__meta-label">Location</span>
-                  <span className="project-detail__meta-value">{location}</span>
-                </div>
-              ) : null}
-
               {contributors.length > 0 ? (
                 <div className="project-detail__meta-row project-detail__meta-row--wide">
                   <span className="project-detail__meta-label">
@@ -1153,6 +1191,28 @@ export default function ProjectDetail({
               ) : null}
             </aside>
           ) : null}
+
+          {/* Location — same interactive map the activity detail page
+              uses. A resolvable location record maps; a legacy inline
+              string shows as plain text. */}
+          {hasLocation ? (
+            <section
+              className="project-detail__location-section"
+              aria-label="Location"
+            >
+              <span className="cert-detail__meta-label">
+                <MapPin size={11} strokeWidth={2} aria-hidden />
+                Location
+              </span>
+              {locationRefUri ? (
+                <CertLocationsMap locations={locationStrongRefs} />
+              ) : (
+                <span className="project-detail__meta-value">
+                  {inlineLocation}
+                </span>
+              )}
+            </section>
+          ) : null}
           {/* Certs preview — up to one row (3 cards at widest
               viewport, fewer on narrower). When the project has
               more than the preview cap, a "See all" link points at
@@ -1169,38 +1229,46 @@ export default function ProjectDetail({
                 <span className="project-detail__certs-count">
                   {certCount}
                 </span>
-                {certCount > OVERVIEW_CERT_PREVIEW ? (
-                  <Link
-                    href={certsHref}
-                    replace
-                    className="project-detail__see-all"
-                  >
-                    See all →
-                  </Link>
-                ) : null}
+                <TransitionLink
+                  href={certsHref}
+                  replace
+                  className="project-detail__see-all"
+                >
+                  See all →
+                </TransitionLink>
               </div>
-              <div className="feed">
-                {resolvedActivities
-                  .slice(0, OVERVIEW_CERT_PREVIEW)
-                  .map((rec) => (
-                    <ActivityCard
-                      key={rec.uri}
-                      record={rec}
-                      did={didByUri.get(rec.uri) ?? did}
-                    />
-                  ))}
-              </div>
+              {isDesktop ? (
+                <div className="feed">
+                  {resolvedActivities
+                    .slice(0, OVERVIEW_CERT_PREVIEW)
+                    .map((rec) => (
+                      <ActivityCard
+                        key={rec.uri}
+                        record={rec}
+                        did={didByUri.get(rec.uri) ?? did}
+                      />
+                    ))}
+                </div>
+              ) : (
+                <ul className="project-detail__certs-list">
+                  {resolvedActivities
+                    .slice(0, OVERVIEW_CERT_PREVIEW)
+                    .map((rec) => (
+                      <li key={rec.uri}>
+                        <CertListRow
+                          record={rec}
+                          did={didByUri.get(rec.uri) ?? did}
+                        />
+                      </li>
+                    ))}
+                </ul>
+              )}
             </section>
           ) : null}
-          {!hasAnyMeta && certCount === 0 ? (
-            <p className="project-detail__tab-empty">
-              No additional details yet for this project.
-            </p>
-          ) : null}
-
           <ContextUpdates
             subjectUri={`at://${did}/org.hypercerts.collection/${rkey}`}
             variant="overview"
+            maxItems={1}
             seeAllHref={updatesHref}
           />
         </>
@@ -1355,23 +1423,26 @@ export default function ProjectDetail({
                 ))
               )}
             </div>
-          ) : (
-            <FeedLayout
-              activities={resolvedActivities}
-              getDid={(uri) => didByUri.get(uri) ?? did}
-              isLoading={itemsLoading && resolvedActivities.length === 0}
-              isLoadingMore={itemsLoading && resolvedActivities.length > 0}
-              error={null}
-              hasMore={false}
-              loadMore={() => {}}
-              emptyState={
-                <EmptyState
-                  icon={Inbox}
-                  title="No activities in this project yet"
-                  description="When activities are added to this project, they'll appear here."
-                />
-              }
+          ) : itemsLoading && resolvedActivities.length === 0 ? (
+            <p className="project-detail__certs-loading">Loading…</p>
+          ) : resolvedActivities.length === 0 ? (
+            <EmptyState
+              icon={Inbox}
+              title="No activities in this project yet"
+              description="When activities are added to this project, they'll appear here."
             />
+          ) : (
+            // Gallery view — activity cards in the explore grid.
+            <ul className="explore__grid explore__grid--certs">
+              {resolvedActivities.map((rec) => (
+                <li key={rec.uri}>
+                  <ActivityCard
+                    record={rec}
+                    did={didByUri.get(rec.uri) ?? did}
+                  />
+                </li>
+              ))}
+            </ul>
           )}
         </section>
         ) : null}

--- a/src/hooks/use-explore.ts
+++ b/src/hooks/use-explore.ts
@@ -963,23 +963,22 @@ async function loadAccountsPage(args: LoadArgs): Promise<LoadedPage> {
   // `isOrganization` filter, so the result list paginates over
   // a single kind without the old client-side intersect's silent
   // truncation past the first 200 org DIDs.
+  // Search is server-side (indexer typeahead over displayName / handle /
+  // description — magic-indexer#204), so matches across the whole network
+  // surface on the first page rather than only once Load more pulls a
+  // matching page into memory (the old per-page client-side filter bug).
   const page = await fetchNetworkActors({
     first: PAGE_SIZE,
     after: cursor,
     isOrganization: subToIsOrganization(sub),
+    search,
     signal: signal ?? undefined,
   })
-  let actors = page.actors
-  if (search.trim().length > 0) {
-    const q = search.trim().toLowerCase()
-    actors = actors.filter(
-      (a) =>
-        (a.displayName ?? "").toLowerCase().includes(q) ||
-        (a.description ?? "").toLowerCase().includes(q) ||
-        a.did.includes(q),
-    )
-  }
-  actors = await applyOrgExcludeFilter(actors, excludeOrgLabels ?? null, signal)
+  const actors = await applyOrgExcludeFilter(
+    page.actors,
+    excludeOrgLabels ?? null,
+    signal,
+  )
   return {
     ...EMPTY_PAGE,
     users: actors,

--- a/src/hooks/use-scroll-restoration.ts
+++ b/src/hooks/use-scroll-restoration.ts
@@ -1,0 +1,83 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+/**
+ * Window-scroll save/restore for list pages, so returning from a detail
+ * page (the back button calls `router.back()`) lands the reader back at
+ * the offset they left from instead of the top.
+ *
+ * Positions live in a module-level map so they survive the list
+ * component unmounting (navigating into the detail page) and remounting
+ * (clicking back). Keyed by the caller — pass the list's URL so each
+ * filter/search combination restores independently.
+ *
+ * `ready` should flip true once the list has rendered enough content to
+ * be tall enough to hold the saved offset (e.g. `!isLoading`). Restoring
+ * while the list is still empty/loading would clamp against the short
+ * page and land at the top. The saved target is captured on first render
+ * (before any scroll events fire) so the browser's own scroll-to-top on
+ * navigation can't clobber it before we read it back.
+ *
+ * Caveat: this restores against whatever the list re-renders on return.
+ * If the reader had paged far past the first page via "Load more", the
+ * remounted list starts at page one, so a very deep offset clamps to the
+ * current bottom until more pages load.
+ */
+
+const MAX_ENTRIES = 50
+const positions = new Map<string, number>()
+
+function remember(key: string, y: number): void {
+  // Re-insert to keep the map in LRU order, then evict the oldest.
+  if (positions.has(key)) positions.delete(key)
+  positions.set(key, y)
+  while (positions.size > MAX_ENTRIES) {
+    const oldest = positions.keys().next().value
+    if (oldest === undefined) break
+    positions.delete(oldest)
+  }
+}
+
+export function useScrollRestoration(key: string, ready: boolean): void {
+  // Capture the saved offset for the mount-time key once, during the
+  // first render, before any scroll listener can overwrite it with 0.
+  const target = useRef<number | undefined>(undefined)
+  const mountKey = useRef(key)
+  if (target.current === undefined) target.current = positions.get(key)
+
+  // Save on scroll (coalesced to one write per frame) and on unmount,
+  // which covers the click-into-detail navigation.
+  useEffect(() => {
+    let raf = 0
+    const onScroll = () => {
+      if (raf) return
+      raf = requestAnimationFrame(() => {
+        raf = 0
+        remember(key, window.scrollY)
+      })
+    }
+    window.addEventListener("scroll", onScroll, { passive: true })
+    return () => {
+      window.removeEventListener("scroll", onScroll)
+      if (raf) cancelAnimationFrame(raf)
+      remember(key, window.scrollY)
+    }
+  }, [key])
+
+  // Restore once per mount, after the list is ready. Only for the
+  // mount-time key — a filter change (which swaps the key while mounted)
+  // should not yank the reader's scroll.
+  const done = useRef(false)
+  useEffect(() => {
+    if (done.current || !ready) return
+    done.current = true
+    if (key !== mountKey.current) return
+    const y = target.current
+    if (!y) return
+    // Two frames: let the just-committed list settle its layout first.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => window.scrollTo(0, y))
+    })
+  }, [key, ready])
+}

--- a/src/lib/atproto/workspace.ts
+++ b/src/lib/atproto/workspace.ts
@@ -84,10 +84,20 @@ export async function fetchNetworkActors(
      * subset of a mixed page.
      */
     isOrganization?: boolean
+    /**
+     * Server-side typeahead search over the actor's displayName,
+     * handle, and description (indexer-side unaccent + ILIKE — see
+     * magic-indexer#204). Empty / undefined returns the full list.
+     * Replaces the old per-page client-side filter that only matched
+     * whatever page was already loaded (certified-app /explore bug:
+     * "nothing found until you click Load more").
+     */
+    search?: string
     signal?: AbortSignal
   } = {},
 ): Promise<NetworkActorsPage> {
-  const { first = 30, after = null, isOrganization, signal } = opts
+  const { first = 30, after = null, isOrganization, search, signal } = opts
+  const searchVar = search && search.trim().length > 0 ? search.trim() : null
   // Two upstream operations: the unfiltered `NetworkActors`, and
   // `NetworkActorsByKind` which adds the `isOrganization` where-arg.
   // graphql-go rejects an explicit `null` on the `eq` operator, so
@@ -100,8 +110,8 @@ export async function fetchNetworkActors(
     body: JSON.stringify({
       operationName: useKindFilter ? "NetworkActorsByKind" : "NetworkActors",
       variables: useKindFilter
-        ? { first, after, isOrganization }
-        : { first, after },
+        ? { first, after, isOrganization, search: searchVar }
+        : { first, after, search: searchVar },
     }),
     signal,
   })

--- a/src/lib/navbar-context.tsx
+++ b/src/lib/navbar-context.tsx
@@ -26,11 +26,33 @@ export interface PageTitleBreadcrumb {
   right?: PageTitleBreadcrumbPart;
 }
 
+/**
+ * Config for the record-level overflow menu (Share / Add to list / Copy
+ * AT URI) shown in the mobile navbar's right slot on detail pages. Stored
+ * as plain primitives (not a ReactNode) so the navbar can construct the
+ * `<AddToListMenu>` itself and the publishing hook's effect deps stay
+ * stable across renders.
+ */
+export interface PageRecordMenu {
+  targetUri: string;
+  targetCid: string;
+  /** A `TypedListType` ("list:certs" | "list:projects" | "list:accounts").
+   *  Typed as string here to keep this context free of an atproto import. */
+  targetType: string;
+  /** Active sub-tab key, so the menu's Share link deep-links to it.
+   *  Null/omitted on the overview. */
+  shareTab?: string | null;
+}
+
 interface NavbarContextValue {
   pageTitle: string | null;
   setPageTitle: (title: string | null) => void;
   breadcrumb: PageTitleBreadcrumb | null;
   setBreadcrumb: (b: PageTitleBreadcrumb | null) => void;
+  /** Record-level overflow menu rendered in the mobile navbar's right
+   *  slot on detail (sub-)pages. Null on pages that don't set it. */
+  recordMenu: PageRecordMenu | null;
+  setRecordMenu: (m: PageRecordMenu | null) => void;
   profileOverlay: boolean;
   setProfileOverlay: (v: boolean) => void;
   /** True when the viewed profile has a non-empty `longDescription`.
@@ -58,6 +80,8 @@ const NavbarContext = createContext<NavbarContextValue>({
   setPageTitle: () => {},
   breadcrumb: null,
   setBreadcrumb: () => {},
+  recordMenu: null,
+  setRecordMenu: () => {},
   profileOverlay: false,
   setProfileOverlay: () => {},
   profileAboutAvailable: false,
@@ -71,6 +95,7 @@ const NavbarContext = createContext<NavbarContextValue>({
 export function NavbarProvider({ children }: { children: ReactNode }) {
   const [pageTitle, setPageTitle] = useState<string | null>(null);
   const [breadcrumb, setBreadcrumb] = useState<PageTitleBreadcrumb | null>(null);
+  const [recordMenu, setRecordMenu] = useState<PageRecordMenu | null>(null);
   const [profileOverlay, setProfileOverlay] = useState<boolean>(false);
   const [profileAboutAvailable, setProfileAboutAvailable] =
     useState<boolean>(false);
@@ -83,6 +108,8 @@ export function NavbarProvider({ children }: { children: ReactNode }) {
       setPageTitle,
       breadcrumb,
       setBreadcrumb,
+      recordMenu,
+      setRecordMenu,
       profileOverlay,
       setProfileOverlay,
       profileAboutAvailable,
@@ -95,6 +122,7 @@ export function NavbarProvider({ children }: { children: ReactNode }) {
     [
       pageTitle,
       breadcrumb,
+      recordMenu,
       profileOverlay,
       profileAboutAvailable,
       profileGroupsAvailable,
@@ -150,6 +178,29 @@ export function usePageTitleBreadcrumb(b: PageTitleBreadcrumb | null) {
     // would fire every render the caller builds a new object literal.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setBreadcrumb, key]);
+}
+
+/**
+ * Publish the record-level overflow menu (Share / Add to list / Copy AT
+ * URI) to the mobile navbar's right slot. Detail pages call this so the
+ * menu reads as page-level chrome that acts on the whole record, instead
+ * of sitting in the author row where it can be mistaken for an action on
+ * the author. Pass `null` while data is loading. No-op visually on
+ * desktop (the navbar isn't rendered there — detail pages keep their own
+ * in-body menu at ≥800px).
+ */
+export function usePageRecordMenu(menu: PageRecordMenu | null) {
+  const { setRecordMenu } = useContext(NavbarContext);
+  const key = menu
+    ? `${menu.targetUri}|${menu.targetCid}|${menu.targetType}|${menu.shareTab ?? ""}`
+    : null;
+  useEffect(() => {
+    setRecordMenu(menu);
+    return () => setRecordMenu(null);
+    // `key` captures every field of `menu`; depending on `menu` itself
+    // would re-fire every render the caller builds a new object literal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setRecordMenu, key]);
 }
 
 /**

--- a/src/lib/view-transitions.tsx
+++ b/src/lib/view-transitions.tsx
@@ -1,0 +1,179 @@
+"use client"
+
+import {
+  createContext,
+  Suspense,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from "react"
+import Link from "next/link"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+
+/**
+ * Directional page-slide transitions for in-app tab navigation (e.g. a
+ * detail page's "Read full description" / "Show all" → sub-tab, and the
+ * Back button returning). Built on the browser View Transitions API:
+ *
+ *   - Forward navigations slide the new view in from the right.
+ *   - Back navigations reverse it (new view in from the left).
+ *
+ * App Router navigations are async (the DOM updates after the route
+ * commits), so we hand startViewTransition a promise and resolve it from
+ * a route-change effect once the new URL has rendered. A timeout backstop
+ * resolves the promise if the route never changes, so the page can never
+ * stay frozen. Browsers without the API — and reduced-motion users — get
+ * a plain, instant navigation.
+ */
+
+type Direction = "forward" | "back"
+
+interface ViewTransitionApi {
+  /** Navigate forward to `href` with a slide-from-right transition. */
+  transitionTo: (href: string, options?: { scroll?: boolean }) => void
+  /** Navigate back with the reverse slide. Pass a custom navigate fn
+   *  (defaults to router.back()). */
+  transitionBack: (navigate?: () => void) => void
+}
+
+const ViewTransitionContext = createContext<ViewTransitionApi | null>(null)
+
+type StartViewTransition = (callback: () => void | Promise<void>) => {
+  finished: Promise<void>
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  )
+}
+
+/** Renders nothing; fires `onChange` whenever the path or query changes.
+ *  Isolated under its own Suspense boundary so useSearchParams can't
+ *  suspend the whole app during static rendering. */
+function RouteWatcher({ onChange }: { onChange: () => void }) {
+  const pathname = usePathname()
+  const search = useSearchParams()
+  useEffect(() => {
+    onChange()
+  }, [pathname, search, onChange])
+  return null
+}
+
+export function ViewTransitionProvider({ children }: { children: ReactNode }) {
+  const router = useRouter()
+  const finishRef = useRef<(() => void) | null>(null)
+
+  const handleRouteChange = useCallback(() => {
+    if (finishRef.current) {
+      finishRef.current()
+      finishRef.current = null
+    }
+  }, [])
+
+  const run = useCallback((direction: Direction, navigate: () => void) => {
+    const start = (
+      document as Document & { startViewTransition?: StartViewTransition }
+    ).startViewTransition?.bind(document)
+    if (!start || prefersReducedMotion()) {
+      navigate()
+      return
+    }
+    document.documentElement.dataset.vtDir = direction
+    const transition = start(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRef.current = resolve
+          navigate()
+          // Backstop: never leave the page frozen if the route doesn't
+          // actually change (e.g. navigating to the current URL).
+          window.setTimeout(() => {
+            if (finishRef.current === resolve) {
+              finishRef.current = null
+              resolve()
+            }
+          }, 500)
+        }),
+    )
+    transition.finished.finally(() => {
+      delete document.documentElement.dataset.vtDir
+    })
+  }, [])
+
+  const transitionTo = useCallback(
+    (href: string, options?: { scroll?: boolean }) =>
+      run("forward", () => router.push(href, options)),
+    [run, router],
+  )
+
+  const transitionBack = useCallback(
+    (navigate?: () => void) =>
+      run("back", navigate ?? (() => router.back())),
+    [run, router],
+  )
+
+  return (
+    <ViewTransitionContext.Provider value={{ transitionTo, transitionBack }}>
+      <Suspense fallback={null}>
+        <RouteWatcher onChange={handleRouteChange} />
+      </Suspense>
+      {children}
+    </ViewTransitionContext.Provider>
+  )
+}
+
+export function useViewTransition(): ViewTransitionApi {
+  const ctx = useContext(ViewTransitionContext)
+  if (!ctx) {
+    throw new Error(
+      "useViewTransition must be used within a <ViewTransitionProvider>",
+    )
+  }
+  return ctx
+}
+
+/** Drop-in <Link> that plays the forward slide transition on click while
+ *  preserving normal link behaviour (modifier-click opens a new tab). */
+export function TransitionLink({
+  href,
+  className,
+  children,
+  scroll = true,
+  ...rest
+}: {
+  href: string
+  className?: string
+  children: ReactNode
+  scroll?: boolean
+} & Omit<
+  React.ComponentProps<typeof Link>,
+  "href" | "className" | "onClick" | "scroll"
+>) {
+  const { transitionTo } = useViewTransition()
+  return (
+    <Link
+      href={href}
+      className={className}
+      scroll={scroll}
+      onClick={(e) => {
+        if (
+          e.metaKey ||
+          e.ctrlKey ||
+          e.shiftKey ||
+          e.altKey ||
+          e.button !== 0
+        ) {
+          return
+        }
+        e.preventDefault()
+        transitionTo(href, { scroll })
+      }}
+      {...rest}
+    >
+      {children}
+    </Link>
+  )
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -11,3 +11,44 @@ Object.defineProperty(window, "matchMedia", {
     dispatchEvent: () => false,
   }),
 })
+
+// Node 21+ exposes a native global `localStorage` (Web Storage, behind
+// `--localstorage-file`). On Node 25 it's present by default but has no
+// real backing store, and it shadows jsdom's working `window.localStorage`
+// on both `globalThis` and `window` — so the storage-util suites blow up
+// with "localStorage.clear is not a function". CI pins Node 20 (where the
+// native global doesn't exist and jsdom's Storage is used), but to keep
+// the suite deterministic on any local Node version we install a small
+// in-memory Storage and force it onto both globals.
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>()
+  get length() {
+    return this.store.size
+  }
+  clear() {
+    this.store.clear()
+  }
+  getItem(key: string) {
+    return this.store.has(key) ? this.store.get(key)! : null
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, String(value))
+  }
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+  key(index: number) {
+    return Array.from(this.store.keys())[index] ?? null
+  }
+}
+
+// One shared instance so `localStorage` (global) and `window.localStorage`
+// are the same store — production code reads either form.
+const memoryStorage = new MemoryStorage()
+for (const target of [window, globalThis]) {
+  Object.defineProperty(target, "localStorage", {
+    configurable: true,
+    writable: true,
+    value: memoryStorage,
+  })
+}


### PR DESCRIPTION
## Summary

Mobile-focused redesign of the activity and project detail pages, plus the explore account-search fix and landing-page additions accumulated on this branch.

### Detail pages (activity + project)
- Single-column mobile flow with consistent 24px spacing between every block (title, author, project, image, time period, work scope, contributors, rights, summary, updates, location).
- The navbar now carries the record: the title shows the activity/project **name** (no author prefix — too narrow for both), and the record-level overflow menu (Share / Add to list / Copy AT URI) lives in the navbar right slot so it reads as page-level chrome rather than an action on the author. Desktop keeps its in-body menu (the navbar isn't rendered at >=800px).
- **Share** deep-links to the current sub-tab (`?tab=...`) when on one; the overview copies the clean canonical URL.
- Sub-tabs (Description / Updates / Activities / Contributors) show their name + count in the navbar and drop in-page chrome. Contributors are capped at 5 on the overview with a "See all" link mirroring Updates.
- Updates restyled to plain stacked rows with light dividers, numbered "Update N" headings with right-aligned dates, and a fade only when the body is actually truncated.
- Forward/back slide via View Transitions + scroll-position restoration on back navigation; navbar back-depth fix so Back never exits to `/home`.

### Explore
- Account search wired to the magic-indexer `search` param so certified profiles surface (preferred) alongside Bluesky results, instead of returning nothing until "load more".
- Compact cert/explore list rows: image, title, work period, work scope only, with single-line ellipsis and no separators on wrapped rows.

### Landing
- New AI-narrative section (anyone can produce a compelling pitch; why verifiable, transparent records matter for human-AI decision-making), clickable wordmark on the editorial pages, Maya walkthrough tweaks.

### Test infra
- In-memory `localStorage` shim in the test setup so the storage-util suites are deterministic on Node 21+ (whose native global Storage shadows jsdom's; CI pins Node 20).

## Test plan
- `npm run lint` — 0 errors (62 warnings, baseline)
- `npx tsc --noEmit` — clean
- `npm run typecheck:test` — clean
- `npm test` — 621 passing
- Verified in-browser at mobile width: navbar title/menu, tab-aware share, consistent spacing, contributors "See all", popover sizing; desktop in-body menu intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)