### PR TITLE
feat(explore): funding receipts + server-side label filtering + list typography

### DIFF
--- a/src/app/api/indexer/route.ts
+++ b/src/app/api/indexer/route.ts
@@ -3,6 +3,10 @@ import { checkCsrf } from "@/lib/auth/csrf"
 import { enforceRateLimit, makeLimiter } from "@/lib/auth/rate-limit"
 import { clientIp } from "@/lib/utils/ip"
 import { logSafe } from "@/lib/utils/log-safe"
+import {
+  DEFAULT_HIDDEN_CERT_LABELS,
+  DEFAULT_HIDDEN_ORG_LABELS,
+} from "@/lib/atproto/labels"
 
 /**
  * Same-origin proxy in front of the Magic Indexer's public GraphQL
@@ -140,6 +144,8 @@ const OPERATIONS: Record<string, string> = {
       $labels: [String!]
       $excludeLabels: [String!]
       $authors: [String!]
+      $authorLabels: [String!]
+      $excludeAuthorLabels: [String!]
       $search: String
     ) {
       orgHypercertsClaimActivity(
@@ -148,6 +154,8 @@ const OPERATIONS: Record<string, string> = {
         labels: $labels
         excludeLabels: $excludeLabels
         authors: $authors
+        authorLabels: $authorLabels
+        excludeAuthorLabels: $excludeAuthorLabels
         search: $search
       ) {
 ${ACTIVITY_NODE_SELECTION}
@@ -166,12 +174,16 @@ ${ACTIVITY_NODE_SELECTION}
       $uris: [String!]!
       $labels: [String!]
       $excludeLabels: [String!]
+      $authorLabels: [String!]
+      $excludeAuthorLabels: [String!]
     ) {
       orgHypercertsClaimActivity(
         first: 100
         where: { uri: { in: $uris } }
         labels: $labels
         excludeLabels: $excludeLabels
+        authorLabels: $authorLabels
+        excludeAuthorLabels: $excludeAuthorLabels
       ) {
 ${ACTIVITY_NODE_SELECTION}
       }
@@ -334,8 +346,20 @@ ${ACTIVITY_NODE_SELECTION}
   // most-recently-indexed profiles so the actor switcher has
   // something to show even before the user has interacted.
   NetworkActors: `
-    query NetworkActors($first: Int!, $after: String, $search: String) {
-      appCertifiedActorProfile(first: $first, after: $after, search: $search) {
+    query NetworkActors(
+      $first: Int!
+      $after: String
+      $search: String
+      $authorLabels: [String!]
+      $excludeAuthorLabels: [String!]
+    ) {
+      appCertifiedActorProfile(
+        first: $first
+        after: $after
+        search: $search
+        authorLabels: $authorLabels
+        excludeAuthorLabels: $excludeAuthorLabels
+      ) {
         totalCount
         edges {
           cursor
@@ -379,11 +403,15 @@ ${ACTIVITY_NODE_SELECTION}
       $after: String
       $isOrganization: Boolean!
       $search: String
+      $authorLabels: [String!]
+      $excludeAuthorLabels: [String!]
     ) {
       appCertifiedActorProfile(
         first: $first
         after: $after
         search: $search
+        authorLabels: $authorLabels
+        excludeAuthorLabels: $excludeAuthorLabels
         where: { isOrganization: { eq: $isOrganization } }
       ) {
         totalCount
@@ -569,38 +597,15 @@ ${ACTIVITY_NODE_SELECTION}
   // shape every other op uses (`totalCount + edges + pageInfo`)
   // because some GraphQL schemas reject a bare-aggregate selection
   // on a connection root.
+  // "Users" = personal + org actors. Excludes accounts labelled "likely-test"
+  // via `excludeAuthorLabels` (account-quality labels live on the bare account
+  // DID, so the profile connection's own-record-URI `excludeLabels` would NOT
+  // match — see magic-indexer#206/#207). Unlabeled accounts still count.
   ProfileCount: `
     query ProfileCount {
-      appCertifiedActorProfile(first: 1) {
-        totalCount
-        edges { node { uri } }
-        pageInfo { hasNextPage }
-      }
-    }
-  `,
-  OrganizationCount: `
-    query OrganizationCount {
-      appCertifiedActorOrganization(first: 1) {
-        totalCount
-        edges { node { uri } }
-        pageInfo { hasNextPage }
-      }
-    }
-  `,
-  ActivityCount: `
-    query ActivityCount {
-      orgHypercertsClaimActivity(first: 1) {
-        totalCount
-        edges { node { uri } }
-        pageInfo { hasNextPage }
-      }
-    }
-  `,
-  ProjectCount: `
-    query ProjectCount {
-      orgHypercertsCollection(
+      appCertifiedActorProfile(
         first: 1
-        where: { type: { eqi: "project" } }
+        excludeAuthorLabels: ${JSON.stringify([...DEFAULT_HIDDEN_ORG_LABELS])}
       ) {
         totalCount
         edges { node { uri } }
@@ -608,9 +613,62 @@ ${ACTIVITY_NODE_SELECTION}
       }
     }
   `,
+  // Excludes orgs labelled "likely-test" so the public counter matches the
+  // explore/feed default policy (DEFAULT_HIDDEN_ORG_LABELS). Unlabeled orgs
+  // still count — labelers only weigh in once they've caught up.
+  OrganizationCount: `
+    query OrganizationCount {
+      appCertifiedActorOrganization(
+        first: 1
+        excludeLabels: ${JSON.stringify([...DEFAULT_HIDDEN_ORG_LABELS])}
+      ) {
+        totalCount
+        edges { node { uri } }
+        pageInfo { hasNextPage }
+      }
+    }
+  `,
+  // Excludes activities by both the record's own label (draft / likely-test,
+  // Activity-Labeler tier — DEFAULT_HIDDEN_CERT_LABELS) AND the author's
+  // account label (records authored by likely-test accounts, via
+  // excludeAuthorLabels — magic-indexer#207). Unlabeled records / authors
+  // still count.
+  ActivityCount: `
+    query ActivityCount {
+      orgHypercertsClaimActivity(
+        first: 1
+        excludeLabels: ${JSON.stringify([...DEFAULT_HIDDEN_CERT_LABELS])}
+        excludeAuthorLabels: ${JSON.stringify([...DEFAULT_HIDDEN_ORG_LABELS])}
+      ) {
+        totalCount
+        edges { node { uri } }
+        pageInfo { hasNextPage }
+      }
+    }
+  `,
+  // Excludes projects authored by likely-test accounts (projects carry no
+  // own quality label, so only the author-account filter applies).
+  ProjectCount: `
+    query ProjectCount {
+      orgHypercertsCollection(
+        first: 1
+        where: { type: { eqi: "project" } }
+        excludeAuthorLabels: ${JSON.stringify([...DEFAULT_HIDDEN_ORG_LABELS])}
+      ) {
+        totalCount
+        edges { node { uri } }
+        pageInfo { hasNextPage }
+      }
+    }
+  `,
+  // Excludes endorsements created by likely-test accounts (the award's author
+  // is its issuer).
   AwardCount: `
     query AwardCount {
-      appCertifiedBadgeAward(first: 1) {
+      appCertifiedBadgeAward(
+        first: 1
+        excludeAuthorLabels: ${JSON.stringify([...DEFAULT_HIDDEN_ORG_LABELS])}
+      ) {
         totalCount
         edges { node { uri } }
         pageInfo { hasNextPage }
@@ -627,6 +685,8 @@ ${ACTIVITY_NODE_SELECTION}
       $first: Int!
       $after: String
       $authors: [String!]
+      $authorLabels: [String!]
+      $excludeAuthorLabels: [String!]
       $search: String
     ) {
       orgHypercertsCollection(
@@ -634,6 +694,8 @@ ${ACTIVITY_NODE_SELECTION}
         after: $after
         where: { type: { eqi: "project" } }
         authors: $authors
+        authorLabels: $authorLabels
+        excludeAuthorLabels: $excludeAuthorLabels
         search: $search
       ) {
         totalCount
@@ -745,6 +807,93 @@ ${ACTIVITY_NODE_SELECTION}
               ... on OrgHypercertsDefsUri { uri }
               ... on OrgHypercertsDefsLargeImage { image { ref mimeType } }
             }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  `,
+
+  // Funding receipts (org.hypercerts.funding.receipt) for the /explore
+  // Funding tab. Both `from` and `to` are unions that are either an AT
+  // Protocol account (AppCertifiedDefsDid) or a free-text label
+  // (OrgHypercertsFundingReceiptText); `from` is nullable, `to` is not.
+  // `for` is an optional strongRef pointing at an
+  // org.hypercerts.claim.activity. The indexer can't filter by union
+  // variant, so the explore loader applies the "from OR to is an
+  // account" gate client-side after fetching.
+  FundingReceipts: `
+    query FundingReceipts($first: Int!, $after: String) {
+      orgHypercertsFundingReceipt(first: $first, after: $after) {
+        totalCount
+        edges {
+          cursor
+          node {
+            uri
+            cid
+            did
+            createdAt
+            occurredAt
+            amount
+            currency
+            from {
+              __typename
+              ... on AppCertifiedDefsDid { did }
+              ... on OrgHypercertsFundingReceiptText { value }
+            }
+            to {
+              __typename
+              ... on AppCertifiedDefsDid { did }
+              ... on OrgHypercertsFundingReceiptText { value }
+            }
+            for { uri cid }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  `,
+
+  // Funding receipts for a single activity — backs the activity detail
+  // page's Funding tab + overview preview. Same node shape as
+  // FundingReceipts above, but filtered to receipts whose `for` strongRef
+  // points at the given activity URI (`where: { for: { eq: $forUri } }`).
+  // Both `from` and `to` are unions (AppCertifiedDefsDid account /
+  // OrgHypercertsFundingReceiptText free-text); on this surface text
+  // parties are surfaced (wallet addresses) rather than blanked.
+  FundingReceiptsForActivity: `
+    query FundingReceiptsForActivity(
+      $forUri: String!
+      $first: Int!
+      $after: String
+    ) {
+      orgHypercertsFundingReceipt(
+        first: $first
+        after: $after
+        where: { for: { eq: $forUri } }
+      ) {
+        totalCount
+        edges {
+          cursor
+          node {
+            uri
+            cid
+            did
+            createdAt
+            occurredAt
+            amount
+            currency
+            from {
+              __typename
+              ... on AppCertifiedDefsDid { did }
+              ... on OrgHypercertsFundingReceiptText { value }
+            }
+            to {
+              __typename
+              ... on AppCertifiedDefsDid { did }
+              ... on OrgHypercertsFundingReceiptText { value }
+            }
+            for { uri cid }
           }
         }
         pageInfo { hasNextPage endCursor }
@@ -1189,6 +1338,8 @@ function buildVariables(
         labels: readLabelList(vars.labels),
         excludeLabels: readLabelList(vars.excludeLabels),
         authors: authors === undefined ? null : authors,
+        authorLabels: readLabelList(vars.authorLabels),
+        excludeAuthorLabels: readLabelList(vars.excludeAuthorLabels),
         search: readString(vars.search, MAX_SEARCH_LEN),
       }
     }
@@ -1199,6 +1350,8 @@ function buildVariables(
         uris,
         labels: readLabelList(vars.labels),
         excludeLabels: readLabelList(vars.excludeLabels),
+        authorLabels: readLabelList(vars.authorLabels),
+        excludeAuthorLabels: readLabelList(vars.excludeAuthorLabels),
       }
     }
     case "AuthoredActivities":
@@ -1270,6 +1423,8 @@ function buildVariables(
         first: clampFirst(vars.first, MAX_FIRST, 24),
         after: readString(vars.after, MAX_AFTER_LEN),
         authors: authors === undefined ? null : authors,
+        authorLabels: readLabelList(vars.authorLabels),
+        excludeAuthorLabels: readLabelList(vars.excludeAuthorLabels),
         search: readString(vars.search, MAX_SEARCH_LEN),
       }
     }
@@ -1278,6 +1433,8 @@ function buildVariables(
         first: clampFirst(vars.first, MAX_FIRST, 20),
         after: readString(vars.after, MAX_AFTER_LEN),
         search: readString(vars.search, MAX_SEARCH_LEN),
+        authorLabels: readLabelList(vars.authorLabels),
+        excludeAuthorLabels: readLabelList(vars.excludeAuthorLabels),
       }
     }
     case "OrganizationDids": {
@@ -1296,6 +1453,8 @@ function buildVariables(
         after: readString(vars.after, MAX_AFTER_LEN),
         isOrganization: vars.isOrganization,
         search: readString(vars.search, MAX_SEARCH_LEN),
+        authorLabels: readLabelList(vars.authorLabels),
+        excludeAuthorLabels: readLabelList(vars.excludeAuthorLabels),
       }
     }
     case "OrganizationDidsByLabel": {
@@ -1337,6 +1496,25 @@ function buildVariables(
       const did = readDid(vars.did)
       if (!did) return null
       return { did }
+    }
+    case "FundingReceipts": {
+      // Simple paginated read — no required vars. Clamp `first` like the
+      // other paginated ops; `after` is the opaque cursor.
+      return {
+        first: clampFirst(vars.first, MAX_FIRST, 50),
+        after: readString(vars.after, MAX_AFTER_LEN),
+      }
+    }
+    case "FundingReceiptsForActivity": {
+      // Required `forUri` — a single at:// activity URI to filter by.
+      // Mirrors the URI validation the ProjectsContainingCert op uses.
+      const forUri = readString(vars.forUri, MAX_URI_LEN)
+      if (!forUri || !forUri.startsWith("at://")) return null
+      return {
+        forUri,
+        first: clampFirst(vars.first, MAX_FIRST, 50),
+        after: readString(vars.after, MAX_AFTER_LEN),
+      }
     }
     case "EndorsementClosure": {
       // Viewer-centric BFS closure (magic-indexer #117). `viewer`

--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -1130,7 +1130,9 @@
 }
 
 .cert-detail__section-title {
-  font-size: 0.8125rem;
+  /* Match the .cert-detail__meta-label headings (Summary / Author / …) so
+     every section label on the activity page reads at the same scale. */
+  font-size: 0.6875rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -1146,6 +1148,28 @@
   border-radius: 999px;
   background: var(--overlay-weak);
   font-feature-settings: 'tnum' 1;
+}
+
+/* ---------- Funding receipts list ----------
+
+   Reuses the `.funding-receipt-row` component styles (defined in
+   explore.css). The explore page draws inter-row separators via its
+   own `.explore__list > li + li` selector, so this list supplies its
+   own equivalent. */
+.cert-detail__funding-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cert-detail__funding-list > li + li .funding-receipt-row {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.cert-detail__funding-loading {
+  display: flex;
+  justify-content: center;
+  padding: 24px 0;
 }
 
 /* ---------- Contributors list ----------

--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -760,7 +760,8 @@
 
 .cert-list-row__title {
   margin: 0;
-  font-size: 0.9rem;
+  /* Standard text, bold (primary line). */
+  font-size: 0.85rem;
   font-weight: 600;
   color: var(--fg-primary);
   line-height: 1.3;
@@ -775,7 +776,8 @@
 .cert-list-row__subtitle {
   display: none;
   margin: 0;
-  font-size: 0.8rem;
+  /* Second-row text — smaller. */
+  font-size: 0.75rem;
   color: var(--fg-muted);
   line-height: 1.3;
   overflow: hidden;
@@ -863,9 +865,10 @@
   }
 
   .cert-list-row__title {
-    font-family: var(--font-headline), "Noto Serif", Georgia, serif;
-    font-size: 1.0625rem;
-    font-weight: 700;
+    /* Standard Inter text everywhere (no serif headline bump) — bold as
+       the primary line. */
+    font-size: 0.85rem;
+    font-weight: 600;
   }
 
   .cert-list-row__meta {
@@ -1096,7 +1099,8 @@
 }
 
 .account-list-row__name {
-  font-size: 0.9rem;
+  /* Standard text, bold (primary line). */
+  font-size: 0.85rem;
   font-weight: 600;
   color: var(--fg-primary);
   overflow: hidden;
@@ -1106,7 +1110,8 @@
 }
 
 .account-list-row__handle {
-  font-size: 0.78rem;
+  /* Second-row text — smaller. */
+  font-size: 0.75rem;
   color: var(--fg-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1157,6 +1162,221 @@
      identity (avatar + name + @handle). */
   .account-list-row__joined {
     display: none;
+  }
+}
+
+/* ---------- Funding receipt row ---------- */
+
+.funding-receipt-row {
+  display: grid;
+  /* Fixed amount + date columns with equal 1fr from/to columns. Every
+     row is its own grid at the same (full) width, so the four columns —
+     amount | from | to | date — line up vertically across all rows in a
+     list. */
+  grid-template-columns: 7rem minmax(0, 1fr) minmax(0, 1fr) 7rem;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 14px;
+  transition: background var(--transition-fast);
+}
+
+.explore__list > li + li .funding-receipt-row {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.funding-receipt-row:hover {
+  background: var(--bg-sunken);
+}
+
+/* Column-header row: small uppercase labels (matching the app's other
+   section labels), no hover. */
+.funding-receipt-row--header:hover {
+  background: transparent;
+}
+
+.funding-receipt-row__heading {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+}
+
+.funding-receipt-row__heading--amount {
+  text-align: right;
+}
+
+/* Trailing column: amount + currency. Standard body text, like the
+   date / to / for fields. */
+.funding-receipt-row__amount {
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: var(--fg-primary);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* Trailing column — flush right. */
+  text-align: right;
+}
+
+.funding-receipt-row__currency {
+  margin-left: 4px;
+  font-weight: 400;
+  color: var(--fg-primary);
+}
+
+/* From / to columns. min-width:0 lets a long account name or wallet
+   address truncate rather than blow the column out. */
+.funding-receipt-row__from,
+.funding-receipt-row__to-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.funding-receipt-row__party {
+  min-width: 0;
+}
+
+.funding-receipt-row__word {
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: var(--fg-secondary);
+  flex-shrink: 0;
+}
+
+.funding-receipt-row__text-party {
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: var(--fg-primary);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.funding-receipt-row__for {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.funding-receipt-row__activity {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  text-decoration: none;
+  color: var(--fg-primary);
+}
+
+/* Square activity thumbnail. */
+.funding-receipt-row__activity-img {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--bg-sunken);
+  display: block;
+}
+
+.funding-receipt-row__activity-img img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* Activity title — standard body text, wraps to at most two lines. */
+.funding-receipt-row__activity-title {
+  min-width: 0;
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: var(--fg-primary);
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.funding-receipt-row__activity:hover .funding-receipt-row__activity-title {
+  text-decoration: underline;
+}
+
+.funding-receipt-row__date {
+  /* Dates are secondary metadata — smaller + muted, like the date on the
+     cert / account rows. */
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--fg-secondary);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Explore funding list → a true table. The <ul> owns the column tracks
+   (content-sized amount / from / date, flexible to) and each row adopts
+   them via `subgrid`, so the four columns line up tightly across every
+   item — not just aligned but content-fitted, the way the other list
+   surfaces read. The row keeps its own box, so the hairline divider and
+   hover wash still work. Desktop only; phones use the stacked layout
+   below. */
+@media (min-width: 800px) {
+  .explore__list--funding {
+    display: grid;
+    /* date | from | to | for (flexible — holds the activity image +
+       2-line title) | amount. No side padding here so a row's hover
+       background spans the full width; the edge inset lives on the
+       first/last cells below. */
+    grid-template-columns:
+      max-content max-content max-content minmax(0, 1fr) max-content;
+  }
+  .explore__list--funding > li {
+    display: contents;
+  }
+  .explore__list--funding .funding-receipt-row {
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+    padding: 12px 0;
+    column-gap: 16px;
+  }
+  /* Edge inset: keep content off the list border while letting the row
+     background (hover) and the divider span the full width. */
+  .explore__list--funding .funding-receipt-row > :first-child {
+    padding-left: 14px;
+  }
+  .explore__list--funding .funding-receipt-row > :last-child {
+    padding-right: 14px;
+  }
+}
+
+@media (max-width: 799px) {
+  /* Stack on phones: amount + date share the top line; from and to each
+     take a full-width line below. */
+  .funding-receipt-row {
+    grid-template-columns: 1fr auto;
+    gap: 4px 12px;
+    padding: 14px 0;
+  }
+  .funding-receipt-row:hover {
+    background: transparent;
+  }
+  .funding-receipt-row__date {
+    grid-column: 1;
+    grid-row: 1;
+  }
+  .funding-receipt-row__amount {
+    grid-column: 2;
+    grid-row: 1;
+  }
+  .funding-receipt-row__from,
+  .funding-receipt-row__to-cell,
+  .funding-receipt-row__for {
+    grid-column: 1 / -1;
   }
 }
 

--- a/src/app/styles/feed.css
+++ b/src/app/styles/feed.css
@@ -451,7 +451,8 @@
 }
 
 .feed-card__author-name {
-  font-size: 0.875rem;
+  /* Standard text, bold (primary line). */
+  font-size: 0.85rem;
   font-weight: 600;
   color: var(--fg-primary);
   white-space: nowrap;
@@ -461,7 +462,8 @@
 }
 
 .feed-card__author-handle {
-  font-size: 0.8125rem;
+  /* Second-row text — smaller. */
+  font-size: 0.75rem;
   color: var(--fg-muted);
   white-space: nowrap;
   overflow: hidden;

--- a/src/components/explore-page/cert-list-row.tsx
+++ b/src/components/explore-page/cert-list-row.tsx
@@ -19,9 +19,14 @@ import ExploreListRow from "./explore-list-row"
 export default function CertListRow({
   record,
   did,
+  showByline = false,
 }: {
   record: ActivityRecord
   did: string
+  /** Show the author byline + createdAt date (the projects-style row,
+   *  with the byline/date columns). Defaults to false — the compact,
+   *  full-width variant used on the project detail page. */
+  showByline?: boolean
 }) {
   const { value } = record
   const imageUrl = value.image
@@ -55,9 +60,13 @@ export default function CertListRow({
       }
       title={value.title}
       metaItems={metaItems}
-      authorDid={null}
-      timestampIso={null}
-      compact
+      authorDid={showByline ? did : null}
+      timestampIso={
+        showByline && typeof value.createdAt === "string"
+          ? value.createdAt
+          : null
+      }
+      compact={!showByline}
     />
   )
 }

--- a/src/components/explore-page/explore-types.ts
+++ b/src/components/explore-page/explore-types.ts
@@ -1,4 +1,4 @@
-export type ExploreKind = "accounts" | "projects" | "activities"
+export type ExploreKind = "accounts" | "projects" | "activities" | "funding"
 
 /** The kind switcher in the top bar plus the synthetic "all" tab,
  *  which isn't a real loader kind — it's a combined view that runs the
@@ -68,9 +68,17 @@ const ALL_FILTERS: FilterOption[] = [
   { key: "all", label: "All" },
 ]
 
+/** Funding has a single, minimal listing — no social-graph or
+ *  Ma-Earth filters (the gate is applied in the loader, not via the
+ *  sidebar). Just "All funding". */
+const FUNDING_FILTERS: FilterOption[] = [
+  { key: "all", label: "All funding" },
+]
+
 export function filtersForKind(kind: ExploreKind): FilterOption[] {
   if (kind === "accounts") return ACCOUNT_FILTERS
   if (kind === "projects") return PROJECT_FILTERS
+  if (kind === "funding") return FUNDING_FILTERS
   return CERT_FILTERS
 }
 
@@ -79,8 +87,11 @@ export function filtersForView(view: ExploreView): FilterOption[] {
   return filtersForKind(view)
 }
 
-export function defaultFilterForKind(_kind: ExploreKind): string {
-  // Ma Earth is curated as the front door for every kind today.
+export function defaultFilterForKind(kind: ExploreKind): string {
+  // Funding has no curated Ma Earth front door — its only filter is the
+  // plain "all" listing, so default there.
+  if (kind === "funding") return "all"
+  // Ma Earth is curated as the front door for every other kind today.
   // First-load on /explore (no `?filter=` in the URL) lands on this
   // featured set; the All / By me / etc. filters stay one click
   // away in the standard list below the divider.
@@ -139,6 +150,8 @@ export const SUB_OPTIONS: Record<
   // Activities have no sub-toggle — the "Created" / "Contributed"
   // options were removed; an empty list renders no sub-pills.
   activities: [],
+  // Funding is a flat list — no sub-categories.
+  funding: [],
 }
 
 function defaultSubForKind(): string {

--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   Filter as FilterIcon,
   FolderGit2,
+  HandCoins,
   LayoutGrid,
   List as ListIcon,
   Search,
@@ -41,6 +42,7 @@ import ExploreUserCard from "./explore-user-card"
 import ExploreProjectCard from "./explore-project-card"
 import ProjectListRow from "./project-list-row"
 import AccountListRow from "./account-list-row"
+import FundingReceiptRow, { FundingReceiptHeader } from "./funding-receipt-row"
 import {
   SUB_OPTIONS,
   defaultFilterForView,
@@ -810,12 +812,16 @@ function ExploreMain({
                   All view. The cert (Activity Labeler) section shows
                   only on the certs kind; the account (Orglabeler)
                   section shows on every kind. */}
-              <QualityFilterPopover
-                q={quality}
-                showCertSection={kind === "activities"}
-                open={qualityOpen}
-                onOpenChange={setQualityOpen}
-              />
+              {/* Funding receipts carry no quality labels — hide the
+                  popover so the control isn't a no-op there. */}
+              {kind === "funding" ? null : (
+                <QualityFilterPopover
+                  q={quality}
+                  showCertSection={kind === "activities"}
+                  open={qualityOpen}
+                  onOpenChange={setQualityOpen}
+                />
+              )}
             </div>
           </div>
 
@@ -959,7 +965,13 @@ function isValidViewFilter(filter: string): boolean {
 type AllShow = "all" | ExploreKind
 
 function parseAllShow(v: string | null): AllShow {
-  if (v === "activities" || v === "projects" || v === "accounts") return v
+  if (
+    v === "activities" ||
+    v === "projects" ||
+    v === "accounts" ||
+    v === "funding"
+  )
+    return v
   return "all"
 }
 
@@ -968,6 +980,7 @@ const SHOW_OPTIONS: { key: AllShow; label: string }[] = [
   { key: "activities", label: "Activities" },
   { key: "projects", label: "Projects" },
   { key: "accounts", label: "Accounts" },
+  { key: "funding", label: "Funding" },
 ]
 
 /** Shared URL state for the All view — the unified sidebar filter, the
@@ -1125,6 +1138,15 @@ function ExploreAllBlocks() {
     excludeOrgLabels: quality.excludeOrgLabels,
     includeOrgLabels: quality.includeOrgLabels,
   })
+  // Funding has no social-graph / featured filters and no quality axis;
+  // the loader lists receipts gated to an AT Protocol account on either
+  // side, so it always runs with the plain "all" filter.
+  const funding = useExploreData({
+    kind: "funding",
+    filter: "all",
+    sub: "all",
+    search,
+  })
 
   const activityItems = useMemo(
     () => sortCerts(activities.certs, "newest").slice(0, ALL_VIEW_BLOCK_SIZE),
@@ -1137,6 +1159,10 @@ function ExploreAllBlocks() {
   const accountItems = useMemo(
     () => sortUsers(accounts.users, "newest").slice(0, ALL_VIEW_BLOCK_SIZE),
     [accounts.users],
+  )
+  const fundingItems = useMemo(
+    () => funding.fundingReceipts.slice(0, ALL_VIEW_BLOCK_SIZE),
+    [funding.fundingReceipts],
   )
 
   return (
@@ -1196,7 +1222,7 @@ function ExploreAllBlocks() {
                   const did = activities.certDids.get(rec.uri) ?? ""
                   return (
                     <li key={rec.uri}>
-                      <CertListRow record={rec} did={did} />
+                      <CertListRow record={rec} did={did} showByline />
                     </li>
                   )
                 })}
@@ -1230,6 +1256,25 @@ function ExploreAllBlocks() {
                 {accountItems.map((a) => (
                   <li key={a.did}>
                     <AccountListRow actor={a} />
+                  </li>
+                ))}
+              </ul>
+            </AllSection>
+
+            <AllSection
+              title="Funding"
+              icon={HandCoins}
+              isLoading={funding.isLoading}
+              isEmpty={fundingItems.length === 0}
+              onShowAll={() => setShow("funding")}
+            >
+              <ul className="explore__list explore__list--funding">
+                <li>
+                  <FundingReceiptHeader />
+                </li>
+                {fundingItems.map((r) => (
+                  <li key={r.uri}>
+                    <FundingReceiptRow receipt={r} showTextParties />
                   </li>
                 ))}
               </ul>
@@ -1714,6 +1759,7 @@ function SubPrefixDropdown({
 function searchPlaceholder(kind: ExploreKind): string {
   if (kind === "accounts") return "Search accounts by name…"
   if (kind === "projects") return "Search projects…"
+  if (kind === "funding") return "Funding receipts"
   return "Search activities…"
 }
 
@@ -1746,11 +1792,34 @@ function ResultsArea({
     return degrees.has(meta.degree)
   }
 
-  if (data.isLoading && data.users.length === 0 && data.projects.length === 0 && data.certs.length === 0) {
+  if (
+    data.isLoading &&
+    data.users.length === 0 &&
+    data.projects.length === 0 &&
+    data.certs.length === 0 &&
+    data.fundingReceipts.length === 0
+  ) {
     return (
       <div className="explore__loading">
         <LoadingSpinner size="md" />
       </div>
+    )
+  }
+
+  if (kind === "funding") {
+    const receipts = data.fundingReceipts
+    if (receipts.length === 0) return <EmptyResults kind={kind} />
+    return (
+      <ul className="explore__list explore__list--funding">
+        <li>
+          <FundingReceiptHeader />
+        </li>
+        {receipts.map((r) => (
+          <li key={r.uri}>
+            <FundingReceiptRow receipt={r} showTextParties />
+          </li>
+        ))}
+      </ul>
     )
   }
 
@@ -1836,7 +1905,7 @@ function ResultsArea({
           const did = certDids.get(rec.uri) ?? ""
           return (
             <li key={rec.uri}>
-              <CertListRow record={rec} did={did} />
+              <CertListRow record={rec} did={did} showByline />
             </li>
           )
         })}
@@ -1860,10 +1929,24 @@ function ResultsArea({
 
 function EmptyResults({ kind }: { kind: ExploreKind }) {
   const label =
-    kind === "accounts" ? "accounts" : kind === "projects" ? "projects" : "activities"
+    kind === "accounts"
+      ? "accounts"
+      : kind === "projects"
+        ? "projects"
+        : kind === "funding"
+          ? "funding receipts"
+          : "activities"
+  const icon =
+    kind === "accounts"
+      ? Users
+      : kind === "projects"
+        ? FolderGit2
+        : kind === "funding"
+          ? HandCoins
+          : CertIcon
   return (
     <EmptyState
-      icon={kind === "accounts" ? Users : kind === "projects" ? FolderGit2 : CertIcon}
+      icon={icon}
       title={`No ${label} match`}
       description="Try a different filter, clear the search, or pick a broader scope."
     />

--- a/src/components/explore-page/funding-receipt-row.tsx
+++ b/src/components/explore-page/funding-receipt-row.tsx
@@ -1,0 +1,207 @@
+"use client"
+
+import Link from "next/link"
+import IdentityRow from "@/components/ui/identity-row"
+import { useAuthorInfo } from "@/hooks/use-author-info"
+import { useActivity } from "@/hooks/use-activity"
+import { profileUrl } from "@/lib/urls"
+import { parseAtUri, activityDetailHref } from "@/lib/atproto/activity-uri"
+import { resolveActivityImageUrl } from "@/lib/atproto/activity"
+import { formatShortDate } from "@/lib/utils/format-date"
+import type { FundingParty, FundingReceipt } from "@/lib/atproto/indexer"
+
+const ACTIVITY_COLLECTION = "org.hypercerts.claim.activity"
+
+/**
+ * Dense single-row representation of an `org.hypercerts.funding.receipt`
+ * for the /explore Funding list.
+ *
+ *   [from account] to [to account] for [activity]      occurredAt
+ *
+ * `from` / `to` are unions: an AT Protocol account
+ * (`AppCertifiedDefsDid`) renders as avatar + name + @handle (hydrated
+ * per-row from the DID via {@link useAuthorInfo}, like the other
+ * explore account rows). A text label renders as plain text when
+ * `showTextParties` is set (used on the activity detail page, where the
+ * text values are wallet addresses), and renders nothing otherwise (the
+ * /explore default). `for` (when it points at an activity) is hydrated
+ * to its title and linked to the activity detail page — omit it via
+ * `showFor={false}` on surfaces where the `for` is already implied
+ * (e.g. the activity detail page itself).
+ */
+export default function FundingReceiptRow({
+  receipt,
+  showTextParties = false,
+  showFor = true,
+}: {
+  receipt: FundingReceipt
+  /** Render text (non-account) parties as their literal value rather
+   *  than blanking them. Defaults to false to preserve /explore. */
+  showTextParties?: boolean
+  /** Render the trailing "for [activity]" tail. Defaults to true; pass
+   *  false on the activity detail page where `for` is redundant. */
+  showFor?: boolean
+}) {
+  return (
+    <article className="funding-receipt-row">
+      {/* Columns: date | from | to | for | amount. Date leads, amount
+          (the "punchline") trails. */}
+      {receipt.occurredAt ? (
+        <time
+          className="funding-receipt-row__date"
+          dateTime={receipt.occurredAt}
+          title={receipt.occurredAt}
+        >
+          {formatShortDate(receipt.occurredAt)}
+        </time>
+      ) : (
+        <span className="funding-receipt-row__date" aria-hidden />
+      )}
+      <span className="funding-receipt-row__from">
+        <FundingPartySlot party={receipt.from} showText={showTextParties} />
+      </span>
+      <span className="funding-receipt-row__to-cell">
+        <FundingPartySlot party={receipt.to} showText={showTextParties} />
+      </span>
+      {/* "for" activity is its own column (image + title); the column
+          header labels it, so no inline connector word. */}
+      {showFor ? <FundingForActivity uri={receipt.forUri} /> : null}
+      <span className="funding-receipt-row__amount">
+        {receipt.amount ? (
+          <>
+            {receipt.amount}
+            {receipt.currency ? (
+              <span className="funding-receipt-row__currency">
+                {receipt.currency}
+              </span>
+            ) : null}
+          </>
+        ) : null}
+      </span>
+    </article>
+  )
+}
+
+/** Renders one side of the transfer. Accounts hydrate per-row and show
+ *  avatar + name + @handle. Text slots render their literal value when
+ *  `showText` is set (the activity detail page surfaces wallet
+ *  addresses); otherwise text / null slots render nothing (the /explore
+ *  default). */
+function FundingPartySlot({
+  party,
+  showText = false,
+}: {
+  party: FundingParty
+  showText?: boolean
+}) {
+  const did = party?.kind === "account" ? party.did : null
+  const { info } = useAuthorInfo(did)
+  if (!did) {
+    if (showText && party?.kind === "text" && party.value) {
+      return <FundingTextParty value={party.value} />
+    }
+    return null
+  }
+  const handle = info?.handle ?? undefined
+  return (
+    <IdentityRow
+      did={did}
+      handle={handle}
+      displayName={info?.displayName ?? undefined}
+      avatarUrl={info?.avatarUrl ?? undefined}
+      href={profileUrl(handle || did)}
+      size="sm"
+      className="funding-receipt-row__party"
+    />
+  )
+}
+
+/** Truncate a long wallet-address-style string to `head…tail` so a
+ *  full 0x… hex doesn't blow out the row, while keeping the literal
+ *  value reachable via the title attribute. Short / non-hex values
+ *  pass through unchanged. */
+function shortenAddress(value: string): string {
+  if (value.length <= 16) return value
+  if (!value.startsWith("0x")) return value
+  return `${value.slice(0, 6)}…${value.slice(-4)}`
+}
+
+/** A free-text funding party (wallet address). Rendered as plain text
+ *  (no link / hydration) since there's no account behind it. */
+function FundingTextParty({ value }: { value: string }) {
+  const display = shortenAddress(value)
+  return (
+    <span
+      className="funding-receipt-row__text-party"
+      title={display === value ? undefined : value}
+    >
+      {display}
+    </span>
+  )
+}
+
+/** The "for [activity]" column. Resolves the activity (title + square
+ *  image) from its URI via {@link useActivity} and links to its detail
+ *  page; the title wraps to at most two lines. Always renders the cell
+ *  span (empty when the `for` ref is missing or doesn't point at an
+ *  activity) so the funding table's columns stay aligned across rows. */
+function FundingForActivity({ uri }: { uri: string | null }) {
+  const parsed = uri ? parseAtUri(uri) : null
+  const isActivity = parsed?.collection === ACTIVITY_COLLECTION
+  const { activity } = useActivity(
+    isActivity ? parsed!.did : null,
+    isActivity ? parsed!.rkey : null,
+  )
+
+  if (!parsed || !isActivity) {
+    return <span className="funding-receipt-row__for" />
+  }
+
+  const title =
+    (typeof activity?.value.title === "string" && activity.value.title) ||
+    "activity"
+  const imageUrl = activity
+    ? resolveActivityImageUrl(activity.value.image, parsed.did)
+    : null
+  const href = activityDetailHref(parsed.did, parsed.rkey)
+
+  return (
+    <span className="funding-receipt-row__for">
+      <Link href={href} className="funding-receipt-row__activity">
+        <span className="funding-receipt-row__activity-img">
+          {imageUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={imageUrl} alt="" loading="lazy" />
+          ) : null}
+        </span>
+        <span className="funding-receipt-row__activity-title">{title}</span>
+      </Link>
+    </span>
+  )
+}
+
+/**
+ * Column-header row for a funding list — the labels that replace the old
+ * inline "to" / "for" connector words. Carries the `funding-receipt-row`
+ * class so it adopts the same grid (subgrid on /explore) and its cells
+ * line up with the data rows. `showFor` mirrors the rows so the column
+ * count matches.
+ */
+export function FundingReceiptHeader({ showFor = true }: { showFor?: boolean }) {
+  return (
+    <div
+      className="funding-receipt-row funding-receipt-row--header"
+      role="presentation"
+    >
+      <span className="funding-receipt-row__heading">Date</span>
+      <span className="funding-receipt-row__heading">From</span>
+      <span className="funding-receipt-row__heading">To</span>
+      {showFor ? (
+        <span className="funding-receipt-row__heading">For</span>
+      ) : null}
+      <span className="funding-receipt-row__heading funding-receipt-row__heading--amount">
+        Amount
+      </span>
+    </div>
+  )
+}

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -40,6 +40,10 @@ import LoadingSpinner from "@/components/ui/loading-spinner"
 import EditBanner from "@/components/ui/edit-banner"
 import Tooltip from "@/components/ui/tooltip"
 import { useCertProjects } from "@/hooks/use-cert-projects"
+import { useActivityFunding } from "@/hooks/use-activity-funding"
+import FundingReceiptRow, {
+  FundingReceiptHeader,
+} from "@/components/explore-page/funding-receipt-row"
 import { useAuthorInfo } from "@/hooks/use-author-info"
 import { TransitionLink } from "@/lib/view-transitions"
 import LeafletDocument, {
@@ -213,6 +217,17 @@ export default function ActivityDetail({
     value.rights?.uri ?? null,
   )
 
+  // Funding receipts whose `for` strongRef points at this activity.
+  // Loaded once (first: 100) and shared by the overview preview (up to
+  // 5 + "See all") and the Funding tab (all of them). Read-only — no
+  // bearing on the inline-edit state machine.
+  const {
+    receipts: fundingReceipts,
+    totalCount: fundingTotal,
+    isLoading: fundingLoading,
+  } = useActivityFunding(did, rkey)
+  const fundingCount = fundingTotal ?? fundingReceipts.length
+
   // Tab strip on the top bar (back-row) drives which slice of the
   // record renders in the right pane. Keep the left aside identical
   // across all tabs.
@@ -223,9 +238,11 @@ export default function ActivityDetail({
     | "overview"
     | "description"
     | "contributors"
+    | "funding"
     | "updates" =
     tabParam === "description" ||
     tabParam === "contributors" ||
+    tabParam === "funding" ||
     tabParam === "updates"
       ? tabParam
       : "overview"
@@ -245,9 +262,13 @@ export default function ActivityDetail({
         ? contributorCount > 0
           ? `Contributors (${contributorCount})`
           : "Contributors"
-        : activeTab === "updates"
-          ? "Updates"
-          : value.title || "Activity",
+        : activeTab === "funding"
+          ? fundingCount > 0
+            ? `Funding (${fundingCount})`
+            : "Funding"
+          : activeTab === "updates"
+            ? "Updates"
+            : value.title || "Activity",
   )
   // Record-level overflow menu in the mobile navbar's right slot (Share /
   // Add to list / Copy AT URI). Reads as page-level chrome instead of an
@@ -307,6 +328,7 @@ export default function ActivityDetail({
   const descriptionHref = pathname
     ? `${pathname}?tab=description`
     : null
+  const fundingHref = pathname ? `${pathname}?tab=funding` : null
 
   // -------------------------------------------------------------------
   // Inline edit state — same pattern as the profile page. Drafts are
@@ -1182,6 +1204,46 @@ export default function ActivityDetail({
               />
             ) : null}
 
+            {/* Funding preview — up to 5 receipts for this activity,
+                with a "See all" link into the dedicated Funding tab.
+                Hidden entirely when there are no receipts. Read-only;
+                no bearing on the inline-edit state. The `for` tail is
+                omitted (it's this activity) and text wallet-address
+                funders are surfaced. */}
+            {fundingCount > 0 ? (
+              <section className="cert-detail__section">
+                <div className="cert-detail__section-header">
+                  <h2 className="cert-detail__section-title">Funding</h2>
+                  <span className="cert-detail__section-count">
+                    {fundingCount}
+                  </span>
+                  {fundingHref ? (
+                    <TransitionLink
+                      href={fundingHref}
+                      replace
+                      className="cert-detail__section-see-all"
+                    >
+                      See all →
+                    </TransitionLink>
+                  ) : null}
+                </div>
+                <ul className="cert-detail__funding-list">
+                  <li>
+                    <FundingReceiptHeader showFor={false} />
+                  </li>
+                  {fundingReceipts.slice(0, 5).map((r) => (
+                    <li key={r.uri}>
+                      <FundingReceiptRow
+                        receipt={r}
+                        showTextParties
+                        showFor={false}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+
             {/* Locations + map. Overview-only (the main pane is
                 tab-gated); the aside no longer carries a Locations
                 row.
@@ -1268,6 +1330,39 @@ export default function ActivityDetail({
               })()
             ) : (
               <p className="cert-detail__short-desc">No contributors listed.</p>
+            )}
+          </section>
+        ) : activeTab === "funding" ? (
+          <section className="cert-detail__section">
+            <div className="cert-detail__section-header">
+              <h2 className="cert-detail__section-title">Funding</h2>
+              <span className="cert-detail__section-count">
+                {fundingCount}
+              </span>
+            </div>
+            {fundingLoading && fundingReceipts.length === 0 ? (
+              <div className="cert-detail__funding-loading">
+                <LoadingSpinner size="sm" />
+              </div>
+            ) : fundingReceipts.length > 0 ? (
+              <ul className="cert-detail__funding-list">
+                <li>
+                  <FundingReceiptHeader showFor={false} />
+                </li>
+                {fundingReceipts.map((r) => (
+                  <li key={r.uri}>
+                    <FundingReceiptRow
+                      receipt={r}
+                      showTextParties
+                      showFor={false}
+                    />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="cert-detail__short-desc">
+                No funding receipts for this activity yet.
+              </p>
             )}
           </section>
         ) : activeTab === "updates" ? (

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -97,6 +97,7 @@ const CERT_DETAIL_TABS: DetailTab[] = [
   { key: "overview", label: "Overview" },
   { key: "description", label: "Description" },
   { key: "contributors", label: "Contributors" },
+  { key: "funding", label: "Funding" },
   { key: "updates", label: "Updates" },
 ];
 
@@ -609,15 +610,19 @@ export default function DesktopTopBar() {
           data-tour="profile-tabs"
         >
           {/* Profile ?tab= strip — canonical <Tabs> (underline). onChange
-              pushes the ?tab= URL (scroll:false) so the page mirrors it,
-              matching the prior <Link scroll={false}> default-push. */}
+              REPLACES the ?tab= URL (scroll:false) so the page mirrors it
+              without stacking a history entry per tab. With `replace`, the
+              browser Back button leaves the profile entirely (returning to
+              wherever the user came from) instead of stepping back through
+              each tab they opened. Mirrors the in-page mobile tab strip in
+              src/app/[actor]/page.tsx, which already uses `router.replace`. */}
           <Tabs
             value={lockTabs && !isTabEditable(activeTab) ? "overview" : activeTab}
             onChange={(next) => {
               // While locked, swallow switches to non-editable sections.
               if (lockTabs && !isTabEditable(next)) return;
               const tab = visibleProfileTabs.find((t) => t.key === next);
-              if (tab) router.push(tabHref(tab), { scroll: false });
+              if (tab) router.replace(tabHref(tab), { scroll: false });
             }}
           >
             <TabList aria-label="Profile sections" className="border-0">

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -54,7 +54,7 @@ const Avatar: React.FC<AvatarProps> = ({
 
   return (
     <div
-      className={`${sizeMap[size]} rounded-full overflow-hidden flex items-center justify-center ${borderStyles} ${className}`}
+      className={`${sizeMap[size]} shrink-0 rounded-full overflow-hidden flex items-center justify-center ${borderStyles} ${className}`}
     >
       {showFallback ? (
         <div className="w-full h-full bg-[var(--color-surface-container-high)] text-[var(--fg-primary)] font-semibold flex items-center justify-center">

--- a/src/components/ui/identity-row.tsx
+++ b/src/components/ui/identity-row.tsx
@@ -25,7 +25,10 @@ export interface IdentityRowProps {
 
 const avatarSizeMap = { sm: "sm", md: "md" } as const;
 const gapMap = { sm: "gap-2", md: "gap-3" } as const;
-const nameSizeMap = { sm: "text-body-sm", md: "text-body" } as const;
+// sm = the standard dense-list text (0.85rem) with a smaller second-row
+// handle; md keeps the larger body scale used on roomier surfaces.
+const nameSizeMap = { sm: "text-[0.85rem]", md: "text-body" } as const;
+const handleSizeMap = { sm: "text-[0.75rem]", md: "text-body-sm" } as const;
 const skelAvatarPx = { sm: 32, md: 48 } as const;
 
 /**
@@ -81,7 +84,9 @@ export default function IdentityRow({
           {primary}
         </span>
         {hasHandle ? (
-          <span className="text-body-sm text-[var(--fg-muted)] truncate">
+          <span
+            className={`${handleSizeMap[size]} text-[var(--fg-muted)] truncate`}
+          >
             @{handle}
           </span>
         ) : null}

--- a/src/hooks/use-activity-funding.ts
+++ b/src/hooks/use-activity-funding.ts
@@ -1,0 +1,71 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  fetchFundingReceiptsForActivity,
+  type FundingReceipt,
+} from "@/lib/atproto/indexer"
+
+/**
+ * Load every `org.hypercerts.funding.receipt` whose `for` strongRef
+ * points at a single activity (`did` + `rkey`). Backs the activity
+ * detail page's Funding tab + overview preview.
+ *
+ * Mirrors `useCertProjects`: a single indexer call in an effect, an
+ * AbortController for cleanup, and a fail-soft empty result on error so
+ * the surface degrades to an empty state rather than crashing. `first`
+ * is clamped server-side to the proxy's MAX_FIRST (100).
+ */
+export function useActivityFunding(
+  did: string | null,
+  rkey: string | null,
+  options: { first?: number } = {},
+) {
+  const { first = 100 } = options
+  const [receipts, setReceipts] = useState<FundingReceipt[]>([])
+  const [totalCount, setTotalCount] = useState<number | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!did || !rkey) {
+      setReceipts([])
+      setTotalCount(null)
+      setIsLoading(false)
+      setError(null)
+      return
+    }
+
+    const forUri = `at://${did}/org.hypercerts.claim.activity/${rkey}`
+    const controller = new AbortController()
+    const { signal } = controller
+
+    setIsLoading(true)
+    setError(null)
+
+    fetchFundingReceiptsForActivity(forUri, { first, signal })
+      .then((result) => {
+        if (signal.aborted) return
+        setReceipts(result.records)
+        setTotalCount(result.totalCount)
+      })
+      .catch((err: unknown) => {
+        if (signal.aborted) return
+        console.error("[useActivityFunding] indexer fetch failed:", err)
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load funding receipts for this activity",
+        )
+        setReceipts([])
+        setTotalCount(null)
+      })
+      .finally(() => {
+        if (!signal.aborted) setIsLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [did, rkey, first])
+
+  return { receipts, totalCount, isLoading, error }
+}

--- a/src/hooks/use-explore.ts
+++ b/src/hooks/use-explore.ts
@@ -10,12 +10,14 @@ import {
 } from "react"
 import {
   fetchEndorsementClosure,
+  fetchFundingReceipts,
   fetchIndexerActivities,
   fetchIndexerActivitiesByUris,
   fetchProjects,
   fetchUserIndexerActivities,
   EndorsementClosureError,
   type EndorsementClosureAccount,
+  type FundingReceipt,
 } from "@/lib/atproto/indexer"
 import {
   subscribeClosureCacheVersion,
@@ -25,7 +27,6 @@ import {
   fetchNetworkActors,
   fetchNetworkActorsByDids,
   fetchDidsByKindInSet,
-  fetchOrgDidsByLabel,
 } from "@/lib/atproto/workspace"
 import type { NetworkActor } from "@/lib/atproto/workspace"
 import type { ActivityRecord } from "@/lib/atproto/activity-types"
@@ -82,6 +83,9 @@ interface ExploreData {
   projects: CollectionRecord[]
   certs: ActivityRecord[]
   certDids: Map<string, string>
+  /** Funding receipts (the "funding" kind), already gated to those with
+   *  at least one account side. Empty for every other kind. */
+  fundingReceipts: FundingReceipt[]
   isLoading: boolean
   isLoadingMore: boolean
   hasMore: boolean
@@ -95,6 +99,7 @@ interface InternalState {
   projects: CollectionRecord[]
   certs: ActivityRecord[]
   certDids: Map<string, string>
+  fundingReceipts: FundingReceipt[]
   isLoading: boolean
   isLoadingMore: boolean
   hasMore: boolean
@@ -107,6 +112,7 @@ const EMPTY: InternalState = {
   projects: [],
   certs: [],
   certDids: new Map(),
+  fundingReceipts: [],
   isLoading: false,
   isLoadingMore: false,
   hasMore: false,
@@ -422,12 +428,21 @@ export function useExploreData(opts: {
               ...page.users.filter((u) => !seenUsers.has(u.did)),
             ]
 
+            const seenFunding = new Set(
+              current.fundingReceipts.map((f) => f.uri),
+            )
+            const fundingReceipts = [
+              ...current.fundingReceipts,
+              ...page.fundingReceipts.filter((f) => !seenFunding.has(f.uri)),
+            ]
+
             return {
               ...current,
               users,
               projects,
               certs,
               certDids,
+              fundingReceipts,
               cursor: page.cursor,
               hasMore: page.hasMore,
               isLoadingMore: false,
@@ -454,11 +469,6 @@ export function useExploreData(opts: {
     managedAuthorDids,
     degree,
     noEndorsementRings,
-    closureVersion,
-    excludeKey,
-    includeKey,
-    excludeOrgKey,
-    includeOrgKey,
     excludeCertLabels,
     includeCertLabels,
     excludeOrgLabels,
@@ -470,6 +480,7 @@ export function useExploreData(opts: {
     projects: state.projects,
     certs: state.certs,
     certDids: state.certDids,
+    fundingReceipts: state.fundingReceipts,
     isLoading: state.isLoading,
     isLoadingMore: state.isLoadingMore,
     hasMore: state.hasMore,
@@ -487,6 +498,7 @@ interface LoadedPage {
   projects: CollectionRecord[]
   certs: ActivityRecord[]
   certDids: Map<string, string>
+  fundingReceipts: FundingReceipt[]
   cursor: string | null
   hasMore: boolean
   /** Set when the loader actually fetched a closure; null otherwise.
@@ -501,6 +513,7 @@ const EMPTY_PAGE: LoadedPage = {
   projects: [],
   certs: [],
   certDids: new Map(),
+  fundingReceipts: [],
   cursor: null,
   hasMore: false,
   endorsementClosure: null,
@@ -545,6 +558,9 @@ interface LoadArgs {
 }
 
 async function loadPage(args: LoadArgs): Promise<LoadedPage> {
+  // Funding has no label / endorsement / sub filters — dispatch before
+  // the cert/project label short-circuits below (which don't apply).
+  if (args.kind === "funding") return loadFundingPage(args)
   // Explicit-empty "include" filter = the user deselected every
   // option in that filter's popover. The indexer's HTTP proxy
   // normalises empty arrays to `null` (i.e. "no filter"), which would
@@ -688,26 +704,6 @@ async function loadFeaturedItemUrisUncached(
   return out
 }
 
-/**
- * Drop actors whose org carries one of the excluded labels. No-op
- * when the exclude list is empty / null. Returns the input array
- * unmodified in the no-op case (no allocation churn on the common
- * "no filter" path).
- */
-async function applyOrgExcludeFilter(
-  actors: NetworkActor[],
-  excludeOrgLabels: readonly string[] | null,
-  signal: AbortSignal | null,
-): Promise<NetworkActor[]> {
-  if (!excludeOrgLabels || excludeOrgLabels.length === 0) return actors
-  const badDids = await fetchOrgDidsByLabel({
-    labels: excludeOrgLabels,
-    signal: signal ?? undefined,
-  })
-  if (badDids.size === 0) return actors
-  return actors.filter((a) => !badDids.has(a.did))
-}
-
 // ----------------------------- Accounts --------------------------------
 
 async function loadAccountsPage(args: LoadArgs): Promise<LoadedPage> {
@@ -726,39 +722,25 @@ async function loadAccountsPage(args: LoadArgs): Promise<LoadedPage> {
     excludeOrgLabels,
   } = args
 
-  // Include-only org-label mode bypasses every other actor source.
-  // The viewer asked for "labeled X accounts only" — the result set
-  // IS the orgs with those labels, so we fetch matching DIDs from
-  // the orgs connection and pull their profiles in one shot. This
-  // sidesteps the 100-actor `NetworkActors` cap that would
-  // otherwise drop orgs outside the most-recently-indexed window.
-  if (includeOrgLabels && includeOrgLabels.length > 0) {
-    if (cursor !== null) return EMPTY_PAGE
-    const matchingDids = await fetchOrgDidsByLabel({
-      labels: includeOrgLabels,
-      signal: signal ?? undefined,
-    })
-    if (signal?.aborted) return EMPTY_PAGE
-    if (matchingDids.size === 0) return EMPTY_PAGE
-    let scoped = await fetchNetworkActorsByDids(
-      Array.from(matchingDids),
-      signal ?? undefined,
-    )
-    if (signal?.aborted) return EMPTY_PAGE
-    // sub: "people" returns empty (orgs only have labels);
-    // "organizations" and "all" return the labeled-org set as-is.
-    if (sub === "people") return EMPTY_PAGE
-    if (search.trim().length > 0) {
-      const q = search.trim().toLowerCase()
-      scoped = scoped.filter(
-        (a) =>
-          (a.displayName ?? "").toLowerCase().includes(q) ||
-          (a.description ?? "").toLowerCase().includes(q) ||
-          a.did.includes(q),
-      )
-    }
-    return { ...EMPTY_PAGE, users: scoped }
-  }
+  // Account-quality (orglabeler) include / exclude now filter
+  // server-side on the `appCertifiedActorProfile` connection via the
+  // `authorLabels` / `excludeAuthorLabels` args (magic-indexer#207).
+  // Account-quality labels live on the bare account DID and match
+  // both people AND organizations, so the previous "include-mode =
+  // orgs only, fetch DIDs from the orgs connection then pull
+  // profiles" early branch is gone — the main paginating
+  // `fetchNetworkActors` path (with the People/Organizations
+  // `isOrganization` sub-toggle) handles include just like any other
+  // server-side filter, with no 100-actor cap. These pass straight
+  // through to the paginating branch below.
+  const authorLabels =
+    includeOrgLabels && includeOrgLabels.length > 0
+      ? [...includeOrgLabels]
+      : undefined
+  const excludeAuthorLabels =
+    excludeOrgLabels && excludeOrgLabels.length > 0
+      ? [...excludeOrgLabels]
+      : undefined
 
   // "My organizations" — resolve the viewer's group DIDs DIRECTLY rather
   // than scanning the most-recently-indexed top-100 actors and
@@ -801,7 +783,11 @@ async function loadAccountsPage(args: LoadArgs): Promise<LoadedPage> {
           a.did.includes(q),
       )
     }
-    scoped = await applyOrgExcludeFilter(scoped, excludeOrgLabels ?? null, signal)
+    // No account-quality filter here: "My organizations" is the
+    // viewer's own groups (resolved by DID, fetched via
+    // fetchNetworkActorsByDids which has no author-label arg). The
+    // viewer's own groups are not a quality-curation surface, so the
+    // exclude filter is a no-op on this branch by design.
     return { ...EMPTY_PAGE, users: scoped }
   }
 
@@ -858,7 +844,11 @@ async function loadAccountsPage(args: LoadArgs): Promise<LoadedPage> {
       const q = search.trim().toLowerCase()
       users = users.filter((a) => a.did.includes(q))
     }
-    users = await applyOrgExcludeFilter(users, excludeOrgLabels ?? null, signal)
+    // No server-side account-quality filter here: the Featured set is
+    // a fixed curator-picked DID list (Ma Earth), already a trusted
+    // curation surface, and its actor rows are DID-stubs (no
+    // label-filterable connection). The exclude filter is a no-op on
+    // this branch by design.
     return { ...EMPTY_PAGE, users }
   }
 
@@ -926,12 +916,19 @@ async function loadAccountsPage(args: LoadArgs): Promise<LoadedPage> {
             a.did.includes(q),
         )
       }
-      scoped = await applyOrgExcludeFilter(scoped, excludeOrgLabels ?? null, signal)
+      // No server-side account-quality filter here: the endorsed set
+      // comes from the trust-graph closure (the viewer's own
+      // endorsement web — already a curation signal), and its rows are
+      // built from the closure's inline issuer block, not a
+      // label-filterable connection. The exclude filter is a no-op on
+      // this branch by design.
       return { ...EMPTY_PAGE, users: scoped, endorsementClosure: closureMeta }
     }
     const page = await fetchNetworkActors({
       first: 100,
       isOrganization: subToIsOrganization(sub),
+      authorLabels,
+      excludeAuthorLabels,
       signal: signal ?? undefined,
     })
     let scoped = page.actors
@@ -954,7 +951,6 @@ async function loadAccountsPage(args: LoadArgs): Promise<LoadedPage> {
           a.did.includes(q),
       )
     }
-    scoped = await applyOrgExcludeFilter(scoped, excludeOrgLabels ?? null, signal)
     return { ...EMPTY_PAGE, users: scoped }
   }
 
@@ -972,16 +968,13 @@ async function loadAccountsPage(args: LoadArgs): Promise<LoadedPage> {
     after: cursor,
     isOrganization: subToIsOrganization(sub),
     search,
+    authorLabels,
+    excludeAuthorLabels,
     signal: signal ?? undefined,
   })
-  const actors = await applyOrgExcludeFilter(
-    page.actors,
-    excludeOrgLabels ?? null,
-    signal,
-  )
   return {
     ...EMPTY_PAGE,
-    users: actors,
+    users: page.actors,
     cursor: page.endCursor,
     hasMore: page.hasMore,
   }
@@ -990,7 +983,34 @@ async function loadAccountsPage(args: LoadArgs): Promise<LoadedPage> {
 // ----------------------------- Projects --------------------------------
 
 async function loadProjectsPage(args: LoadArgs): Promise<LoadedPage> {
-  const { filter, search, viewerDid, followedDids, managedAuthorDids, cursor, signal, degree } = args
+  const {
+    filter,
+    search,
+    viewerDid,
+    followedDids,
+    managedAuthorDids,
+    cursor,
+    signal,
+    degree,
+    includeOrgLabels,
+    excludeOrgLabels,
+  } = args
+
+  // Account-quality (orglabeler) include / exclude filter server-side
+  // on the `orgHypercertsCollection` connection via `authorLabels` /
+  // `excludeAuthorLabels` (magic-indexer#207). Only the indexer-backed
+  // branches (by-endorsed + the default Projects listing) can apply
+  // these; the URI-keyed branches (Ma Earth featured, Recently viewed)
+  // resolve via PDS getRecord, which has no label-filterable
+  // connection, so they ignore the org-quality filter by design.
+  const authorLabels =
+    includeOrgLabels && includeOrgLabels.length > 0
+      ? [...includeOrgLabels]
+      : undefined
+  const excludeAuthorLabels =
+    excludeOrgLabels && excludeOrgLabels.length > 0
+      ? [...excludeOrgLabels]
+      : undefined
 
   if (filter === MA_EARTH_FILTER) {
     if (cursor !== null) return EMPTY_PAGE
@@ -1029,6 +1049,8 @@ async function loadProjectsPage(args: LoadArgs): Promise<LoadedPage> {
       first: PAGE_SIZE,
       after: cursor ?? undefined,
       authors,
+      authorLabels,
+      excludeAuthorLabels,
       search: search || undefined,
       signal: signal ?? undefined,
     })
@@ -1073,6 +1095,8 @@ async function loadProjectsPage(args: LoadArgs): Promise<LoadedPage> {
     first: PAGE_SIZE,
     after: cursor ?? undefined,
     authors,
+    authorLabels,
+    excludeAuthorLabels,
     search: search || undefined,
     signal: signal ?? undefined,
   })
@@ -1101,49 +1125,24 @@ async function loadCertsPage(args: LoadArgs): Promise<LoadedPage> {
     excludeOrgLabels,
   } = args
 
-  // Resolve the org-label DID sets once. Include mode narrows the
-  // result to certs authored by labeled orgs; exclude mode drops
-  // certs whose author carries an excluded org label. Both modes
-  // are no-ops when the corresponding list is empty.
-  let orgIncludeAuthors: Set<string> | null = null
-  let orgExcludeAuthors: Set<string> | null = null
-  if (includeOrgLabels && includeOrgLabels.length > 0) {
-    orgIncludeAuthors = await fetchOrgDidsByLabel({
-      labels: includeOrgLabels,
-      signal: signal ?? undefined,
-    })
-    if (signal?.aborted) return EMPTY_PAGE
-    // Include with an empty target set means "nothing matches".
-    if (orgIncludeAuthors.size === 0) return EMPTY_PAGE
-  }
-  if (excludeOrgLabels && excludeOrgLabels.length > 0) {
-    orgExcludeAuthors = await fetchOrgDidsByLabel({
-      labels: excludeOrgLabels,
-      signal: signal ?? undefined,
-    })
-    if (signal?.aborted) return EMPTY_PAGE
-  }
-
-  // Helper: intersect a branch's `authors` filter with the
-  // org-include set. Undefined existing → use include set as-is.
-  const orgScope = (authors: string[] | undefined): string[] | undefined => {
-    if (!orgIncludeAuthors) return authors
-    if (!authors) return Array.from(orgIncludeAuthors)
-    return authors.filter((a) => orgIncludeAuthors!.has(a))
-  }
-
-  // Helper: drop certs whose author DID is in the excluded set.
-  // No-op when no excludes are configured or the set is empty.
-  const dropExcluded = (
-    certs: ActivityRecord[],
-    dids: Map<string, string>,
-  ): ActivityRecord[] => {
-    if (!orgExcludeAuthors || orgExcludeAuthors.size === 0) return certs
-    return certs.filter((c) => {
-      const author = dids.get(c.uri)
-      return !author || !orgExcludeAuthors!.has(author)
-    })
-  }
+  // Account-quality (orglabeler) include / exclude now filter
+  // server-side on the `orgHypercertsClaimActivity` connection via
+  // the `authorLabels` / `excludeAuthorLabels` args
+  // (magic-indexer#207). The indexer ANDs `authors` + `authorLabels`,
+  // so a branch that previously intersected its own `authors` filter
+  // (follows / by-endorsed) with the include-org DID set now just
+  // passes both args and lets the server compose them. The previous
+  // `fetchOrgDidsByLabel` DID-resolution + `orgScope` / `dropExcluded`
+  // client filtering (which broke pagination — a 100-row page came
+  // back short) is gone.
+  const authorLabels =
+    includeOrgLabels && includeOrgLabels.length > 0
+      ? [...includeOrgLabels]
+      : undefined
+  const excludeAuthorLabels =
+    excludeOrgLabels && excludeOrgLabels.length > 0
+      ? [...excludeOrgLabels]
+      : undefined
 
   if (filter === MA_EARTH_FILTER) {
     if (cursor !== null) return EMPTY_PAGE
@@ -1161,6 +1160,8 @@ async function loadCertsPage(args: LoadArgs): Promise<LoadedPage> {
     const res = await fetchIndexerActivitiesByUris(itemUris, {
       labels: args.includeCertLabels?.length ? [...args.includeCertLabels] : undefined,
       excludeLabels: args.excludeCertLabels?.length ? [...args.excludeCertLabels] : undefined,
+      authorLabels,
+      excludeAuthorLabels,
       signal: signal ?? undefined,
     })
     if (signal?.aborted) return EMPTY_PAGE
@@ -1173,22 +1174,16 @@ async function loadCertsPage(args: LoadArgs): Promise<LoadedPage> {
         return title.toLowerCase().includes(q) || desc.toLowerCase().includes(q)
       })
     }
-    if (orgIncludeAuthors) {
-      certs = certs.filter((c) => {
-        const author = res.dids.get(c.uri)
-        return !!author && orgIncludeAuthors!.has(author)
-      })
-    }
-    certs = dropExcluded(certs, res.dids)
     return { ...EMPTY_PAGE, certs, certDids: res.dids }
   }
 
-  // Sub-category overrides — pinned to viewer.
+  // Sub-category overrides — pinned to viewer. Account-quality
+  // include / exclude is incoherent here (the records are the
+  // viewer's own — either the viewer is labeled or not), and the
+  // AuthoredActivities / ContributedActivities ops don't carry the
+  // author-label args, so this branch ignores the org-quality filter
+  // by design.
   if (sub === "created" && viewerDid) {
-    // "Created by me" + org-include filter is incoherent (either
-    // viewer is in the labeled-org set or not). Skip filtering by
-    // org-include but still apply the exclude post-filter for
-    // consistency with the rest of the loader.
     const r = await fetchUserIndexerActivities(viewerDid, {
       mode: "authored",
       first: PAGE_SIZE,
@@ -1200,7 +1195,7 @@ async function loadCertsPage(args: LoadArgs): Promise<LoadedPage> {
     })
     return {
       ...EMPTY_PAGE,
-      certs: dropExcluded(r.records, r.dids),
+      certs: r.records,
       certDids: r.dids,
       cursor: r.endCursor,
       hasMore: r.hasMore,
@@ -1218,7 +1213,7 @@ async function loadCertsPage(args: LoadArgs): Promise<LoadedPage> {
     })
     return {
       ...EMPTY_PAGE,
-      certs: dropExcluded(r.records, r.dids),
+      certs: r.records,
       certDids: r.dids,
       cursor: r.endCursor,
       hasMore: r.hasMore,
@@ -1239,22 +1234,23 @@ async function loadCertsPage(args: LoadArgs): Promise<LoadedPage> {
       return { ...EMPTY_PAGE, endorsementClosure: closureMeta }
     }
     const closureAuthors = Array.from(closureMeta.closureByDid.keys())
-    const scopedAuthors = orgScope(closureAuthors) ?? closureAuthors
-    if (scopedAuthors.length === 0) {
-      return { ...EMPTY_PAGE, endorsementClosure: closureMeta }
-    }
+    // The indexer ANDs `authors` + `authorLabels`, so pass the
+    // closure DIDs as authors and let the server apply the
+    // account-quality include / exclude on top.
     const r = await fetchIndexerActivities({
       first: PAGE_SIZE,
       after: cursor ?? undefined,
-      authors: scopedAuthors,
+      authors: closureAuthors,
       search: search || undefined,
       excludeLabels: args.excludeCertLabels?.length ? [...args.excludeCertLabels] : undefined,
       labels: args.includeCertLabels?.length ? [...args.includeCertLabels] : undefined,
+      authorLabels,
+      excludeAuthorLabels,
       signal: signal ?? undefined,
     })
     return {
       ...EMPTY_PAGE,
-      certs: dropExcluded(r.records, r.dids),
+      certs: r.records,
       certDids: r.dids,
       cursor: r.endCursor,
       hasMore: r.hasMore,
@@ -1275,16 +1271,13 @@ async function loadCertsPage(args: LoadArgs): Promise<LoadedPage> {
     // Restore the user's visit order — the cache holds it (newest
     // first), the parallel fetches don't guarantee response order.
     const order = new Map(recent.map((u, i) => [u, i] as const))
-    let certs = [...res.records].sort(
+    const certs = [...res.records].sort(
       (a, b) => (order.get(a.uri) ?? 0) - (order.get(b.uri) ?? 0),
     )
-    if (orgIncludeAuthors) {
-      certs = certs.filter((c) => {
-        const author = res.dids.get(c.uri)
-        return !!author && orgIncludeAuthors!.has(author)
-      })
-    }
-    certs = dropExcluded(certs, res.dids)
+    // No account-quality filter here: "Recently viewed" is the
+    // viewer's own personal cache (resolved by URI via PDS getRecord,
+    // not a label-filterable indexer connection), so the org-quality
+    // include / exclude is a no-op on this branch by design.
     return { ...EMPTY_PAGE, certs, certDids: res.dids }
   }
 
@@ -1300,25 +1293,58 @@ async function loadCertsPage(args: LoadArgs): Promise<LoadedPage> {
     authors = Array.from(followedDids)
   }
 
-  const scopedAuthors = orgScope(authors)
-  if (orgIncludeAuthors && scopedAuthors && scopedAuthors.length === 0) {
-    // Include-only set was non-empty but intersected with the
-    // branch's authors filter to nothing — short-circuit empty.
-    return EMPTY_PAGE
-  }
+  // The indexer ANDs `authors` + `authorLabels`, so pass the branch's
+  // author filter (if any) plus the account-quality include / exclude
+  // and let the server compose them — no client-side intersection.
   const r = await fetchIndexerActivities({
     first: PAGE_SIZE,
     after: cursor ?? undefined,
-    authors: scopedAuthors,
+    authors,
     search: search || undefined,
     excludeLabels: args.excludeCertLabels?.length ? [...args.excludeCertLabels] : undefined,
     labels: args.includeCertLabels?.length ? [...args.includeCertLabels] : undefined,
+    authorLabels,
+    excludeAuthorLabels,
     signal: signal ?? undefined,
   })
   return {
     ...EMPTY_PAGE,
-    certs: dropExcluded(r.records, r.dids),
+    certs: r.records,
     certDids: r.dids,
+    cursor: r.endCursor,
+    hasMore: r.hasMore,
+  }
+}
+
+// ----------------------------- Funding ---------------------------------
+
+/**
+ * Fetch a page of funding receipts and apply the explore gate: keep a
+ * receipt only when `from` OR `to` is an AT Protocol account
+ * (`AppCertifiedDefsDid`). The indexer can't filter by union variant,
+ * so we post-process after fetching — mirrors how the other explore
+ * loaders client-filter (recently-viewed, follows, …). The funding
+ * tab has no filter / sub / search axes, so those args are ignored.
+ *
+ * `hasMore` reflects the indexer's raw page (pre-gate): "Load more"
+ * keeps pulling pages even when a given page gated down to few rows, so
+ * the sparse account-bearing receipts surface across the dataset rather
+ * than stopping at the first page's handful.
+ */
+async function loadFundingPage(args: LoadArgs): Promise<LoadedPage> {
+  const { cursor, signal } = args
+  const r = await fetchFundingReceipts({
+    first: PAGE_SIZE,
+    after: cursor ?? undefined,
+    signal: signal ?? undefined,
+  })
+  if (signal?.aborted) return EMPTY_PAGE
+  const gated = r.records.filter(
+    (rec) => rec.from?.kind === "account" || rec.to?.kind === "account",
+  )
+  return {
+    ...EMPTY_PAGE,
+    fundingReceipts: gated,
     cursor: r.endCursor,
     hasMore: r.hasMore,
   }

--- a/src/lib/atproto/indexer.ts
+++ b/src/lib/atproto/indexer.ts
@@ -147,6 +147,20 @@ export interface FetchIndexerOptions {
    * filter" and [] for "explicit match nothing."
    */
   authors?: string[]
+  /**
+   * Server-side author-account-label include filter. Keeps only
+   * records whose AUTHOR account carries one of these orglabeler
+   * tier labels (account-quality labels live on the bare account
+   * DID — magic-indexer#207). Composes with `authors` via AND.
+   * Omit / empty array to skip.
+   */
+  authorLabels?: readonly string[]
+  /**
+   * Server-side author-account-label exclude filter. Drops records
+   * whose author account carries one of these labels. Unlabeled
+   * authors pass through. Omit / empty array to skip.
+   */
+  excludeAuthorLabels?: readonly string[]
   /** Full-text search query. Searched across title, shortDescription,
    *  description, and workScope. Terms are implicitly ANDed. */
   search?: string
@@ -197,6 +211,8 @@ export async function fetchIndexerActivitiesByUris(
   opts: {
     labels?: LabelValue[] | string[]
     excludeLabels?: LabelValue[] | string[]
+    authorLabels?: readonly string[]
+    excludeAuthorLabels?: readonly string[]
     signal?: AbortSignal
   } = {},
 ): Promise<IndexerActivitiesResult> {
@@ -220,6 +236,14 @@ export async function fetchIndexerActivitiesByUris(
         excludeLabels:
           opts.excludeLabels && opts.excludeLabels.length > 0
             ? opts.excludeLabels
+            : null,
+        authorLabels:
+          opts.authorLabels && opts.authorLabels.length > 0
+            ? [...opts.authorLabels]
+            : null,
+        excludeAuthorLabels:
+          opts.excludeAuthorLabels && opts.excludeAuthorLabels.length > 0
+            ? [...opts.excludeAuthorLabels]
             : null,
       }
       const res = await fetch(INDEXER_PROXY_URL, {
@@ -273,7 +297,17 @@ export async function fetchIndexerActivitiesByUris(
 export async function fetchIndexerActivities(
   options: FetchIndexerOptions = {},
 ): Promise<IndexerActivitiesResult> {
-  const { first = 20, after, labels, excludeLabels, authors, search, signal } = options
+  const {
+    first = 20,
+    after,
+    labels,
+    excludeLabels,
+    authors,
+    authorLabels,
+    excludeAuthorLabels,
+    search,
+    signal,
+  } = options
 
   const variables: Record<string, unknown> = {
     first,
@@ -284,6 +318,12 @@ export async function fetchIndexerActivities(
     // Preserve the nil-vs-empty distinction: undefined => null (no filter),
     // [] => [] (explicit "match nothing"), non-empty => pass through.
     authors: authors !== undefined ? (authors.length > 0 ? authors : []) : null,
+    authorLabels:
+      authorLabels && authorLabels.length > 0 ? [...authorLabels] : null,
+    excludeAuthorLabels:
+      excludeAuthorLabels && excludeAuthorLabels.length > 0
+        ? [...excludeAuthorLabels]
+        : null,
   }
 
   const res = await fetch(INDEXER_PROXY_URL, {
@@ -328,6 +368,242 @@ export async function fetchIndexerActivities(
     records,
     dids,
     labels: recordLabels,
+    hasMore: connection.pageInfo.hasNextPage,
+    endCursor: connection.pageInfo.endCursor,
+    totalCount: connection.totalCount,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Funding receipts (org.hypercerts.funding.receipt)
+// ---------------------------------------------------------------------------
+
+/**
+ * One side of a funding receipt's `from` / `to`. The indexer projects a
+ * union that is either an AT Protocol account (`AppCertifiedDefsDid`,
+ * carrying a `did`) or a free-text label
+ * (`OrgHypercertsFundingReceiptText`, carrying a `value`). Discriminated
+ * by `__typename`.
+ */
+export type FundingParty =
+  | { kind: "account"; did: string }
+  | { kind: "text"; value: string }
+  | null
+
+/**
+ * A single `org.hypercerts.funding.receipt` record, with both sides of
+ * the transfer normalised into {@link FundingParty}. `forUri` points at
+ * an `org.hypercerts.claim.activity` when present.
+ */
+export interface FundingReceipt {
+  uri: string
+  cid: string
+  did: string
+  createdAt: string | null
+  occurredAt: string | null
+  /** Funding amount + currency as recorded (e.g. "0.1" / "USDC"). Either
+   *  may be null when the receipt didn't record it. */
+  amount: string | null
+  currency: string | null
+  from: FundingParty
+  to: FundingParty
+  forUri: string | null
+  forCid: string | null
+}
+
+interface FundingPartyNode {
+  __typename?: string
+  did?: string | null
+  value?: string | null
+}
+
+interface FundingReceiptNode {
+  uri: string
+  cid: string
+  did: string
+  createdAt: string | null
+  occurredAt: string | null
+  amount: string | null
+  currency: string | null
+  from: FundingPartyNode | null
+  to: FundingPartyNode | null
+  for: { uri: string | null; cid: string | null } | null
+}
+
+interface FundingReceiptsGraphQLResponse {
+  data?: {
+    orgHypercertsFundingReceipt?: {
+      totalCount: number | null
+      edges: { cursor: string; node: FundingReceiptNode | null }[]
+      pageInfo: { hasNextPage: boolean; endCursor: string | null }
+    } | null
+  } | null
+  errors?: { message: string }[]
+}
+
+function mapFundingParty(node: FundingPartyNode | null): FundingParty {
+  if (!node) return null
+  if (node.__typename === "AppCertifiedDefsDid" && typeof node.did === "string") {
+    return { kind: "account", did: node.did }
+  }
+  if (
+    node.__typename === "OrgHypercertsFundingReceiptText" &&
+    typeof node.value === "string"
+  ) {
+    return { kind: "text", value: node.value }
+  }
+  // Fall back on the populated field even when __typename is absent, so a
+  // schema that drops the discriminator still resolves the party.
+  if (typeof node.did === "string") return { kind: "account", did: node.did }
+  if (typeof node.value === "string") return { kind: "text", value: node.value }
+  return null
+}
+
+export interface FundingReceiptsResult {
+  records: FundingReceipt[]
+  hasMore: boolean
+  endCursor: string | null
+  totalCount: number | null
+}
+
+/**
+ * Fetch a page of `org.hypercerts.funding.receipt` records. Both sides
+ * are normalised into {@link FundingParty}; the explore loader applies
+ * the "from OR to is an account" gate client-side (the indexer can't
+ * filter by union variant). Mirrors {@link fetchProjects}: failures or
+ * a missing connection return an empty page rather than throwing the
+ * tab into an error state.
+ */
+export async function fetchFundingReceipts(
+  options: { first?: number; after?: string; signal?: AbortSignal } = {},
+): Promise<FundingReceiptsResult> {
+  const { first = 50, after, signal } = options
+
+  const res = await fetch(INDEXER_PROXY_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      operationName: "FundingReceipts",
+      variables: { first, after: after ?? null },
+    }),
+    signal,
+  })
+
+  const json = (await res.json()) as FundingReceiptsGraphQLResponse
+  const empty: FundingReceiptsResult = {
+    records: [],
+    hasMore: false,
+    endCursor: null,
+    totalCount: null,
+  }
+
+  if (!json.data?.orgHypercertsFundingReceipt) {
+    if (json.errors?.length) {
+      console.warn(
+        "[Indexer] FundingReceipts GraphQL error:",
+        json.errors[0].message,
+      )
+    } else if (!res.ok) {
+      throw new Error(`Indexer request failed: ${res.status}`)
+    }
+    return empty
+  }
+
+  const connection = json.data.orgHypercertsFundingReceipt
+  const records: FundingReceipt[] = []
+  for (const edge of connection.edges) {
+    const node = edge.node
+    if (!node) continue
+    records.push({
+      uri: node.uri,
+      cid: node.cid,
+      did: node.did,
+      createdAt: node.createdAt ?? null,
+      occurredAt: node.occurredAt ?? null,
+      amount: node.amount ?? null,
+      currency: node.currency ?? null,
+      from: mapFundingParty(node.from),
+      to: mapFundingParty(node.to),
+      forUri: node.for?.uri ?? null,
+      forCid: node.for?.cid ?? null,
+    })
+  }
+
+  return {
+    records,
+    hasMore: connection.pageInfo.hasNextPage,
+    endCursor: connection.pageInfo.endCursor,
+    totalCount: connection.totalCount,
+  }
+}
+
+/**
+ * Fetch a page of `org.hypercerts.funding.receipt` records whose `for`
+ * strongRef points at a single activity (`forUri`). Returns the same
+ * {@link FundingReceiptsResult} shape as {@link fetchFundingReceipts};
+ * the only difference is the server-side `where: { for: { eq } }`
+ * filter. Used by the activity detail page's Funding tab + overview
+ * preview. Failures or a missing connection return an empty page
+ * rather than throwing the surface into an error state.
+ */
+export async function fetchFundingReceiptsForActivity(
+  forUri: string,
+  options: { first?: number; after?: string; signal?: AbortSignal } = {},
+): Promise<FundingReceiptsResult> {
+  const { first = 50, after, signal } = options
+
+  const res = await fetch(INDEXER_PROXY_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      operationName: "FundingReceiptsForActivity",
+      variables: { forUri, first, after: after ?? null },
+    }),
+    signal,
+  })
+
+  const json = (await res.json()) as FundingReceiptsGraphQLResponse
+  const empty: FundingReceiptsResult = {
+    records: [],
+    hasMore: false,
+    endCursor: null,
+    totalCount: null,
+  }
+
+  if (!json.data?.orgHypercertsFundingReceipt) {
+    if (json.errors?.length) {
+      console.warn(
+        "[Indexer] FundingReceiptsForActivity GraphQL error:",
+        json.errors[0].message,
+      )
+    } else if (!res.ok) {
+      throw new Error(`Indexer request failed: ${res.status}`)
+    }
+    return empty
+  }
+
+  const connection = json.data.orgHypercertsFundingReceipt
+  const records: FundingReceipt[] = []
+  for (const edge of connection.edges) {
+    const node = edge.node
+    if (!node) continue
+    records.push({
+      uri: node.uri,
+      cid: node.cid,
+      did: node.did,
+      createdAt: node.createdAt ?? null,
+      occurredAt: node.occurredAt ?? null,
+      amount: node.amount ?? null,
+      currency: node.currency ?? null,
+      from: mapFundingParty(node.from),
+      to: mapFundingParty(node.to),
+      forUri: node.for?.uri ?? null,
+      forCid: node.for?.cid ?? null,
+    })
+  }
+
+  return {
+    records,
     hasMore: connection.pageInfo.hasNextPage,
     endCursor: connection.pageInfo.endCursor,
     totalCount: connection.totalCount,
@@ -887,11 +1163,21 @@ export async function fetchProjects(
     first?: number
     after?: string
     authors?: string[]
+    authorLabels?: readonly string[]
+    excludeAuthorLabels?: readonly string[]
     search?: string
     signal?: AbortSignal
   } = {},
 ): Promise<UserProjectsResult> {
-  const { first = 24, after, authors, search, signal } = options
+  const {
+    first = 24,
+    after,
+    authors,
+    authorLabels,
+    excludeAuthorLabels,
+    search,
+    signal,
+  } = options
 
   const res = await fetch(INDEXER_PROXY_URL, {
     method: "POST",
@@ -903,6 +1189,12 @@ export async function fetchProjects(
         after: after ?? null,
         authors:
           authors === undefined ? null : authors.length > 0 ? authors : [],
+        authorLabels:
+          authorLabels && authorLabels.length > 0 ? [...authorLabels] : null,
+        excludeAuthorLabels:
+          excludeAuthorLabels && excludeAuthorLabels.length > 0
+            ? [...excludeAuthorLabels]
+            : null,
         search: search || null,
       },
     }),

--- a/src/lib/atproto/workspace.ts
+++ b/src/lib/atproto/workspace.ts
@@ -93,11 +93,39 @@ export async function fetchNetworkActors(
      * "nothing found until you click Load more").
      */
     search?: string
+    /**
+     * Server-side author-account-label include filter — keeps only
+     * actors whose account carries one of these orglabeler tier
+     * labels (account-quality labels live on the bare account DID,
+     * matched via the profile connection's `authorLabels` arg —
+     * magic-indexer#207). Omit / empty to skip.
+     */
+    authorLabels?: readonly string[]
+    /**
+     * Server-side author-account-label exclude filter — drops actors
+     * whose account carries one of these labels. Unlabeled accounts
+     * pass through. Omit / empty to skip.
+     */
+    excludeAuthorLabels?: readonly string[]
     signal?: AbortSignal
   } = {},
 ): Promise<NetworkActorsPage> {
-  const { first = 30, after = null, isOrganization, search, signal } = opts
+  const {
+    first = 30,
+    after = null,
+    isOrganization,
+    search,
+    authorLabels,
+    excludeAuthorLabels,
+    signal,
+  } = opts
   const searchVar = search && search.trim().length > 0 ? search.trim() : null
+  const authorLabelsVar =
+    authorLabels && authorLabels.length > 0 ? [...authorLabels] : null
+  const excludeAuthorLabelsVar =
+    excludeAuthorLabels && excludeAuthorLabels.length > 0
+      ? [...excludeAuthorLabels]
+      : null
   // Two upstream operations: the unfiltered `NetworkActors`, and
   // `NetworkActorsByKind` which adds the `isOrganization` where-arg.
   // graphql-go rejects an explicit `null` on the `eq` operator, so
@@ -110,8 +138,21 @@ export async function fetchNetworkActors(
     body: JSON.stringify({
       operationName: useKindFilter ? "NetworkActorsByKind" : "NetworkActors",
       variables: useKindFilter
-        ? { first, after, isOrganization, search: searchVar }
-        : { first, after, search: searchVar },
+        ? {
+            first,
+            after,
+            isOrganization,
+            search: searchVar,
+            authorLabels: authorLabelsVar,
+            excludeAuthorLabels: excludeAuthorLabelsVar,
+          }
+        : {
+            first,
+            after,
+            search: searchVar,
+            authorLabels: authorLabelsVar,
+            excludeAuthorLabels: excludeAuthorLabelsVar,
+          },
     }),
     signal,
   })

--- a/src/lib/tour/tour-steps.ts
+++ b/src/lib/tour/tour-steps.ts
@@ -61,7 +61,7 @@ export const TOUR_STEPS: readonly TourStep[] = [
     navigateTo: "/home",
     anchor: null,
     title: "Welcome to Certified",
-    body: "The Certified network is where you record and recognize real work and impact.\n\nThis app is just one view into the open network — other apps share the same data, so your work is never locked in. Let's take a quick look around.",
+    body: "The Certified network is where you record and recognize real work and impact. This app is one view into this open network — other apps share the same data, so your work is never locked in.\n\nLet's take a quick look around.",
   },
 
   // ---- Mobile navigation (sidebar) -----------------------------------
@@ -120,7 +120,7 @@ export const TOUR_STEPS: readonly TourStep[] = [
     navigateTo: "/apps",
     anchor: "nav-apps",
     title: "Apps",
-    body: "Apps is the growing set of apps built on the same open network as Certified.",
+    body: "This is where you can see all the apps that are built with Certified on AT Protocol.",
     placement: "bottom",
     platform: "desktop",
   },
@@ -128,7 +128,7 @@ export const TOUR_STEPS: readonly TourStep[] = [
     id: "apps-grid",
     navigateTo: "/apps",
     anchor: "apps-grid",
-    title: "One record, every app",
+    title: "One account, every app",
     body: "Each app reads and writes the same underlying records, so the work you publish here shows up across all of them — your data isn't locked into any single one.",
     placement: "bottom",
   },


### PR DESCRIPTION
## Summary

Adds **funding receipts** to the app, moves explore account-quality filtering **server-side**, filters the **landing-page counts**, and normalizes **explore/list typography**.

### Funding receipts (`org.hypercerts.funding.receipt`)
- New **Funding** kind on `/explore` (single view + the combined All view's 4th block) and a **Funding** section + tab on the activity detail page.
- `FundingReceiptRow` renders an aligned table — **date · from · to · for · amount** — using CSS **subgrid** on `/explore` (content-sized columns aligned across rows; full-width row hover). A **column-header row** replaces the old inline "to"/"for" words. The `for` activity shows a **square thumbnail + 2-line title**; account parties render via `IdentityRow`, text/wallet parties inline.
- Indexer proxy ops `FundingReceipts` / `FundingReceiptsForActivity` (`where.for.eq`), `fetchFundingReceipts*`, `FundingReceipt` types, and a `useActivityFunding` hook.
- Gating: explore lists receipts where `from` or `to` is an AT Protocol account.

### Server-side label filtering (consumes magic-indexer #206/#207/#208/#210/#211)
- Landing-page network counts exclude `draft`/`likely-test` records and `likely-test` accounts (`excludeLabels` / `excludeAuthorLabels`).
- `/explore` account-quality filtering now runs server-side via `authorLabels` / `excludeAuthorLabels`, removing the client-side per-page filter (fixes short-page pagination).

### Polish
- Explore/list **typography** unified to standard Inter **0.85rem** (bold primary lines; smaller **0.75rem** secondary lines) across `cert-list-row`, `account-list-row`, `feed-card__author`, and `IdentityRow`; activity-page section labels match the meta-label scale.
- Explore **activities** now show the author byline + `createdAt`, like projects.
- **Avatar** no longer shrinks in tight flex rows (`shrink-0`).
- Profile **sub-tab** switching uses `router.replace`, so Back leaves the profile instead of cycling tabs.

## Checks
- `tsc --noEmit` clean
- design guards (radii / breakpoints) clean
- eslint: **0 errors**, 64 warnings (all the pre-existing `setState-in-effect` category; none new)

## Notes
- Verified signed-in across `/explore` (all four kinds), the activity Funding tab/overview, and the home feed (byline propagation).
- Most funding records currently have text (wallet-address) parties; only a few have account `from`/`to`, so the funding lists are sparse today by design.