### PR TITLE
feat(explore): "Confirmed by" third-party-attestor filter on Funding

### DIFF
--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -1320,6 +1320,21 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* "Confirmed by" filter popover — attestor row (avatar + name). */
+.funding-confirmer-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.funding-confirmer-item__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Provenance "Source" column — one or more kind chips (Badge square). */
 .funding-receipt-row__source {
   display: inline-flex;

--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -43,6 +43,7 @@ import ExploreProjectCard from "./explore-project-card"
 import ProjectListRow from "./project-list-row"
 import AccountListRow from "./account-list-row"
 import FundingReceiptRow, { FundingReceiptHeader } from "./funding-receipt-row"
+import FundingConfirmedByPopover from "./funding-confirmed-by-popover"
 import {
   SUB_OPTIONS,
   defaultFilterForView,
@@ -525,6 +526,14 @@ function ExploreMain({
 
   const sub = parseSubForKind(kind, searchParams?.get("sub") ?? null)
   const search = searchParams?.get("q") ?? ""
+  // Funding-only "Confirmed by" filter — a third-party-attestor DID.
+  // Only honored on the funding kind; validated to a `did:` value so a
+  // stale param on another kind can't perturb its loader.
+  const confirmedByParam = searchParams?.get("confirmedBy") ?? null
+  const confirmedBy =
+    kind === "funding" && confirmedByParam?.startsWith("did:")
+      ? confirmedByParam
+      : null
   const sort = parseSort(searchParams?.get("sort") ?? null)
   const view = parseView(searchParams?.get("view") ?? null)
   const { isDesktop } = useLayoutBreakpoints()
@@ -604,6 +613,13 @@ function ExploreMain({
     setSortOpen(false)
   }, [setUrl])
 
+  const onConfirmedByChange = useCallback(
+    (did: string | null) => {
+      setUrl({ confirmedBy: did })
+    },
+    [setUrl],
+  )
+
   const data = useExploreData({
     kind,
     filter,
@@ -632,6 +648,8 @@ function ExploreMain({
       kind === "accounts" || kind === "activities" || kind === "projects"
         ? quality.includeOrgLabels
         : undefined,
+    // Funding-only third-party "Confirmed by" filter.
+    confirmedBy: kind === "funding" ? confirmedBy : undefined,
   })
 
   // Restore the window scroll offset when the reader returns from a
@@ -684,6 +702,7 @@ function ExploreMain({
 
   const [sortOpen, setSortOpen] = useState(false)
   const [qualityOpen, setQualityOpen] = useState(false)
+  const [confirmedByOpen, setConfirmedByOpen] = useState(false)
   const [subPrefixOpen, setSubPrefixOpen] = useState(false)
 
   return (
@@ -813,8 +832,17 @@ function ExploreMain({
                   only on the certs kind; the account (Orglabeler)
                   section shows on every kind. */}
               {/* Funding receipts carry no quality labels — hide the
-                  popover so the control isn't a no-op there. */}
-              {kind === "funding" ? null : (
+                  quality popover (a no-op there) and instead offer the
+                  "Confirmed by" third-party-attestor filter. */}
+              {kind === "funding" ? (
+                <FundingConfirmedByPopover
+                  receipts={data.fundingReceipts}
+                  value={confirmedBy}
+                  onChange={onConfirmedByChange}
+                  open={confirmedByOpen}
+                  onOpenChange={setConfirmedByOpen}
+                />
+              ) : (
                 <QualityFilterPopover
                   q={quality}
                   showCertSection={kind === "activities"}

--- a/src/components/explore-page/funding-confirmed-by-popover.tsx
+++ b/src/components/explore-page/funding-confirmed-by-popover.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import { useCallback, useMemo } from "react"
+import { UserRoundCheck } from "lucide-react"
+import {
+  Popover as UiPopover,
+  PopoverContent,
+  PopoverItem,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import Tooltip from "@/components/ui/tooltip"
+import Avatar from "@/components/ui/avatar"
+import { useAuthorInfo } from "@/hooks/use-author-info"
+import { thirdPartyDids } from "@/lib/atproto/funding-provenance"
+import type { FundingReceipt } from "@/lib/atproto/indexer"
+
+/** Short `did:plc:abcd…wxyz` fallback when a candidate has no resolved
+ *  handle/display name yet. */
+function shortDid(did: string): string {
+  if (did.length <= 20) return did
+  return `${did.slice(0, 12)}…${did.slice(-4)}`
+}
+
+/**
+ * /explore Funding "Confirmed by" filter — narrows the list to payments a
+ * specific **third-party** attestor confirmed (the indexer's `confirmedBy`
+ * arg; recipient/sender filtering is already the From/To account filter).
+ *
+ * Candidates are the distinct third-party attestors present in the loaded
+ * receipts. Because the filter is server-side, once one is active the list
+ * collapses to that attestor — so the active selection is always offered
+ * (checked) plus a "Clear" item to widen again.
+ */
+export default function FundingConfirmedByPopover({
+  receipts,
+  value,
+  onChange,
+  open,
+  onOpenChange,
+}: {
+  receipts: FundingReceipt[]
+  value: string | null
+  onChange: (did: string | null) => void
+  open: boolean
+  onOpenChange: (v: boolean) => void
+}) {
+  // Distinct third-party attestors seen in the current result set, plus
+  // the active selection (which may be the only thing in `receipts` once
+  // the server filter is applied).
+  const candidates = useMemo(() => {
+    const seen = new Set<string>()
+    const out: string[] = []
+    const push = (did: string) => {
+      if (seen.has(did)) return
+      seen.add(did)
+      out.push(did)
+    }
+    if (value) push(value)
+    for (const r of receipts) for (const did of thirdPartyDids(r.attestations)) push(did)
+    return out
+  }, [receipts, value])
+
+  // Minifier-safe selection (reads the DID off the clicked element's
+  // dataset rather than capturing the map variable — same pattern the
+  // sidebar filter buttons use). Empty `data-did` clears the filter.
+  const onItemClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      const did = e.currentTarget.dataset.did
+      onChange(did ? did : null)
+      onOpenChange(false)
+    },
+    [onChange, onOpenChange],
+  )
+
+  const active = !!value
+  // Nothing to filter by and no active selection → don't render a dead
+  // control (mirrors hiding the quality popover on funding).
+  if (candidates.length === 0 && !active) return null
+
+  return (
+    <UiPopover open={open} onOpenChange={onOpenChange}>
+      <Tooltip label="Filter by confirmer">
+        <PopoverTrigger>
+          <button
+            type="button"
+            className={`explore__chrome-btn explore__chrome-btn--icon${
+              active ? " explore__chrome-btn--active" : ""
+            }`}
+            aria-label={`Filter by confirmer${active ? " (filtered)" : ""}`}
+          >
+            <UserRoundCheck size={13} strokeWidth={1.75} aria-hidden />
+          </button>
+        </PopoverTrigger>
+      </Tooltip>
+      <PopoverContent align="end">
+        <p className="popover__section-heading">Confirmed by</p>
+        {active ? (
+          <PopoverItem data-did="" onClick={onItemClick}>
+            All confirmers
+          </PopoverItem>
+        ) : null}
+        {candidates.map((did) => (
+          <ConfirmerItem
+            key={did}
+            did={did}
+            selected={did === value}
+            onClick={onItemClick}
+          />
+        ))}
+      </PopoverContent>
+    </UiPopover>
+  )
+}
+
+/** One attestor row — hydrates avatar + name from the DID. */
+function ConfirmerItem({
+  did,
+  selected,
+  onClick,
+}: {
+  did: string
+  selected: boolean
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void
+}) {
+  const { info } = useAuthorInfo(did)
+  const name = info?.displayName || info?.handle || shortDid(did)
+  return (
+    <PopoverItem data-did={did} selected={selected} onClick={onClick}>
+      <span className="funding-confirmer-item">
+        <Avatar src={info?.avatarUrl ?? undefined} size="sm" alt="" />
+        <span className="funding-confirmer-item__name">{name}</span>
+      </span>
+    </PopoverItem>
+  )
+}

--- a/src/hooks/use-explore.ts
+++ b/src/hooks/use-explore.ts
@@ -199,6 +199,10 @@ export function useExploreData(opts: {
    *  ring (degrees set is empty). The hook short-circuits to an
    *  empty result list instead of defaulting back to degree=1. */
   noEndorsementRings?: boolean
+  /** Funding kind only — restrict to payments confirmed by this
+   *  third-party attestor DID (magic-indexer `confirmedBy`). Null /
+   *  omit for "no filter". Changing it resets + refetches. */
+  confirmedBy?: string | null
 }): ExploreData {
   const {
     kind,
@@ -212,6 +216,7 @@ export function useExploreData(opts: {
   } = opts
   const degree: 1 | 2 | 3 = opts.degree ?? 1
   const noEndorsementRings: boolean = opts.noEndorsementRings ?? false
+  const confirmedBy: string | null = opts.confirmedBy ?? null
   // Stable key so the load effect can refetch when the exclude list
   // changes without retriggering when an identical-content array
   // arrives by reference.
@@ -323,6 +328,7 @@ export function useExploreData(opts: {
           includeCertLabels: includeCertLabels ?? null,
           excludeOrgLabels: excludeOrgLabels ?? null,
           includeOrgLabels: includeOrgLabels ?? null,
+          confirmedBy,
         })
         if (controller.signal.aborted) return
         if (generation !== generationRef.current) return
@@ -368,6 +374,7 @@ export function useExploreData(opts: {
     includeCertLabels,
     excludeOrgLabels,
     includeOrgLabels,
+    confirmedBy,
   ])
 
   const loadMore = useCallback(() => {
@@ -402,6 +409,7 @@ export function useExploreData(opts: {
             includeCertLabels: includeCertLabels ?? null,
             excludeOrgLabels: excludeOrgLabels ?? null,
             includeOrgLabels: includeOrgLabels ?? null,
+            confirmedBy,
           })
           if (generation !== generationRef.current) return
           setState((current) => {
@@ -473,6 +481,7 @@ export function useExploreData(opts: {
     includeCertLabels,
     excludeOrgLabels,
     includeOrgLabels,
+    confirmedBy,
   ])
 
   return {
@@ -555,6 +564,8 @@ interface LoadArgs {
    *  no-op when null. */
   excludeOrgLabels: readonly string[] | null
   includeOrgLabels: readonly string[] | null
+  /** Funding kind only — third-party-attestor DID filter, or null. */
+  confirmedBy: string | null
 }
 
 async function loadPage(args: LoadArgs): Promise<LoadedPage> {
@@ -1325,6 +1336,8 @@ async function loadCertsPage(args: LoadArgs): Promise<LoadedPage> {
  * so we post-process after fetching — mirrors how the other explore
  * loaders client-filter (recently-viewed, follows, …). The funding
  * tab has no filter / sub / search axes, so those args are ignored.
+ * The one exception is `confirmedBy` — a server-side third-party-attestor
+ * DID filter forwarded to the indexer (null = no filter).
  *
  * `hasMore` reflects the indexer's raw page (pre-gate): "Load more"
  * keeps pulling pages even when a given page gated down to few rows, so
@@ -1332,11 +1345,12 @@ async function loadCertsPage(args: LoadArgs): Promise<LoadedPage> {
  * than stopping at the first page's handful.
  */
 async function loadFundingPage(args: LoadArgs): Promise<LoadedPage> {
-  const { cursor, signal } = args
+  const { cursor, signal, confirmedBy } = args
   const r = await fetchFundingReceipts({
     first: PAGE_SIZE,
     after: cursor ?? undefined,
     signal: signal ?? undefined,
+    confirmedBy: confirmedBy ?? undefined,
   })
   if (signal?.aborted) return EMPTY_PAGE
   const gated = r.records.filter(


### PR DESCRIPTION
Implements the deferred follow-up from #173 (now merged) — the **"Confirmed by X" filter** on `/explore` Funding (e.g. *only show receipts confirmed by Ma Earth*).

## What

A new chrome control on the Funding view (replacing the no-op quality popover there): pick a third-party attestor → the list narrows **server-side** to payments that attestor confirmed. URL-backed (`?confirmedBy=<did>`), so it's shareable and survives back/forward.

## How
- **`use-explore.ts`** — thread a `confirmedBy` DID through `useExploreData` opts → `LoadArgs` → `loadFundingPage` → `fetchFundingReceipts`; added to both load-effect dep arrays so changing it resets + refetches.
- **`explore.tsx`** — URL-backed `?confirmedBy=` (funding kind only, validated to a `did:` value); render the picker in place of the quality popover on funding.
- **`funding-confirmed-by-popover.tsx`** — candidates are the distinct third-party attestors in the loaded receipts (deduped via `thirdPartyDids`), hydrated to avatar + name; the active selection is always offered (checked) plus an "All confirmers" clear item; minifier-safe `data-did` selection; the control hides when there's nothing to filter by.

## Verified
Against the **deployed** magic-indexer (#214): a real third-party attestor DID narrows to its payments (and only those), a bogus DID returns none, `null` is unfiltered.

- [x] `npx tsc --noEmit` — clean (changed files).
- [x] `npm run lint` — no new warnings (baseline 64 unchanged).
- [x] `npm run build` — succeeds.
- [x] `vitest` — `funding-provenance` suite green.

## Known limitation (acceptable v1)
Candidates come from the currently-loaded receipts, so the picker surfaces attestors actually present in view; with the server filter active the list collapses to the selection (hence the always-present "All confirmers" clear item). A dedicated attestor index / typeahead is a later enhancement if the attestor set grows large.

Related: #173 (display, merged), #174 ("Confirm this receipt" write path), magic-indexer #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)