### PR TITLE
feat(tour): nav-driven product walk-through + desktop UI polish

### DIFF
--- a/src/app/[actor]/page.tsx
+++ b/src/app/[actor]/page.tsx
@@ -420,6 +420,7 @@ export default function UserProfilePage() {
       <nav
         className="profile-page__mobile-tabs profile-tabs"
         aria-label="Profile sections"
+        data-tour="profile-tabs"
       >
         {mobileTabs.map((t) => {
           // While editing, only the editable section(s) stay switchable —

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -20,7 +20,7 @@ export default function AppsPage() {
         </p>
       </header>
 
-      <ul className="apps-store__grid">
+      <ul className="apps-store__grid" data-tour="apps-grid">
         {CONNECTED_APPS.map((app) => {
           // Silent SSO: if the partner exposes an ePDS handle-login
           // endpoint AND the viewer is signed in, deep-link them via

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -849,6 +849,7 @@ export default function CreatePage() {
                 maxLength={TITLE_MAX}
                 onChange={(e) => setTitle(e.target.value)}
                 autoFocus
+                data-tour="create-title"
               />
               <p
                 className={`create-cert__counter${
@@ -1183,6 +1184,7 @@ export default function CreatePage() {
               variant="primary"
               loading={isSubmitting}
               disabled={!canSubmit}
+              data-tour="create-submit"
             >
               {isSubmitting ? "Publishing…" : "Publish activity"}
             </Button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,7 @@
 @import "./styles/leaflet.css";
 @import "./styles/landing.css";
 @import "./styles/view-transitions.css";
+@import "./styles/tour.css";
 
 @tailwind base;
 @tailwind components;

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import PageTitle from "@/components/layout/page-title";
 import HelpFeedbackLink from "@/components/help/help-feedback-link";
+import HelpTourButton from "@/components/help/help-tour-button";
 
 export const metadata: Metadata = {
   title: "Help",
@@ -59,6 +60,18 @@ export default function HelpPage() {
               still have questions or spot something that&apos;s off, fill out the{" "}
               <HelpFeedbackLink />.
             </p>
+          </section>
+
+          <section>
+            <h2 className="font-headline text-h2 text-[var(--fg-primary)] mb-4">
+              Take the walk-through
+            </h2>
+            <p className="mb-4">
+              New here, or want a refresher? The walk-through highlights the main parts of the app —
+              your feed, Explore, Create, and your profile — in a few quick steps. You can start it
+              any time.
+            </p>
+            <HelpTourButton />
           </section>
 
           <section>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,8 @@ import AppShell from "@/components/layout/app-shell";
 import { OrgProvider } from "@/lib/groups/org-context";
 import { OnboardingProvider } from "@/lib/onboarding/onboarding-context";
 import OnboardingModal from "@/components/onboarding/onboarding-modal";
+import { TourProvider } from "@/lib/tour/tour-context";
+import ProductTour from "@/components/tour/product-tour";
 import FeedbackModal from "@/components/ui/feedback-modal";
 import { FeedbackProvider } from "@/lib/feedback-context";
 import BottomNav from "@/components/layout/bottom-nav";
@@ -157,6 +159,7 @@ export default function RootLayout({
           <AuthProvider>
             <OrgProvider>
               <OnboardingProvider>
+              <TourProvider>
               <NavbarProvider>
                 <FeedbackProvider>
                 <ViewTransitionProvider>
@@ -178,9 +181,11 @@ export default function RootLayout({
                 <PwaInstallGuard />
                 <FeedbackModal />
                 <OnboardingModal />
+                <ProductTour />
                 </ViewTransitionProvider>
                 </FeedbackProvider>
               </NavbarProvider>
+              </TourProvider>
               </OnboardingProvider>
             </OrgProvider>
           </AuthProvider>

--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -315,12 +315,12 @@
   margin: 0 auto;
 }
 
-/* News rail shows at the canonical 1100px step (was a non-canonical 1200px).
-   It still appears one step before the sidebar widens at 1300px — the
-   1100–1299px band gets the news rail alongside the trimmed sidebar. Below
-   1100px the layout collapses to a single column and the rail is hidden
-   entirely (never stacked under the feed). */
-@media (max-width: 1099.98px) {
+/* News rail only shows at the canonical 1300px step. With the feed capped
+   at 600px (below) plus the 320px rail, gaps, and the left sidebar, there
+   isn't room for the rail below ~1300px — so below that the layout collapses
+   to a single feed column and the rail is hidden entirely (never squished,
+   never stacked under the feed). */
+@media (max-width: 1299.98px) {
   .home__split {
     grid-template-columns: minmax(0, 1fr);
     gap: 0;
@@ -332,6 +332,17 @@
 
 .home__feed {
   min-width: 0;
+}
+
+/* Desktop: cap the feed at a 600px reading column and center it inside
+   its grid track (the feed column keeps its full 1fr width; the timeline
+   just sits centered within it). Applies in both the single-column band
+   (800–1299px, news rail hidden) and the two-column layout (≥1300px). */
+@media (min-width: 800px) {
+  .home__feed {
+    max-width: 600px;
+    margin-inline: auto;
+  }
 }
 
 .home__news {

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -2869,7 +2869,7 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 36px;
+  height: 30px;
   padding: 0 12px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
@@ -2916,8 +2916,8 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 30px;
+  height: 30px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
   border-radius: var(--radius);

--- a/src/app/styles/profile-endorsements.css
+++ b/src/app/styles/profile-endorsements.css
@@ -32,7 +32,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 36px;
+  height: 30px;
   padding: 0 12px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
@@ -109,8 +109,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 30px;
+  height: 30px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
   border-radius: var(--radius);
@@ -138,8 +138,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 30px;
+  height: 30px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
   border-radius: var(--radius);

--- a/src/app/styles/profile-groups.css
+++ b/src/app/styles/profile-groups.css
@@ -60,7 +60,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 36px;
+  height: 30px;
   padding: 0 12px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
@@ -137,8 +137,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 30px;
+  height: 30px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
   border-radius: var(--radius);

--- a/src/app/styles/profile-projects.css
+++ b/src/app/styles/profile-projects.css
@@ -34,6 +34,26 @@
   margin-left: auto;
 }
 
+/* Desktop: keep the search/sort controls from "jumping" when switching
+   between the Activities and Projects tabs. The Activities toolbar reserves
+   height for its Created / Contributed sub-tab strip (underline tabs:
+   py-3 24px + text-sm 20px line + 2px border = 46px, plus the toolbar's own
+   1px bottom border = 47px) and offsets its controls with padding-bottom: 8px.
+   Projects has no sub-tabs, so reserve the same height and replicate the
+   divider + control offset so the controls land in the same place. Spacing
+   below the toolbar is already provided by the parent's `gap: 24px`, so no
+   margin-bottom here (it would compound with the gap). */
+@media (min-width: 800px) {
+  .profile-projects__toolbar {
+    align-items: center;
+    min-height: 47px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .profile-projects__controls {
+    padding-bottom: 8px;
+  }
+}
+
 /* ---------- Project box ---------- */
 
 .profile-projects__box {

--- a/src/app/styles/profile.css
+++ b/src/app/styles/profile.css
@@ -497,6 +497,19 @@
   display: none;
 }
 
+/* Desktop: pin the labelled "New X" CTA to the shared 30px toolbar-control
+   height so it lines up exactly with the search field and the sort / add
+   icon buttons (the Button primitive's `sm` size is padding-driven and
+   would otherwise render a couple of px shorter). Scoped under
+   `.profile-page` so it beats the Button primitive's single-class
+   utilities. */
+@media (min-width: 800px) {
+  .profile-page .profile-new-record-btn {
+    height: 30px;
+    min-height: 0;
+  }
+}
+
 /* "New activity / project / group" CTAs collapse to an icon-only plus on
    mobile, styled IDENTICALLY to the Lists tab's create control: a 30px
    bordered, transparent square with the plus in fg-primary. The visible

--- a/src/app/styles/tokens.css
+++ b/src/app/styles/tokens.css
@@ -204,6 +204,8 @@
   --z-skip-nav: 9999;               /* skip-nav link */
   --z-feedback: 10000;              /* feedback modal portal (above skip-nav) */
   --z-feedback-above: 10001;        /* feedback expanded variant */
+  --z-tour-backdrop: 10015;         /* walk-through spotlight dim panels + ring */
+  --z-tour-card: 10016;             /* walk-through step card (above its backdrop) */
   --z-tooltip: 10020;               /* hover/focus tooltips — always topmost */
 }
 

--- a/src/app/styles/tour.css
+++ b/src/app/styles/tour.css
@@ -1,0 +1,147 @@
+/* Product walk-through (anchored spotlight tour).
+ *
+ * The renderer (components/tour/product-tour.tsx) portals these elements
+ * to <body>. Dim panels surround the spotlight hole; the ring outlines it;
+ * the card carries the step copy + controls. Colors/tokens only — no raw
+ * hex/rgb, no literal z-index (see CLAUDE.md hard rules). */
+
+.product-tour {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-tour-card);
+  /* The wrapper itself is inert; its children own their own positioning
+     and pointer behaviour. */
+  pointer-events: none;
+}
+
+/* Dim panel — one of the four rectangles around the spotlight hole, or a
+   single full-screen panel in the centered fallback. Captures pointer
+   events so the rest of the page can't be interacted with mid-tour; the
+   spotlight hole (between the panels) stays clickable. */
+.product-tour__panel {
+  position: fixed;
+  z-index: var(--z-tour-backdrop);
+  background: var(--modal-backdrop);
+  pointer-events: auto;
+}
+
+.product-tour__panel--full {
+  inset: 0;
+}
+
+/* Highlight ring drawn over the spotlight hole. Non-interactive so clicks
+   pass through to the highlighted element. */
+.product-tour__ring {
+  position: fixed;
+  z-index: var(--z-tour-backdrop);
+  border-radius: var(--radius);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 0;
+  pointer-events: none;
+}
+
+.product-tour__card {
+  z-index: var(--z-tour-card);
+  width: min(360px, calc(100vw - 32px));
+  max-width: 360px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
+  padding: 20px;
+  pointer-events: auto;
+}
+
+.product-tour__card:focus {
+  outline: none;
+}
+
+.product-tour__card--centered {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+/* Pinned-to-corner cards. `top` clears the sticky chrome; the side inset
+   keeps the card off the viewport edge. */
+.product-tour__card--pin-top-left,
+.product-tour__card--pin-top-right,
+.product-tour__card--pin-bottom-left,
+.product-tour__card--pin-bottom-right {
+  position: fixed;
+}
+
+.product-tour__card--pin-top-left {
+  top: 80px;
+  left: 16px;
+}
+
+.product-tour__card--pin-top-right {
+  top: 80px;
+  right: 16px;
+}
+
+.product-tour__card--pin-bottom-left {
+  bottom: 16px;
+  left: 16px;
+}
+
+.product-tour__card--pin-bottom-right {
+  bottom: 16px;
+  right: 16px;
+}
+
+.product-tour__title {
+  color: var(--fg-primary);
+  margin: 0 0 8px;
+}
+
+.product-tour__body {
+  color: var(--fg-secondary);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  margin: 0 0 20px;
+}
+
+.product-tour__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.product-tour__dots {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.product-tour__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--border-default);
+  transition: background 150ms ease;
+}
+
+.product-tour__dot--active {
+  background: var(--fg-primary);
+}
+
+.product-tour__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Skip + Next group, pushed to the right edge of the row. With
+   margin-left:auto it stays right-aligned whether or not Back is present. */
+.product-tour__actions-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}

--- a/src/components/dashboard/username-card.tsx
+++ b/src/components/dashboard/username-card.tsx
@@ -249,7 +249,7 @@ export default function UsernameCard({ handle, pdsUrl, did, groupDid }: Username
               button is kept — it routes through the group-aware path. */}
           {!showingForm && (
             <div className="settings-field">
-              <span className="settings-field__value">@{handle || "..."}</span>
+              <span className="settings-field__value" data-tour="settings-handle">@{handle || "..."}</span>
               {isCertifiedHandle && (
                 <Button variant="ghost" size="sm" onClick={handleEdit}>
                   <Pencil size={14} />

--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -706,7 +706,7 @@ function ExploreMain({
               />
             ) : null}
 
-            <div className="explore__search-field">
+            <div className="explore__search-field" data-tour="explore-search">
               <Input
                 type="search"
                 size="sm"
@@ -1159,7 +1159,7 @@ function ExploreAllBlocks() {
               />
             </span>
 
-            <div className="explore__search-field">
+            <div className="explore__search-field" data-tour="explore-search">
               <Input
                 type="search"
                 size="sm"

--- a/src/components/help/help-tour-button.tsx
+++ b/src/components/help/help-tour-button.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { useTour } from "@/lib/tour/tour-context"
+import { useAuth } from "@/lib/auth/auth-context"
+import Button from "@/components/ui/button"
+
+/**
+ * "Start the walk-through" button for the (server-rendered) Help page —
+ * launches the product tour via `useTour()`. Kept in its own client file
+ * so the Help page itself can stay a server component (and keep exporting
+ * `metadata`). Mirrors the HelpFeedbackLink pattern.
+ *
+ * The tour visits authenticated surfaces (/home, /create, …), so for a
+ * signed-out visitor the button prompts sign-in instead of starting a tour
+ * that would only hit redirect walls.
+ */
+export default function HelpTourButton() {
+  const { start } = useTour()
+  const { isAuthenticated, openSignIn } = useAuth()
+  return (
+    <Button
+      variant="secondary"
+      size="sm"
+      onClick={isAuthenticated ? start : openSignIn}
+    >
+      {isAuthenticated ? "Start the walk-through" : "Sign in to start the walk-through"}
+    </Button>
+  )
+}

--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -100,7 +100,7 @@ export default function Home() {
         </aside>
         <main className="home__main">
           <div className="home__split">
-            <div className="home__feed">
+            <div className="home__feed" data-tour="home-feed">
               <HomeFeed activeDid={activeDid} />
             </div>
             <aside className="home__news" aria-label="News from Certified">

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -36,25 +36,26 @@ export default function BottomNav() {
 
   const showCreate = isRouteVisibleToActor("create", !!activeOrg);
   const items = [
-    { key: "home", label: "Home", icon: Newspaper, onClick: handleHomeClick, active: isHome },
-    { key: "explore", label: "Explore", icon: Search, onClick: () => router.push("/explore"), active: pathname === "/explore" },
+    { key: "home", label: "Home", icon: Newspaper, onClick: handleHomeClick, active: isHome, tour: "nav-home" },
+    { key: "explore", label: "Explore", icon: Search, onClick: () => router.push("/explore"), active: pathname === "/explore", tour: "nav-explore" },
     ...(showCreate
-      ? [{ key: "create", label: "Create", icon: PlusCircle, onClick: () => router.push("/create"), active: pathname === "/create" }]
+      ? [{ key: "create", label: "Create", icon: PlusCircle, onClick: () => router.push("/create"), active: pathname === "/create", tour: "nav-create" }]
       : []),
-    { key: "apps", label: "Apps", icon: LayoutGrid, onClick: () => router.push("/apps"), active: pathname === "/apps" },
-    { key: "feedback", label: "Feedback", icon: MessageSquare, onClick: () => openFeedback(), active: false },
+    { key: "apps", label: "Apps", icon: LayoutGrid, onClick: () => router.push("/apps"), active: pathname === "/apps", tour: "nav-apps" },
+    { key: "feedback", label: "Feedback", icon: MessageSquare, onClick: () => openFeedback(), active: false, tour: undefined },
   ];
 
   return (
     <nav className="bottom-nav" aria-label="Main navigation">
       <div className="bottom-nav__inner">
-        {items.map(({ key, label, icon: Icon, onClick, active }) => (
+        {items.map(({ key, label, icon: Icon, onClick, active, tour }) => (
           <Tooltip key={key} label={label} className="flex-1 h-full">
             <button
               className={`bottom-nav__item ${active ? "bottom-nav__item--active" : ""}`}
               onClick={onClick}
               aria-label={label}
               aria-current={active ? "page" : undefined}
+              data-tour={tour}
             >
               <span className="bottom-nav__icon-wrap">
                 <Icon size={24} strokeWidth={active ? 2.5 : 1.5} />

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -441,6 +441,7 @@ export default function DesktopTopBar() {
             <div
               ref={createRef}
               className="desktop-top-bar__create-wrap"
+              data-tour="nav-create"
             >
               <Button
                 type="button"
@@ -461,6 +462,7 @@ export default function DesktopTopBar() {
               href="/home"
               className="desktop-top-bar__icon-btn"
               aria-label="Home"
+              data-tour="nav-home"
             >
               <Home size={20} strokeWidth={1.5} aria-hidden />
               <span className="desktop-top-bar__icon-label">Home</span>
@@ -471,6 +473,7 @@ export default function DesktopTopBar() {
             href="/explore"
             className="desktop-top-bar__icon-btn"
             aria-label="Explore"
+            data-tour="nav-explore"
           >
             <Compass size={20} strokeWidth={1.5} aria-hidden />
             <span className="desktop-top-bar__icon-label">Explore</span>
@@ -480,6 +483,7 @@ export default function DesktopTopBar() {
             href="/apps"
             className="desktop-top-bar__icon-btn"
             aria-label="Apps"
+            data-tour="nav-apps"
           >
             <LayoutGrid size={20} strokeWidth={1.5} aria-hidden />
             <span className="desktop-top-bar__icon-label">Apps</span>
@@ -490,6 +494,7 @@ export default function DesktopTopBar() {
               href={profileHref}
               className="desktop-top-bar__icon-btn"
               aria-label="My profile"
+              data-tour="nav-profile"
             >
               <User size={20} strokeWidth={1.5} aria-hidden />
               <span className="desktop-top-bar__icon-label">Profile</span>
@@ -501,6 +506,7 @@ export default function DesktopTopBar() {
               href="/settings"
               className="desktop-top-bar__icon-btn"
               aria-label="Settings"
+              data-tour="nav-settings"
             >
               <Settings size={20} strokeWidth={1.5} aria-hidden />
               <span className="desktop-top-bar__icon-label">Settings</span>
@@ -511,6 +517,7 @@ export default function DesktopTopBar() {
             href="/help"
             className="desktop-top-bar__icon-btn"
             aria-label="Help"
+            data-tour="nav-help"
           >
             <HelpCircle size={20} strokeWidth={1.5} aria-hidden />
             <span className="desktop-top-bar__icon-label">Help</span>
@@ -597,7 +604,10 @@ export default function DesktopTopBar() {
       </div>
 
       {showTabsRow ? (
-        <div className="desktop-top-bar__row desktop-top-bar__row--tabs">
+        <div
+          className="desktop-top-bar__row desktop-top-bar__row--tabs"
+          data-tour="profile-tabs"
+        >
           {/* Profile ?tab= strip — canonical <Tabs> (underline). onChange
               pushes the ?tab= URL (scroll:false) so the page mirrors it,
               matching the prior <Link scroll={false}> default-push. */}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -215,6 +215,7 @@ const Navbar: React.FC = () => {
       aria-label={dropdownOpen ? "Close menu" : "Open menu"}
       aria-haspopup="menu"
       aria-expanded={dropdownOpen}
+      data-tour="nav-menu"
     >
       {dropdownOpen ? <X size={22} /> : <Menu size={22} />}
     </button>

--- a/src/components/profile/profile-header.tsx
+++ b/src/components/profile/profile-header.tsx
@@ -125,7 +125,7 @@ export default function ProfileHeader({
             {hasAdminActions ? (
               <div className="profile-hero__action-group">
                 {editHref ? (
-                  <Link href={editHref}>
+                  <Link href={editHref} data-tour="profile-edit">
                     <Button variant="secondary" size="sm">
                       <Pencil size={14} />
                       Edit

--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -268,12 +268,17 @@ export default function ProfileSidebar({
             type="button"
             className="profile-sidebar__action-primary"
             onClick={onEditClick}
+            data-tour="profile-edit"
           >
             <Pencil size={14} strokeWidth={1.75} aria-hidden />
             Edit profile
           </button>
         ) : hasEditLink ? (
-          <Link href={editHref!} className="profile-sidebar__action-primary">
+          <Link
+            href={editHref!}
+            className="profile-sidebar__action-primary"
+            data-tour="profile-edit"
+          >
             <Pencil size={14} strokeWidth={1.75} aria-hidden />
             Edit profile
           </Link>

--- a/src/components/settings/sync-social-graph-section.tsx
+++ b/src/components/settings/sync-social-graph-section.tsx
@@ -64,7 +64,7 @@ export default function SyncSocialGraphSection({
   const summary = sync.isLoading ? "Comparing graphs…" : null
 
   return (
-    <div className="social-graph-sync">
+    <div className="social-graph-sync" data-tour="settings-bsky-sync">
       <div className="social-graph-sync__stats">
         <StatTile
           label="Followed on both"

--- a/src/components/tour/product-tour.tsx
+++ b/src/components/tour/product-tour.tsx
@@ -1,0 +1,454 @@
+"use client"
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react"
+import { createPortal } from "react-dom"
+import { usePathname, useRouter } from "next/navigation"
+import { useMounted } from "@/hooks/use-mounted"
+import { useTour } from "@/lib/tour/tour-context"
+import Button from "@/components/ui/button"
+
+// Gap between the spotlight ring and the card, and the minimum distance the
+// card keeps from each viewport edge while clamping.
+const CARD_GAP = 12
+const VIEWPORT_PAD = 8
+// Breathing room painted around the targeted element inside the spotlight.
+const HOLE_PAD = 6
+// When bringing a step's target into view we align its TOP this far below
+// the viewport top (clearing the sticky chrome) rather than centering it —
+// so tall targets like the feed start from the top instead of scrolling
+// past their beginning.
+const SCROLL_TOP_OFFSET = 96
+// Max animation frames to wait for a step's anchor to mount after navigating
+// (~2.5s at 60fps) before giving up and showing a centered card instead.
+const MAX_RESOLVE_FRAMES = 150
+
+interface CardPos {
+  left: number
+  top: number
+}
+
+/** Resolved per-step geometry. `rect === null` means "render a centered
+ *  card over a full dim backdrop" (anchorless step, or anchor never
+ *  appeared). */
+interface TourLayout {
+  /** Which step this layout was measured for — guards against painting a
+   *  stale position for one frame after the step changes. */
+  step: number
+  rect: DOMRect | null
+  card: CardPos | null
+}
+
+/** Card placement next to the target rect, flipping sides when the
+ *  preferred side lacks room and clamping within the viewport. Mirrors the
+ *  FLIP/clamp logic in `computePortalCoords` (popover.tsx). */
+function computeCardPos(
+  target: DOMRect,
+  cardW: number,
+  cardH: number,
+  placement: "top" | "bottom" | "left" | "right",
+  align: "start" | "center" | "end",
+): CardPos {
+  const vw = globalThis.innerWidth
+  const vh = globalThis.innerHeight
+
+  // Side placement: card sits beside the target, flipping if the preferred
+  // side lacks room. Its top aligns to the target's top, clamped to stay on
+  // screen — so it sits next to the visible start of a tall target.
+  if (placement === "left" || placement === "right") {
+    const spaceRight = vw - target.right
+    const spaceLeft = target.left
+    let side = placement
+    if (
+      side === "right" &&
+      spaceRight < cardW + CARD_GAP + VIEWPORT_PAD &&
+      spaceLeft > spaceRight
+    ) {
+      side = "left"
+    } else if (
+      side === "left" &&
+      spaceLeft < cardW + CARD_GAP + VIEWPORT_PAD &&
+      spaceRight > spaceLeft
+    ) {
+      side = "right"
+    }
+    let left =
+      side === "right" ? target.right + CARD_GAP : target.left - CARD_GAP - cardW
+    const maxL = vw - VIEWPORT_PAD - cardW
+    left = Math.min(Math.max(left, VIEWPORT_PAD), Math.max(VIEWPORT_PAD, maxL))
+    const maxT = vh - VIEWPORT_PAD - cardH
+    const top = Math.min(
+      Math.max(target.top, VIEWPORT_PAD),
+      Math.max(VIEWPORT_PAD, maxT),
+    )
+    return { left, top }
+  }
+
+  const spaceBelow = vh - target.bottom
+  const spaceAbove = target.top
+  let side = placement
+  if (
+    side === "bottom" &&
+    spaceBelow < cardH + CARD_GAP + VIEWPORT_PAD &&
+    spaceAbove > spaceBelow
+  ) {
+    side = "top"
+  } else if (
+    side === "top" &&
+    spaceAbove < cardH + CARD_GAP + VIEWPORT_PAD &&
+    spaceBelow > spaceAbove
+  ) {
+    side = "bottom"
+  }
+
+  let top =
+    side === "bottom"
+      ? target.bottom + CARD_GAP
+      : target.top - CARD_GAP - cardH
+  const maxTop = vh - VIEWPORT_PAD - cardH
+  top = Math.min(Math.max(top, VIEWPORT_PAD), Math.max(VIEWPORT_PAD, maxTop))
+
+  let left: number
+  if (align === "start") {
+    left = target.left
+  } else if (align === "end") {
+    left = target.right - cardW
+  } else {
+    left = target.left + target.width / 2 - cardW / 2
+  }
+  const maxLeft = vw - VIEWPORT_PAD - cardW
+  left = Math.min(Math.max(left, VIEWPORT_PAD), Math.max(VIEWPORT_PAD, maxLeft))
+
+  return { left, top }
+}
+
+/** Scroll the page so the target's TOP sits just below the sticky chrome.
+ *  Sticky targets (nav buttons) don't move, so this is a no-op for them; for
+ *  in-flow targets (the feed, settings sections) it scrolls their start into
+ *  view rather than centering — clamped at the document top. */
+function scrollAnchorToTop(el: HTMLElement): void {
+  const rect = el.getBoundingClientRect()
+  const targetTop = globalThis.scrollY + rect.top - SCROLL_TOP_OFFSET
+  globalThis.scrollTo({ top: Math.max(0, targetTop), behavior: "auto" })
+}
+
+/** First *rendered* element carrying the anchor id (width/height > 0, i.e.
+ *  not display:none), so the visible variant wins when the same anchor
+ *  exists in more than one layout (e.g. desktop vs mobile). */
+function findAnchor(anchor: string): { el: HTMLElement; rect: DOMRect } | null {
+  const els = document.querySelectorAll<HTMLElement>(`[data-tour="${anchor}"]`)
+  for (const el of els) {
+    const rect = el.getBoundingClientRect()
+    if (rect.width > 0 && rect.height > 0) return { el, rect }
+  }
+  return null
+}
+
+/**
+ * The product walk-through renderer. Mounted once in the root layout; it
+ * returns null unless the tour is active. Each step navigates to its page,
+ * waits for the target element to mount, scrolls it into view, and renders
+ * a spotlight (four dim panels leaving a hole around the element) plus a
+ * positioned step card. Anchorless steps — and steps whose anchor never
+ * appears — show a centered card over a full dim backdrop.
+ */
+export default function ProductTour() {
+  const { isActive, step, stepIndex, totalSteps, next, back, skip, finish } =
+    useTour()
+  const mounted = useMounted()
+  const router = useRouter()
+  const pathname = usePathname()
+  const cardRef = useRef<HTMLDivElement>(null)
+  const navedForStep = useRef<number | null>(null)
+  const [layout, setLayout] = useState<TourLayout | null>(null)
+  const titleId = useId()
+
+  const isLast = stepIndex === totalSteps - 1
+
+  // Navigation: on entering a step with a `navigateTo`, route there unless
+  // the step's anchor is already on the page (or, for anchorless steps,
+  // we're already on the target path). Guarded by a ref so a redirect or
+  // pathname change mid-step doesn't re-trigger the push.
+  useEffect(() => {
+    if (!isActive || !step || !mounted) return
+    if (!step.navigateTo) return
+    if (step.anchor) {
+      if (findAnchor(step.anchor)) return // already where we need to be
+    } else if (pathname === step.navigateTo) {
+      return
+    }
+    if (navedForStep.current === stepIndex) return
+    navedForStep.current = stepIndex
+    router.push(step.navigateTo)
+  }, [isActive, step, stepIndex, mounted, pathname, router])
+
+  // Resolve + position the spotlight. Polls for the anchor (it mounts
+  // asynchronously after navigation), scrolls it into view on first sight,
+  // then keeps the card glued to it on scroll/resize. Falls back to a
+  // centered card if the anchor never shows.
+  useLayoutEffect(() => {
+    if (!isActive || !step || !mounted) return
+    let rafId = 0
+    let frames = 0
+    let found = false
+    let scrolled = false
+
+    const finalize = (rect: DOMRect) => {
+      // Pinned steps keep the spotlight on the anchor but park the card in a
+      // fixed corner (positioned via CSS), so no per-target coords needed.
+      if (step.pin) {
+        setLayout({ step: stepIndex, rect, card: null })
+        return
+      }
+      const cardRect = cardRef.current?.getBoundingClientRect()
+      const card = cardRect
+        ? computeCardPos(
+            rect,
+            cardRect.width,
+            cardRect.height,
+            step.placement ?? "bottom",
+            step.align ?? "center",
+          )
+        : null
+      setLayout({ step: stepIndex, rect, card })
+    }
+
+    const centered = () => setLayout({ step: stepIndex, rect: null, card: null })
+
+    const tick = () => {
+      if (!step.anchor) {
+        centered()
+        return
+      }
+      const hit = findAnchor(step.anchor)
+      if (hit) {
+        if (!scrolled) {
+          scrolled = true
+          scrollAnchorToTop(hit.el)
+          // Re-measure next frame, after the scroll has applied.
+          rafId = requestAnimationFrame(() => {
+            found = true
+            finalize(hit.el.getBoundingClientRect())
+          })
+          return
+        }
+        found = true
+        finalize(hit.rect)
+        return
+      }
+      // Anchor not present yet (page still mounting after navigation).
+      if (!found && frames++ < MAX_RESOLVE_FRAMES) {
+        rafId = requestAnimationFrame(tick)
+      } else {
+        centered()
+      }
+    }
+
+    tick()
+    const onReflow = () => {
+      if (found) tick()
+    }
+    globalThis.addEventListener("scroll", onReflow, {
+      passive: true,
+      capture: true,
+    })
+    globalThis.addEventListener("resize", onReflow, { passive: true })
+    return () => {
+      cancelAnimationFrame(rafId)
+      globalThis.removeEventListener("scroll", onReflow, {
+        capture: true,
+      } as EventListenerOptions)
+      globalThis.removeEventListener("resize", onReflow)
+    }
+  }, [isActive, step, stepIndex, mounted])
+
+  // Move focus into the card on each step so keyboard users land on the
+  // controls. preventScroll so the freshly-positioned card doesn't yank the
+  // page around.
+  useEffect(() => {
+    if (!isActive) return
+    cardRef.current?.focus({ preventScroll: true })
+  }, [isActive, stepIndex])
+
+  // Esc dismisses the tour (same as Skip).
+  useEffect(() => {
+    if (!isActive) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault()
+        skip()
+      }
+    }
+    document.addEventListener("keydown", onKey)
+    return () => document.removeEventListener("keydown", onKey)
+  }, [isActive, skip])
+
+  // Finishing the tour returns the user to their feed.
+  const handleFinish = useCallback(() => {
+    finish()
+    router.push("/home")
+  }, [finish, router])
+
+  // Lightweight focus trap: keep Tab cycling within the card's controls.
+  const handleCardKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key !== "Tab") return
+    const card = cardRef.current
+    if (!card) return
+    const focusable = card.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
+    )
+    if (focusable.length === 0) return
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    const activeEl = document.activeElement
+    if (e.shiftKey && (activeEl === first || activeEl === card)) {
+      e.preventDefault()
+      last.focus()
+    } else if (!e.shiftKey && activeEl === last) {
+      e.preventDefault()
+      first.focus()
+    }
+  }, [])
+
+  if (!isActive || !step || !mounted) return null
+
+  const measured = layout?.step === stepIndex
+  const anchored = measured && layout?.rect != null
+  const pinned = anchored && step.pin != null
+  const rect = anchored ? layout!.rect! : null
+  const cardPos = anchored && !pinned ? layout!.card : null
+  const cardReady = measured && (pinned || !anchored || cardPos != null)
+
+  // Spotlight hole (padded target rect) and its four surrounding dim panels.
+  const hole = rect
+    ? {
+        top: rect.top - HOLE_PAD,
+        left: rect.left - HOLE_PAD,
+        width: rect.width + HOLE_PAD * 2,
+        height: rect.height + HOLE_PAD * 2,
+      }
+    : null
+
+  const cardStyle: React.CSSProperties = cardReady
+    ? !pinned && anchored && cardPos
+      ? { position: "fixed", left: cardPos.left, top: cardPos.top }
+      : {}
+    : { position: "fixed", left: 0, top: 0, visibility: "hidden" }
+
+  // Card placement class: a fixed corner (pinned), centered (anchorless /
+  // unresolved), or coords-positioned (anchored, handled via cardStyle).
+  const cardPlacementClass = pinned
+    ? ` product-tour__card--pin-${step.pin}`
+    : anchored
+      ? ""
+      : " product-tour__card--centered"
+
+  return createPortal(
+    <div className="product-tour" role="presentation">
+      {hole ? (
+        <>
+          <div
+            className="product-tour__panel"
+            style={{ top: 0, left: 0, right: 0, height: Math.max(0, hole.top) }}
+          />
+          <div
+            className="product-tour__panel"
+            style={{ top: hole.top + hole.height, left: 0, right: 0, bottom: 0 }}
+          />
+          <div
+            className="product-tour__panel"
+            style={{
+              top: hole.top,
+              left: 0,
+              width: Math.max(0, hole.left),
+              height: hole.height,
+            }}
+          />
+          <div
+            className="product-tour__panel"
+            style={{
+              top: hole.top,
+              left: hole.left + hole.width,
+              right: 0,
+              height: hole.height,
+            }}
+          />
+          <div
+            className="product-tour__ring"
+            style={{
+              top: hole.top,
+              left: hole.left,
+              width: hole.width,
+              height: hole.height,
+            }}
+          />
+        </>
+      ) : (
+        <div className="product-tour__panel product-tour__panel--full" />
+      )}
+
+      <div
+        ref={cardRef}
+        className={`product-tour__card${cardPlacementClass}`}
+        style={cardStyle}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        onKeyDown={handleCardKeyDown}
+      >
+        <h2 id={titleId} className="product-tour__title font-headline text-h3">
+          {step.title}
+        </h2>
+        {step.body.split("\n\n").map((para, i) => (
+          <p key={i} className="product-tour__body">
+            {para}
+          </p>
+        ))}
+
+        <div className="product-tour__footer">
+          <ol
+            className="product-tour__dots"
+            aria-label={`Step ${stepIndex + 1} of ${totalSteps}`}
+          >
+            {Array.from({ length: totalSteps }, (_, i) => (
+              <li
+                key={i}
+                className={`product-tour__dot${i === stepIndex ? " product-tour__dot--active" : ""}`}
+                aria-current={i === stepIndex ? "step" : undefined}
+              />
+            ))}
+          </ol>
+          <div className="product-tour__actions">
+            {stepIndex > 0 ? (
+              <Button variant="ghost" size="sm" onClick={back}>
+                Back
+              </Button>
+            ) : null}
+            <div className="product-tour__actions-right">
+              {!isLast ? (
+                <Button variant="ghost" size="sm" onClick={skip}>
+                  Skip
+                </Button>
+              ) : null}
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={isLast ? handleFinish : next}
+              >
+                {isLast ? "Finish" : "Next"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/lib/onboarding/onboarding-context.tsx
+++ b/src/lib/onboarding/onboarding-context.tsx
@@ -16,6 +16,7 @@ import {
   markOnboardingDismissed,
   clearOnboardingDismissed,
 } from "./dismissed-sentinel"
+import { markTourPending } from "@/lib/tour/tour-sentinel"
 
 /**
  * Bluesky seed values surfaced by /api/resolve-did. The shape
@@ -168,6 +169,11 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
     // when commit.status === "success". The user closes it via the
     // explicit "Take me to my profile" button on that screen.
     if (did) clearOnboardingDismissed(did)
+    // Queue the product walk-through to auto-start on the next load. The
+    // success screen does a full page reload to the profile page, so the
+    // "just onboarded" intent has to survive in localStorage rather than
+    // in memory; TourProvider reads + clears this flag after the reload.
+    if (did) markTourPending(did)
     // Optimistically reflect the finished state so the banner
     // disappears immediately; the next resolve-did fetch will
     // confirm.

--- a/src/lib/tour/tour-context.tsx
+++ b/src/lib/tour/tour-context.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+import { useAuth } from "@/lib/auth/auth-context"
+import { useOrg } from "@/lib/groups/org-context"
+import { useLayoutBreakpoints } from "@/hooks/use-layout-breakpoints"
+import { TOUR_STEPS, type TourStep } from "./tour-steps"
+import {
+  isTourCompleted,
+  markTourCompleted,
+  isTourPending,
+  clearTourPending,
+} from "./tour-sentinel"
+
+export interface TourContextValue {
+  /** True while the walk-through is running. */
+  readonly isActive: boolean
+  /** Index into TOUR_STEPS of the current step (0-based). */
+  readonly stepIndex: number
+  /** The current step, or null when inactive. */
+  readonly step: TourStep | null
+  readonly totalSteps: number
+  /** Manual start (e.g. the /help button). Ignores the completed/pending
+   *  flags — always runs from the first step. */
+  start: () => void
+  /** Advance to the next step, finishing on the last one. */
+  next: () => void
+  /** Go back a step (no-op on the first). */
+  back: () => void
+  /** Dismiss early. Marks the tour completed so it won't auto-trigger. */
+  skip: () => void
+  /** Finish from the last step. Marks the tour completed. */
+  finish: () => void
+}
+
+const TourContext = createContext<TourContextValue | undefined>(undefined)
+
+export function TourProvider({ children }: { children: ReactNode }) {
+  const { isAuthenticated, did } = useAuth()
+  const { activeOrg } = useOrg()
+  const { isDesktop } = useLayoutBreakpoints()
+
+  // Steps that apply to the current layout. Desktop navigates from the
+  // top-bar buttons; mobile from the hamburger sidebar — so each platform
+  // gets its own nav steps (see `platform` in tour-steps).
+  const steps = useMemo(
+    () =>
+      TOUR_STEPS.filter(
+        (s) =>
+          !s.platform || (s.platform === "desktop" ? isDesktop : !isDesktop),
+      ),
+    [isDesktop],
+  )
+
+  const [isActive, setIsActive] = useState(false)
+  const [stepIndex, setStepIndex] = useState(0)
+  // Track which DID we've already made an auto-start decision for this
+  // session, so account switches get a fresh decision but a single DID
+  // never auto-starts twice.
+  const [autoCheckedDid, setAutoCheckedDid] = useState<string | null>(null)
+
+  // Reset everything when the signed-in identity goes away.
+  useEffect(() => {
+    if (!isAuthenticated || !did) {
+      setIsActive(false)
+      setStepIndex(0)
+      setAutoCheckedDid(null)
+    }
+  }, [isAuthenticated, did])
+
+  // Auto-start decision: once per DID per session, only in a personal
+  // (non-org) context, only when onboarding flagged the tour pending and
+  // it hasn't already been completed. Clears the pending flag immediately
+  // so a later reload doesn't re-trigger.
+  useEffect(() => {
+    if (!isAuthenticated || !did) return
+    if (activeOrg) return
+    if (autoCheckedDid === did) return
+    setAutoCheckedDid(did)
+    if (isTourPending(did) && !isTourCompleted(did)) {
+      clearTourPending(did)
+      setStepIndex(0)
+      setIsActive(true)
+    }
+  }, [isAuthenticated, did, activeOrg, autoCheckedDid])
+
+  const start = useCallback(() => {
+    setStepIndex(0)
+    setIsActive(true)
+  }, [])
+
+  const endCompleted = useCallback(() => {
+    setIsActive(false)
+    setStepIndex(0)
+    if (did) markTourCompleted(did)
+  }, [did])
+
+  // Pure-advance, clamped at the last step. Finishing from the last step
+  // is handled by the renderer calling `finish` directly (its primary
+  // button switches to "Finish" there), so `next` never runs past the end.
+  const next = useCallback(() => {
+    setStepIndex((i) => Math.min(steps.length - 1, i + 1))
+  }, [steps.length])
+
+  const back = useCallback(() => {
+    setStepIndex((i) => Math.max(0, i - 1))
+  }, [])
+
+  const value = useMemo<TourContextValue>(() => {
+    const step =
+      isActive && stepIndex >= 0 && stepIndex < steps.length
+        ? steps[stepIndex]
+        : null
+    return {
+      isActive,
+      stepIndex,
+      step,
+      totalSteps: steps.length,
+      start,
+      next,
+      back,
+      skip: endCompleted,
+      finish: endCompleted,
+    }
+  }, [isActive, stepIndex, steps, start, next, back, endCompleted])
+
+  return <TourContext.Provider value={value}>{children}</TourContext.Provider>
+}
+
+export function useTour(): TourContextValue {
+  const ctx = useContext(TourContext)
+  if (!ctx) {
+    throw new Error("useTour must be used within a TourProvider")
+  }
+  return ctx
+}

--- a/src/lib/tour/tour-sentinel.ts
+++ b/src/lib/tour/tour-sentinel.ts
@@ -1,0 +1,84 @@
+/**
+ * Tracks the product walk-through state per DID. Two independent flags,
+ * both keyed by DID so account switches don't bleed tour state across
+ * identities, both stored in localStorage (not in any PDS record):
+ *
+ *  - "completed": the user has finished or skipped the walk-through. The
+ *    auto-trigger is suppressed once this is set. Cleared only by an
+ *    explicit restart from /help would NOT clear it — restart just runs
+ *    the tour again without touching the flag.
+ *  - "pending": the user just finished profile onboarding and the tour
+ *    should auto-start on the next load. Onboarding success does a full
+ *    page reload, so the in-memory "just finished" signal is lost — this
+ *    flag carries the intent across that reload. The provider clears it
+ *    as soon as it auto-starts.
+ *
+ * Mirrors the guard + try/catch shape of the onboarding dismissed
+ * sentinel (private-mode / quota safe; SSR no-ops).
+ */
+
+const COMPLETED_PREFIX = "certified:tour-completed:"
+const PENDING_PREFIX = "certified:tour-pending:"
+
+function completedKey(did: string): string {
+  return `${COMPLETED_PREFIX}${did}`
+}
+
+function pendingKey(did: string): string {
+  return `${PENDING_PREFIX}${did}`
+}
+
+export function isTourCompleted(did: string): boolean {
+  if (typeof window === "undefined") return false
+  try {
+    return window.localStorage.getItem(completedKey(did)) === "1"
+  } catch {
+    return false
+  }
+}
+
+export function markTourCompleted(did: string): void {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.setItem(completedKey(did), "1")
+  } catch {
+    // private-mode / quota — best effort; the tour reappearing once more
+    // is a safer fallback than crashing.
+  }
+}
+
+export function clearTourCompleted(did: string): void {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.removeItem(completedKey(did))
+  } catch {
+    /* swallow */
+  }
+}
+
+export function isTourPending(did: string): boolean {
+  if (typeof window === "undefined") return false
+  try {
+    return window.localStorage.getItem(pendingKey(did)) === "1"
+  } catch {
+    return false
+  }
+}
+
+export function markTourPending(did: string): void {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.setItem(pendingKey(did), "1")
+  } catch {
+    /* swallow */
+  }
+}
+
+export function clearTourPending(did: string): void {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.removeItem(pendingKey(did))
+  } catch {
+    /* swallow */
+  }
+}

--- a/src/lib/tour/tour-steps.ts
+++ b/src/lib/tour/tour-steps.ts
@@ -1,0 +1,235 @@
+/**
+ * The product walk-through script — a single source of truth for both
+ * the auto-triggered (post-onboarding) and manually-restarted (/help)
+ * runs.
+ *
+ * Unlike a static spotlight, this tour *navigates*: each step can carry a
+ * `navigateTo` route. When a step activates, the renderer routes there (if
+ * the step's anchor isn't already on the page), waits for the target
+ * element to mount, scrolls it into view, and spotlights it. Steps with
+ * `anchor: null` show a centered card; steps whose anchor never appears
+ * degrade gracefully to a centered card too.
+ *
+ * The tour is structured around the main navigation: for each destination
+ * it first spotlights the nav button you'd click (the `nav-*` anchors live
+ * on both the desktop top bar and the mobile bottom nav — the renderer
+ * picks whichever is visible), routes to that page, then dives into what
+ * you can do there. The order mirrors the nav itself: Home, Explore, Apps,
+ * Create, Profile, Settings, Help.
+ *
+ * Anchors are matched against `data-tour="<anchor>"` attributes placed on
+ * page content. The same anchor id may appear on more than one element
+ * (e.g. a nav button in both the desktop top bar and the mobile bottom
+ * nav) — the renderer picks the first *rendered* one, so the visible
+ * variant wins per layout.
+ *
+ * Copy mirrors the concept sections on /help; keep them in sync.
+ */
+
+export interface TourStep {
+  /** Stable id (React key). */
+  readonly id: string
+  /** Route to visit when this step activates, or null to stay put. */
+  readonly navigateTo: string | null
+  /** `data-tour` value to spotlight, or null for a centered card. */
+  readonly anchor: string | null
+  readonly title: string
+  readonly body: string
+  /** Preferred side the card opens toward when anchored. Default "bottom".
+   *  "left"/"right" place the card beside the target (flipping if there's
+   *  no room); "top"/"bottom" place it above/below. */
+  readonly placement?: "top" | "bottom" | "left" | "right"
+  /** Horizontal alignment of the card relative to the target. "center"
+   *  (default) centers on it; "start"/"end" align the card's left/right
+   *  edge to the target's — use "end" to keep the card off a left-aligned
+   *  heading inside a wide target (e.g. the feed's "For you" title). */
+  readonly align?: "start" | "center" | "end"
+  /** Pin the card to a fixed viewport corner instead of positioning it
+   *  next to the target. The spotlight still highlights the anchor; only
+   *  the card is detached. Overrides `placement`/`align`. */
+  readonly pin?: "top-left" | "top-right" | "bottom-left" | "bottom-right"
+  /** Restrict this step to one layout. Desktop navigates from the top-bar
+   *  buttons; mobile navigates from the hamburger sidebar — so the
+   *  per-destination nav spotlights are desktop-only, replaced on mobile by
+   *  a single "use the sidebar" step. Undefined = shown on both. */
+  readonly platform?: "desktop" | "mobile"
+}
+
+export const TOUR_STEPS: readonly TourStep[] = [
+  {
+    id: "welcome",
+    navigateTo: "/home",
+    anchor: null,
+    title: "Welcome to Certified",
+    body: "The Certified network is where you record and recognize real work and impact.\n\nThis app is just one view into the open network — other apps share the same data, so your work is never locked in. Let's take a quick look around.",
+  },
+
+  // ---- Mobile navigation (sidebar) -----------------------------------
+  {
+    id: "nav-menu",
+    navigateTo: "/home",
+    anchor: "nav-menu",
+    title: "Getting around",
+    body: "On mobile you navigate from the menu. Tap it to open the sidebar — Home, Explore, Apps, your Profile, Settings, and Help all live in there.",
+    placement: "bottom",
+    align: "start",
+    platform: "mobile",
+  },
+
+  // ---- Home ----------------------------------------------------------
+  {
+    id: "nav-home",
+    navigateTo: "/home",
+    anchor: "nav-home",
+    title: "Home",
+    body: "Home always brings you back to your feed. It's your starting point in the app.",
+    placement: "bottom",
+    platform: "desktop",
+  },
+  {
+    id: "home-feed",
+    navigateTo: "/home",
+    anchor: "home-feed",
+    title: "Your feed",
+    body: "Your feed shows recent activities, projects, and endorsements from the accounts and groups you follow. The more you follow, the richer it gets.",
+    placement: "right",
+  },
+
+  // ---- Explore -------------------------------------------------------
+  {
+    id: "nav-explore",
+    navigateTo: "/explore",
+    anchor: "nav-explore",
+    title: "Explore",
+    body: "Explore takes you beyond who you already follow — to discover work from across the whole network.",
+    placement: "bottom",
+    platform: "desktop",
+  },
+  {
+    id: "explore-search",
+    navigateTo: "/explore",
+    anchor: "explore-search",
+    title: "Search the network",
+    body: "Search across activities, projects, and accounts from every app on the network, no matter which one created them.",
+    placement: "bottom",
+  },
+
+  // ---- Apps ----------------------------------------------------------
+  {
+    id: "nav-apps",
+    navigateTo: "/apps",
+    anchor: "nav-apps",
+    title: "Apps",
+    body: "Apps is the growing set of apps built on the same open network as Certified.",
+    placement: "bottom",
+    platform: "desktop",
+  },
+  {
+    id: "apps-grid",
+    navigateTo: "/apps",
+    anchor: "apps-grid",
+    title: "One record, every app",
+    body: "Each app reads and writes the same underlying records, so the work you publish here shows up across all of them — your data isn't locked into any single one.",
+    placement: "bottom",
+  },
+
+  // ---- Create --------------------------------------------------------
+  {
+    id: "nav-create",
+    navigateTo: "/create",
+    anchor: "nav-create",
+    title: "Create",
+    body: "The + button is where you publish your own work — new activities and projects.",
+    placement: "bottom",
+    platform: "desktop",
+  },
+  {
+    id: "create-title",
+    navigateTo: "/create",
+    anchor: "create-title",
+    title: "Give it a title",
+    body: "Publishing starts here. Give your activity a clear title — a verifiable claim about the work or impact you want to record.",
+    placement: "bottom",
+  },
+  {
+    id: "create-submit",
+    navigateTo: "/create",
+    anchor: "create-submit",
+    title: "Publish when you're ready",
+    body: "Fill in the details, then publish. Your activity becomes part of your portable record — visible across every compatible app.",
+    placement: "top",
+  },
+
+  // ---- Profile -------------------------------------------------------
+  {
+    id: "nav-profile",
+    navigateTo: "/profile",
+    anchor: "nav-profile",
+    title: "Profile",
+    body: "Profile is your public page — your work, endorsements, and followers, all in one place.",
+    placement: "bottom",
+    platform: "desktop",
+  },
+  {
+    id: "profile-tabs",
+    navigateTo: "/profile",
+    anchor: "profile-tabs",
+    title: "Everything in one place",
+    body: "Switch between your activities, projects, endorsements, followers, and lists from these sections.",
+    placement: "bottom",
+  },
+  {
+    id: "profile-edit",
+    navigateTo: "/profile",
+    anchor: "profile-edit",
+    title: "Make it yours",
+    body: "Use Edit to set your display name, bio, avatar, and links.",
+    placement: "bottom",
+  },
+
+  // ---- Settings ------------------------------------------------------
+  {
+    id: "nav-settings",
+    navigateTo: "/settings",
+    anchor: "nav-settings",
+    title: "Settings",
+    body: "Settings is where you manage your identity and account.",
+    placement: "bottom",
+    platform: "desktop",
+  },
+  {
+    id: "settings-handle",
+    navigateTo: "/settings",
+    anchor: "settings-handle",
+    title: "Your handle and identity",
+    body: "This is your handle — your username on the network. Behind it sits a permanent DID that owns your data, so your work stays yours even if you rename your handle.",
+    placement: "bottom",
+  },
+  {
+    id: "settings-sync",
+    navigateTo: "/settings",
+    anchor: "settings-bsky-sync",
+    title: "Bring your Bluesky follows",
+    body: "Certified has its own follow graph, kept separate from Bluesky. Sync here any time so you don't have to rebuild your network from scratch.",
+    placement: "top",
+  },
+
+  // ---- Help ----------------------------------------------------------
+  {
+    id: "nav-help",
+    navigateTo: "/help",
+    anchor: "nav-help",
+    title: "Help",
+    body: "Help has guides for everything we just covered — and you can replay this walk-through any time from here.",
+    placement: "bottom",
+    platform: "desktop",
+  },
+
+  {
+    id: "all-set",
+    navigateTo: null,
+    anchor: null,
+    title: "You're all set",
+    body: "That's the tour. You can replay it any time from the Help page. Welcome to Certified!",
+  },
+] as const


### PR DESCRIPTION
## Summary

Two pieces of work on top of the merged mobile-ui-polish line.

### Product tour (new feature)
An integrated, navigation-driven walk-through that orients new users. For each destination it spotlights the nav button you'd click (Home, Explore, Apps, Create, Profile, Settings, Help), routes to that page, then explains what you can do there. Auto-runs once after onboarding and replays from /help; mobile starts from a single "use the sidebar" step.

- `src/lib/tour/*` — step script + context/state
- `src/components/tour/product-tour.tsx` — portal spotlight renderer (navigates per step, degrades to a centered card when an anchor is absent)
- `data-tour` anchors on the desktop top bar + mobile bottom nav (`nav-*`), the apps grid, and existing page content
- `/help` "Start the walk-through" trigger; `--z-tour-*` tokens; `tour.css`

### Desktop UI polish
- `/home` feed capped at 600px centered in its column; "News from Certified" rail hides below 1300px so it never squishes the feed
- Profile toolbars: search / sort / endorse-add / "New X" controls unified to a single 30px height across Activities, Projects, Groups, Endorsements, Followers
- Projects tab reserves the Activities sub-tab-strip height so the controls don't jump when switching tabs

## Checks
- `tsc --noEmit` clean
- design guards (radii / breakpoints) clean
- eslint: 0 errors, 64 warnings (baseline 60; +4 are the existing "setState in effect" category from the new tour code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)