### PR TITLE
feat(mobile): explore, profile, and create/edit form polish

### DIFF
--- a/src/app/[actor]/page.tsx
+++ b/src/app/[actor]/page.tsx
@@ -14,7 +14,7 @@ import {
 import { useUserProfile } from "@/hooks/use-user-profile"
 import { getProfileWithCid } from "@/lib/atproto/profile"
 import type { CertifiedProfile } from "@/lib/atproto/types"
-import { useUserActivities } from "@/hooks/use-user-activities"
+import { useUserActivityCount } from "@/hooks/use-user-activity-count"
 import { useOrgMarker } from "@/hooks/use-org-marker"
 import { useOrg } from "@/lib/groups/org-context"
 import { useAuth } from "@/lib/auth/auth-context"
@@ -336,10 +336,13 @@ export default function UserProfilePage() {
       ? "Admin of this group"
       : undefined
 
-  const { activities, hasMore } = useUserActivities(did)
-  const activityCountLabel = hasMore
-    ? `${activities.length}+`
-    : `${activities.length}`
+  // Exact deduped count of activities this profile created or
+  // contributed to (union via the indexer's `_or` totalCount), rather
+  // than the capped "N+" a first-page fetch produced. "…" while the
+  // count resolves.
+  const activityCount = useUserActivityCount(did)
+  const activityCountLabel =
+    activityCount === null ? "…" : `${activityCount}`
 
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -436,7 +439,11 @@ export default function UserProfilePage() {
               }`}
               onClick={() => {
                 if (locked) return
-                router.push(
+                // `replace`, not `push`, so switching profile sub-tabs
+                // doesn't stack history entries — the navbar Back button
+                // then leaves the profile entirely instead of stepping
+                // back through each tab the user opened.
+                router.replace(
                   t.key === "overview" ? pathname : `${pathname}?tab=${t.key}`,
                   { scroll: false },
                 )

--- a/src/app/api/indexer/route.ts
+++ b/src/app/api/indexer/route.ts
@@ -114,6 +114,7 @@ const ACTIVITY_NODE_SELECTION = `
       }
       workScope {
         ... on OrgHypercertsClaimActivityWorkScopeString { scope }
+        ... on OrgHypercertsWorkscopeCel { expression }
       }
     }
   }
@@ -219,6 +220,24 @@ ${ACTIVITY_NODE_SELECTION}
         where: { contributor: { eq: $did } }
       ) {
 ${ACTIVITY_NODE_SELECTION}
+      }
+    }
+  `,
+
+  // Deduped union count of activities a profile CREATED or CONTRIBUTED
+  // to. The `_or` returns each matching record once, so `totalCount` is
+  // the exact unique count (created ∪ contributed) — unlike summing the
+  // two per-bucket totals, which double-counts a record where the user
+  // is both author and contributor.
+  UserActivityCount: `
+    query UserActivityCount($did: String!) {
+      orgHypercertsClaimActivity(
+        first: 1
+        where: { _or: [{ did: { eq: $did } }, { contributor: { eq: $did } }] }
+      ) {
+        totalCount
+        edges { node { uri } }
+        pageInfo { hasNextPage }
       }
     }
   `,
@@ -862,6 +881,7 @@ ${ACTIVITY_NODE_SELECTION}
             }
             workScope {
               ... on OrgHypercertsClaimActivityWorkScopeString { scope }
+              ... on OrgHypercertsWorkscopeCel { expression }
             }
           }
         }
@@ -1203,6 +1223,11 @@ function buildVariables(
         first: clampFirst(vars.first, MAX_FIRST, 100),
         after: readString(vars.after, MAX_AFTER_LEN),
       }
+    }
+    case "UserActivityCount": {
+      const did = readDid(vars.did)
+      if (!did) return null
+      return { did }
     }
     case "EndorsementDefs": {
       const dids = readDidList(vars.dids, MAX_DID_LIST)

--- a/src/app/groups/create/page.tsx
+++ b/src/app/groups/create/page.tsx
@@ -3,7 +3,15 @@
 import { useCallback, useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import Image from "next/image"
-import { Building2, Globe, Image as ImageIcon, Users } from "lucide-react"
+import {
+  AtSign,
+  Building2,
+  Calendar,
+  FileText,
+  Globe,
+  Image as ImageIcon,
+  Users,
+} from "lucide-react"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useOrg } from "@/lib/groups/org-context"
 import { useOrgCreationLimit } from "@/lib/groups/use-org-limit"
@@ -355,7 +363,7 @@ export default function CreateGroupPage() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <article className="project-detail-page project-detail--wide create-project">
+      <article className="project-detail-page project-detail--wide create-project create-group">
         <div className="project-detail">
           {/* Avatar (circular) on the left, banner image on the
               right — both pickers sit on a single header row so the
@@ -366,68 +374,80 @@ export default function CreateGroupPage() {
               in the app. The banner keeps the project-form hero
               aspect via `flex: 1`. */}
           <div className="create-group__identity-row">
-            <div
-              className={
-                avatarPreviewUrl
-                  ? "create-group__avatar-tile"
-                  : "create-group__avatar-tile create-group__avatar-tile--placeholder"
-              }
-            >
-              {avatarPreviewUrl ? (
-                <Image
-                  src={avatarPreviewUrl}
-                  alt=""
-                  fill
-                  className="create-group__avatar-img"
-                  unoptimized
+            <div className="create-group__identity-col">
+              <span className="project-detail__meta-label">
+                <Users size={11} strokeWidth={2} aria-hidden />
+                Avatar
+              </span>
+              <div
+                className={
+                  avatarPreviewUrl
+                    ? "create-group__avatar-tile"
+                    : "create-group__avatar-tile create-group__avatar-tile--placeholder"
+                }
+              >
+                {avatarPreviewUrl ? (
+                  <Image
+                    src={avatarPreviewUrl}
+                    alt=""
+                    fill
+                    className="create-group__avatar-img"
+                    unoptimized
+                  />
+                ) : (
+                  <Users
+                    size={36}
+                    strokeWidth={1.25}
+                    aria-hidden
+                    className="create-group__avatar-placeholder-icon"
+                  />
+                )}
+                <ImageEditOverlay
+                  onFile={handleAvatarFile}
+                  hasPending={!!avatarFile}
+                  variant="with-remove"
+                  onRemove={handleAvatarRemove}
+                  hasImage={!!avatarFile}
                 />
-              ) : (
-                <Users
-                  size={36}
-                  strokeWidth={1.25}
-                  aria-hidden
-                  className="create-group__avatar-placeholder-icon"
-                />
-              )}
-              <ImageEditOverlay
-                onFile={handleAvatarFile}
-                hasPending={!!avatarFile}
-                variant="with-remove"
-                onRemove={handleAvatarRemove}
-                hasImage={!!avatarFile}
-              />
+              </div>
             </div>
 
-            <div
-              className={
-                bannerPreviewUrl
-                  ? "project-detail__hero create-project__hero create-group__banner-tile"
-                  : "project-detail__hero project-detail__hero--placeholder create-project__hero create-group__banner-tile"
-              }
-            >
-              {bannerPreviewUrl ? (
-                <Image
-                  src={bannerPreviewUrl}
-                  alt=""
-                  fill
-                  className="project-detail__hero-img"
-                  unoptimized
+            <div className="create-group__identity-col">
+              <span className="project-detail__meta-label">
+                <ImageIcon size={11} strokeWidth={2} aria-hidden />
+                Banner
+              </span>
+              <div
+                className={
+                  bannerPreviewUrl
+                    ? "project-detail__hero create-project__hero create-group__banner-tile"
+                    : "project-detail__hero project-detail__hero--placeholder create-project__hero create-group__banner-tile"
+                }
+              >
+                {bannerPreviewUrl ? (
+                  <Image
+                    src={bannerPreviewUrl}
+                    alt=""
+                    fill
+                    className="project-detail__hero-img"
+                    unoptimized
+                  />
+                ) : (
+                  <ImageIcon
+                    size={48}
+                    strokeWidth={1.25}
+                    aria-hidden
+                    className="project-detail__hero-placeholder-icon"
+                  />
+                )}
+                <ImageEditOverlay
+                  onFile={handleBannerFile}
+                  hasPending={!!bannerFile}
+                  variant="with-remove"
+                  onRemove={handleBannerRemove}
+                  hasImage={!!bannerFile}
                 />
-              ) : (
-                <ImageIcon
-                  size={48}
-                  strokeWidth={1.25}
-                  aria-hidden
-                  className="project-detail__hero-placeholder-icon"
-                />
-              )}
-              <ImageEditOverlay
-                onFile={handleBannerFile}
-                hasPending={!!bannerFile}
-                variant="with-remove"
-                onRemove={handleBannerRemove}
-                hasImage={!!bannerFile}
-              />
+              </div>
             </div>
           </div>
 
@@ -460,7 +480,11 @@ export default function CreateGroupPage() {
             </div>
           </header>
 
-          <section className="cert-detail__section">
+          <section className="cert-detail__section create-group__about">
+            <span className="project-detail__meta-label">
+              <FileText size={11} strokeWidth={2} aria-hidden />
+              About
+            </span>
             <div className="create-cert__input-with-counter">
               <textarea
                 className="cert-detail__short-desc-input"
@@ -480,7 +504,7 @@ export default function CreateGroupPage() {
           <section className="project-detail__meta create-project__meta">
             <div className="project-detail__meta-row">
               <span className="project-detail__meta-label">
-                <Building2 size={11} strokeWidth={2} aria-hidden />
+                <AtSign size={11} strokeWidth={2} aria-hidden />
                 Handle
               </span>
               <input
@@ -530,6 +554,7 @@ export default function CreateGroupPage() {
 
             <div className="project-detail__meta-row">
               <span className="project-detail__meta-label">
+                <Calendar size={11} strokeWidth={2} aria-hidden />
                 Founded
               </span>
               <input
@@ -543,6 +568,7 @@ export default function CreateGroupPage() {
 
             <div className="project-detail__meta-row project-detail__meta-row--wide">
               <span className="project-detail__meta-label">
+                <Building2 size={11} strokeWidth={2} aria-hidden />
                 Organization type
               </span>
               <input

--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -139,6 +139,24 @@
     order: 9;
   }
 
+  /* Create / edit activity form: lead with the title, then the image,
+     then the metadata and the rest of the form. The headline (order 1)
+     and image (order 2) already come from the read-view rules above; the
+     form's generic meta-rows and sections carry no modifier class, so
+     they defaulted to order:0 and jumped ahead of the title. Push them
+     after the image. */
+  .create-cert .cert-detail__meta-row {
+    order: 3;
+  }
+  .create-cert .cert-detail__section {
+    order: 4;
+  }
+  /* Cancel / Publish sit at the very end of the form (they carry no
+     order otherwise and would default to 0, jumping above the title). */
+  .create-cert .create-cert__actions {
+    order: 5;
+  }
+
   /* The single-column grid already provides a uniform 24px row gap
      between every promoted leaf (headline, image, each meta-row).
      The promoted `.cert-detail__section` blocks (Summary, Locations)
@@ -154,15 +172,18 @@
     border-top: none;
   }
 
-  /* Description / Contributors tabs: show only the tab content. Hide the
-     headline, image, and meta rows (the tab name + count live in the
-     navbar; the navbar Back button returns). */
+  /* Description / Contributors / Updates tabs: show only the tab
+     content. Hide the headline, image, and meta rows (the tab name +
+     count live in the navbar; the navbar Back button returns). */
   .cert-detail--tab-description .cert-detail__headline,
   .cert-detail--tab-contributors .cert-detail__headline,
+  .cert-detail--tab-updates .cert-detail__headline,
   .cert-detail--tab-description .cert-detail__image,
   .cert-detail--tab-contributors .cert-detail__image,
+  .cert-detail--tab-updates .cert-detail__image,
   .cert-detail--tab-description .cert-detail__meta-row,
-  .cert-detail--tab-contributors .cert-detail__meta-row {
+  .cert-detail--tab-contributors .cert-detail__meta-row,
+  .cert-detail--tab-updates .cert-detail__meta-row {
     display: none;
   }
 
@@ -170,6 +191,20 @@
      in-main section header. */
   .cert-detail--tab-contributors .cert-detail__section-header {
     display: none;
+  }
+
+  /* Updates tab: the title + count live in the navbar, so drop the
+     in-body updates header (heading + count) and reset the section's
+     top divider/padding so the first update sits at the top — matching
+     the project detail page's Updates tab. */
+  .cert-detail--tab-updates .context-updates__head {
+    display: none;
+  }
+  .cert-detail--wide.cert-detail--tab-updates:not(.cert-detail--editing)
+    .context-updates {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: none;
   }
 
   /* "Read full description" centers on phones (both the activity and

--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -316,28 +316,33 @@
   }
   /* Second row: dropdown on the left, action cluster pushed to the right.
      Stretch the cluster to the row height so its icon buttons can match
-     the category pills (which set the line height). */
+     the category pills (which set the line height). `flex-shrink: 0`
+     keeps the filter button from being squeezed off the right edge when
+     the category pills get wide (they scroll instead — see below). */
   .explore__chrome-actions {
     margin-left: auto;
     gap: 8px;
     align-self: stretch;
+    flex-shrink: 0;
   }
   .explore__chrome-btn {
     min-height: 44px;
     padding-top: 10px;
     padding-bottom: 10px;
   }
-  /* Mobile icon buttons (sort + filter): match the category pill's
-     height and stay square. Dropping the inherited 44px min-height lets
-     the cluster size to the pills (~30px); stretching to the cluster +
-     aspect-ratio then makes each icon a pill-height square. */
+  /* Mobile icon buttons (sort + filter): a deterministic square.
+     A fixed width/height (rather than aspect-ratio + align-self:stretch,
+     whose height-derived width under-sized the flex cluster and pushed
+     the filter button off the right edge) keeps the action cluster a
+     predictable size so `margin-left: auto` pins it flush to the right. */
   .explore__chrome-btn--icon {
-    align-self: stretch;
-    aspect-ratio: 1 / 1;
-    width: auto;
-    height: auto;
+    width: 36px;
+    height: 36px;
     min-height: 0;
     padding: 0;
+    align-self: center;
+    aspect-ratio: auto;
+    flex-shrink: 0;
   }
   /* The type dropdown trigger matches the 44px control height too. */
   .explore__sub-dropdown-trigger {
@@ -369,8 +374,15 @@
     display: flex;
     align-items: center;
     gap: 6px;
-    flex: 1;
+    /* Take only the width the pills need (don't grow) so the action
+       cluster keeps its full width and `margin-left: auto` can pin it to
+       the right edge — `flex: 1` here grew the pills and pushed the
+       filter button off-screen. Shrink + wrap handle the rare case where
+       the pills can't fit beside the actions. No `overflow` clip: the
+       category dropdown popover is a child and must escape the box. */
+    flex: 0 1 auto;
     min-width: 0;
+    flex-wrap: wrap;
   }
 
   .explore__category-pill {
@@ -584,31 +596,29 @@
   color: var(--fg-secondary);
 }
 
-/* Thin "Show all" row — the last <li> inside a capped block's list, so
-   it sits flush against the rows above (no gap) and shares the list's
-   border + clipped corners. Clicking collapses the All view to that
-   single category. */
-.explore__show-all {
-  display: flex;
+/* "Show all" action in the section header — sits on the same line as
+   the section title (pushed right by the head's space-between). Matches
+   the project detail page's "See all →" link: small, muted, underline
+   on hover. Collapses the All view to that single category. */
+.explore__all-section-action {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 4px;
-  width: 100%;
-  padding: 5px;
+  gap: 2px;
+  flex-shrink: 0;
+  padding: 0;
   border: 0;
-  border-top: 1px solid var(--border-subtle);
-  background: var(--bg-elevated);
-  font-family: var(--font-inter), system-ui, sans-serif;
-  font-size: 0.8rem;
+  background: none;
+  font-size: 0.75rem;
   font-weight: 500;
   color: var(--fg-secondary);
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  transition: color var(--transition-fast);
 }
 
-.explore__show-all:hover {
-  background: var(--bg-sunken);
+.explore__all-section-action:hover {
   color: var(--fg-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* All view, single-category mode: the row that hosts the inline
@@ -759,6 +769,20 @@
   white-space: nowrap;
 }
 
+/* "by Display Name" line under a project row's title. Hidden on
+   desktop (the avatar author column carries the byline there); shown on
+   mobile, where the column is dropped (see the mobile block below). */
+.cert-list-row__subtitle {
+  display: none;
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .cert-list-row__meta {
   margin: 0;
   /* Single line: time period · work scope, truncated with an ellipsis
@@ -827,30 +851,11 @@
   }
 
   .cert-list-row {
-    grid-template-columns: minmax(0, 1fr) auto;
-    grid-template-areas:
-      "author time"
-      "link link";
-    gap: 10px 12px;
     padding: 16px 0;
   }
 
   .cert-list-row:hover {
     background: transparent;
-  }
-
-  .cert-list-row__author-col {
-    grid-area: author;
-  }
-
-  .cert-list-row__time {
-    grid-area: time;
-    color: var(--fg-muted);
-  }
-
-  .cert-list-row__link {
-    grid-area: link;
-    align-items: flex-start;
   }
 
   .cert-list-row__body {
@@ -865,6 +870,51 @@
 
   .cert-list-row__meta {
     color: var(--fg-muted);
+  }
+
+  /* Activities (compact): thumb + serif title + meta in one row — the
+     same treatment the mobile project-detail activities list uses. */
+  .cert-list-row.cert-list-row--compact .cert-list-row__link {
+    align-items: flex-start;
+  }
+
+  /* Let the activity meta (time period · work scope) wrap on mobile so
+     the work scope stays visible instead of being clipped by the
+     single-line ellipsis. The dot separator is hidden at wrap points by
+     ExploreListRow's line-start measurement. */
+  .cert-list-row.cert-list-row--compact .cert-list-row__meta {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+  }
+
+  /* Projects (non-compact): [thumb + title / "by …"] on the left, the
+     date pinned to the right of the same row. Author avatar column and
+     the count·location meta line are dropped on mobile. */
+  .cert-list-row:not(.cert-list-row--compact) {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas: "link time";
+    align-items: center;
+    gap: 12px;
+  }
+
+  .cert-list-row:not(.cert-list-row--compact) .cert-list-row__link {
+    grid-area: link;
+    align-items: center;
+  }
+
+  .cert-list-row:not(.cert-list-row--compact) .cert-list-row__time {
+    grid-area: time;
+    color: var(--fg-muted);
+  }
+
+  .cert-list-row:not(.cert-list-row--compact) .cert-list-row__author-col,
+  .cert-list-row:not(.cert-list-row--compact) .cert-list-row__meta {
+    display: none;
+  }
+
+  .cert-list-row:not(.cert-list-row--compact) .cert-list-row__subtitle {
+    display: block;
   }
 }
 
@@ -1100,9 +1150,13 @@
   .account-list-row:hover {
     background: transparent;
   }
-  .account-list-row__badge,
-  .account-list-row__joined {
+  .account-list-row__badge {
     justify-self: start;
+  }
+  /* "Joined …" date is dropped on mobile — the row is just the
+     identity (avatar + name + @handle). */
+  .account-list-row__joined {
+    display: none;
   }
 }
 

--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -494,6 +494,15 @@
   align-self: flex-start;
 }
 
+/* Expanded endorsement-group list: each row is an <IdentityRow>
+   (avatar + display name + @handle), so give them breathing room. */
+.home-feed__group-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+}
+
 .home-feed__loading {
   display: flex;
   justify-content: center;
@@ -638,6 +647,12 @@ a.home-feed__card-body:hover .home-feed__card-title {
   /* Expandable endorsement-group list rows get comfortable touch height. */
   .home-feed__group-list-item {
     padding: 4px 0;
+  }
+
+  /* Center the "Show all / Show fewer" toggle in the thumb-scrolled
+     feed (desktop keeps it flush-left, the default above). */
+  .home-feed__group-toggle {
+    align-self: center;
   }
 }
 

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -2901,6 +2901,32 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   outline-offset: 2px;
 }
 
+@media (max-width: 799px) {
+  /* Certs + Projects toolbar: controls take their own full-width row
+     below the sub-tabs so the search can stretch across it. Search +
+     sort match the plus button's 30px height; the search grows to fill
+     the row beside the buttons. */
+  .profile-certs__controls,
+  .profile-projects__controls {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+  .profile-certs__search {
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 30px;
+  }
+  .profile-certs__search-input {
+    width: auto;
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+  .profile-certs__sort-btn {
+    width: 30px;
+    height: 30px;
+  }
+}
+
 /* On wider viewports, lay cert cards out as a grid. Drop the default
    per-card bottom divider (the shared .feed style) since grid gap now
    provides separation. Cards are uniform size: square image + 2-line

--- a/src/app/styles/profile-endorsements.css
+++ b/src/app/styles/profile-endorsements.css
@@ -68,6 +68,38 @@
   appearance: none;
 }
 
+@media (max-width: 799px) {
+  /* Controls take their own full-width row; the search stretches to fill
+     it beside the buttons, and every control matches the plus button's
+     30px height. */
+  .profile-endorsements-v2__controls {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+  .profile-endorsements-v2__search {
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 30px;
+  }
+  .profile-endorsements-v2__search-input {
+    width: auto;
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+  /* Scoped under their containers so they beat the base `…__sort-btn`
+     / `…__endorse-add` rules declared LATER in this file (equal
+     specificity would otherwise let the taller 36px base win). */
+  .profile-endorsements-v2__controls .profile-endorsements-v2__sort-btn,
+  .profile-endorsements-v2__controls .profile-endorsements-v2__endorse-add {
+    width: 30px;
+    height: 30px;
+  }
+  .endorsement-lists .endorsement-lists__sort-btn {
+    width: 30px;
+    height: 30px;
+  }
+}
+
 .profile-endorsements-v2__sort-wrap {
   position: relative;
   display: inline-flex;

--- a/src/app/styles/profile-groups.css
+++ b/src/app/styles/profile-groups.css
@@ -96,6 +96,38 @@
   appearance: none;
 }
 
+@media (max-width: 799px) {
+  /* The mobile tab strip already labels this section "Groups" — drop the
+     duplicate in-content heading. */
+  .profile-groups__title {
+    display: none;
+  }
+  /* Controls take their own full-width row; the search stretches to fill
+     it beside the buttons, and every control matches the plus button's
+     30px height. */
+  .profile-groups__controls {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+  .profile-groups__search {
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 30px;
+  }
+  .profile-groups__search-input {
+    width: auto;
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+  /* Scoped under the controls so it beats the base `.profile-groups__
+     sort-btn { 36px }` rule, which is declared LATER in this file (equal
+     specificity would otherwise let the taller base win). */
+  .profile-groups__controls .profile-groups__sort-btn {
+    width: 30px;
+    height: 30px;
+  }
+}
+
 .profile-groups__sort-wrap {
   position: relative;
   display: inline-flex;
@@ -268,7 +300,7 @@
 
 .profile-groups__row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 12px;
   padding: 12px;
   background: transparent;
@@ -282,29 +314,28 @@
   border-color: var(--border-hover-soft);
 }
 
-.profile-groups__row-link {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex: 1;
-  min-width: 0;
+.profile-groups__avatar-link {
+  flex-shrink: 0;
   text-decoration: none;
-  color: inherit;
+  line-height: 0;
 }
 
-.profile-groups__meta {
+.profile-groups__main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  flex: 1;
+}
+
+/* Name stacked above the @handle (one identity link next to the
+   avatar). */
+.profile-groups__identity {
   display: flex;
   flex-direction: column;
   min-width: 0;
-  flex: 1;
-  gap: 2px;
-}
-
-.profile-groups__identity {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  min-width: 0;
+  text-decoration: none;
+  color: inherit;
 }
 
 .profile-groups__name {
@@ -337,16 +368,24 @@
 }
 
 .profile-groups__joined {
-  margin-top: 2px;
   font-size: 0.75rem;
   color: var(--fg-muted);
+  white-space: nowrap;
+}
+
+/* Role tag on the left, "Joined …" to its right, on one line. */
+.profile-groups__rolerow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
 }
 
 .profile-groups__row-actions {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  flex-shrink: 0;
+  margin-top: 6px;
 }
 
 .profile-groups__role {
@@ -358,6 +397,17 @@
   padding: 1px 6px;
   background: var(--overlay-weak);
   border-radius: 999px;
+  flex-shrink: 0;
+}
+
+/* "Operate as" / "Operating" — drop the global 44px mobile tap-floor on
+   Button size="sm" so it reads as a compact action rather than a tall
+   block. */
+.profile-groups__operate-btn {
+  min-height: 0;
+  height: 30px;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .profile-groups__action-btn {

--- a/src/app/styles/profile-projects.css
+++ b/src/app/styles/profile-projects.css
@@ -45,6 +45,32 @@
   overflow: hidden;
 }
 
+@media (max-width: 799px) {
+  /* Drop the outer box on mobile — each project reads as a plain block
+     in the list rather than a bordered card. */
+  .profile-projects__box {
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    overflow: visible;
+  }
+  /* Scoped under .profile-projects__box so they beat the base
+     `…__box-head` / `…__box-certs` rules declared LATER in this file
+     (equal specificity would otherwise let the later base win). */
+  .profile-projects__box .profile-projects__box-head {
+    padding-left: 0;
+    padding-right: 0;
+    /* With the member-activities section hidden below, the head's
+       divider would dangle at the bottom of each project; drop it. */
+    border-bottom: 0;
+  }
+  /* Don't list each project's member activities on mobile — the Projects
+     tab stays a compact list of projects. */
+  .profile-projects__box .profile-projects__box-certs {
+    display: none;
+  }
+}
+
 .profile-projects__box-head {
   display: flex;
   flex-direction: column;

--- a/src/app/styles/profile.css
+++ b/src/app/styles/profile.css
@@ -454,3 +454,72 @@
   justify-content: center;
   padding: 24px 0;
 }
+
+/* The Edit / Settings / Follow buttons in the profile hero drop the
+   global 44px mobile min tap-height (`min-h-11` on Button size="sm"),
+   which made them look oversized in the compact hero. Padding then
+   drives a tighter height, matching the desktop look. */
+@media (max-width: 799px) {
+  .profile-hero__action button {
+    min-height: 0;
+  }
+}
+
+/* Profile sub-tab strips (Created / Contributed, Received / Given,
+   Followers / Following) read as explore-style pills on mobile instead
+   of the tall underline tabs. Scoped to role="tab" so it only hits the
+   ui/Tabs sub-strips, not the main `.profile-tabs__tab` strip. */
+@media (max-width: 799px) {
+  .profile-page [role="tab"] {
+    padding: 4px 12px;
+    border: 1px solid var(--border-default);
+    border-radius: 999px;
+    background: var(--bg-elevated);
+    color: var(--fg-primary);
+    font-size: 0.75rem;
+    font-weight: 500;
+    min-height: 30px;
+  }
+  .profile-page [role="tab"][aria-selected="true"] {
+    background: var(--fg-primary);
+    color: var(--bg-canvas);
+    border-color: var(--fg-primary);
+    font-weight: 600;
+  }
+  .profile-page [role="tab"][aria-disabled="true"] {
+    opacity: 0.5;
+  }
+}
+
+/* Profile Activities tab: when an activity has no image, show no
+   thumbnail at all rather than the grey CertIcon placeholder box. */
+.profile-certs .feed-card__image-wrap--placeholder {
+  display: none;
+}
+
+/* "New activity / project / group" CTAs collapse to an icon-only plus on
+   mobile, styled IDENTICALLY to the Lists tab's create control: a 30px
+   bordered, transparent square with the plus in fg-primary. The visible
+   label is dropped (the button keeps its `aria-label` for assistive
+   tech). Scoped under `.profile-page` so it overrides the Button
+   primitive's filled "primary" variant (single-class utilities). */
+@media (max-width: 799px) {
+  .profile-new-record-btn__label {
+    display: none;
+  }
+  .profile-page .profile-new-record-btn {
+    width: 30px;
+    height: 30px;
+    min-width: 0;
+    min-height: 0;
+    padding: 0;
+    gap: 0;
+    border: 1px solid var(--border-medium);
+    border-radius: var(--radius);
+    background: transparent;
+    color: var(--fg-primary);
+  }
+  .profile-page .profile-new-record-btn:hover {
+    background: var(--bg-sunken);
+  }
+}

--- a/src/app/styles/project-detail.css
+++ b/src/app/styles/project-detail.css
@@ -1256,3 +1256,70 @@
   margin: 0;
   min-width: 0;
 }
+
+/* ---- Create-group form ---- */
+
+/* Avatar / Banner each get a small labelled heading above the picker,
+   matching the Handle / Website meta labels below. */
+.create-group__identity-col {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+/* Remove the boxed chrome around the Handle / Website / Founded /
+   Organization-type fields — they read as plain labelled rows. */
+.create-group .project-detail__meta {
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+
+/* "About" label sits above the short-description field, matching the
+   other field headings. */
+.create-group__about {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+@media (max-width: 799px) {
+  /* Display-name field reads at the same size as the short-description
+     placeholder rather than the large serif title size. */
+  .create-group .cert-detail__title-input {
+    font-size: 1rem;
+  }
+  /* Half-size avatar dropzone, centred horizontally — the full-width
+     circle was oversized. */
+  .create-group .create-group__avatar-tile {
+    max-width: 50%;
+    margin-inline: auto;
+  }
+  /* Cancel / Create group pinned to the very end of the form, after the
+     organization-type field. Higher specificity than the create-project
+     `> *` order rule so it wins regardless of source order. */
+  .create-group .project-detail > .create-cert__actions {
+    order: 9;
+  }
+}
+
+/* Create / edit project form (mobile): lead with the title, then the
+   image, then the rest of the form. The hero image is DOM-first (before
+   the headline), so a base `order:3` on every child pushes the
+   non-title/non-image blocks below the image, and the headline + hero
+   are pulled to the front. Appended last so the hero's order wins over
+   the read-view `.project-detail__hero { order: 3 }` rule above. */
+@media (max-width: 799px) {
+  .create-project .project-detail > * {
+    order: 3;
+  }
+  .create-project .project-detail > .cert-detail__headline {
+    order: 1;
+  }
+  .create-project .project-detail > .create-project__hero {
+    order: 2;
+    /* A little breathing room between the title and the image section. */
+    margin-top: 12px;
+  }
+}

--- a/src/components/explore-page/explore-list-row.tsx
+++ b/src/components/explore-page/explore-list-row.tsx
@@ -36,6 +36,10 @@ export interface ExploreListRowProps {
   /** Icon shown when `thumbUrl` is null or fails to load. */
   fallbackIcon: ReactNode
   title: string
+  /** Optional second line under the title (e.g. "by Display Name").
+   *  Hidden on desktop — there the author shows in its own column;
+   *  surfaced on mobile where the column is dropped. */
+  subtitle?: ReactNode
   /** Meta segments rendered as a `·`-separated line under the title.
    *  Empty array hides the meta line. */
   metaItems: ReactNode[]
@@ -58,6 +62,7 @@ export default function ExploreListRow({
   thumbUrl,
   fallbackIcon,
   title,
+  subtitle,
   metaItems,
   authorDid,
   endorsementMeta,
@@ -113,6 +118,9 @@ export default function ExploreListRow({
       </div>
       <div className="cert-list-row__body">
         <h3 className="cert-list-row__title">{title}</h3>
+        {subtitle ? (
+          <p className="cert-list-row__subtitle">{subtitle}</p>
+        ) : null}
         {metaItems.length > 0 ? (
           <p className="cert-list-row__meta" ref={metaRef}>
             {metaItems.map((item, i) => (

--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -1189,6 +1189,7 @@ function ExploreAllBlocks() {
               icon={CertIcon}
               isLoading={activities.isLoading}
               isEmpty={activityItems.length === 0}
+              onShowAll={() => setShow("activities")}
             >
               <ul className="explore__list explore__list--certs">
                 {activityItems.map((rec) => {
@@ -1199,7 +1200,6 @@ function ExploreAllBlocks() {
                     </li>
                   )
                 })}
-                <ShowAllRow onClick={() => setShow("activities")} />
               </ul>
             </AllSection>
 
@@ -1208,6 +1208,7 @@ function ExploreAllBlocks() {
               icon={FolderGit2}
               isLoading={projects.isLoading}
               isEmpty={projectItems.length === 0}
+              onShowAll={() => setShow("projects")}
             >
               <ul className="explore__list explore__list--projects">
                 {projectItems.map((p) => (
@@ -1215,7 +1216,6 @@ function ExploreAllBlocks() {
                     <ProjectListRow project={p} />
                   </li>
                 ))}
-                <ShowAllRow onClick={() => setShow("projects")} />
               </ul>
             </AllSection>
 
@@ -1224,6 +1224,7 @@ function ExploreAllBlocks() {
               icon={Users}
               isLoading={accounts.isLoading}
               isEmpty={accountItems.length === 0}
+              onShowAll={() => setShow("accounts")}
             >
               <ul className="explore__list explore__list--accounts">
                 {accountItems.map((a) => (
@@ -1231,7 +1232,6 @@ function ExploreAllBlocks() {
                     <AccountListRow actor={a} />
                   </li>
                 ))}
-                <ShowAllRow onClick={() => setShow("accounts")} />
               </ul>
             </AllSection>
           </div>
@@ -1280,23 +1280,6 @@ function ExploreAllSingle({ show }: { show: ExploreKind }) {
         />
       </div>
     </div>
-  )
-}
-
-/** The thin "Show all" row pinned as the last item inside a capped
- *  block's list — collapses the All view to that single category. Lives
- *  inside the bordered list so it reads as the list's final row (no gap
- *  to the rows above). */
-function ShowAllRow({ onClick }: { onClick: () => void }) {
-  return (
-    <li>
-      <Tooltip label="Show all" className="w-full">
-        <button type="button" className="explore__show-all" onClick={onClick}>
-          Show all
-          <ChevronRight size={14} strokeWidth={1.75} aria-hidden />
-        </button>
-      </Tooltip>
-    </li>
   )
 }
 
@@ -1491,21 +1474,27 @@ function AllCategoryDropdown({
 
 /**
  * One block on the All view's default (three-block) layout: an uppercase
- * section heading, then either a spinner (still loading), a muted empty
- * line (no matches), or the result list passed as children. The list
- * itself carries the trailing {@link ShowAllRow}.
+ * section heading with a "Show all" action pinned to its right (when the
+ * block has content), then either a spinner (still loading), a muted
+ * empty line (no matches), or the result list passed as children.
  */
 function AllSection({
   title,
   icon: Icon,
   isLoading,
   isEmpty,
+  onShowAll,
   children,
 }: {
   title: string
   icon: SectionIcon
   isLoading: boolean
   isEmpty: boolean
+  /** Collapses the All view to this single category. The "Show all"
+   *  control renders in the section header (matching the project
+   *  detail page's "See all →" affordance) only when there's content
+   *  to expand into. */
+  onShowAll: () => void
   children: React.ReactNode
 }) {
   return (
@@ -1515,6 +1504,16 @@ function AllSection({
           <Icon size={14} strokeWidth={1.75} aria-hidden />
           {title}
         </h2>
+        {!isLoading && !isEmpty ? (
+          <button
+            type="button"
+            className="explore__all-section-action"
+            onClick={onShowAll}
+          >
+            Show all
+            <ChevronRight size={13} strokeWidth={1.75} aria-hidden />
+          </button>
+        ) : null}
       </div>
       {isLoading ? (
         <div className="explore__all-loading">

--- a/src/components/explore-page/project-list-row.tsx
+++ b/src/components/explore-page/project-list-row.tsx
@@ -5,6 +5,7 @@ import { recordUrl } from "@/lib/urls"
 import { resolveActivityImageUrl } from "@/lib/atproto/activity"
 import { parseAtUri } from "@/lib/atproto/activity-uri"
 import { useLocation } from "@/hooks/use-location"
+import { useAuthorInfo } from "@/hooks/use-author-info"
 import type { CollectionRecord } from "@/lib/atproto/collection"
 import type { EndorsementClosureAccount } from "@/lib/atproto/indexer"
 import ExploreListRow from "./explore-list-row"
@@ -49,6 +50,13 @@ export default function ProjectListRow({
           did,
         )
       : null
+
+  // Author byline for the mobile "by Display Name" subtitle. Desktop
+  // keeps the avatar byline column (rendered by ExploreListRow); this
+  // resolves the bare name the compact mobile row shows under the title.
+  const { info: authorInfo } = useAuthorInfo(did || "")
+  const authorName = authorInfo?.displayName || authorInfo?.handle || null
+  const subtitle = authorName ? `by ${authorName}` : null
 
   const itemCount = countItems(value.items)
   const countLabel = `${itemCount} ${itemCount === 1 ? "activity" : "activities"}`
@@ -97,6 +105,7 @@ export default function ProjectListRow({
         />
       }
       title={title}
+      subtitle={subtitle}
       metaItems={metaItems}
       authorDid={did || null}
       endorsementMeta={endorsementMeta}

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -30,6 +30,7 @@ import {
   isAtprotoIdentity,
 } from "@/hooks/use-contributor-info"
 import { useContributorInformationRecord } from "@/hooks/use-contributor-information-record"
+import { useScrollTopOnTabChange } from "@/hooks/use-scroll-top-on-tab-change"
 import { useRights } from "@/hooks/use-rights"
 import { getInitials } from "@/lib/utils/initials"
 import { formatShortDate } from "@/lib/utils/format-date"
@@ -228,6 +229,10 @@ export default function ActivityDetail({
     tabParam === "updates"
       ? tabParam
       : "overview"
+
+  // On mobile, reset to the top when switching sub-tabs so the tab's
+  // first rows aren't left hidden behind the fixed navbar.
+  useScrollTopOnTabChange(activeTab)
 
   // Navbar title: sub-tabs show the tab name next to the back arrow; the
   // overview shows the activity's own name. (We deliberately don't prefix

--- a/src/components/home/home-feed.tsx
+++ b/src/components/home/home-feed.tsx
@@ -12,6 +12,7 @@ import { profileUrl, recordUrl } from "@/lib/urls"
 import Link from "next/link"
 import { ChevronDown, Inbox, MapPin, Users } from "lucide-react"
 import Avatar from "@/components/ui/avatar"
+import IdentityRow from "@/components/ui/identity-row"
 import Badge, { type BadgeTone } from "@/components/ui/badge"
 import Banner from "@/components/ui/banner"
 import Button from "@/components/ui/button"
@@ -842,12 +843,16 @@ function EndorsementGroupSummary({
 
 function EndorsedAccountLink({ did }: { did: string }) {
   const { info } = useAuthorInfo(did)
-  const name = info?.displayName || (info?.handle ? `@${info.handle}` : null)
   const href = profileUrl(info?.handle || did)
   return (
-    <Link href={href} className="home-feed__target">
-      {name ?? did.slice(0, 16)}
-    </Link>
+    <IdentityRow
+      did={did}
+      handle={info?.handle ?? undefined}
+      displayName={info?.displayName ?? undefined}
+      avatarUrl={info?.avatarUrl ?? undefined}
+      href={href}
+      size="sm"
+    />
   )
 }
 

--- a/src/components/profile/endorsement-lists.tsx
+++ b/src/components/profile/endorsement-lists.tsx
@@ -307,10 +307,12 @@ export default function EndorsementLists({
             <Button
               variant="primary"
               size="sm"
+              className="profile-new-record-btn"
+              aria-label="New list"
               onClick={() => setModalMode("create")}
             >
               <Plus size={14} strokeWidth={1.75} aria-hidden />
-              New list
+              <span className="profile-new-record-btn__label">New list</span>
             </Button>
           ) : null}
         </div>

--- a/src/components/profile/profile-certs.tsx
+++ b/src/components/profile/profile-certs.tsx
@@ -163,9 +163,16 @@ export default function ProfileCerts({
         <div className="profile-certs__controls">
           {viewerIsOwner ? (
             <Link href="/create">
-              <Button variant="primary" size="sm">
+              <Button
+                variant="primary"
+                size="sm"
+                className="profile-new-record-btn"
+                aria-label="New activity"
+              >
                 <Plus size={14} strokeWidth={1.75} aria-hidden />
-                New activity
+                <span className="profile-new-record-btn__label">
+                  New activity
+                </span>
               </Button>
             </Link>
           ) : null}

--- a/src/components/profile/profile-groups.tsx
+++ b/src/components/profile/profile-groups.tsx
@@ -94,9 +94,14 @@ export default function ProfileGroups({ did }: ProfileGroupsProps) {
         <div className="profile-groups__controls">
           {isOwnProfile ? (
             <Link href="/groups/create">
-              <Button variant="primary" size="sm">
+              <Button
+                variant="primary"
+                size="sm"
+                className="profile-new-record-btn"
+                aria-label="New group"
+              >
                 <Plus size={14} strokeWidth={1.75} aria-hidden />
-                New group
+                <span className="profile-new-record-btn__label">New group</span>
               </Button>
             </Link>
           ) : null}
@@ -232,8 +237,9 @@ function GroupRow({ group }: GroupRowProps) {
       <div className="profile-groups__row">
         <Link
           href={profileUrl(group.handle)}
-          className="profile-groups__row-link"
-          title={`${name} (@${group.handle})`}
+          className="profile-groups__avatar-link"
+          aria-label={name}
+          tabIndex={-1}
         >
           <Avatar
             size="md"
@@ -241,40 +247,51 @@ function GroupRow({ group }: GroupRowProps) {
             fallbackInitials={initials}
             alt=""
           />
-          <div className="profile-groups__meta">
-            <div className="profile-groups__identity">
-              <span className="profile-groups__name">{name}</span>
-              <span className="profile-groups__handle">@{group.handle}</span>
-            </div>
-            {group.description ? (
-              <p className="profile-groups__description">{group.description}</p>
+        </Link>
+        <div className="profile-groups__main">
+          <Link
+            href={profileUrl(group.handle)}
+            className="profile-groups__identity"
+            title={`${name} (@${group.handle})`}
+          >
+            <span className="profile-groups__name">{name}</span>
+            <span className="profile-groups__handle">@{group.handle}</span>
+          </Link>
+          {group.description ? (
+            <p className="profile-groups__description">{group.description}</p>
+          ) : null}
+          <div className="profile-groups__rolerow">
+            {group.role ? (
+              <span className="profile-groups__role">{group.role}</span>
             ) : null}
             {joinedLabel ? (
               <span className="profile-groups__joined">{joinedLabel}</span>
             ) : null}
           </div>
-        </Link>
-
-        <div className="profile-groups__row-actions">
-          {group.role ? (
-            <span className="profile-groups__role">{group.role}</span>
-          ) : null}
-          {isOperating ? (
-            <Button variant="secondary" size="sm" disabled>
-              <Check size={14} strokeWidth={2} aria-hidden />
-              Operating
-            </Button>
-          ) : (
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={handleOperateAs}
-              title={`Operate as ${name}`}
-            >
-              <LogIn size={14} strokeWidth={1.75} aria-hidden />
-              Operate as
-            </Button>
-          )}
+          <div className="profile-groups__row-actions">
+            {isOperating ? (
+              <Button
+                variant="secondary"
+                size="sm"
+                className="profile-groups__operate-btn"
+                disabled
+              >
+                <Check size={14} strokeWidth={2} aria-hidden />
+                Operating
+              </Button>
+            ) : (
+              <Button
+                variant="secondary"
+                size="sm"
+                className="profile-groups__operate-btn"
+                onClick={handleOperateAs}
+                title={`Operate as ${name}`}
+              >
+                <LogIn size={14} strokeWidth={1.75} aria-hidden />
+                Operate as
+              </Button>
+            )}
+          </div>
         </div>
       </div>
     </li>

--- a/src/components/profile/profile-projects.tsx
+++ b/src/components/profile/profile-projects.tsx
@@ -103,9 +103,14 @@ export default function ProfileProjects({
       <div className="profile-projects__controls">
         {viewerIsOwner ? (
           <Link href="/project/new">
-            <Button variant="primary" size="sm">
+            <Button
+              variant="primary"
+              size="sm"
+              className="profile-new-record-btn"
+              aria-label="New project"
+            >
               <Plus size={14} strokeWidth={1.75} aria-hidden />
-              New project
+              <span className="profile-new-record-btn__label">New project</span>
             </Button>
           </Link>
         ) : null}
@@ -281,9 +286,11 @@ function ProjectBox({ project, owner }: ProjectBoxProps) {
   // below sit OUTSIDE this wrapper so they keep their own anchors.
   const HeadContents = (
     <>
-      <div className="profile-projects__box-image-wrap">
-        {showImage ? (
-          /* eslint-disable-next-line @next/next/no-img-element */
+      {/* No placeholder when the project has no image — just omit the
+          image area entirely rather than showing a grey fallback box. */}
+      {showImage ? (
+        <div className="profile-projects__box-image-wrap">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={imageUrl!}
             alt=""
@@ -291,12 +298,8 @@ function ProjectBox({ project, owner }: ProjectBoxProps) {
             onError={() => setImageFailed(true)}
             loading="lazy"
           />
-        ) : (
-          <div className="profile-projects__box-image profile-projects__box-image--placeholder">
-            <FolderGit2 size={40} strokeWidth={1.25} aria-hidden />
-          </div>
-        )}
-      </div>
+        </div>
+      ) : null}
 
       <div className="profile-projects__box-meta">
         <div className="profile-projects__box-titleline">

--- a/src/components/project/project-detail.tsx
+++ b/src/components/project/project-detail.tsx
@@ -45,6 +45,7 @@ import { useOrg } from "@/lib/groups/org-context"
 import { useProjectItems } from "@/hooks/use-project-items"
 import { useContextUpdates } from "@/hooks/use-context-updates"
 import { useLayoutBreakpoints } from "@/hooks/use-layout-breakpoints"
+import { useScrollTopOnTabChange } from "@/hooks/use-scroll-top-on-tab-change"
 import CertListRow from "@/components/explore-page/cert-list-row"
 import {
   resolveActivityImageUrl,
@@ -284,6 +285,10 @@ export default function ProjectDetail({
     normalizedTab === "updates"
       ? normalizedTab
       : "overview"
+
+  // On mobile, reset to the top when switching sub-tabs so the tab's
+  // first rows aren't left hidden behind the fixed navbar.
+  useScrollTopOnTabChange(activeTab)
 
   // Updates count for the navbar title on the Updates tab. Fetched only
   // on that tab (null subjectUri = no fetch elsewhere).

--- a/src/hooks/use-scroll-top-on-tab-change.ts
+++ b/src/hooks/use-scroll-top-on-tab-change.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from "react"
+import { useLayoutBreakpoints } from "./use-layout-breakpoints"
+
+/**
+ * Scroll the window to the top whenever `tab` changes on mobile.
+ *
+ * Detail-page sub-tabs (Description / Contributors / Updates /
+ * Activities) switch by writing `?tab=` to the URL, which preserves the
+ * previous scroll offset. On mobile that left a freshly-opened tab
+ * scrolled down with its first rows hidden behind the fixed navbar. This
+ * resets to the top on each real tab change.
+ *
+ * No-op on the initial render (a fresh load / deep link already sits at
+ * the top, so we don't clobber browser scroll restoration) and on
+ * desktop, where tab switches intentionally preserve scroll position
+ * (`scroll: false` on the top-bar tab links).
+ */
+export function useScrollTopOnTabChange(tab: string): void {
+  const { isDesktop } = useLayoutBreakpoints()
+  const prevTab = useRef(tab)
+  useEffect(() => {
+    if (prevTab.current === tab) return
+    prevTab.current = tab
+    if (!isDesktop) window.scrollTo(0, 0)
+  }, [tab, isDesktop])
+}

--- a/src/hooks/use-user-activity-count.ts
+++ b/src/hooks/use-user-activity-count.ts
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { fetchUserActivityCount } from "@/lib/atproto/indexer"
+
+/**
+ * Exact deduped count of the activities a profile (`did`) CREATED or
+ * CONTRIBUTED to — the union of both buckets, counted once each. Backed
+ * by the indexer's `_or` totalCount (see `fetchUserActivityCount`), so
+ * it's a precise number rather than the "N+" a capped page fetch gives.
+ *
+ * Returns null while loading or on failure; callers should fall back to
+ * a neutral label (or hide the count) in that case.
+ */
+export function useUserActivityCount(did: string | null): number | null {
+  const [count, setCount] = useState<number | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    // `fetchUserActivityCount` resolves to null for an empty did, so the
+    // reset path runs through the same async setState — avoids a
+    // synchronous setState in the effect body.
+    fetchUserActivityCount(did ?? "").then((c) => {
+      if (!cancelled) setCount(c)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [did])
+  return count
+}

--- a/src/lib/atproto/indexer.ts
+++ b/src/lib/atproto/indexer.ts
@@ -43,7 +43,10 @@ export interface ActivityGraphQLNode {
   endDate: string | null
   labels: string[] | null
   image: { __typename: string; uri?: string | null; image?: { ref: string; mimeType: string } } | null
-  workScope: { scope: string } | null
+  // Two union members are projected: the plain `{ scope }` string form
+  // and the CEL `{ expression }` form (`scope.hasAny([...])`). Either may
+  // be null depending on which member the record carries.
+  workScope: { scope?: string | null; expression?: string | null } | null
 }
 
 interface GraphQLResponse {
@@ -55,6 +58,26 @@ interface GraphQLResponse {
     } | null
   } | null
   errors?: { message: string }[]
+}
+
+/**
+ * Map the indexer's projected workScope union into a value
+ * `evaluateWorkScope` can render. The plain-string member surfaces as
+ * `{ scope }`; the CEL member (`scope.hasAny([...])`) surfaces as
+ * `{ expression }`, which `evaluateWorkScope` parses into a tag list.
+ * Returns undefined when neither member carries a value.
+ */
+function mapWorkScope(
+  workScope: ActivityGraphQLNode["workScope"],
+): ActivityRecord["value"]["workScope"] {
+  if (!workScope) return undefined
+  if (typeof workScope.scope === "string" && workScope.scope.length > 0) {
+    return { scope: workScope.scope }
+  }
+  if (typeof workScope.expression === "string" && workScope.expression.length > 0) {
+    return { expression: workScope.expression } as ActivityRecord["value"]["workScope"]
+  }
+  return undefined
 }
 
 export function nodeToActivityRecord(node: ActivityGraphQLNode): ActivityRecord {
@@ -80,7 +103,7 @@ export function nodeToActivityRecord(node: ActivityGraphQLNode): ActivityRecord 
       startDate: node.startDate ?? undefined,
       endDate: node.endDate ?? undefined,
       image: image as ActivityRecord["value"]["image"],
-      workScope: node.workScope ? { scope: node.workScope.scope } : undefined,
+      workScope: mapWorkScope(node.workScope),
     },
   }
 }
@@ -614,6 +637,41 @@ const COUNT_OPERATIONS = [
   { key: "projects", op: "ProjectCount", root: "orgHypercertsCollection" },
   { key: "endorsements", op: "AwardCount", root: "appCertifiedBadgeAward" },
 ] as const
+
+/**
+ * Exact deduped count of the activities a profile CREATED or
+ * CONTRIBUTED to (the union, via the indexer's `_or` filter — see the
+ * `UserActivityCount` op). One cheap `first: 1` query that reads only
+ * `totalCount`. Returns null on any failure so callers fall back
+ * gracefully instead of rendering a wrong number.
+ */
+export async function fetchUserActivityCount(
+  did: string,
+): Promise<number | null> {
+  if (!did) return null
+  try {
+    const res = await fetch(INDEXER_PROXY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        operationName: "UserActivityCount",
+        variables: { did },
+      }),
+    })
+    if (!res.ok) return null
+    const json = (await res.json()) as {
+      data?: {
+        orgHypercertsClaimActivity?: { totalCount?: number | null } | null
+      }
+      errors?: { message?: string }[]
+    }
+    if (json.errors && json.errors.length > 0) return null
+    const total = json.data?.orgHypercertsClaimActivity?.totalCount
+    return typeof total === "number" ? total : null
+  } catch {
+    return null
+  }
+}
 
 async function fetchCount(op: string, root: string): Promise<number | null> {
   try {


### PR DESCRIPTION
Mobile-focused UI polish across the home feed, explore, profile tabs, detail pages, and create/edit forms.

## Home feed
- Centered the endorsement-group "Show all" toggle; expanded accounts now use the canonical `IdentityRow` (avatar + display name + handle).

## Explore (mobile)
- Activity rows now show the **work scope next to the time period** (`·`-separated). Root cause was upstream: the indexer GraphQL only projected the plain-string workscope member, so CEL-based scopes came back empty — added `OrgHypercertsWorkscopeCel { expression }` to the query + client mapping.
- Fixed the **filter/sort icons overflowing** the right edge (deterministic 36px squares) and the **category dropdown being clipped** (removed the `overflow` that trapped the non-portal popover).

## Profile (mobile)
- **Exact deduped activity-claims count** (no more "N+") via a new `UserActivityCount` indexer op using `_or` totalCount.
- Sub-tabs (Created/Contributed, Received/Given, Followers/Following) render as **explore-style pills**.
- "New activity/project/group/list" CTAs collapse to an **icon-only plus** matching the Lists tab.
- Toolbar rows **equalized to 30px** with a **stretched search**; endorsements/groups search no longer overflow.
- Removed the **duplicate Groups heading**, the per-project **member-activities list**, the **project card box**, and **placeholder thumbnails** on Activities/Projects.
- **Redesigned group-tab rows**: avatar | name / handle / role+joined / shorter Operate-as button.
- **Back button** now leaves the profile instead of cycling through sub-tabs (tab nav uses `replace`).
- Trimmed the oversized profile-hero Edit button on mobile.

## Detail + create/edit forms (mobile)
- Activity **Updates tab** redesigned to match the project Updates tab.
- Fixed sub-tab content **hiding behind the navbar** on first open (new `useScrollTopOnTabChange` hook).
- Create/edit **activity + project forms** lead with the title, then the image; activity Cancel/Publish sort to the end.
- **Create-group form**: labelled avatar/banner pickers with icons, icons on all field headings, unboxed handle section, centred half-size avatar, "About" heading, smaller display-name field, buttons at the end.

## Verification
- `tsc --noEmit` clean; lint at the repo's 60/64-warning baseline; no off-spec radii/breakpoints.
- Browser-verified on a 390px viewport: explore work-scope/filter/dropdown, profile count, sub-tab pills, toolbar heights, search stretch, projects box + member-activities removal, back button.
- **Not browser-verified (auth/data-gated, signed-out):** owner-only buttons, the groups tab (requires group membership), and the create/edit forms (require sign-in) — these are validated by DOM/CSS structure and computed-style checks. Worth a signed-in pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)