### PR TITLE
feat: explore funding (filter, ENS, receipt modal) + desktop tab-switch animation

### DIFF
--- a/src/app/[actor]/page.tsx
+++ b/src/app/[actor]/page.tsx
@@ -35,6 +35,7 @@ import type { LinearDocument } from "@/lib/leaflet/types"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import EditBanner from "@/components/ui/edit-banner"
 import EmptyState from "@/components/ui/empty-state"
+import { TabPanelTransition } from "@/components/ui/tab-panel-transition"
 import OnboardingBanner from "@/components/onboarding/onboarding-banner"
 import { AlignLeft, UserX } from "lucide-react"
 import { trackRecentlyViewed } from "@/lib/utils/recently-viewed"
@@ -66,6 +67,9 @@ const TABS: { key: TabKey; label: string }[] = [
   { key: "about", label: "About" },
   { key: "settings", label: "Settings" },
 ]
+
+// Left-to-right key order for the desktop tab-switch slide direction.
+const TAB_ORDER = TABS.map((t) => t.key)
 
 // Inline-edit state machine + display helpers live in
 // `useProfileInlineEdit` so the page reads as orchestration + tab
@@ -505,6 +509,7 @@ export default function UserProfilePage() {
           />
 
           <div className="page-layout__main">
+            <TabPanelTransition activeKey={activeTab} order={TAB_ORDER}>
             {activeTab === "overview" && (
               <div role="tabpanel" id="tabpanel-overview" aria-labelledby="tab-overview">
                 <ProfileOverview
@@ -626,6 +631,7 @@ export default function UserProfilePage() {
                 <ProfileLists did={did} viewerIsOwner={isViewerThisEntity} />
               </div>
             )}
+            </TabPanelTransition>
           </div>
         </div>
       )}

--- a/src/app/api/ens/route.ts
+++ b/src/app/api/ens/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server"
+
+/**
+ * Reverse-resolve an Ethereum address to its primary ENS name.
+ *
+ *   GET /api/ens?address=0x… → { address, name, avatar }
+ *     name:   "vitalik.eth" | null
+ *     avatar: "https://metadata.ens.domains/…" | null
+ *
+ * The app has no web3 dependency, so resolution is delegated to a public
+ * ENS resolver (ensideas) server-side rather than pulling viem/ethers and
+ * an RPC endpoint into the client bundle. Routing it through our own
+ * origin (instead of fetching the third-party from the browser) keeps the
+ * resolver swappable — a future move to an in-house RPC / subgraph only
+ * touches this file — and lets us cache responses at the edge.
+ *
+ * Failure is never fatal: an invalid address 400s, but a flaky upstream,
+ * timeout, or address with no reverse record all resolve to `name: null`
+ * so the caller falls back to showing the raw address rather than erroring.
+ */
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
+const UPSTREAM = "https://api.ensideas.com/ens/resolve/"
+// ENS primary names change rarely; cache a day and serve stale while we
+// revalidate so repeated rows / re-renders don't re-hit the upstream.
+const CACHE_TTL_SECONDS = 60 * 60 * 24
+
+function cacheHeaders(): Record<string, string> {
+  return {
+    "Cache-Control": `public, s-maxage=${CACHE_TTL_SECONDS}, stale-while-revalidate=${CACHE_TTL_SECONDS}`,
+  }
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const address = (new URL(request.url).searchParams.get("address") ?? "").trim()
+  if (!ADDRESS_RE.test(address)) {
+    return NextResponse.json({ error: "invalid address" }, { status: 400 })
+  }
+
+  try {
+    const res = await fetch(`${UPSTREAM}${address}`, {
+      headers: { accept: "application/json" },
+      next: { revalidate: CACHE_TTL_SECONDS },
+      signal: AbortSignal.timeout(8000),
+    })
+    if (!res.ok) {
+      return NextResponse.json(
+        { address, name: null, avatar: null },
+        { headers: cacheHeaders() },
+      )
+    }
+    const data = (await res.json()) as { name?: string | null; avatar?: string | null }
+    const name =
+      typeof data.name === "string" && data.name.length > 0 ? data.name : null
+    // Only surface http(s) avatars — the ENS metadata service already
+    // resolves NFT / ipfs avatars to a hosted image, so anything else
+    // (data:, ipfs://, raw token refs) wouldn't render and is dropped.
+    const avatar =
+      typeof data.avatar === "string" && /^https?:\/\//.test(data.avatar)
+        ? data.avatar
+        : null
+    return NextResponse.json({ address, name, avatar }, { headers: cacheHeaders() })
+  } catch {
+    // Network / timeout / parse failure — degrade to "no name" (uncached so
+    // a transient blip doesn't get pinned) rather than erroring the row.
+    return NextResponse.json({ address, name: null, avatar: null })
+  }
+}

--- a/src/app/api/indexer/route.ts
+++ b/src/app/api/indexer/route.ts
@@ -823,8 +823,18 @@ ${ACTIVITY_NODE_SELECTION}
   // variant, so the explore loader applies the "from OR to is an
   // account" gate client-side after fetching.
   FundingReceipts: `
-    query FundingReceipts($first: Int!, $after: String) {
-      orgHypercertsFundingReceipt(first: $first, after: $after) {
+    query FundingReceipts(
+      $first: Int!
+      $after: String
+      $authorLabels: [String!]
+      $excludeAuthorLabels: [String!]
+    ) {
+      orgHypercertsFundingReceipt(
+        first: $first
+        after: $after
+        authorLabels: $authorLabels
+        excludeAuthorLabels: $excludeAuthorLabels
+      ) {
         totalCount
         edges {
           cursor
@@ -847,6 +857,10 @@ ${ACTIVITY_NODE_SELECTION}
               ... on OrgHypercertsFundingReceiptText { value }
             }
             for { uri cid }
+            paymentRail
+            paymentNetwork
+            transactionId
+            notes
           }
         }
         pageInfo { hasNextPage endCursor }
@@ -894,6 +908,10 @@ ${ACTIVITY_NODE_SELECTION}
               ... on OrgHypercertsFundingReceiptText { value }
             }
             for { uri cid }
+            paymentRail
+            paymentNetwork
+            transactionId
+            notes
           }
         }
         pageInfo { hasNextPage endCursor }
@@ -1499,10 +1517,15 @@ function buildVariables(
     }
     case "FundingReceipts": {
       // Simple paginated read — no required vars. Clamp `first` like the
-      // other paginated ops; `after` is the opaque cursor.
+      // other paginated ops; `after` is the opaque cursor. The optional
+      // author-label filters gate receipts by the creator's account
+      // (orglabeler) tier, so the explore Funding tab can hide receipts
+      // authored by likely-test accounts (magic-indexer#207).
       return {
         first: clampFirst(vars.first, MAX_FIRST, 50),
         after: readString(vars.after, MAX_AFTER_LEN),
+        authorLabels: readLabelList(vars.authorLabels),
+        excludeAuthorLabels: readLabelList(vars.excludeAuthorLabels),
       }
     }
     case "FundingReceiptsForActivity": {

--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -647,17 +647,29 @@
   margin-top: 0;
 }
 
-/* Divider above the 2-col row when it isn't the first child — keeps
-   the main pane's visual rhythm consistent with `.cert-detail__section`
-   siblings around it. */
-.cert-detail__main > *:not(:first-child).cert-detail__two-col {
+/* The per-tab content lives in `.cert-detail__content` (the
+   TabPanelTransition wrapper, which carries the desktop tab-switch slide;
+   the headline sits OUTSIDE it so the title stays put across tabs). It
+   mirrors `.cert-detail__main`'s flex column + 32px rhythm so spacing and
+   the section dividers below read exactly as before. */
+.cert-detail__content {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  min-width: 0;
+}
+
+/* Divider above the 2-col row. (The headline is no longer a sibling, so
+   the 2-col is never spuriously treated as "first" here — every 2-col
+   gets the divider, as before when the headline preceded it.) */
+.cert-detail__content > .cert-detail__two-col {
   border-top: 1px solid var(--border-subtle);
 }
 
 /* Divider before a `.cert-detail__section` that immediately follows the
    2-col row — the existing `section + section` rule doesn't match
    across the 2-col wrapper, so add the equivalent here. */
-.cert-detail__main > .cert-detail__two-col + .cert-detail__section {
+.cert-detail__content > .cert-detail__two-col + .cert-detail__section {
   border-top: 1px solid var(--border-subtle);
 }
 
@@ -1058,7 +1070,7 @@
   margin-top: 0;
 }
 
-.cert-detail__main > .cert-detail__section + .cert-detail__section {
+.cert-detail__content > .cert-detail__section + .cert-detail__section {
   border-top: 1px solid var(--border-subtle);
 }
 

--- a/src/app/styles/components.css
+++ b/src/app/styles/components.css
@@ -2467,3 +2467,67 @@
   color: var(--fg-secondary);
   line-height: 1.5;
 }
+
+/* ========== Wallet Address ==========
+   Inline, copyable wallet address / ENS name (WalletAddress primitive).
+   A bare button so it nests inside dense rows; the full address shows in
+   a tooltip on hover, the copy icon fades in, and a click copies. */
+.wallet-address {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: var(--fg-primary);
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: color var(--transition-fast);
+}
+
+/* ENS avatar sits flush against the name like an AT-account row; it owns
+   its own size (Avatar sm = 32px) so we only stop it from shrinking. */
+.wallet-address__avatar {
+  flex-shrink: 0;
+}
+
+.wallet-address__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  /* Hex digits line up with tabular figures; an ENS name reads better in
+     proportional figures, so the data-ens variant opts back out below. */
+  font-variant-numeric: tabular-nums;
+}
+
+.wallet-address[data-ens] .wallet-address__label {
+  font-variant-numeric: normal;
+}
+
+.wallet-address:hover {
+  color: var(--color-accent);
+}
+
+.wallet-address:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.wallet-address__copy {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--fg-muted);
+  opacity: 0;
+  transition: opacity var(--transition-fast), color var(--transition-fast);
+}
+
+.wallet-address:hover .wallet-address__copy,
+.wallet-address:focus-visible .wallet-address__copy {
+  opacity: 1;
+  color: var(--color-accent);
+}

--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -1188,6 +1188,18 @@
   background: var(--bg-sunken);
 }
 
+/* Clickable rows open the detail modal. Signal it with a pointer cursor;
+   the existing hover background already reads as "interactive". Inner
+   links / buttons keep their own cursor + behaviour. */
+.funding-receipt-row--interactive {
+  cursor: pointer;
+}
+
+.funding-receipt-row--interactive:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
 /* Column-header row: small uppercase labels (matching the app's other
    section labels), no hover. */
 .funding-receipt-row--header:hover {
@@ -1247,14 +1259,12 @@
   flex-shrink: 0;
 }
 
+/* The text party is now the WalletAddress primitive (ENS / copyable
+   address); it owns truncation + numeric figures. Only the row's font
+   size needs pinning here — it inherits down to the address label. */
 .funding-receipt-row__text-party {
   font-size: 0.85rem;
   font-weight: 400;
-  color: var(--fg-primary);
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .funding-receipt-row__for {
@@ -1543,4 +1553,158 @@
   color: var(--fg-muted);
   font-size: 12px;
   line-height: 1;
+}
+
+/* ========== Funding receipt detail modal ========== */
+/* Receipt details are split into three collapsible groups (Transfer /
+   Payment / Record), each its own section + definition list. Only the
+   first is expanded on open. */
+.funding-receipt-detail__section + .funding-receipt-detail__section {
+  margin-top: 2px;
+}
+
+/* Group heading wraps the disclosure button. Reset the heading's own box
+   so the button owns all the spacing. */
+.funding-receipt-detail__section-heading {
+  margin: 0;
+}
+
+/* Disclosure button: a real heading-weight title with a rotating chevron,
+   underlined full-width so each group reads as a labelled, clickable
+   section header (not a per-row label). */
+.funding-receipt-detail__section-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 10px 4px;
+  border: 0;
+  border-bottom: 1px solid var(--border-default);
+  background: none;
+  text-align: left;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--fg-primary);
+  cursor: pointer;
+  border-radius: var(--radius) var(--radius) 0 0;
+  transition: background var(--transition-fast);
+}
+
+.funding-receipt-detail__section-toggle:hover {
+  background: var(--bg-sunken);
+}
+
+.funding-receipt-detail__section-toggle:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.funding-receipt-detail__chevron {
+  flex-shrink: 0;
+  color: var(--fg-muted);
+  transition: transform var(--transition-fast);
+}
+
+/* Points right when collapsed; rotates down when the section is open. */
+.funding-receipt-detail__chevron[data-open] {
+  transform: rotate(90deg);
+}
+
+/* Label / value definition list shown by FundingReceiptDetailModal. */
+.funding-receipt-detail__list {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+}
+
+.funding-receipt-detail__row {
+  display: grid;
+  grid-template-columns: 7.5rem minmax(0, 1fr);
+  align-items: start;
+  gap: 12px;
+  padding: 10px 0;
+}
+
+.funding-receipt-detail__row + .funding-receipt-detail__row {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.funding-receipt-detail__label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  /* Nudge the label down so its cap-height sits on the value's first line. */
+  padding-top: 3px;
+}
+
+.funding-receipt-detail__value {
+  margin: 0;
+  min-width: 0;
+  font-size: 0.85rem;
+  color: var(--fg-primary);
+}
+
+.funding-receipt-detail__amount {
+  font-variant-numeric: tabular-nums;
+}
+
+.funding-receipt-detail__currency {
+  margin-left: 4px;
+  color: var(--fg-muted);
+}
+
+.funding-receipt-detail__empty {
+  color: var(--fg-muted);
+}
+
+/* Free-text note: wrap naturally, and break overlong tokens (e.g. a
+   wallet address pasted into the note) rather than overflowing the cell. */
+.funding-receipt-detail__note {
+  overflow-wrap: anywhere;
+}
+
+.funding-receipt-detail__copyable {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.funding-receipt-detail__mono {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--fg-secondary);
+}
+
+.funding-receipt-detail__copy-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.funding-receipt-detail__copy-btn:hover {
+  background: var(--bg-sunken);
+  color: var(--fg-primary);
+}
+
+.funding-receipt-detail__copy-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }

--- a/src/app/styles/project-detail.css
+++ b/src/app/styles/project-detail.css
@@ -33,6 +33,16 @@
   flex-direction: column;
 }
 
+/* The per-tab content sits in its own flex column (the
+   TabPanelTransition wrapper, which carries the desktop tab-switch
+   slide). Matching `.project-detail`'s flow keeps the blocks as flex
+   items — same vertical spacing as when they were direct children, with
+   no margin-collapse. */
+.project-detail__body {
+  display: flex;
+  flex-direction: column;
+}
+
 @media (min-width: 800px) {
   /* Match the fullbleed width used by profile / settings / workspace
      / cert-detail so the app reads with one consistent "wide" width. */

--- a/src/app/styles/view-transitions.css
+++ b/src/app/styles/view-transitions.css
@@ -57,3 +57,57 @@ html[data-vt-dir="back"]::view-transition-old(root) {
 html[data-vt-dir="back"]::view-transition-new(root) {
   animation: vt-slide-in-left 280ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
+
+/* ---------- Desktop tab-content transition ----------
+   The full-page slide above is mobile-only (the provider navigates plainly
+   on desktop). On desktop, switching tabs animates only the content panel —
+   the chrome and the surface's own sidebar/aside stay put. TabPanelTransition
+   re-mounts the panel with a direction class matching the tab's position in
+   its strip: a tab further right slides the new content in from the right.
+   A "contained" slide (fuller offset, same directional feel as the mobile
+   page slide) scoped to the content panel so the chrome + title stay put. */
+@keyframes tab-panel-in-right {
+  from {
+    opacity: 0;
+    transform: translateX(64px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes tab-panel-in-left {
+  from {
+    opacity: 0;
+    transform: translateX(-64px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Layout-neutral: the wrapper carries only the animation. `min-width: 0`
+   keeps it from overflowing its flex/grid parent (it may either BE the
+   content container — e.g. .cert-detail__main — or nest inside one). */
+.tab-panel {
+  min-width: 0;
+}
+
+@media (min-width: 800px) {
+  .tab-panel--from-right {
+    animation: tab-panel-in-right 300ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  .tab-panel--from-left {
+    animation: tab-panel-in-left 300ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab-panel--from-right,
+  .tab-panel--from-left {
+    animation: none;
+  }
+}
+

--- a/src/components/explore-page/explore.tsx
+++ b/src/components/explore-page/explore.tsx
@@ -622,14 +622,21 @@ function ExploreMain({
     // passing it for other kinds is a no-op at the load-page level.
     excludeCertLabels: kind === "activities" ? quality.excludeCertLabels : undefined,
     includeCertLabels: kind === "activities" ? quality.includeCertLabels : undefined,
-    // Org-quality filter — used on accounts (filters the actor list)
-    // and certs (filters certs whose author org carries the tier).
+    // Org-quality filter — used on accounts (filters the actor list),
+    // certs (filters certs whose author org carries the tier), and
+    // funding (filters receipts whose creator account carries the tier).
     excludeOrgLabels:
-      kind === "accounts" || kind === "activities" || kind === "projects"
+      kind === "accounts" ||
+      kind === "activities" ||
+      kind === "projects" ||
+      kind === "funding"
         ? quality.excludeOrgLabels
         : undefined,
     includeOrgLabels:
-      kind === "accounts" || kind === "activities" || kind === "projects"
+      kind === "accounts" ||
+      kind === "activities" ||
+      kind === "projects" ||
+      kind === "funding"
         ? quality.includeOrgLabels
         : undefined,
   })
@@ -735,7 +742,9 @@ function ExploreMain({
             ) : null}
 
             <div className="explore__chrome-actions">
-              {isDesktop && (
+              {/* Funding receipts have a single list layout (no gallery
+                  card), so the list/gallery toggle is suppressed there. */}
+              {isDesktop && kind !== "funding" && (
                 <SegmentedControl
                   aria-label={`${kind === "activities" ? "Activity" : kind === "projects" ? "Project" : "Account"} view`}
                   value={view}
@@ -811,17 +820,15 @@ function ExploreMain({
               {/* Activity + account quality filter — shared with the
                   All view. The cert (Activity Labeler) section shows
                   only on the certs kind; the account (Orglabeler)
-                  section shows on every kind. */}
-              {/* Funding receipts carry no quality labels — hide the
-                  popover so the control isn't a no-op there. */}
-              {kind === "funding" ? null : (
-                <QualityFilterPopover
-                  q={quality}
-                  showCertSection={kind === "activities"}
-                  open={qualityOpen}
-                  onOpenChange={setQualityOpen}
-                />
-              )}
+                  section shows on every kind. On funding it filters
+                  receipts by the creator account's quality tier, so the
+                  account section is the only meaningful control there. */}
+              <QualityFilterPopover
+                q={quality}
+                showCertSection={kind === "activities"}
+                open={qualityOpen}
+                onOpenChange={setQualityOpen}
+              />
             </div>
           </div>
 

--- a/src/components/explore-page/funding-receipt-detail-modal.tsx
+++ b/src/components/explore-page/funding-receipt-detail-modal.tsx
@@ -1,0 +1,261 @@
+"use client"
+
+import { useId, useState, type ReactNode } from "react"
+import { Check, ChevronRight, Copy } from "lucide-react"
+import AppDialog, { AppDialogHeader } from "@/components/ui/app-dialog"
+import IdentityRow from "@/components/ui/identity-row"
+import Tooltip from "@/components/ui/tooltip"
+import { FundingForActivity, FundingPartySlot } from "./funding-receipt-parts"
+import { useAuthorInfo } from "@/hooks/use-author-info"
+import { formatShortDate } from "@/lib/utils/format-date"
+import { profileUrl } from "@/lib/urls"
+import type { FundingReceipt } from "@/lib/atproto/indexer"
+
+/**
+ * Read-only detail view for a single `org.hypercerts.funding.receipt`,
+ * opened by clicking a row in the /explore Funding list. Surfaces every
+ * field the indexer returns, ordered as a top-to-bottom narrative:
+ *   1. The transfer — who paid whom, how much, for what, plus any note.
+ *   2. The payment — when it happened and how it settled (rail / network /
+ *      transaction id).
+ *   3. The record — when it was logged, by which account, and its raw
+ *      at:// URI + CID.
+ * Optional payment-method fields render only when present so receipts that
+ * omit them stay compact; copyable values (transaction id, URI, CID) carry
+ * a copy button.
+ *
+ * Parties and the `for` activity reuse the same renderers the list row
+ * uses ({@link FundingPartySlot} / {@link FundingForActivity}) so an
+ * account shows avatar + name and a wallet address shows its ENS name /
+ * copyable hex exactly as in the row.
+ */
+export default function FundingReceiptDetailModal({
+  receipt,
+  onClose,
+}: {
+  receipt: FundingReceipt
+  onClose: () => void
+}) {
+  const hasAmount = !!receipt.amount
+  const hasForActivity = !!receipt.forUri
+
+  return (
+    <AppDialog
+      ariaLabel="Funding receipt details"
+      className="funding-receipt-detail"
+      maxWidth={460}
+      onClose={onClose}
+    >
+      <AppDialogHeader title="Funding receipt" onClose={onClose} />
+
+      <div className="px-5 pb-5 pt-0">
+        {/* Grouped as a top-to-bottom narrative: who paid whom (Transfer),
+            how it settled (Payment), and how it's recorded (Record). */}
+        <DetailSection title="Transfer" defaultOpen>
+          <DetailRow label="From">
+            <FundingPartySlot party={receipt.from} showText />
+          </DetailRow>
+
+          <DetailRow label="To">
+            <FundingPartySlot party={receipt.to} showText />
+          </DetailRow>
+
+          <DetailRow label="Amount">
+            {hasAmount ? (
+              <span className="funding-receipt-detail__amount">
+                {receipt.amount}
+                {receipt.currency ? (
+                  <span className="funding-receipt-detail__currency">
+                    {receipt.currency}
+                  </span>
+                ) : null}
+              </span>
+            ) : (
+              <EmptyValue />
+            )}
+          </DetailRow>
+
+          {hasForActivity ? (
+            <DetailRow label="For">
+              <FundingForActivity uri={receipt.forUri} />
+            </DetailRow>
+          ) : null}
+
+          {receipt.notes ? (
+            <DetailRow label="Note">
+              <span className="funding-receipt-detail__note">{receipt.notes}</span>
+            </DetailRow>
+          ) : null}
+        </DetailSection>
+
+        <DetailSection title="Payment">
+          <DetailRow label="Occurred">
+            <DateValue iso={receipt.occurredAt} />
+          </DetailRow>
+
+          {receipt.paymentRail ? (
+            <DetailRow label="Payment rail">{receipt.paymentRail}</DetailRow>
+          ) : null}
+
+          {receipt.paymentNetwork ? (
+            <DetailRow label="Payment network">
+              {receipt.paymentNetwork}
+            </DetailRow>
+          ) : null}
+
+          {receipt.transactionId ? (
+            <DetailRow label="Transaction">
+              <CopyableValue
+                value={receipt.transactionId}
+                label="Copy transaction ID"
+              />
+            </DetailRow>
+          ) : null}
+        </DetailSection>
+
+        <DetailSection title="Record">
+          <DetailRow label="Recorded">
+            <DateValue iso={receipt.createdAt} />
+          </DetailRow>
+
+          <DetailRow label="Published by">
+            <CreatorIdentity did={receipt.did} />
+          </DetailRow>
+
+          <DetailRow label="Record">
+            <CopyableValue value={receipt.uri} label="Copy record URI" />
+          </DetailRow>
+
+          <DetailRow label="CID">
+            <CopyableValue value={receipt.cid} label="Copy CID" />
+          </DetailRow>
+        </DetailSection>
+      </div>
+    </AppDialog>
+  )
+}
+
+/** A collapsible titled group of detail rows (Transfer / Payment /
+ *  Record). The heading is a disclosure button (`<h3><button>` — the
+ *  standard accordion pattern); `defaultOpen` controls the initial state,
+ *  so only the first group is expanded on open. Each section owns its own
+ *  `<dl>` so the inter-row hairlines reset at the group boundary. */
+function DetailSection({
+  title,
+  defaultOpen = false,
+  children,
+}: {
+  title: string
+  defaultOpen?: boolean
+  children: ReactNode
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+  const contentId = useId()
+  return (
+    <section className="funding-receipt-detail__section">
+      <h3 className="funding-receipt-detail__section-heading">
+        <button
+          type="button"
+          className="funding-receipt-detail__section-toggle"
+          aria-expanded={open}
+          aria-controls={contentId}
+          onClick={() => setOpen((v) => !v)}
+        >
+          <ChevronRight
+            size={16}
+            strokeWidth={2}
+            aria-hidden
+            className="funding-receipt-detail__chevron"
+            data-open={open ? "" : undefined}
+          />
+          {title}
+        </button>
+      </h3>
+      {open ? (
+        <dl id={contentId} className="funding-receipt-detail__list">
+          {children}
+        </dl>
+      ) : null}
+    </section>
+  )
+}
+
+/** One label/value pair in the detail list. */
+function DetailRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="funding-receipt-detail__row">
+      <dt className="funding-receipt-detail__label">{label}</dt>
+      <dd className="funding-receipt-detail__value">{children}</dd>
+    </div>
+  )
+}
+
+/** A null / missing field rendered as a muted em dash. */
+function EmptyValue() {
+  return <span className="funding-receipt-detail__empty">—</span>
+}
+
+/** A timestamp shown as the YYYY-MM-DD calendar date with the full ISO
+ *  string available on hover (and in the `<time>` dateTime). */
+function DateValue({ iso }: { iso: string | null }) {
+  if (!iso) return <EmptyValue />
+  return (
+    <time dateTime={iso} title={iso}>
+      {formatShortDate(iso)}
+    </time>
+  )
+}
+
+/** The account that published the receipt record (its repo DID), shown as
+ *  an avatar + name row linking to the profile — hydrated like every other
+ *  account byline. */
+function CreatorIdentity({ did }: { did: string }) {
+  const { info } = useAuthorInfo(did)
+  const handle = info?.handle ?? undefined
+  return (
+    <IdentityRow
+      did={did}
+      handle={handle}
+      displayName={info?.displayName ?? undefined}
+      avatarUrl={info?.avatarUrl ?? undefined}
+      href={profileUrl(handle || did)}
+      size="sm"
+    />
+  )
+}
+
+/** A long, monospaced identifier (at:// URI, CID) with a click-to-copy
+ *  button and a brief "Copied" confirmation. */
+function CopyableValue({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false)
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* clipboard unavailable — silent */
+    }
+  }
+  return (
+    <span className="funding-receipt-detail__copyable">
+      <span className="funding-receipt-detail__mono" title={value}>
+        {value}
+      </span>
+      <Tooltip label={copied ? "Copied" : label}>
+        <button
+          type="button"
+          className="funding-receipt-detail__copy-btn"
+          onClick={onCopy}
+          aria-label={copied ? "Copied" : label}
+        >
+          {copied ? (
+            <Check size={13} strokeWidth={2} aria-hidden />
+          ) : (
+            <Copy size={13} strokeWidth={1.75} aria-hidden />
+          )}
+        </button>
+      </Tooltip>
+    </span>
+  )
+}

--- a/src/components/explore-page/funding-receipt-parts.tsx
+++ b/src/components/explore-page/funding-receipt-parts.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import Link from "next/link"
+import IdentityRow from "@/components/ui/identity-row"
+import WalletAddress from "@/components/ui/wallet-address"
+import { useAuthorInfo } from "@/hooks/use-author-info"
+import { useActivity } from "@/hooks/use-activity"
+import { profileUrl } from "@/lib/urls"
+import { parseAtUri, activityDetailHref } from "@/lib/atproto/activity-uri"
+import { resolveActivityImageUrl } from "@/lib/atproto/activity"
+import type { FundingParty } from "@/lib/atproto/indexer"
+
+/**
+ * Shared renderers for the two sides of a funding receipt (the transfer
+ * parties and the `for` activity). Extracted from `funding-receipt-row`
+ * so both the dense list row and the detail modal render them identically
+ * without the row and the modal importing each other (circular).
+ */
+
+const ACTIVITY_COLLECTION = "org.hypercerts.claim.activity"
+
+/** Renders one side of the transfer. Accounts hydrate per-row and show
+ *  avatar + name + @handle. Text slots render their literal value when
+ *  `showText` is set (the activity detail page surfaces wallet
+ *  addresses); otherwise text / null slots render nothing (the /explore
+ *  default). */
+export function FundingPartySlot({
+  party,
+  showText = false,
+}: {
+  party: FundingParty
+  showText?: boolean
+}) {
+  const did = party?.kind === "account" ? party.did : null
+  const { info } = useAuthorInfo(did)
+  if (!did) {
+    if (showText && party?.kind === "text" && party.value) {
+      return <FundingTextParty value={party.value} />
+    }
+    return null
+  }
+  const handle = info?.handle ?? undefined
+  return (
+    <IdentityRow
+      did={did}
+      handle={handle}
+      displayName={info?.displayName ?? undefined}
+      avatarUrl={info?.avatarUrl ?? undefined}
+      href={profileUrl(handle || did)}
+      size="sm"
+      className="funding-receipt-row__party"
+    />
+  )
+}
+
+/** A free-text funding party (typically a wallet address). Renders via
+ *  {@link WalletAddress}, which shows the ENS name when one resolves,
+ *  reveals the full address on hover, and copies it on click. Non-address
+ *  text passes through verbatim. */
+function FundingTextParty({ value }: { value: string }) {
+  return (
+    <WalletAddress address={value} className="funding-receipt-row__text-party" />
+  )
+}
+
+/** The "for [activity]" column. Resolves the activity (title + square
+ *  image) from its URI via {@link useActivity} and links to its detail
+ *  page; the title wraps to at most two lines. Always renders the cell
+ *  span (empty when the `for` ref is missing or doesn't point at an
+ *  activity) so the funding table's columns stay aligned across rows. */
+export function FundingForActivity({ uri }: { uri: string | null }) {
+  const parsed = uri ? parseAtUri(uri) : null
+  const isActivity = parsed?.collection === ACTIVITY_COLLECTION
+  const { activity } = useActivity(
+    isActivity ? parsed!.did : null,
+    isActivity ? parsed!.rkey : null,
+  )
+
+  if (!parsed || !isActivity) {
+    return <span className="funding-receipt-row__for" />
+  }
+
+  const title =
+    (typeof activity?.value.title === "string" && activity.value.title) ||
+    "activity"
+  const imageUrl = activity
+    ? resolveActivityImageUrl(activity.value.image, parsed.did)
+    : null
+  const href = activityDetailHref(parsed.did, parsed.rkey)
+
+  return (
+    <span className="funding-receipt-row__for">
+      <Link href={href} className="funding-receipt-row__activity">
+        <span className="funding-receipt-row__activity-img">
+          {imageUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={imageUrl} alt="" loading="lazy" />
+          ) : null}
+        </span>
+        <span className="funding-receipt-row__activity-title">{title}</span>
+      </Link>
+    </span>
+  )
+}

--- a/src/components/explore-page/funding-receipt-row.tsx
+++ b/src/components/explore-page/funding-receipt-row.tsx
@@ -1,16 +1,10 @@
 "use client"
 
-import Link from "next/link"
-import IdentityRow from "@/components/ui/identity-row"
-import { useAuthorInfo } from "@/hooks/use-author-info"
-import { useActivity } from "@/hooks/use-activity"
-import { profileUrl } from "@/lib/urls"
-import { parseAtUri, activityDetailHref } from "@/lib/atproto/activity-uri"
-import { resolveActivityImageUrl } from "@/lib/atproto/activity"
+import { useState, type KeyboardEvent, type MouseEvent } from "react"
+import FundingReceiptDetailModal from "./funding-receipt-detail-modal"
+import { FundingPartySlot, FundingForActivity } from "./funding-receipt-parts"
 import { formatShortDate } from "@/lib/utils/format-date"
-import type { FundingParty, FundingReceipt } from "@/lib/atproto/indexer"
-
-const ACTIVITY_COLLECTION = "org.hypercerts.claim.activity"
+import type { FundingReceipt } from "@/lib/atproto/indexer"
 
 /**
  * Dense single-row representation of an `org.hypercerts.funding.receipt`
@@ -33,6 +27,7 @@ export default function FundingReceiptRow({
   receipt,
   showTextParties = false,
   showFor = true,
+  interactive = true,
 }: {
   receipt: FundingReceipt
   /** Render text (non-account) parties as their literal value rather
@@ -41,9 +36,47 @@ export default function FundingReceiptRow({
   /** Render the trailing "for [activity]" tail. Defaults to true; pass
    *  false on the activity detail page where `for` is redundant. */
   showFor?: boolean
+  /** Make the row open a detail modal on click. Defaults to true; the
+   *  inner account / wallet / activity controls keep their own behaviour
+   *  (the click handler ignores clicks that land on a link or button). */
+  interactive?: boolean
 }) {
+  const [detailOpen, setDetailOpen] = useState(false)
+
+  // Open the modal only for clicks on the row's "chrome" — clicks that
+  // land on an inner link (account, activity) or button (wallet copy)
+  // are left to those controls. Mirrors the keyboard guard below.
+  const onRowClick = (e: MouseEvent<HTMLElement>) => {
+    if ((e.target as HTMLElement).closest("a, button")) return
+    setDetailOpen(true)
+  }
+  // Enter / Space open the modal only when the row itself holds focus;
+  // when a nested link/button is focused we let it handle the key.
+  const onRowKeyDown = (e: KeyboardEvent<HTMLElement>) => {
+    if (e.target !== e.currentTarget) return
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault()
+      setDetailOpen(true)
+    }
+  }
+
+  const interactiveProps = interactive
+    ? {
+        role: "button" as const,
+        tabIndex: 0,
+        onClick: onRowClick,
+        onKeyDown: onRowKeyDown,
+        "aria-haspopup": "dialog" as const,
+        "aria-label": "View funding receipt details",
+      }
+    : {}
+
   return (
-    <article className="funding-receipt-row">
+    <>
+    <article
+      className={`funding-receipt-row${interactive ? " funding-receipt-row--interactive" : ""}`}
+      {...interactiveProps}
+    >
       {/* Columns: date | from | to | for | amount. Date leads, amount
           (the "punchline") trails. */}
       {receipt.occurredAt ? (
@@ -79,104 +112,17 @@ export default function FundingReceiptRow({
         ) : null}
       </span>
     </article>
-  )
-}
-
-/** Renders one side of the transfer. Accounts hydrate per-row and show
- *  avatar + name + @handle. Text slots render their literal value when
- *  `showText` is set (the activity detail page surfaces wallet
- *  addresses); otherwise text / null slots render nothing (the /explore
- *  default). */
-function FundingPartySlot({
-  party,
-  showText = false,
-}: {
-  party: FundingParty
-  showText?: boolean
-}) {
-  const did = party?.kind === "account" ? party.did : null
-  const { info } = useAuthorInfo(did)
-  if (!did) {
-    if (showText && party?.kind === "text" && party.value) {
-      return <FundingTextParty value={party.value} />
-    }
-    return null
-  }
-  const handle = info?.handle ?? undefined
-  return (
-    <IdentityRow
-      did={did}
-      handle={handle}
-      displayName={info?.displayName ?? undefined}
-      avatarUrl={info?.avatarUrl ?? undefined}
-      href={profileUrl(handle || did)}
-      size="sm"
-      className="funding-receipt-row__party"
-    />
-  )
-}
-
-/** Truncate a long wallet-address-style string to `head…tail` so a
- *  full 0x… hex doesn't blow out the row, while keeping the literal
- *  value reachable via the title attribute. Short / non-hex values
- *  pass through unchanged. */
-function shortenAddress(value: string): string {
-  if (value.length <= 16) return value
-  if (!value.startsWith("0x")) return value
-  return `${value.slice(0, 6)}…${value.slice(-4)}`
-}
-
-/** A free-text funding party (wallet address). Rendered as plain text
- *  (no link / hydration) since there's no account behind it. */
-function FundingTextParty({ value }: { value: string }) {
-  const display = shortenAddress(value)
-  return (
-    <span
-      className="funding-receipt-row__text-party"
-      title={display === value ? undefined : value}
-    >
-      {display}
-    </span>
-  )
-}
-
-/** The "for [activity]" column. Resolves the activity (title + square
- *  image) from its URI via {@link useActivity} and links to its detail
- *  page; the title wraps to at most two lines. Always renders the cell
- *  span (empty when the `for` ref is missing or doesn't point at an
- *  activity) so the funding table's columns stay aligned across rows. */
-function FundingForActivity({ uri }: { uri: string | null }) {
-  const parsed = uri ? parseAtUri(uri) : null
-  const isActivity = parsed?.collection === ACTIVITY_COLLECTION
-  const { activity } = useActivity(
-    isActivity ? parsed!.did : null,
-    isActivity ? parsed!.rkey : null,
-  )
-
-  if (!parsed || !isActivity) {
-    return <span className="funding-receipt-row__for" />
-  }
-
-  const title =
-    (typeof activity?.value.title === "string" && activity.value.title) ||
-    "activity"
-  const imageUrl = activity
-    ? resolveActivityImageUrl(activity.value.image, parsed.did)
-    : null
-  const href = activityDetailHref(parsed.did, parsed.rkey)
-
-  return (
-    <span className="funding-receipt-row__for">
-      <Link href={href} className="funding-receipt-row__activity">
-        <span className="funding-receipt-row__activity-img">
-          {imageUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={imageUrl} alt="" loading="lazy" />
-          ) : null}
-        </span>
-        <span className="funding-receipt-row__activity-title">{title}</span>
-      </Link>
-    </span>
+    {/* Rendered as a sibling (not a child of the row) so the modal's
+        backdrop / content clicks don't bubble back into the row's click
+        handler and re-open it. A closed <dialog> is display:none, so it
+        doesn't disturb the list's grid. */}
+    {detailOpen ? (
+      <FundingReceiptDetailModal
+        receipt={receipt}
+        onClose={() => setDetailOpen(false)}
+      />
+    ) : null}
+    </>
   )
 }
 

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -39,6 +39,8 @@ import Input from "@/components/ui/input"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import EditBanner from "@/components/ui/edit-banner"
 import Tooltip from "@/components/ui/tooltip"
+import { TabPanelTransition } from "@/components/ui/tab-panel-transition"
+import { CERT_DETAIL_TABS } from "@/lib/detail-tabs"
 import { useCertProjects } from "@/hooks/use-cert-projects"
 import { useActivityFunding } from "@/hooks/use-activity-funding"
 import FundingReceiptRow, {
@@ -1178,8 +1180,15 @@ export default function ActivityDetail({
       </aside>
 
       <div className="page-layout__main cert-detail__main">
+        {/* Title stays put across tabs (the active tab shows in the top
+            bar's second row); only the per-tab content below slides. */}
         {headline}
 
+        <TabPanelTransition
+          className="cert-detail__content"
+          activeKey={activeTab}
+          order={CERT_DETAIL_TABS.map((t) => t.key)}
+        >
         {activeTab === "overview" ? (
           <>
             {/* Short description + Read-full-description button sit
@@ -1375,6 +1384,7 @@ export default function ActivityDetail({
             />
           ) : null
         ) : null}
+        </TabPanelTransition>
       </div>
     </article>
     {deleteOpen ? (

--- a/src/components/layout/desktop-top-bar.tsx
+++ b/src/components/layout/desktop-top-bar.tsx
@@ -2,6 +2,11 @@
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { parseActor, profileUrl } from "@/lib/urls"
+import {
+  CERT_DETAIL_TABS,
+  PROJECT_DETAIL_TABS,
+  type DetailTab,
+} from "@/lib/detail-tabs"
 import { createPortal } from "react-dom";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -82,33 +87,6 @@ const PROFILE_TABS: ProfileTab[] = [
   // standalone page reachable only from the hamburger site drawer
   // (and from the legacy /settings deep link). The profile tab
   // strip stays focused on viewing-your-own-profile concerns.
-];
-
-/** Tabs for the cert-detail back-row strip. Mirrors the routing
- *  contract that `<ActivityDetail>` reads via `?tab=`. Keep keys in
- *  sync with the switch in that component. */
-/** A detail-page subtab. Plain `key` entries map to `?tab=<key>` on
- *  the current pathname. `subRoute` entries link to a child route
- *  (`<pathname>/<subRoute>`) instead — used by `Explore` which has
- *  its own page. */
-type DetailTab = { key: string; label: string; subRoute?: string };
-
-const CERT_DETAIL_TABS: DetailTab[] = [
-  { key: "overview", label: "Overview" },
-  { key: "description", label: "Description" },
-  { key: "contributors", label: "Contributors" },
-  { key: "funding", label: "Funding" },
-  { key: "updates", label: "Updates" },
-];
-
-/** Project detail page subtabs. Same `?tab=` URL contract as the
- *  cert detail above — `<ProjectDetail>` reads it and switches
- *  content. "overview" is the implicit default (no param). */
-const PROJECT_DETAIL_TABS: DetailTab[] = [
-  { key: "overview", label: "Overview" },
-  { key: "description", label: "Description" },
-  { key: "activities", label: "Activities" },
-  { key: "updates", label: "Updates" },
 ];
 
 /**

--- a/src/components/project/project-detail.tsx
+++ b/src/components/project/project-detail.tsx
@@ -32,6 +32,8 @@ import ImageEditOverlay from "@/components/feed/image-edit-overlay"
 import EditBanner from "@/components/ui/edit-banner"
 import EmptyState from "@/components/ui/empty-state"
 import Tooltip from "@/components/ui/tooltip"
+import { TabPanelTransition } from "@/components/ui/tab-panel-transition"
+import { PROJECT_DETAIL_TABS } from "@/lib/detail-tabs"
 import LeafletDocument, {
   isRenderableDescription,
 } from "@/components/leaflet/leaflet-document"
@@ -1042,6 +1044,11 @@ export default function ProjectDetail({
           <ActivityAuthor did={did} />
         </div>
 
+        <TabPanelTransition
+          className="project-detail__body"
+          activeKey={activeTab}
+          order={PROJECT_DETAIL_TABS.map((t) => t.key)}
+        >
         {/* Overview-only: hero banner + short description + the
             "more" link. Hidden on Description / Certs so those tabs
             get the full page width for their content. */}
@@ -1460,6 +1467,7 @@ export default function ProjectDetail({
             viewerDid={sessionDid}
           />
         ) : null}
+        </TabPanelTransition>
       </article>
       {deleteOpen ? (
         <DeleteRecordDialog

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -123,6 +123,9 @@ export * from "./switch";
 export { default as Tabs } from "./tabs";
 export * from "./tabs";
 
+export { default as TabPanelTransition } from "./tab-panel-transition";
+export * from "./tab-panel-transition";
+
 export { default as Textarea } from "./textarea";
 export * from "./textarea";
 
@@ -131,3 +134,6 @@ export * from "./theme-toggle";
 
 export { default as ToastProvider } from "./toast";
 export * from "./toast";
+
+export { default as WalletAddress } from "./wallet-address";
+export * from "./wallet-address";

--- a/src/components/ui/tab-panel-transition.tsx
+++ b/src/components/ui/tab-panel-transition.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { useState, type ReactNode } from "react"
+
+/**
+ * Direction-aware enter animation for tab content panels (desktop).
+ *
+ * Wrap the per-tab content of a tabbed surface (profile sections, the
+ * activity / project detail tabs) in this. On every `activeKey` change it
+ * re-mounts the content (via `key`) and tags it with a slide-in class
+ * whose direction comes from the key's position in `order` — moving to a
+ * tab further right slides the new content in from the right, further left
+ * from the left. The page chrome and the surface's own sidebar/aside sit
+ * outside this wrapper, so only the content panel moves.
+ *
+ * The animation itself lives in `view-transitions.css`, gated to ≥800px and
+ * disabled under `prefers-reduced-motion` — so below desktop (where the
+ * full-page View Transitions slide still runs) and for reduced-motion users
+ * this is an inert wrapper.
+ */
+export function TabPanelTransition({
+  activeKey,
+  order,
+  children,
+  className,
+}: {
+  /** The currently active tab's key. */
+  activeKey: string
+  /** Tab keys in their left-to-right strip order; drives slide direction. */
+  order: readonly string[]
+  children: ReactNode
+  /** Extra class(es) on the wrapper. */
+  className?: string
+}) {
+  // Track the previous key in state and derive the slide direction when it
+  // changes — React's sanctioned "adjust state during render" pattern
+  // (https://react.dev/reference/react/useState#storing-information-from-previous-renders).
+  // Setting state during render (not in an effect, no ref read in render)
+  // re-renders immediately with the new direction before commit.
+  const [shown, setShown] = useState<{ key: string; dir: string }>({
+    key: activeKey,
+    dir: "",
+  })
+  if (shown.key !== activeKey) {
+    const a = order.indexOf(shown.key)
+    const b = order.indexOf(activeKey)
+    const dir =
+      a !== -1 && b !== -1
+        ? b >= a
+          ? "tab-panel--from-right"
+          : "tab-panel--from-left"
+        : ""
+    setShown({ key: activeKey, dir })
+  }
+
+  return (
+    <div
+      key={activeKey}
+      className={`tab-panel ${shown.dir} ${className ?? ""}`.trim()}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default TabPanelTransition

--- a/src/components/ui/wallet-address.tsx
+++ b/src/components/ui/wallet-address.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { useState } from "react"
+import { Check, Copy } from "lucide-react"
+import Avatar from "@/components/ui/avatar"
+import Tooltip from "@/components/ui/tooltip"
+import { useEnsName } from "@/hooks/use-ens-name"
+import { isEthereumAddress, shortenAddress } from "@/lib/ens/resolve-ens"
+import { getInitials } from "@/lib/utils/initials"
+
+/**
+ * Inline, copyable representation of an Ethereum wallet address.
+ *
+ *   <WalletAddress address="0xE64a…5D51" />
+ *
+ * When the address reverse-resolves to a primary ENS name it shows the
+ * name (e.g. `vitalik.eth`) — with the ENS avatar when `showAvatar` is set,
+ * mirroring how an AT Protocol account renders avatar + name; otherwise it
+ * shows the shortened `0x1234…abcd` form. Either way the full address
+ * surfaces in a tooltip on hover, and clicking copies the full address to
+ * the clipboard with a brief "Copied" confirmation. Built as a generic
+ * primitive — the funding receipt list is the first consumer, but
+ * accounts / transfers / receipts elsewhere can drop it in.
+ *
+ * A value that isn't a syntactically valid address renders as plain text
+ * (no ENS lookup, no copy affordance), so callers can pass any
+ * funding-party string without pre-checking.
+ */
+export interface WalletAddressProps {
+  /** Raw 0x-prefixed address (or arbitrary text, which renders verbatim). */
+  address: string
+  /** Show the ENS avatar (when one resolves) before the name. Default true. */
+  showAvatar?: boolean
+  /** Extra classes on the root element. */
+  className?: string
+  /** Tooltip side. Default "top". */
+  tooltipSide?: "top" | "bottom"
+}
+
+export default function WalletAddress({
+  address,
+  showAvatar = true,
+  className = "",
+  tooltipSide = "top",
+}: WalletAddressProps) {
+  const valid = isEthereumAddress(address)
+  const { name, avatar } = useEnsName(valid ? address : null)
+  const [copied, setCopied] = useState(false)
+
+  if (!valid) {
+    // Not an address — render the literal value, no affordances.
+    return <span className={`wallet-address__plain ${className}`.trim()}>{address}</span>
+  }
+
+  const display = name ?? shortenAddress(address)
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(address)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* clipboard unavailable — silent */
+    }
+  }
+
+  return (
+    <Tooltip label={copied ? "Copied" : address} side={tooltipSide}>
+      <button
+        type="button"
+        className={`wallet-address ${className}`.trim()}
+        onClick={onCopy}
+        aria-label={copied ? "Copied address" : `Copy address ${address}`}
+        data-ens={name ? "" : undefined}
+      >
+        {showAvatar && avatar ? (
+          <Avatar
+            size="sm"
+            src={avatar}
+            alt=""
+            fallbackInitials={getInitials(name, address)}
+            className="wallet-address__avatar"
+          />
+        ) : null}
+        <span className="wallet-address__label">{display}</span>
+        <span className="wallet-address__copy" aria-hidden>
+          {copied ? (
+            <Check size={12} strokeWidth={2} />
+          ) : (
+            <Copy size={12} strokeWidth={1.75} />
+          )}
+        </span>
+      </button>
+    </Tooltip>
+  )
+}

--- a/src/hooks/use-ens-name.ts
+++ b/src/hooks/use-ens-name.ts
@@ -1,0 +1,44 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { isEthereumAddress, peekEns, resolveEns } from "@/lib/ens/resolve-ens"
+
+/**
+ * Resolve one Ethereum address to its ENS name + avatar through the shared
+ * `/api/ens` coalescer. `name` / `avatar` / `isLoading` are derived
+ * directly from the session cache (via `peekEns`), so an address resolved
+ * earlier renders with no loading flash; the effect only nudges a
+ * re-render once a fresh lookup settles. Never throws — an address without
+ * a reverse record (or a failed lookup) settles to `name: null`, and the
+ * caller falls back to the raw address.
+ */
+export function useEnsName(address: string | null | undefined): {
+  name: string | null
+  avatar: string | null
+  isLoading: boolean
+} {
+  const valid = isEthereumAddress(address) ? address.trim() : null
+  // Re-render trigger: the resolved value lives in the module cache, so we
+  // only need to know "something settled", not carry it in state.
+  const [, bump] = useState(0)
+
+  useEffect(() => {
+    // Already cached (resolved or known-missing) — the derived read covers
+    // it, no fetch needed.
+    if (!valid || peekEns(valid) !== undefined) return
+    let cancelled = false
+    resolveEns(valid).then(() => {
+      if (!cancelled) bump((n) => n + 1)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [valid])
+
+  const profile = valid ? peekEns(valid) : undefined
+  return {
+    name: profile?.name ?? null,
+    avatar: profile?.avatar ?? null,
+    isLoading: valid != null && profile === undefined,
+  }
+}

--- a/src/hooks/use-explore.ts
+++ b/src/hooks/use-explore.ts
@@ -1332,10 +1332,28 @@ async function loadCertsPage(args: LoadArgs): Promise<LoadedPage> {
  * than stopping at the first page's handful.
  */
 async function loadFundingPage(args: LoadArgs): Promise<LoadedPage> {
-  const { cursor, signal } = args
+  const { cursor, signal, includeOrgLabels, excludeOrgLabels } = args
+  // Deselecting every account-quality option reads as "nothing matches"
+  // (same affordance as the other kinds), not "no filter → show all".
+  if (isExplicitlyEmpty(includeOrgLabels)) return EMPTY_PAGE
+  // Account-quality (orglabeler) filter applied to the receipt creator
+  // server-side via the connection's `authorLabels` / `excludeAuthorLabels`
+  // (magic-indexer#207). With the default selection this excludes receipts
+  // authored by "likely-test" accounts, so the tab shows only receipts
+  // created by accounts that are likely real.
+  const authorLabels =
+    includeOrgLabels && includeOrgLabels.length > 0
+      ? [...includeOrgLabels]
+      : undefined
+  const excludeAuthorLabels =
+    excludeOrgLabels && excludeOrgLabels.length > 0
+      ? [...excludeOrgLabels]
+      : undefined
   const r = await fetchFundingReceipts({
     first: PAGE_SIZE,
     after: cursor ?? undefined,
+    authorLabels,
+    excludeAuthorLabels,
     signal: signal ?? undefined,
   })
   if (signal?.aborted) return EMPTY_PAGE

--- a/src/lib/atproto/indexer.ts
+++ b/src/lib/atproto/indexer.ts
@@ -409,6 +409,15 @@ export interface FundingReceipt {
   to: FundingParty
   forUri: string | null
   forCid: string | null
+  /** Optional payment-method metadata, as recorded on the receipt. The
+   *  lexicon names are singular `paymentRail` (e.g. "x402-usdc-base") and
+   *  `transactionId` (the on-chain / processor reference). Any may be
+   *  null. */
+  paymentRail: string | null
+  paymentNetwork: string | null
+  transactionId: string | null
+  /** Free-text note attached to the receipt. */
+  notes: string | null
 }
 
 interface FundingPartyNode {
@@ -428,6 +437,10 @@ interface FundingReceiptNode {
   from: FundingPartyNode | null
   to: FundingPartyNode | null
   for: { uri: string | null; cid: string | null } | null
+  paymentRail: string | null
+  paymentNetwork: string | null
+  transactionId: string | null
+  notes: string | null
 }
 
 interface FundingReceiptsGraphQLResponse {
@@ -459,6 +472,29 @@ function mapFundingParty(node: FundingPartyNode | null): FundingParty {
   return null
 }
 
+/** Normalise a raw funding-receipt node into a {@link FundingReceipt}.
+ *  Shared by both the network-wide and per-activity fetchers so the field
+ *  set stays in sync. */
+function mapFundingReceiptNode(node: FundingReceiptNode): FundingReceipt {
+  return {
+    uri: node.uri,
+    cid: node.cid,
+    did: node.did,
+    createdAt: node.createdAt ?? null,
+    occurredAt: node.occurredAt ?? null,
+    amount: node.amount ?? null,
+    currency: node.currency ?? null,
+    from: mapFundingParty(node.from),
+    to: mapFundingParty(node.to),
+    forUri: node.for?.uri ?? null,
+    forCid: node.for?.cid ?? null,
+    paymentRail: node.paymentRail ?? null,
+    paymentNetwork: node.paymentNetwork ?? null,
+    transactionId: node.transactionId ?? null,
+    notes: node.notes ?? null,
+  }
+}
+
 export interface FundingReceiptsResult {
   records: FundingReceipt[]
   hasMore: boolean
@@ -475,16 +511,32 @@ export interface FundingReceiptsResult {
  * tab into an error state.
  */
 export async function fetchFundingReceipts(
-  options: { first?: number; after?: string; signal?: AbortSignal } = {},
+  options: {
+    first?: number
+    after?: string
+    /** Account-quality (orglabeler) tiers the receipt creator must carry. */
+    authorLabels?: readonly string[]
+    /** Account-quality tiers that exclude a receipt by its creator. */
+    excludeAuthorLabels?: readonly string[]
+    signal?: AbortSignal
+  } = {},
 ): Promise<FundingReceiptsResult> {
-  const { first = 50, after, signal } = options
+  const { first = 50, after, authorLabels, excludeAuthorLabels, signal } = options
 
   const res = await fetch(INDEXER_PROXY_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       operationName: "FundingReceipts",
-      variables: { first, after: after ?? null },
+      variables: {
+        first,
+        after: after ?? null,
+        authorLabels: authorLabels && authorLabels.length > 0 ? [...authorLabels] : null,
+        excludeAuthorLabels:
+          excludeAuthorLabels && excludeAuthorLabels.length > 0
+            ? [...excludeAuthorLabels]
+            : null,
+      },
     }),
     signal,
   })
@@ -514,19 +566,7 @@ export async function fetchFundingReceipts(
   for (const edge of connection.edges) {
     const node = edge.node
     if (!node) continue
-    records.push({
-      uri: node.uri,
-      cid: node.cid,
-      did: node.did,
-      createdAt: node.createdAt ?? null,
-      occurredAt: node.occurredAt ?? null,
-      amount: node.amount ?? null,
-      currency: node.currency ?? null,
-      from: mapFundingParty(node.from),
-      to: mapFundingParty(node.to),
-      forUri: node.for?.uri ?? null,
-      forCid: node.for?.cid ?? null,
-    })
+    records.push(mapFundingReceiptNode(node))
   }
 
   return {
@@ -587,19 +627,7 @@ export async function fetchFundingReceiptsForActivity(
   for (const edge of connection.edges) {
     const node = edge.node
     if (!node) continue
-    records.push({
-      uri: node.uri,
-      cid: node.cid,
-      did: node.did,
-      createdAt: node.createdAt ?? null,
-      occurredAt: node.occurredAt ?? null,
-      amount: node.amount ?? null,
-      currency: node.currency ?? null,
-      from: mapFundingParty(node.from),
-      to: mapFundingParty(node.to),
-      forUri: node.for?.uri ?? null,
-      forCid: node.for?.cid ?? null,
-    })
+    records.push(mapFundingReceiptNode(node))
   }
 
   return {

--- a/src/lib/detail-tabs.ts
+++ b/src/lib/detail-tabs.ts
@@ -1,0 +1,28 @@
+/**
+ * Subtab definitions for the activity (cert) and project detail pages,
+ * shared by the desktop top-bar strip (`desktop-top-bar.tsx`) and the
+ * detail components' content transition (`TabPanelTransition`). Single
+ * source of truth for the left-to-right tab order, which drives both the
+ * strip and the direction of the desktop tab-switch slide.
+ *
+ * Plain `key` entries map to `?tab=<key>` on the current pathname;
+ * `subRoute` entries link to a child route (`<pathname>/<subRoute>`) — used
+ * by `Explore`, which has its own page. `overview` is the implicit default
+ * (no `?tab=`).
+ */
+export type DetailTab = { key: string; label: string; subRoute?: string }
+
+export const CERT_DETAIL_TABS: DetailTab[] = [
+  { key: "overview", label: "Overview" },
+  { key: "description", label: "Description" },
+  { key: "contributors", label: "Contributors" },
+  { key: "funding", label: "Funding" },
+  { key: "updates", label: "Updates" },
+]
+
+export const PROJECT_DETAIL_TABS: DetailTab[] = [
+  { key: "overview", label: "Overview" },
+  { key: "description", label: "Description" },
+  { key: "activities", label: "Activities" },
+  { key: "updates", label: "Updates" },
+]

--- a/src/lib/ens/resolve-ens.ts
+++ b/src/lib/ens/resolve-ens.ts
@@ -1,0 +1,95 @@
+/**
+ * Client helpers for turning a raw Ethereum address into a display-ready
+ * ENS name. Resolution goes through our own `/api/ens` proxy (see that
+ * route for why); this module adds the address validation, the
+ * `0x1234…abcd` shortening, and a process-lifetime cache + in-flight
+ * coalescer so a list rendering the same address in many rows resolves it
+ * once. Mirrors the dedupe/cache shape of `resolve-did-batch`.
+ */
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
+
+/** True when `value` is a syntactically valid 0x-prefixed 20-byte address. */
+export function isEthereumAddress(value: string | null | undefined): value is string {
+  return typeof value === "string" && ADDRESS_RE.test(value.trim())
+}
+
+/**
+ * Shorten a wallet address to `0x1234…abcd` for dense inline display.
+ * Non-address strings pass through unchanged so the helper is safe to call
+ * on any funding-party text value.
+ */
+export function shortenAddress(value: string): string {
+  const v = value.trim()
+  if (!isEthereumAddress(v)) return value
+  return `${v.slice(0, 6)}…${v.slice(-4)}`
+}
+
+/** A resolved ENS identity: primary name + avatar, either of which may be
+ *  null. `EMPTY` is the shared "resolved, but nothing found" value. */
+export interface EnsProfile {
+  name: string | null
+  avatar: string | null
+}
+
+const EMPTY: EnsProfile = { name: null, avatar: null }
+
+// Resolved profiles live for the page's lifetime — ENS records are
+// effectively static across a session, and the /api/ens route already
+// owns the real TTL. A cached `EMPTY` means "looked up, nothing found" so
+// we don't re-request addresses that lack a reverse record.
+const cache = new Map<string, EnsProfile>()
+const inFlight = new Map<string, Promise<EnsProfile>>()
+
+/**
+ * Reverse-resolve `address` to its ENS name + avatar (either may be null,
+ * `EMPTY` when it has none / resolution fails — never rejects). Concurrent
+ * callers for the same address share one request; results are cached for
+ * the session.
+ */
+export function resolveEns(address: string): Promise<EnsProfile> {
+  const key = address.trim().toLowerCase()
+  if (!isEthereumAddress(key)) return Promise.resolve(EMPTY)
+  if (cache.has(key)) return Promise.resolve(cache.get(key) ?? EMPTY)
+  const pending = inFlight.get(key)
+  if (pending) return pending
+
+  const request = fetch(`/api/ens?address=${encodeURIComponent(key)}`)
+    .then((res) => (res.ok ? res.json() : null))
+    .then((data: { name?: string | null; avatar?: string | null } | null) => {
+      const profile: EnsProfile = {
+        name:
+          data && typeof data.name === "string" && data.name.length > 0
+            ? data.name
+            : null,
+        avatar:
+          data && typeof data.avatar === "string" && data.avatar.length > 0
+            ? data.avatar
+            : null,
+      }
+      cache.set(key, profile)
+      return profile
+    })
+    .catch(() => {
+      // Cache the miss so the lookup settles (no stuck loading state) and
+      // we don't re-hit a failing upstream every render. The /api/ens
+      // route doesn't cache its error path, so a full reload still retries.
+      cache.set(key, EMPTY)
+      return EMPTY
+    })
+    .finally(() => {
+      inFlight.delete(key)
+    })
+
+  inFlight.set(key, request)
+  return request
+}
+
+/** Synchronously read an already-resolved profile from the cache, if
+ *  present. Lets a hook seed its initial state without a loading flash on
+ *  re-render of an address resolved earlier in the session. Returns
+ *  `undefined` when the address hasn't been resolved yet (distinct from a
+ *  cached "nothing found"). */
+export function peekEns(address: string): EnsProfile | undefined {
+  return cache.get(address.trim().toLowerCase())
+}

--- a/src/lib/view-transitions.tsx
+++ b/src/lib/view-transitions.tsx
@@ -78,7 +78,15 @@ export function ViewTransitionProvider({ children }: { children: ReactNode }) {
     const start = (
       document as Document & { startViewTransition?: StartViewTransition }
     ).startViewTransition?.bind(document)
-    if (!start || prefersReducedMotion()) {
+    // The full-page root slide is a mobile affordance. On desktop (≥800px,
+    // BP_GT_MOBILE) it drags the persistent chrome (top bar, nav rail)
+    // sideways for what are really tab switches — so desktop navigates
+    // plainly and the per-tab content animates locally instead (see
+    // TabPanelTransition). Mobile keeps the directional page slide.
+    const isDesktop =
+      typeof window !== "undefined" &&
+      window.matchMedia("(min-width: 800px)").matches
+    if (!start || prefersReducedMotion() || isDesktop) {
       navigate()
       return
     }


### PR DESCRIPTION
## Summary

Two changes on top of `staging`.

### Explore — Funding
- **Account-quality filter** on funding receipts: shows only receipts whose **creator account is likely real** (server-side `authorLabels` / `excludeAuthorLabels`). Removed the list/gallery switcher for funding (single list layout).
- New **`WalletAddress`** primitive: reverse-resolves **ENS name + avatar** via a new `/api/ens` proxy, shows the full address on hover, click-to-copy. Used for funding-receipt wallet parties.
- Click-to-open **funding receipt detail modal** showing every field (parties, amount, funded activity, `paymentRail` / `paymentNetwork` / `transactionId` / `notes`, timestamps, publishing account, record URI + CID) in collapsible **Transfer / Payment / Record** sections.

### Detail + Profile — desktop tab-switch animation
- The full-page View Transitions slide is now **mobile-only**. On desktop, switching tabs on the activity/project detail and profile pages animates **only the content panel** — a direction-aware "contained" slide keyed to the tab's position in its strip — so the page chrome and the detail **title stay put**. Mobile behaviour is unchanged.

## Checks
- `tsc --noEmit`: clean
- `npm run lint`: 64 warnings (baseline, no new)
- Design pre-merge greps (radii / breakpoints / headings / modal backdrops): clean

## Notes
- Desktop back-button navigation is now plain (no full-page slide), as a consequence of making the slide mobile-only.
- A visual pass is suggested for the detail/profile tab animation and the funding receipt modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)