### PR TITLE
feat(funding): perspectives, per-role records, rights modal, filter polish

### DIFF
--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -1055,6 +1055,30 @@
   word-break: break-all;
 }
 
+/* The Rights meta value reads as plain text but opens the rights detail
+   modal on click — underline on hover signals it's interactive. */
+.cert-detail__rights-link {
+  display: inline;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.cert-detail__rights-link:hover {
+  text-decoration: underline;
+}
+
+.cert-detail__rights-link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius);
+}
+
 /* ---------- Sections (contributors / locations / description) ---------- */
 
 .cert-detail__section {

--- a/src/components/explore-page/funding-confirmed-by-popover.tsx
+++ b/src/components/explore-page/funding-confirmed-by-popover.tsx
@@ -8,6 +8,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 import Tooltip from "@/components/ui/tooltip"
+import Button from "@/components/ui/button"
 import Checkbox from "@/components/ui/checkbox"
 import { HydratedIdentityRow } from "./funding-receipt-parts"
 import {
@@ -19,7 +20,7 @@ import type { FundingReceipt } from "@/lib/atproto/indexer"
 
 const ROLE_LABEL: Record<ConfirmRole, string> = {
   both: "Both",
-  sender: "Sender",
+  sender: "Funder",
   recipient: "Recipient",
 }
 
@@ -45,6 +46,7 @@ export default function FundingConfirmedByPopover({
   onReset,
   open,
   onOpenChange,
+  triggerVariant = "chrome",
 }: {
   /** Full loaded result set — the source of third-party candidates. */
   receipts: FundingReceipt[]
@@ -58,6 +60,10 @@ export default function FundingConfirmedByPopover({
   onReset: () => void
   open: boolean
   onOpenChange: (v: boolean) => void
+  /** "chrome" — the /explore toolbar icon button (default). "section" — a
+   *  labelled secondary button matching the "Record funding" action on the
+   *  activity-detail Funding header. */
+  triggerVariant?: "chrome" | "section"
 }) {
   // Associate each checkbox section with its visible label for AT (the
   // popover renders role="group", not a menu).
@@ -92,15 +98,27 @@ export default function FundingConfirmedByPopover({
     <UiPopover open={open} onOpenChange={onOpenChange}>
       <Tooltip label="Filter by confirmer">
         <PopoverTrigger>
-          <button
-            type="button"
-            className={`explore__chrome-btn explore__chrome-btn--icon${
-              isDefault ? "" : " explore__chrome-btn--active"
-            }`}
-            aria-label={`Filter by confirmer${isDefault ? "" : " (filtered)"}`}
-          >
-            <UserRoundCheck size={13} strokeWidth={1.75} aria-hidden />
-          </button>
+          {triggerVariant === "section" ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              pressed={!isDefault}
+              className="cert-detail__section-action-btn"
+              aria-label={`Filter by confirmer${isDefault ? "" : " (filtered)"}`}
+            >
+              <UserRoundCheck size={14} strokeWidth={1.75} aria-hidden />
+            </Button>
+          ) : (
+            <button
+              type="button"
+              className={`explore__chrome-btn explore__chrome-btn--icon${
+                isDefault ? "" : " explore__chrome-btn--active"
+              }`}
+              aria-label={`Filter by confirmer${isDefault ? "" : " (filtered)"}`}
+            >
+              <UserRoundCheck size={13} strokeWidth={1.75} aria-hidden />
+            </button>
+          )}
         </PopoverTrigger>
       </Tooltip>
       <PopoverContent align="end" role="group" aria-label="Confirmed by filter">

--- a/src/components/explore-page/funding-receipt-detail-modal.tsx
+++ b/src/components/explore-page/funding-receipt-detail-modal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useId, useMemo, useState, type ReactNode } from "react"
+import { useEffect, useId, useMemo, useState, type ReactNode } from "react"
 import { Check, ChevronRight, Copy, Trash2 } from "lucide-react"
 import AppDialog, { AppDialogHeader, AppDialogBody } from "@/components/ui/app-dialog"
 import Button from "@/components/ui/button"
@@ -19,13 +19,13 @@ import {
   fundingConfirmEligibility,
   type FundingRole,
 } from "@/lib/atproto/funding-provenance"
-import { receiptAuthorRole } from "@/lib/atproto/funding-merge"
+import { receiptAuthorRole, sameClusterKeys } from "@/lib/atproto/funding-merge"
+import { deleteFundingReceipt, listFundingReceiptsInRepo } from "@/lib/atproto/funding-receipt-record"
 import type { FundingAttestation } from "@/lib/atproto/indexer"
 import {
   useFundingConfirmedLocally,
   markFundingDeleted,
 } from "@/lib/atproto/funding-confirmed-store"
-import { deleteFundingReceipt } from "@/lib/atproto/funding-receipt-record"
 import { formatShortDate } from "@/lib/utils/format-date"
 import type { FundingReceipt } from "@/lib/atproto/indexer"
 
@@ -100,24 +100,64 @@ export default function FundingReceiptDetailModal({
   const hasAmount = !!receipt.amount
   const hasForActivity = !!receipt.forUri
 
-  // One "Record" section per author of the payment. Prefer the attestations
-  // (they cover the whole cluster); fall back to this receipt alone when
-  // unattested. Match each author to a member receipt we hold (if any) for its
-  // date / URI / CID — non-canonical members the indexer dropped are unknown.
-  const recordAuthors: FundingAttestation[] =
-    receipt.attestations.length > 0
-      ? receipt.attestations
-      : [{ role: receiptAuthorRole(receipt), did: receipt.did }]
-  const multipleRecords = recordAuthors.length > 1
-  const memberByDid = new Map(
-    (receipt.members ?? [receipt]).map((m) => [m.did, m] as const),
-  )
-
   const { did: viewerDid } = useAuth()
   const { groups } = useOrg()
   // A confirmation this session (before the indexer reflects it) keeps the
   // viewer's own affordance hidden so the payment can't be confirmed twice.
   const confirmedLocally = useFundingConfirmedLocally(receipt.uri)
+
+  // One "Record" section per author of the payment. Prefer the attestations
+  // (they cover the whole cluster); fall back to this receipt alone when
+  // unattested.
+  const recordAuthors: FundingAttestation[] =
+    receipt.attestations.length > 0
+      ? receipt.attestations
+      : [{ role: receiptAuthorRole(receipt), did: receipt.did }]
+  const multipleRecords = recordAuthors.length > 1
+
+  // The indexer collapses a confirmed payment into one canonical node, dropping
+  // the other members — and the canonical exposes no link to them (its
+  // `matchingReceipt` is cleared). So an attestation author we don't hold a
+  // receipt for has no date/URI/CID and can't be taken back. Recover each by
+  // listing that author's repo and matching the payment's cluster keys. Keyed
+  // by the receipt URI so members from a previous receipt are ignored without a
+  // synchronous reset.
+  const [resolved, setResolved] = useState<{
+    uri: string
+    members: FundingReceipt[]
+  } | null>(null)
+  useEffect(() => {
+    const base = receipt.members ?? [receipt]
+    const haveDids = new Set(base.map((m) => m.did))
+    const missingDids = [
+      ...new Set(receipt.attestations.map((a) => a.did)),
+    ].filter((did) => !haveDids.has(did))
+    if (missingDids.length === 0) return
+    let cancelled = false
+    Promise.all(
+      missingDids.map(async (did) => {
+        const all = await listFundingReceiptsInRepo(did)
+        return all.find((r) => sameClusterKeys(receipt, r)) ?? null
+      }),
+    ).then((found) => {
+      const members = found.filter((r): r is FundingReceipt => r !== null)
+      if (!cancelled && members.length > 0) {
+        setResolved({ uri: receipt.uri, members })
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [receipt])
+
+  const memberByDid = useMemo(() => {
+    const map = new Map<string, FundingReceipt>()
+    for (const m of receipt.members ?? [receipt]) map.set(m.did, m)
+    if (resolved?.uri === receipt.uri) {
+      for (const m of resolved.members) if (!map.has(m.did)) map.set(m.did, m)
+    }
+    return map
+  }, [receipt, resolved])
 
   // The identities the viewer can act through on this payment: themselves,
   // plus any group they're an owner/admin of that the payment involves (a
@@ -135,9 +175,7 @@ export default function FundingReceiptDetailModal({
       out.push(buildPerspective(receipt, g.groupDid, true, memberByDid, false))
     }
     return out
-    // memberByDid is derived from `receipt` each render; depend on `receipt`.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [receipt, viewerDid, groups, confirmedLocally])
+  }, [receipt, viewerDid, groups, confirmedLocally, memberByDid])
 
   const [confirmingAs, setConfirmingAs] = useState<{
     did: string
@@ -450,7 +488,7 @@ export default function FundingReceiptDetailModal({
  *  standard accordion pattern); `defaultOpen` controls the initial state,
  *  so only the first group is expanded on open. Each section owns its own
  *  `<dl>` so the inter-row hairlines reset at the group boundary. */
-function DetailSection({
+export function DetailSection({
   title,
   defaultOpen = false,
   children,
@@ -491,7 +529,7 @@ function DetailSection({
 }
 
 /** One label/value pair in the detail list. */
-function DetailRow({ label, children }: { label: string; children: ReactNode }) {
+export function DetailRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="funding-receipt-detail__row">
       <dt className="funding-receipt-detail__label">{label}</dt>
@@ -501,13 +539,13 @@ function DetailRow({ label, children }: { label: string; children: ReactNode }) 
 }
 
 /** A null / missing field rendered as a muted em dash. */
-function EmptyValue() {
+export function EmptyValue() {
   return <span className="funding-receipt-detail__empty">—</span>
 }
 
 /** A timestamp shown as the YYYY-MM-DD calendar date with the full ISO
  *  string available on hover (and in the `<time>` dateTime). */
-function DateValue({ iso }: { iso: string | null }) {
+export function DateValue({ iso }: { iso: string | null }) {
   if (!iso) return <EmptyValue />
   return (
     <time dateTime={iso} title={iso}>
@@ -534,7 +572,7 @@ function RecordSectionTitle({
   did: string
 }) {
   const { info } = useAuthorInfo(did)
-  if (role === "sender") return <>Record (Sender)</>
+  if (role === "sender") return <>Record (Funder)</>
   if (role === "recipient") return <>Record (Recipient)</>
   const name =
     info?.displayName || (info?.handle ? `@${info.handle}` : "third party")
@@ -543,7 +581,7 @@ function RecordSectionTitle({
 
 /** A long, monospaced identifier (at:// URI, CID) with a click-to-copy
  *  button and a brief "Copied" confirmation. */
-function CopyableValue({ value, label }: { value: string; label: string }) {
+export function CopyableValue({ value, label }: { value: string; label: string }) {
   const { copied, copy } = useCopyToClipboard()
   return (
     <span className="funding-receipt-detail__copyable">

--- a/src/components/explore-page/funding-receipt-row.tsx
+++ b/src/components/explore-page/funding-receipt-row.tsx
@@ -155,9 +155,9 @@ function FundingConfirmedBy({ receipt }: { receipt: FundingReceipt }) {
 
   const partyLabel =
     hasSender && hasRecipient
-      ? "Sender & Recipient"
+      ? "Funder & Recipient"
       : hasSender
-        ? "Sender"
+        ? "Funder"
         : hasRecipient
           ? "Recipient"
           : null

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -60,6 +60,7 @@ import FundingConfirmedByPopover from "@/components/explore-page/funding-confirm
 import { matchesConfirmedBy, isTrustedEvaluator } from "@/lib/atproto/funding-provenance"
 import FundingReceiptFormModal from "@/components/funding/funding-receipt-form-modal"
 import FundingIdentityChoiceDialog from "@/components/funding/funding-identity-choice-dialog"
+import RightsDetailModal from "@/components/feed/rights-detail-modal"
 import Button from "@/components/ui/button"
 import { useFundingConfirmedBy } from "@/hooks/use-funding-confirmed-by"
 import { useAuthorInfo } from "@/hooks/use-author-info"
@@ -262,6 +263,8 @@ export default function ActivityDetail({
   const [recordIdentityOpen, setRecordIdentityOpen] = useState(false)
   const [recordFundingAs, setRecordFundingAs] =
     useState<"individual" | "group">("individual")
+  // Rights detail modal (opened from the Rights meta row).
+  const [rightsModalOpen, setRightsModalOpen] = useState(false)
 
   // Funding "Confirmed by" filter — same URL-backed state + popover as
   // /explore. Applied client-side to the loaded receipts (shared by the
@@ -303,6 +306,7 @@ export default function ActivityDetail({
       onReset={confirmedBy.reset}
       open={confirmedByOpen}
       onOpenChange={setConfirmedByOpen}
+      triggerVariant="section"
     />
   )
 
@@ -460,10 +464,20 @@ export default function ActivityDetail({
       ) ?? null
   const [groupEditOpen, setGroupEditOpen] = useState(false)
   const editHref = `${recordUrl(did, "activity", rkey ?? "")}/edit`
-  const descriptionHref = pathname
-    ? `${pathname}?tab=description`
-    : null
-  const fundingHref = pathname ? `${pathname}?tab=funding` : null
+  // Build a tab href that PRESERVES the current query params (e.g. the
+  // funding "Confirmed by" filter `?confirmedRoles=`), so jumping from the
+  // overview to a sub-tab via "See all" doesn't reset the filter. Mirrors the
+  // top-bar tab strip's `hrefFor`.
+  const tabHref = (tab: string): string | null => {
+    if (!pathname) return null
+    const params = new URLSearchParams(searchParams?.toString() ?? "")
+    if (tab === "overview") params.delete("tab")
+    else params.set("tab", tab)
+    const qs = params.toString()
+    return qs ? `${pathname}?${qs}` : pathname
+  }
+  const descriptionHref = tabHref("description")
+  const fundingHref = tabHref("funding")
 
   // -------------------------------------------------------------------
   // Inline edit state — same pattern as the profile page. Drafts are
@@ -1232,9 +1246,7 @@ export default function ActivityDetail({
             ? (() => {
                 const ASIDE_CONTRIB_PREVIEW = 5
                 const shown = contributors.slice(0, ASIDE_CONTRIB_PREVIEW)
-                const contributorsHref = pathname
-                  ? `${pathname}?tab=contributors`
-                  : null
+                const contributorsHref = tabHref("contributors")
                 const hasAnyWeight = shown.some(
                   (c) => c.contributionWeight != null,
                 )
@@ -1299,13 +1311,20 @@ export default function ActivityDetail({
                 Rights
               </dt>
               <dd className="cert-detail__meta-value">
-                {rightsName ? (
-                  rightsName
-                ) : rightsLoading ? (
-                  <span className="cert-detail__meta-aux">Loading…</span>
-                ) : (
-                  <span className="cert-detail__uri">{value.rights.uri}</span>
-                )}
+                <button
+                  type="button"
+                  className="cert-detail__rights-link"
+                  onClick={() => setRightsModalOpen(true)}
+                  title="View rights details"
+                >
+                  {rightsName ? (
+                    rightsName
+                  ) : rightsLoading ? (
+                    <span className="cert-detail__meta-aux">Loading…</span>
+                  ) : (
+                    <span className="cert-detail__uri">{value.rights.uri}</span>
+                  )}
+                </button>
               </dd>
             </div>
           ) : null}
@@ -1342,7 +1361,7 @@ export default function ActivityDetail({
                 subjectUri={`at://${did}/org.hypercerts.claim.activity/${rkey}`}
                 variant="overview"
                 maxItems={1}
-                seeAllHref={pathname ? `${pathname}?tab=updates` : null}
+                seeAllHref={tabHref("updates")}
               />
             ) : null}
 
@@ -1618,6 +1637,13 @@ export default function ActivityDetail({
           )
         })()
       : null}
+    {rightsModalOpen && value.rights ? (
+      <RightsDetailModal
+        uri={value.rights.uri}
+        cid={value.rights.cid}
+        onClose={() => setRightsModalOpen(false)}
+      />
+    ) : null}
     </>
   )
 }

--- a/src/components/feed/rights-detail-modal.tsx
+++ b/src/components/feed/rights-detail-modal.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import AppDialog, { AppDialogHeader } from "@/components/ui/app-dialog"
+import LoadingSpinner from "@/components/ui/loading-spinner"
+import { HydratedIdentityRow } from "@/components/explore-page/funding-receipt-parts"
+import {
+  DetailSection,
+  DetailRow,
+  EmptyValue,
+  DateValue,
+  CopyableValue,
+} from "@/components/explore-page/funding-receipt-detail-modal"
+import { useRights } from "@/hooks/use-rights"
+import { parseAtUri } from "@/lib/atproto/activity-uri"
+
+/**
+ * Read-only detail view for the `org.hypercerts.claim.rights` record an
+ * activity references. Opened by clicking the Rights row on the activity
+ * detail page. Mirrors the funding-receipt detail modal's chrome and section
+ * layout (reusing its `DetailSection` / `DetailRow` building blocks):
+ *   1. The rights — name, type, full description.
+ *   2. The record — when it was created, by which account, raw at:// URI + CID.
+ */
+export default function RightsDetailModal({
+  uri,
+  cid,
+  onClose,
+}: {
+  uri: string
+  cid: string
+  onClose: () => void
+}) {
+  const { record, isLoading } = useRights(uri)
+  const did = parseAtUri(uri)?.did ?? null
+
+  const rightsName =
+    typeof record?.rightsName === "string" ? record.rightsName : null
+  const rightsType =
+    typeof record?.rightsType === "string" ? record.rightsType : null
+  const rightsDescription =
+    typeof record?.rightsDescription === "string"
+      ? record.rightsDescription
+      : null
+  const createdAt =
+    typeof record?.createdAt === "string" ? record.createdAt : null
+
+  return (
+    <AppDialog
+      ariaLabel="Rights details"
+      className="funding-receipt-detail"
+      maxWidth={460}
+      onClose={onClose}
+    >
+      <AppDialogHeader title="Rights" onClose={onClose} />
+
+      <div className="px-5 pb-5 pt-0">
+        {isLoading && !record ? (
+          <div className="flex justify-center py-6">
+            <LoadingSpinner size="sm" />
+          </div>
+        ) : (
+          <>
+            <DetailSection title="Rights" defaultOpen>
+              <DetailRow label="Name">
+                {rightsName ? rightsName : <EmptyValue />}
+              </DetailRow>
+
+              <DetailRow label="Type">
+                {rightsType ? rightsType : <EmptyValue />}
+              </DetailRow>
+
+              <DetailRow label="Description">
+                {rightsDescription ? (
+                  <span className="funding-receipt-detail__note">
+                    {rightsDescription}
+                  </span>
+                ) : (
+                  <EmptyValue />
+                )}
+              </DetailRow>
+            </DetailSection>
+
+            <DetailSection title="Record">
+              <DetailRow label="Created">
+                <DateValue iso={createdAt} />
+              </DetailRow>
+
+              <DetailRow label="Published by">
+                {did ? <HydratedIdentityRow did={did} /> : <EmptyValue />}
+              </DetailRow>
+
+              <DetailRow label="Record">
+                <CopyableValue value={uri} label="Copy record URI" />
+              </DetailRow>
+
+              <DetailRow label="CID">
+                <CopyableValue value={cid} label="Copy CID" />
+              </DetailRow>
+            </DetailSection>
+          </>
+        )}
+      </div>
+    </AppDialog>
+  )
+}

--- a/src/components/funding/confirm-funding-dialog.tsx
+++ b/src/components/funding/confirm-funding-dialog.tsx
@@ -28,7 +28,7 @@ import type { FundingReceipt } from "@/lib/atproto/indexer"
  */
 
 const ROLE_LABEL: Record<FundingRole, string> = {
-  sender: "the sender",
+  sender: "the funder",
   recipient: "the recipient",
   "third-party": "a third party",
 }

--- a/src/components/funding/funding-receipt-form-modal.tsx
+++ b/src/components/funding/funding-receipt-form-modal.tsx
@@ -210,7 +210,7 @@ export default function FundingReceiptFormModal({
               fixedIdentity(writerDid)
             ) : (
               <FundingPartyField
-                ariaLabel="Sender"
+                ariaLabel="Funder"
                 value={fromParty}
                 onChange={setFromParty}
                 disabled={submitting}

--- a/src/hooks/use-rights.ts
+++ b/src/hooks/use-rights.ts
@@ -61,6 +61,8 @@ function fetchRights(uri: string): Promise<RightsRecordValue | null> {
  */
 export function useRights(uri: string | null | undefined): {
   name: string | null
+  /** The full record, for the rights detail modal. */
+  record: RightsRecordValue | null
   isLoading: boolean
 } {
   const [record, setRecord] = useState<RightsRecordValue | null>(null)
@@ -95,5 +97,5 @@ export function useRights(uri: string | null | undefined): {
       ? record.rightsType
       : null)
 
-  return { name, isLoading }
+  return { name, record, isLoading }
 }

--- a/src/lib/atproto/funding-receipt-record.ts
+++ b/src/lib/atproto/funding-receipt-record.ts
@@ -287,6 +287,42 @@ export async function createFundingReceipt(
 const AT_URI_RE = /^at:\/\/([^/]+)\/([^/]+)\/([^/]+)$/
 
 /**
+ * List a repo's funding receipts (mapped to {@link FundingReceipt}, with empty
+ * attestations — the role is derived from author-vs-from/to). Used to recover a
+ * payment's member receipts the indexer dropped when it collapsed the cluster:
+ * the collapsed canonical node exposes no link to them (its `matchingReceipt`
+ * is cleared), so the detail view lists each attester's repo and matches by
+ * cluster keys. Returns [] on any failure. (Caps at the first 100 records.)
+ */
+export async function listFundingReceiptsInRepo(
+  repo: string,
+): Promise<FundingReceipt[]> {
+  const params = new URLSearchParams({
+    repo,
+    collection: FUNDING_RECEIPT_COLLECTION,
+    limit: "100",
+  })
+  try {
+    const res = await fetch(
+      `/api/xrpc/com/atproto/repo/listRecords?${params.toString()}`,
+      { headers: { Accept: "application/json" } },
+    )
+    if (!res.ok) return []
+    const data = (await res.json().catch(() => null)) as {
+      records?: { uri?: string; cid?: string; value?: FundingReceiptRecord }[]
+    } | null
+    const out: FundingReceipt[] = []
+    for (const rec of data?.records ?? []) {
+      if (!rec?.value || !rec.uri || !rec.cid) continue
+      out.push(recordToReceipt(rec.value, { uri: rec.uri, cid: rec.cid, did: repo }))
+    }
+    return out
+  } catch {
+    return []
+  }
+}
+
+/**
  * Delete a funding receipt the viewer authored — taking back a recorded
  * payment or a confirmation. A personal receipt goes through the xrpc proxy's
  * deleteRecord (which requires `repo` to be the session DID); a group receipt


### PR DESCRIPTION
Follow-up to #187 (merged), addressing review feedback on the funding record/confirm feature. Verified: `tsc` clean, lint at baseline (65 warnings, 0 added), 677 tests pass, design checks clean.

## Receipt detail
- **One "Record (Funder / Recipient / Name)" section per author** of a clustered payment. The indexer collapses a confirmed payment to one canonical node and **clears its `matchingReceipt`**, so each missing member is recovered by **listing that author's repo** (`listRecords`) and matching cluster keys — which fills the funder's record and enables the viewer's take-back.
- **Both group + individual perspectives**: a labeled row per identity (you + each owner/admin group involved), each with its own Confirm / take-back / confirmed state. Single-identity case keeps the familiar footer.
- Empty fields shown; confirm renders **in the same modal** (no second dialog); trash-toggle no longer resizes the dialog; single hairline under a collapsed Record section.

## Confirm
- `transactionId` is a cluster key the indexer matches on, so it's **copied from the original** (plus rail/network), not entered by the confirmer.

## Other
- Default "Confirmed by" shows only **recipient/both-confirmed** payments.
- **"Sender" → "Funder"** in all user-facing copy (role value unchanged).
- Activity Funding-header filter is an **icon-only secondary button** matching "Record funding"; a refresh affordance sits by the recorded note.
- **Rights** meta value is clickable, opening a rights detail modal styled like the receipt modal (reuses its `DetailSection`/`DetailRow`).
- In-page tab links ("See all", …) **preserve query params** so the funding filter survives a jump to the Funding tab.
- Group-funding take-back via the group BFF `DELETE` route.

## Notes
- The group service (CGS) must permit `org.hypercerts.funding.receipt` create/delete on the group-funding route.
- Member recovery lists up to the first 100 of an author's funding receipts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)