### PR TITLE
feat: search relevance, CGS repo-targeting + import/destroy, ePDS auth polish, UI fixes

### DIFF
--- a/src/app/.well-known/oauth-client-metadata/route.ts
+++ b/src/app/.well-known/oauth-client-metadata/route.ts
@@ -39,6 +39,12 @@ export async function GET() {
     // src/app/api/auth/login/route.ts resolves the handle to its PDS
     // and starts a fresh OAuth flow.
     epds_handle_login_url: `${origin}/api/auth/login`,
+    // Browser-tab icon for trusted-client auth/consent pages (ePDS
+    // emits a <link rel="icon"> from this). SVG so it stays crisp at any
+    // tab size. No `favicon_url_dark` yet — the current brandmark has no
+    // white variant; add one (or an adaptive SVG) to ship a dark-theme
+    // tab icon.
+    favicon_url: `${origin}/brand/brandmark/certified_brandmark_black.svg`,
   }
 
   return NextResponse.json(metadata, {

--- a/src/app/api/auth/callback-handler/route.ts
+++ b/src/app/api/auth/callback-handler/route.ts
@@ -28,6 +28,26 @@ export async function GET(request: NextRequest) {
   try {
     const params = request.nextUrl.searchParams
 
+    // ePDS clean-exit (#154): when the OAuth flow can't complete — the
+    // user denied consent, the PAR/ticket expired, or they walked away —
+    // the provider redirects back here with a standard OAuth `error`
+    // param instead of a `code`. Detect it up front and return a
+    // retryable failure so the sign-in UI can offer "try again", rather
+    // than letting `client.callback()` throw an opaque 500.
+    const oauthError = params.get("error")
+    if (oauthError) {
+      logSafe("[auth] oauth error redirect", undefined, { code: oauthError })
+      const description = params.get("error_description") || undefined
+      return NextResponse.json(
+        {
+          error: description || "Sign-in was not completed",
+          code: oauthError,
+          retry: true,
+        },
+        { status: 400 },
+      )
+    }
+
     const client = await getOAuthClient()
     const { session } = await client.callback(params)
 

--- a/src/app/api/groups/[groupDid]/audit/route.ts
+++ b/src/app/api/groups/[groupDid]/audit/route.ts
@@ -25,7 +25,7 @@ export async function GET(
 
     const groupAgent = createGroupAgent(auth.agent, groupDid)
 
-    const queryParams: Record<string, string> = {}
+    const queryParams: Record<string, string> = { repo: groupDid }
     const actorDid = request.nextUrl.searchParams.get("actorDid")
     const action = request.nextUrl.searchParams.get("action")
     const collection = request.nextUrl.searchParams.get("collection")

--- a/src/app/api/groups/[groupDid]/destroy/route.ts
+++ b/src/app/api/groups/[groupDid]/destroy/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getAuthenticatedAgent, getServiceAuthToken } from "@/lib/groups/proxy-agent"
+import { GROUP_SERVICE } from "@/lib/groups/constants"
+import { checkCsrf } from "@/lib/auth/csrf"
+import { extractRouteError } from "@/lib/utils/api"
+import { isValidDid } from "@/lib/utils/did"
+import { logSafe } from "@/lib/utils/log-safe"
+import { enforceRateLimit, makeLimiter } from "@/lib/auth/rate-limit"
+
+const LIMITER = makeLimiter("groups-destroy", 5, 600)
+
+/**
+ * POST /api/groups/[groupDid]/destroy
+ *
+ * Remove a group from the group service via `app.certified.group.destroy`
+ * (owner-only — CGS enforces the role). This deletes only the service's
+ * record of the group (credentials, member index, per-group database);
+ * the underlying PDS account is left intact and can be re-imported later
+ * via `app.certified.group.import`.
+ *
+ * Direct service-auth call (not proxied), mirroring `register`/`import`.
+ * `destroy` is a body-less procedure, so the target group is named by
+ * `repo` on the querystring (new explicit-targeting form; `aud` = the
+ * service DID via `getServiceAuthToken`). See CGS aud-migration.md.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupDid: string }> },
+) {
+  try {
+    const { groupDid } = await params
+    if (!isValidDid(groupDid)) {
+      return NextResponse.json({ error: "Invalid group DID" }, { status: 400 })
+    }
+
+    const auth = await getAuthenticatedAgent()
+    if (!auth)
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+
+    const rateDenied = await enforceRateLimit(LIMITER, auth.did)
+    if (rateDenied) return rateDenied
+
+    const csrfError = checkCsrf(request)
+    if (csrfError) return csrfError
+
+    const token = await getServiceAuthToken(
+      auth.agent,
+      "app.certified.group.destroy",
+    )
+
+    const url = new URL(`${GROUP_SERVICE}/xrpc/app.certified.group.destroy`)
+    url.searchParams.set("repo", groupDid)
+
+    const res = await fetch(url.toString(), {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    if (!res.ok) {
+      if (res.status >= 500) {
+        return NextResponse.json(
+          { error: "Failed to remove group" },
+          { status: 502 },
+        )
+      }
+      // Forward structured XRPC errors (e.g. GroupNotFound, or a 403 when
+      // the caller isn't the owner) so the client can message precisely.
+      let errorCode: string | undefined
+      let errorMessage = `Failed to remove group: ${res.status}`
+      try {
+        const data = (await res.json()) as { error?: string; message?: string }
+        if (typeof data.error === "string") errorCode = data.error
+        if (typeof data.message === "string") errorMessage = data.message
+        else if (errorCode) errorMessage = errorCode
+      } catch (err) {
+        logSafe("[groups/destroy] upstream non-JSON 4xx body", err, {
+          status: res.status,
+        })
+      }
+      return NextResponse.json(
+        { error: errorMessage, code: errorCode },
+        { status: res.status },
+      )
+    }
+
+    const result = await res.json().catch(() => ({ groupDid }))
+    return NextResponse.json(result)
+  } catch (err: unknown) {
+    const { status, message } = extractRouteError(err)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/src/app/api/groups/[groupDid]/handle/route.ts
+++ b/src/app/api/groups/[groupDid]/handle/route.ts
@@ -42,7 +42,12 @@ export async function PUT(
       return NextResponse.json({ error: "Handle too long (max 253 characters)" }, { status: 400 })
     }
 
-    const groupAgent = createGroupAgent(auth.agent, groupDid)
+    // updateHandle is a stock atproto method with no `repo` field, so it
+    // can't use the new explicit-repo targeting — CGS identifies the
+    // group from the JWT `aud`. Keep this call on the legacy proxy form
+    // (group DID in `aud`) until CGS exposes a repo-targetable handle
+    // update. See CGS aud-migration.md.
+    const groupAgent = createGroupAgent(auth.agent, groupDid, { legacy: true })
 
     // Use the standard identity.updateHandle through the proxy
     // The group service intercepts this and updates the group's handle

--- a/src/app/api/groups/[groupDid]/members/route.ts
+++ b/src/app/api/groups/[groupDid]/members/route.ts
@@ -31,7 +31,7 @@ export async function GET(
 
     const { data } = await groupAgent.call(
       "app.certified.group.member.list",
-      { limit }
+      { repo: groupDid, limit }
     )
 
     return NextResponse.json(data)
@@ -86,7 +86,7 @@ export async function POST(
     const { data } = await groupAgent.call(
       "app.certified.group.member.add",
       {},
-      { memberDid, role },
+      { repo: groupDid, memberDid, role },
       { encoding: "application/json" }
     )
 
@@ -132,7 +132,7 @@ export async function DELETE(
     await groupAgent.call(
       "app.certified.group.member.remove",
       {},
-      { memberDid },
+      { repo: groupDid, memberDid },
       { encoding: "application/json" }
     )
 

--- a/src/app/api/groups/[groupDid]/role/route.ts
+++ b/src/app/api/groups/[groupDid]/role/route.ts
@@ -53,7 +53,7 @@ export async function PUT(
     await groupAgent.call(
       "app.certified.group.role.set",
       {},
-      { memberDid, role },
+      { repo: groupDid, memberDid, role },
       { encoding: "application/json" }
     )
 

--- a/src/app/api/groups/[groupDid]/upload-blob/route.ts
+++ b/src/app/api/groups/[groupDid]/upload-blob/route.ts
@@ -51,9 +51,11 @@ export async function POST(
 
     const groupAgent = createGroupAgent(auth.agent, groupDid)
 
+    // uploadBlob has a binary body, so the group selector goes on the
+    // querystring (body-less convention — see CGS aud-migration.md).
     const { data } = await groupAgent.call(
       "app.certified.group.repo.uploadBlob",
-      {},
+      { repo: groupDid },
       new Uint8Array(buffer),
       { encoding: contentType }
     )

--- a/src/app/api/groups/import/route.ts
+++ b/src/app/api/groups/import/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getAuthenticatedAgent, getServiceAuthToken } from "@/lib/groups/proxy-agent"
+import { GROUP_SERVICE } from "@/lib/groups/constants"
+import { checkCsrf } from "@/lib/auth/csrf"
+import { extractRouteError, parseJsonBody } from "@/lib/utils/api"
+import { isValidDid } from "@/lib/utils/did"
+import { logSafe } from "@/lib/utils/log-safe"
+import { enforceRateLimit, makeLimiter } from "@/lib/auth/rate-limit"
+
+// Same per-DID cap as register: importing is the privileged "promote an
+// existing account into a group" write. Auth-gated, so RL keys off the
+// session DID (no IP enforcement needed).
+const LIMITER = makeLimiter("groups-import", 5, 600)
+
+/**
+ * POST /api/groups/import
+ *
+ * Promote the **currently authenticated account** into a group via
+ * `app.certified.group.import` (the sibling of `register` that reuses an
+ * existing account instead of creating a new one).
+ *
+ * CGS requires the service-auth JWT to be signed by the account being
+ * imported (`iss` = the account's DID), so the imported `groupDid` is
+ * always the authenticated user's DID — never taken from the body. The
+ * caller supplies an app password for that account (stored encrypted by
+ * CGS so it can act on the account's behalf) and the DID that becomes
+ * the group owner (defaults to the importer).
+ *
+ * Unlike `register`, the service holds no recovery key for an imported
+ * account — the owner's own credentials are their credible exit. The
+ * account's DID document is not modified.
+ *
+ * Note: the `MAX_SELF_CREATED_ORGS` guardrail is enforced on `register`
+ * but not yet on `import` (importing requires a real account + app
+ * password, so the abuse surface is small). Tracked as a follow-up.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await getAuthenticatedAgent()
+    if (!auth)
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+
+    const rateDenied = await enforceRateLimit(LIMITER, auth.did)
+    if (rateDenied) return rateDenied
+
+    const csrfError = checkCsrf(request)
+    if (csrfError) return csrfError
+
+    const parsed = await parseJsonBody(request, "[groups/import]")
+    if (!parsed.ok) return parsed.response
+    const { appPassword, ownerDid: rawOwnerDid } = (parsed.body ?? {}) as {
+      appPassword?: string
+      ownerDid?: string
+    }
+
+    if (!appPassword || typeof appPassword !== "string") {
+      return NextResponse.json(
+        { error: "appPassword is required" },
+        { status: 400 },
+      )
+    }
+
+    // The owner defaults to the importer. If supplied explicitly it must
+    // be a valid DID; the importer can only confer ownership on a real
+    // account.
+    const ownerDid = rawOwnerDid ?? auth.did
+    if (!isValidDid(ownerDid)) {
+      return NextResponse.json({ error: "Invalid ownerDid" }, { status: 400 })
+    }
+
+    // groupDid is fixed to the authenticated account: CGS requires the
+    // token's `iss` to equal the imported account, and our service-auth
+    // is signed by the session DID.
+    const groupDid = auth.did
+
+    const token = await getServiceAuthToken(
+      auth.agent,
+      "app.certified.group.import",
+    )
+
+    const res = await fetch(
+      `${GROUP_SERVICE}/xrpc/app.certified.group.import`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ groupDid, appPassword, ownerDid }),
+      },
+    )
+
+    if (!res.ok) {
+      if (res.status >= 500) {
+        return NextResponse.json({ error: "Import failed" }, { status: 502 })
+      }
+      // Forward structured XRPC errors (InvalidAppPassword,
+      // GroupAlreadyRegistered, …) so the client can show field-level
+      // messages.
+      let errorCode: string | undefined
+      let errorMessage = `Import failed: ${res.status}`
+      try {
+        const data = (await res.json()) as { error?: string; message?: string }
+        if (typeof data.error === "string") errorCode = data.error
+        if (typeof data.message === "string") errorMessage = data.message
+        else if (errorCode) errorMessage = errorCode
+      } catch (err) {
+        logSafe("[groups/import] upstream non-JSON 4xx body", err, {
+          status: res.status,
+        })
+      }
+      return NextResponse.json(
+        { error: errorMessage, code: errorCode },
+        { status: res.status },
+      )
+    }
+
+    const result = await res.json()
+    return NextResponse.json(result)
+  } catch (err: unknown) {
+    const { status, message } = extractRouteError(err)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/src/app/api/groups/register/route.ts
+++ b/src/app/api/groups/register/route.ts
@@ -127,7 +127,10 @@ export async function POST(request: NextRequest) {
               // entry is found — no later page can change the boolean answer.
               let memberCursor: string | undefined
               do {
-                const params: Record<string, unknown> = { limit: 100 }
+                const params: Record<string, unknown> = {
+                  repo: g.groupDid,
+                  limit: 100,
+                }
                 if (memberCursor) params.cursor = memberCursor
                 const { data } = await groupAgent.call(
                   "app.certified.group.member.list",

--- a/src/app/groups/create/page.tsx
+++ b/src/app/groups/create/page.tsx
@@ -606,6 +606,18 @@ export default function CreateGroupPage() {
               {isCreating ? "Creating…" : "Create group"}
             </Button>
           </div>
+
+          <p className="settings__note">
+            Already have an account you want to use as a group?{" "}
+            <button
+              type="button"
+              className="cursor-pointer border-0 bg-transparent p-0 text-[var(--fg-primary)] underline disabled:cursor-not-allowed disabled:opacity-50"
+              onClick={() => router.push("/groups/import")}
+              disabled={isCreating}
+            >
+              Import an existing account
+            </button>
+          </p>
         </div>
       </article>
     </form>

--- a/src/app/groups/import/page.tsx
+++ b/src/app/groups/import/page.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { KeyRound, Users } from "lucide-react"
+import { useAuth } from "@/lib/auth/auth-context"
+import { useOrg } from "@/lib/groups/org-context"
+import { usePageTitle } from "@/lib/navbar-context"
+import { importGroup, putMembership, RegisterGroupError } from "@/lib/groups/api"
+import { authFetch } from "@/lib/auth/fetch"
+import Button from "@/components/ui/button"
+import Input from "@/components/ui/input"
+import EmptyState from "@/components/ui/empty-state"
+import ErrorMessage from "@/components/ui/error-message"
+import LoadingSpinner from "@/components/ui/loading-spinner"
+
+/**
+ * `/groups/import` — promote an EXISTING atproto account into a group
+ * (the sibling of `/groups/create`, which mints a brand-new account).
+ *
+ * Key constraint (CGS `app.certified.group.import`): the service-auth
+ * JWT must be signed by the account being imported, so the account that
+ * gets converted is always **the one you're currently signed in as**.
+ * The page makes that explicit so a user can't accidentally convert the
+ * wrong account — to import a different account, sign in as that account
+ * first. The signed-in user becomes the group's owner.
+ *
+ * The caller supplies an app password for the account (CGS stores it
+ * encrypted to act on the account's behalf). After import we stitch the
+ * owner membership marker so the group appears in the account switcher,
+ * mirroring the create flow's final step.
+ */
+export default function ImportGroupPage() {
+  usePageTitle("Import account as group")
+  const router = useRouter()
+  const { did, isLoading: authLoading, openSignIn } = useAuth()
+  const { refetchOrgs } = useOrg()
+
+  const [handle, setHandle] = useState<string | null>(null)
+  const [appPassword, setAppPassword] = useState("")
+  const [isImporting, setIsImporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Resolve the signed-in account's handle so the "which account gets
+  // converted" warning names it explicitly.
+  useEffect(() => {
+    if (!did) return
+    let cancelled = false
+    authFetch(`/api/resolve-did?did=${encodeURIComponent(did)}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!cancelled && data?.handle) setHandle(data.handle)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [did])
+
+  const handleSubmit = useCallback(
+    async (e?: React.FormEvent) => {
+      e?.preventDefault()
+      if (!did || !appPassword.trim() || isImporting) return
+      setIsImporting(true)
+      setError(null)
+      try {
+        const result = await importGroup(appPassword.trim())
+        // Stitch the owner membership marker so the imported group shows
+        // up in the account switcher + group list (mirrors create step 7).
+        try {
+          await putMembership(did, result.groupDid, "owner")
+        } catch (err) {
+          console.error("[groups/import] putMembership failed", err)
+        }
+        await refetchOrgs()
+        router.push("/groups")
+      } catch (err) {
+        if (err instanceof RegisterGroupError && err.code === "GroupAlreadyRegistered") {
+          setError("This account is already registered as a group.")
+        } else if (
+          err instanceof RegisterGroupError &&
+          err.code === "InvalidAppPassword"
+        ) {
+          setError("That app password was not accepted. Check it and try again.")
+        } else {
+          setError(err instanceof Error ? err.message : "Import failed")
+        }
+      } finally {
+        setIsImporting(false)
+      }
+    },
+    [did, appPassword, isImporting, refetchOrgs, router],
+  )
+
+  if (authLoading) {
+    return (
+      <div className="dashboard">
+        <div className="dashboard__body">
+          <div className="dashboard__main">
+            <LoadingSpinner size="sm" />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!did) {
+    return (
+      <div className="dashboard">
+        <div className="dashboard__body">
+          <div className="dashboard__main">
+            <EmptyState
+              icon={Users}
+              title="Sign in to import an account"
+              description="Sign in as the account you want to convert into a group."
+            >
+              <Button variant="primary" onClick={() => openSignIn()}>
+                Sign in
+              </Button>
+            </EmptyState>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const accountLabel = handle ? `@${handle}` : did
+
+  return (
+    <div className="dashboard">
+      <div className="dashboard__body">
+        <div className="dashboard__main">
+          <form className="cert-detail__section" onSubmit={handleSubmit}>
+            <header className="sx-panel__header">
+              <h1 className="sx-panel__title">Import an account as a group</h1>
+              <p className="sx-panel__desc">
+                This converts the account you&apos;re signed in as —{" "}
+                <strong>{accountLabel}</strong> — into a group, with you as its
+                owner. To import a different account, sign in as that account
+                first. The underlying account and its records are kept; nothing
+                is deleted.
+              </p>
+            </header>
+
+            <div className="sx-panel__body">
+              <Input
+                type="password"
+                label="App password"
+                size="md"
+                autoComplete="off"
+                leadingIcon={<KeyRound size={16} aria-hidden="true" />}
+                placeholder="xxxx-xxxx-xxxx-xxxx"
+                value={appPassword}
+                onChange={(e) => setAppPassword(e.target.value)}
+              />
+              <p className="settings__note">
+                Create an app password in your account&apos;s settings. It&apos;s
+                stored encrypted so the service can act for the group; you can
+                revoke it anytime.
+              </p>
+
+              {error && <ErrorMessage message={error} />}
+
+              <div className="org-members__add-submit">
+                <Button
+                  type="submit"
+                  variant="primary"
+                  loading={isImporting}
+                  disabled={!appPassword.trim() || isImporting}
+                >
+                  Import as group
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => router.push("/groups/create")}
+                  disabled={isImporting}
+                >
+                  Create a new account instead
+                </Button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/oauth/callback/page.tsx
+++ b/src/app/oauth/callback/page.tsx
@@ -7,6 +7,10 @@ import { resolvePostSigninPath } from "@/lib/auth/post-signin"
 
 export default function OAuthCallbackPage() {
   const [error, setError] = useState<string | null>(null)
+  // True when the failure is a recoverable sign-in interruption (ePDS
+  // clean-exit / user-denied / expired flow, #154) rather than a hard
+  // error — drives a "try again" affordance instead of a dead end.
+  const [canRetry, setCanRetry] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -18,7 +22,10 @@ export default function OAuthCallbackPage() {
         const res = await fetch(callbackUrl)
 
         if (!res.ok) {
-          const data = await res.json().catch(() => ({ error: "Callback failed" }))
+          const data = await res
+            .json()
+            .catch(() => ({ error: "Callback failed" }))
+          if (!cancelled && data.retry) setCanRetry(true)
           throw new Error(data.error || "Authentication failed")
         }
 
@@ -57,6 +64,11 @@ export default function OAuthCallbackPage() {
       <div className="loading-screen">
         <div className="loading-screen__inner">
           <p className="loading-screen__error">{error}</p>
+          {canRetry ? (
+            <Link href="/welcome" className="loading-screen__link">
+              Try signing in again
+            </Link>
+          ) : null}
           <Link href="/" className="loading-screen__link">
             Return to home
           </Link>

--- a/src/components/explore-page/funding-receipt-detail-modal.tsx
+++ b/src/components/explore-page/funding-receipt-detail-modal.tsx
@@ -247,7 +247,7 @@ export default function FundingReceiptDetailModal({
       maxWidth={460}
       onClose={onClose}
     >
-      <AppDialogHeader title="Funding receipt" onClose={onClose} />
+      <AppDialogHeader title="Funding receipt" onClose={onClose} center />
 
       <div className="px-5 pb-5 pt-0">
         {/* Grouped as a top-to-bottom narrative: who paid whom (Transfer),

--- a/src/components/feed/rights-detail-modal.tsx
+++ b/src/components/feed/rights-detail-modal.tsx
@@ -51,7 +51,7 @@ export default function RightsDetailModal({
       maxWidth={460}
       onClose={onClose}
     >
-      <AppDialogHeader title="Rights" onClose={onClose} />
+      <AppDialogHeader title="Rights" onClose={onClose} center />
 
       <div className="px-5 pb-5 pt-0">
         {isLoading && !record ? (

--- a/src/components/groups/org-settings.tsx
+++ b/src/components/groups/org-settings.tsx
@@ -1,10 +1,12 @@
 "use client"
 
 import React, { useState, useEffect, useCallback, useRef } from "react"
+import { useRouter } from "next/navigation"
 import {
   AtSign,
   ScrollText,
   Share2,
+  ShieldAlert,
   Trash2,
   UserPlus,
   Users,
@@ -17,6 +19,7 @@ import {
   removeOrgMember,
   setOrgMemberRole,
   queryOrgAuditLog,
+  destroyGroup,
 } from "@/lib/groups/api"
 import type { Group, OrgMember, AuditEntry, OrgRole } from "@/lib/groups/types"
 import { authFetch } from "@/lib/auth/fetch"
@@ -29,12 +32,19 @@ import ErrorMessage from "@/components/ui/error-message"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import Tooltip from "@/components/ui/tooltip"
 
-type CategoryKey = "handle" | "members" | "activity" | "social-graph"
+type CategoryKey = "handle" | "members" | "activity" | "social-graph" | "danger"
 type CategoryDef = {
   key: CategoryKey
   label: string
   description: string
   Icon: typeof AtSign
+}
+// Owner-only; appended to the nav + rendered only for owners.
+const DANGER_CATEGORY: CategoryDef = {
+  key: "danger",
+  label: "Danger zone",
+  description: "Remove this group from the service.",
+  Icon: ShieldAlert,
 }
 const CATEGORIES: CategoryDef[] = [
   {
@@ -100,8 +110,35 @@ interface OrgSettingsProps {
 
 export default function OrgSettings({ groupDid, org }: OrgSettingsProps) {
   const { did } = useAuth()
+  const router = useRouter()
   const isOwner = org.role === "owner"
   const isAdmin = org.role === "admin" || isOwner
+
+  // Owners get the Danger zone (remove group) in the nav + panel.
+  const visibleCategories = isOwner ? [...CATEGORIES, DANGER_CATEGORY] : CATEGORIES
+
+  // Remove-group (destroy) state.
+  const [confirmDestroy, setConfirmDestroy] = useState(false)
+  const [destroying, setDestroying] = useState(false)
+  const [destroyError, setDestroyError] = useState<string | null>(null)
+
+  const handleDestroy = async () => {
+    setDestroying(true)
+    setDestroyError(null)
+    try {
+      await destroyGroup(groupDid)
+      setConfirmDestroy(false)
+      // The group is gone from the service — leave the settings page.
+      router.push("/")
+    } catch (err) {
+      setDestroyError(
+        err instanceof Error ? err.message : "Failed to remove group",
+      )
+      setConfirmDestroy(false)
+    } finally {
+      setDestroying(false)
+    }
+  }
 
   // Members state
   const [members, setMembers] = useState<ResolvedMember[]>([])
@@ -334,7 +371,7 @@ export default function OrgSettings({ groupDid, org }: OrgSettingsProps) {
         <aside className="sx__menu">
           <nav aria-label="Group settings sections">
             <ul className="sx-menu">
-              {CATEGORIES.map((cat) => {
+              {visibleCategories.map((cat) => {
                 const isActive = cat.key === active
                 const Icon = cat.Icon
                 return (
@@ -688,6 +725,42 @@ export default function OrgSettings({ groupDid, org }: OrgSettingsProps) {
             </div>
           </section>
 
+          {/* Danger zone — owner-only. Removes the group from the
+              service (account left intact, re-importable). */}
+          {isOwner ? (
+            <section
+              id="danger"
+              ref={setSectionRef("danger")}
+              className="sx-section"
+              aria-labelledby="sx-section-danger-title"
+            >
+              <header className="sx-panel__header">
+                <h2 id="sx-section-danger-title" className="sx-panel__title">
+                  Danger zone
+                </h2>
+                <p className="sx-panel__desc">
+                  Remove this group from Certified. This deletes the group&apos;s
+                  membership and settings from the service only — the underlying
+                  account and its records are left intact, and the group can be
+                  imported again later.
+                </p>
+              </header>
+              <div className="sx-panel__body">
+                {destroyError && <ErrorMessage message={destroyError} />}
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => setConfirmDestroy(true)}
+                  loading={destroying}
+                  disabled={destroying}
+                >
+                  <Trash2 size={14} />
+                  Remove group
+                </Button>
+              </div>
+            </section>
+          ) : null}
+
         </div>
       </div>
 
@@ -698,6 +771,16 @@ export default function OrgSettings({ groupDid, org }: OrgSettingsProps) {
           confirmLabel="Remove"
           onCancel={() => setConfirmRemove(null)}
           onConfirm={() => handleRemoveMember(confirmRemove)}
+        />
+      ) : null}
+
+      {confirmDestroy ? (
+        <ConfirmDialog
+          title="Remove group"
+          message={`Remove @${org.handle} from Certified? This deletes the group from the service only — the underlying account and its records remain. The group can be imported again later.`}
+          confirmLabel="Remove group"
+          onCancel={() => setConfirmDestroy(false)}
+          onConfirm={handleDestroy}
         />
       ) : null}
     </div>

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -121,47 +121,6 @@ const Navbar: React.FC = () => {
     : getInitials(profile?.displayName, did);
   const displayAvatarUrl = activeOrg ? (orgAvatarUrl || undefined) : (avatarUrl || undefined);
 
-  // In-app navigation depth counter. The navbar is mounted once in the
-  // root layout and persists across route changes, so refs survive
-  // pathname updates. We count "how many internal navigations happened
-  // since the user first loaded the app" — not `window.history.length`,
-  // which also includes pages the user visited BEFORE landing on ours
-  // and would send them back out of the app.
-  //
-  //   - First render (landing pathname):      counter = 0
-  //   - Each in-app Link click / push:        counter++
-  //   - Each popstate (back / forward):       counter-- (clamped at 0)
-  //
-  // `handleBack` uses `router.back()` only when counter > 0. When it's
-  // 0, we push `/` — because the back stack would otherwise take the
-  // user to an external URL.
-  //
-  // NOTE: these hooks MUST sit above `if (isLoading) return null` so the
-  // hook count is stable across renders (rules of hooks).
-  // In-app navigation depth. We patch history.pushState (which Next's
-  // router calls for every forward navigation, INCLUDING query-only tab
-  // navigations like `?tab=description`) to increment, and popstate to
-  // decrement. router.replace uses replaceState, so it isn't counted —
-  // the did→handle URL canonicalization can't inflate the count. When
-  // the counter is 0 the back stack would exit the app, so handleBack
-  // pushes `/` instead.
-  const inAppDepthRef = useRef(0);
-  useEffect(() => {
-    const origPushState = history.pushState.bind(history);
-    history.pushState = (...args: Parameters<typeof origPushState>) => {
-      inAppDepthRef.current += 1;
-      return origPushState(...args);
-    };
-    const onPop = () => {
-      inAppDepthRef.current = Math.max(0, inAppDepthRef.current - 1);
-    };
-    window.addEventListener("popstate", onPop);
-    return () => {
-      history.pushState = origPushState;
-      window.removeEventListener("popstate", onPop);
-    };
-  }, []);
-
   // Don't render navbar while auth is loading — prevents white flash.
   // Also hide on desktop — the left rail hosts the brandmark there.
   // Both early returns sit AFTER every hook so the rules-of-hooks
@@ -178,21 +137,10 @@ const Navbar: React.FC = () => {
     .filter(Boolean)
     .join(" ");
 
-  const handleBack = () => {
-    // Reverse slide for the back gesture (see ViewTransitionProvider).
-    transitionBack(() => {
-      if (inAppDepthRef.current > 0) {
-        // We have in-app history — safe to pop. The popstate listener
-        // above will decrement the counter.
-        router.back();
-      } else {
-        // The user entered our app on this page (direct link, external
-        // referrer, or page refresh). `router.back()` would take them
-        // outside the app — push home instead.
-        router.push("/");
-      }
-    });
-  };
+  // Reverse-slide back gesture. The default navigate (see
+  // ViewTransitionProvider) already guards against walking out of the
+  // app when there's no in-app history, pushing "/" instead.
+  const handleBack = () => transitionBack();
 
   // Top-level destinations show the hamburger + account switcher / sign-in
   // even though they also set a centered page title; sub-pages keep the

--- a/src/components/search/cert-search.tsx
+++ b/src/components/search/cert-search.tsx
@@ -13,6 +13,7 @@ import { resolveActivityImageUrl } from "@/lib/atproto/activity"
 import { parseActivityUri } from "@/lib/atproto/activity-uri"
 import { useAuthorInfo } from "@/hooks/use-author-info"
 import type { ActivityRecord } from "@/lib/atproto/activity-types"
+import { SEARCH_DEBOUNCE_MS } from "@/lib/search/constants"
 
 /** Result row shape — the indexer record + the author DID (parsed
  *  from `uri`, since the indexer doesn't always surface it on a
@@ -47,7 +48,6 @@ interface CertSearchProps {
   readonly clearOnSelect?: boolean
 }
 
-const SEARCH_DEBOUNCE_MS = 250
 const SEARCH_PAGE_SIZE = 8
 const OWN_SEARCH_PAGE_SIZE = 4
 

--- a/src/components/search/global-search.tsx
+++ b/src/components/search/global-search.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { profileUrl } from "@/lib/urls"
 import { useRouter } from "next/navigation"
-import { Search as SearchIcon, X } from "lucide-react"
+import { Search as SearchIcon, X, CornerDownLeft } from "lucide-react"
 import CertIcon from "@/components/ui/cert-icon"
 import Avatar from "@/components/ui/avatar"
 import Combobox from "@/components/ui/combobox"
@@ -14,6 +14,9 @@ import { resolveActivityImageUrl } from "@/lib/atproto/activity"
 import { parseActivityUri, activityDetailHref } from "@/lib/atproto/activity-uri"
 import { useAuthorInfo } from "@/hooks/use-author-info"
 import type { ActivityRecord } from "@/lib/atproto/activity-types"
+import { rankBy } from "@/lib/search/rank"
+import { parseSearchIntent, type SearchIntent } from "@/lib/search/parse-search-intent"
+import { SEARCH_DEBOUNCE_MS, CANDIDATE_FETCH_SIZE } from "@/lib/search/constants"
 
 interface Actor {
   did: string
@@ -33,7 +36,12 @@ interface CertRow {
   did: string
 }
 
-type Row = PersonRow | CertRow
+interface IntentRow {
+  kind: "intent"
+  intent: SearchIntent
+}
+
+type Row = IntentRow | PersonRow | CertRow
 
 interface GlobalSearchProps {
   readonly className?: string
@@ -41,7 +49,6 @@ interface GlobalSearchProps {
   readonly autoFocus?: boolean
 }
 
-const SEARCH_DEBOUNCE_MS = 250
 const PEOPLE_LIMIT = 6
 const CERTS_LIMIT = 6
 
@@ -76,6 +83,7 @@ export default function GlobalSearch({
   const [query, setQuery] = useState("")
   const [people, setPeople] = useState<Actor[]>([])
   const [certs, setCerts] = useState<CertRow[]>([])
+  const [intent, setIntent] = useState<SearchIntent | null>(null)
   const [isOpen, setIsOpen] = useState(false)
   const [isSearching, setIsSearching] = useState(false)
 
@@ -91,10 +99,11 @@ export default function GlobalSearch({
   // each render, breaking downstream memoization.
   const rows: Row[] = useMemo(
     () => [
+      ...(intent ? [{ kind: "intent", intent } as IntentRow] : []),
       ...people.map((actor): PersonRow => ({ kind: "person", actor })),
       ...certs,
     ],
-    [people, certs],
+    [intent, people, certs],
   )
 
   const search = useCallback(async (q: string, seq: number) => {
@@ -102,10 +111,14 @@ export default function GlobalSearch({
     if (trimmed.length < 1) {
       setPeople([])
       setCerts([])
+      setIntent(null)
       setIsOpen(false)
       setIsSearching(false)
       return
     }
+    // Synchronous: if the query is a pasted identifier (at-URI / handle /
+    // DID / app URL), offer a direct jump that bypasses the indexer.
+    setIntent(parseSearchIntent(trimmed))
     setIsSearching(true)
     try {
       const [peopleRes, certPage] = await Promise.all([
@@ -119,8 +132,12 @@ export default function GlobalSearch({
               : { actors: [] },
           )
           .catch(() => ({ actors: [] as Actor[] })),
+        // Fetch wide, show narrow: the indexer returns recency order, so
+        // we pull a larger candidate set and re-rank by relevance before
+        // slicing to the display cap. (People keep Bluesky's own
+        // relevance order.)
         fetchIndexerActivities({
-          first: CERTS_LIMIT,
+          first: CANDIDATE_FETCH_SIZE,
           search: trimmed,
         }).catch(() => null),
       ])
@@ -140,7 +157,11 @@ export default function GlobalSearch({
           certRows.push({ kind: "cert", record, did })
         }
       }
-      setCerts(certRows)
+      const rankedCerts = rankBy(trimmed, certRows, (row) => ({
+        primary: row.record.value.title ?? "",
+        secondary: row.record.value.shortDescription ?? "",
+      })).slice(0, CERTS_LIMIT)
+      setCerts(rankedCerts)
       setIsOpen(true)
     } finally {
       if (seq === requestSeq.current) setIsSearching(false)
@@ -157,6 +178,7 @@ export default function GlobalSearch({
     if (!query.trim()) {
       setPeople([])
       setCerts([])
+      setIntent(null)
       setIsOpen(false)
       setIsSearching(false)
       return
@@ -196,7 +218,9 @@ export default function GlobalSearch({
   const select = useCallback(
     (row: Row) => {
       suppressNextSearchRef.current = true
-      if (row.kind === "person") {
+      if (row.kind === "intent") {
+        router.push(row.intent.href)
+      } else if (row.kind === "person") {
         setQuery(row.actor.displayName || row.actor.handle)
         router.push(profileUrl(row.actor.did))
       } else {
@@ -206,6 +230,7 @@ export default function GlobalSearch({
       }
       setPeople([])
       setCerts([])
+      setIntent(null)
       setIsOpen(false)
       setIsSearching(false)
       inputRef.current?.blur()
@@ -217,6 +242,7 @@ export default function GlobalSearch({
     setQuery("")
     setPeople([])
     setCerts([])
+    setIntent(null)
     setIsOpen(false)
     inputRef.current?.focus()
   }
@@ -234,11 +260,18 @@ export default function GlobalSearch({
       setIsOpen(false)
       setIsSearching(false)
       inputRef.current?.blur()
-      router.push(`/explore?q=${encodeURIComponent(q)}`)
+      // A pasted identifier jumps straight to its target (bypassing the
+      // indexer); anything else runs a full Explore search.
+      const jump = parseSearchIntent(q)
+      setIntent(null)
+      router.push(jump ? jump.href : `/explore?q=${encodeURIComponent(q)}`)
     },
     [router],
   )
 
+  // Section offsets for interleaved group headers. The optional intent
+  // row sits at index 0, so people/certs start after it.
+  const intentCount = intent ? 1 : 0
   const peopleCount = people.length
 
   return (
@@ -249,7 +282,11 @@ export default function GlobalSearch({
       onValueChange={setQuery}
       items={rows}
       getItemKey={(row) =>
-        row.kind === "person" ? `p-${row.actor.did}` : `c-${row.record.uri}`
+        row.kind === "intent"
+          ? "intent"
+          : row.kind === "person"
+            ? `p-${row.actor.did}`
+            : `c-${row.record.uri}`
       }
       isLoading={isSearching}
       open={isOpen}
@@ -298,13 +335,24 @@ export default function GlobalSearch({
         return null
       }}
       renderOption={({ item: row, index, highlighted, optionId, onHover, onSelect }) => {
+        if (row.kind === "intent") {
+          // Pinned "Jump to" row at index 0 — a direct, indexer-bypassing
+          // navigation for a pasted identifier.
+          return (
+            <IntentRowItem
+              intent={row.intent}
+              optionId={optionId}
+              highlighted={highlighted}
+              onHover={onHover}
+              onSelect={onSelect}
+            />
+          )
+        }
         if (row.kind === "person") {
           return (
             <>
-              {/* People header — interleaved above the first person row.
-                  Only rendered when people came back (index 0 is a person
-                  iff people.length > 0). */}
-              {index === 0 ? (
+              {/* People header — interleaved above the first person row. */}
+              {index === intentCount ? (
                 <li
                   className="cert-search__group-header"
                   role="presentation"
@@ -325,9 +373,8 @@ export default function GlobalSearch({
         }
         return (
           <>
-            {/* Activities header — interleaved above the first cert row
-                (the row at flat index === people.length). */}
-            {index === peopleCount ? (
+            {/* Activities header — interleaved above the first cert row. */}
+            {index === intentCount + peopleCount ? (
               <li
                 className="cert-search__group-header"
                 role="presentation"
@@ -355,6 +402,48 @@ function activityDetailHrefFromRecord(uri: string): string | null {
   const parsed = parseActivityUri(uri)
   if (!parsed) return null
   return activityDetailHref(parsed.did, parsed.rkey)
+}
+
+interface IntentRowProps {
+  intent: SearchIntent
+  optionId: string
+  highlighted: boolean
+  onHover: () => void
+  onSelect: (e: React.MouseEvent) => void
+}
+
+function IntentRowItem({
+  intent,
+  optionId,
+  highlighted,
+  onHover,
+  onSelect,
+}: IntentRowProps) {
+  const detail = intent.kind === "profile" ? intent.actor : intent.href
+  return (
+    <li
+      id={optionId}
+      role="option"
+      aria-selected={highlighted}
+      data-combobox-option
+      className={`cert-search__item ${
+        highlighted ? "cert-search__item--highlighted" : ""
+      }`}
+      onMouseEnter={onHover}
+      onMouseDown={onSelect}
+    >
+      <div
+        className="cert-search__thumb cert-search__thumb--placeholder"
+        aria-hidden="true"
+      >
+        <CornerDownLeft size={16} strokeWidth={1.5} />
+      </div>
+      <div className="cert-search__item-info">
+        <span className="cert-search__item-title">{intent.label}</span>
+        <span className="cert-search__item-handle">{detail}</span>
+      </div>
+    </li>
+  )
 }
 
 interface PersonRowProps {

--- a/src/components/ui/app-dialog.tsx
+++ b/src/components/ui/app-dialog.tsx
@@ -126,16 +126,28 @@ export function AppDialogHeader({
   title,
   onClose,
   disabled = false,
+  center = false,
 }: {
   title: ReactNode
   /** When omitted the X button is hidden. Use for alertdialog
    *  modals where the only exits are explicit footer buttons. */
   onClose?: () => void
   disabled?: boolean
+  /** Center the title. Uses symmetric horizontal padding so the title
+   *  is centered in the modal while leaving room for the close X. */
+  center?: boolean
 }) {
   return (
-    <div className="flex shrink-0 items-center gap-2.5 border-b border-[var(--color-light-gray)] pl-6 pr-10 pt-5 pb-3">
-      <span className="flex-1 text-[0.8125rem] font-semibold tracking-[0.02em] text-[var(--fg-primary)]">
+    <div
+      className={`flex shrink-0 items-center gap-2.5 border-b border-[var(--color-light-gray)] pt-5 pb-3 ${
+        center ? "px-10" : "pl-6 pr-10"
+      }`}
+    >
+      <span
+        className={`flex-1 text-[0.8125rem] font-semibold tracking-[0.02em] text-[var(--fg-primary)] ${
+          center ? "text-center" : ""
+        }`}
+      >
         {title}
       </span>
       {onClose ? (

--- a/src/lib/groups/api.ts
+++ b/src/lib/groups/api.ts
@@ -189,6 +189,66 @@ export async function registerGroup(
 }
 
 /**
+ * Promote the currently authenticated account into a group (the sibling
+ * of {@link registerGroup} that reuses an existing account). The caller
+ * supplies an app password for that account; `ownerDid` defaults to the
+ * importer server-side. Reuses {@link RegisterGroupError} so callers can
+ * surface structured codes (e.g. `InvalidAppPassword`,
+ * `GroupAlreadyRegistered`).
+ */
+export async function importGroup(
+  appPassword: string,
+  ownerDid?: string,
+): Promise<{ groupDid: string; handle: string }> {
+  const res = await authFetch("/api/groups/import", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ appPassword, ownerDid }),
+  })
+  if (!res.ok) {
+    let message = "Failed to import group"
+    let code: string | undefined
+    try {
+      const data = (await res.json()) as { error?: string; code?: string }
+      if (typeof data.error === "string") message = data.error
+      if (typeof data.code === "string") code = data.code
+    } catch {
+      // fall through
+    }
+    throw new RegisterGroupError(message, code)
+  }
+  return await res.json()
+}
+
+/**
+ * Remove a group from the group service (owner-only; CGS enforces the
+ * role). The underlying PDS account is left intact and can be
+ * re-imported later. Reuses {@link RegisterGroupError} for structured
+ * codes (e.g. `GroupNotFound`).
+ */
+export async function destroyGroup(
+  groupDid: string,
+): Promise<{ groupDid: string }> {
+  const res = await authFetch(
+    `/api/groups/${encodeURIComponent(groupDid)}/destroy`,
+    { method: "POST" },
+  )
+  if (!res.ok) {
+    let message = "Failed to remove group"
+    let code: string | undefined
+    try {
+      const data = (await res.json()) as { error?: string; code?: string }
+      if (typeof data.error === "string") message = data.error
+      if (typeof data.code === "string") code = data.code
+    } catch {
+      // fall through
+    }
+    throw new RegisterGroupError(message, code)
+  }
+  return await res.json()
+}
+
+/**
  * Get a group's profile (reads go to the PDS directly).
  */
 export async function getOrgProfile(

--- a/src/lib/groups/proxy-agent.ts
+++ b/src/lib/groups/proxy-agent.ts
@@ -179,11 +179,37 @@ export async function getAuthenticatedAgent(): Promise<{
 }
 
 /**
- * Create a proxy agent that routes requests through the user's PDS
- * to the group service for a specific group.
+ * Create a proxy agent that routes requests through the user's PDS to
+ * the group service.
+ *
+ * Targeting (CGS #27 migration, see `docs/aud-migration.md` in the
+ * certified-group-service repo):
+ *
+ *   - **Default (new form):** proxy to the *service* DID via the
+ *     `certified_group_service` service id. The user's PDS resolves the
+ *     service's `/.well-known/did.json`, mints `aud` = the service DID,
+ *     and forwards. The target group is then named by an explicit
+ *     `repo` field on each call — in the body for JSON-body procedures
+ *     (`repo.*`, `member.add/remove`, `role.set`), on the querystring
+ *     for queries (`member.list`, `audit.query`) and body-less methods
+ *     (`repo.uploadBlob`). Callers MUST include `repo` or CGS can't
+ *     resolve the group.
+ *   - **Legacy form (`opts.legacy`):** proxy to the *group* DID via the
+ *     `certified_group` service id, so `aud` = the group DID and the
+ *     group is read from `aud`. Deprecated upstream and slated for
+ *     removal; kept only for `com.atproto.identity.updateHandle`, a
+ *     stock method with no `repo` field that CGS targets via `aud`.
  */
-export function createGroupAgent(agent: Agent, groupDid: string): Agent {
-  const proxied = agent.withProxy("certified_group", groupDid) as Agent
+export function createGroupAgent(
+  agent: Agent,
+  groupDid: string,
+  opts?: { legacy?: boolean },
+): Agent {
+  const proxied = (
+    opts?.legacy
+      ? agent.withProxy("certified_group", groupDid)
+      : agent.withProxy("certified_group_service", GROUP_SERVICE_DID)
+  ) as Agent
   for (const doc of GROUP_LEXICONS) {
     proxied.lex.add(doc)
   }

--- a/src/lib/search/__tests__/parse-search-intent.test.ts
+++ b/src/lib/search/__tests__/parse-search-intent.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest"
+import { parseSearchIntent } from "../parse-search-intent"
+
+const DID = "did:plc:eu5c56acxntwhhw5cfkzs43z"
+const ACTIVITY_URI = `at://${DID}/org.hypercerts.claim.activity/3mo5phr5xbp2m`
+
+describe("parseSearchIntent", () => {
+  it("returns null for ordinary search terms", () => {
+    expect(parseSearchIntent("Simocracy")).toBeNull()
+    expect(parseSearchIntent("restore rainforest")).toBeNull()
+    expect(parseSearchIntent("")).toBeNull()
+    expect(parseSearchIntent("   ")).toBeNull()
+  })
+
+  it("resolves a canonical activity at-URI to a record jump", () => {
+    const intent = parseSearchIntent(ACTIVITY_URI)
+    expect(intent).toMatchObject({
+      kind: "record",
+      did: DID,
+      collection: "org.hypercerts.claim.activity",
+      rkey: "3mo5phr5xbp2m",
+      label: "Open activity",
+      resolvable: true,
+    })
+    expect(intent?.href).toBe(`/${DID}/activity/3mo5phr5xbp2m`)
+  })
+
+  it("resolves a collection at-URI to a project jump", () => {
+    const intent = parseSearchIntent(`at://${DID}/org.hypercerts.collection/abc123`)
+    expect(intent).toMatchObject({ kind: "record", label: "Open project" })
+    expect(intent?.href).toBe(`/${DID}/project/abc123`)
+  })
+
+  it("falls back to a profile jump for a non-page collection", () => {
+    const intent = parseSearchIntent(`at://${DID}/app.bsky.feed.post/xyz`)
+    expect(intent).toMatchObject({ kind: "profile", actor: DID })
+  })
+
+  it("resolves a bare DID to a profile jump", () => {
+    expect(parseSearchIntent(DID)).toMatchObject({
+      kind: "profile",
+      actor: DID,
+      href: `/${DID}`,
+      resolvable: true,
+    })
+  })
+
+  it("resolves a handle (with and without @) to a profile jump", () => {
+    const expected = {
+      kind: "profile",
+      actor: "diegorb1329.bsky.social",
+      href: "/diegorb1329.bsky.social",
+    }
+    expect(parseSearchIntent("diegorb1329.bsky.social")).toMatchObject(expected)
+    expect(parseSearchIntent("@diegorb1329.bsky.social")).toMatchObject(expected)
+  })
+
+  it("rejects dotless words as handles (they are search terms)", () => {
+    expect(parseSearchIntent("alice")).toBeNull()
+    expect(parseSearchIntent("@simocracy")).toBeNull()
+  })
+
+  it("does not treat reserved route words as handles", () => {
+    expect(parseSearchIntent("explore")).toBeNull()
+    expect(parseSearchIntent("settings")).toBeNull()
+  })
+
+  it("interprets a pasted app record URL via its pathname", () => {
+    const intent = parseSearchIntent(`https://staging.certified.app/alice.eco/activity/3k`)
+    expect(intent).toMatchObject({
+      kind: "record",
+      collection: "activity",
+      rkey: "3k",
+      label: "Open activity",
+    })
+    expect(intent?.href).toBe("/alice.eco/activity/3k")
+  })
+
+  it("interprets a pasted app profile URL", () => {
+    expect(parseSearchIntent("https://certified.app/alice.eco")).toMatchObject({
+      kind: "profile",
+      actor: "alice.eco",
+    })
+  })
+
+  it("interprets a pasted pdsls-style /at/ URL", () => {
+    const intent = parseSearchIntent(
+      `https://pdsls.dev/at/${DID}/org.hypercerts.claim.activity/3mo5phr5xbp2m`,
+    )
+    expect(intent).toMatchObject({ kind: "record", did: DID, rkey: "3mo5phr5xbp2m" })
+  })
+
+  it("returns null for a foreign URL that doesn't match the app scheme", () => {
+    expect(parseSearchIntent("https://example.com/some/random/path")).toBeNull()
+    expect(parseSearchIntent("not a url at all !!")).toBeNull()
+  })
+})

--- a/src/lib/search/__tests__/rank.test.ts
+++ b/src/lib/search/__tests__/rank.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest"
+import {
+  normalizeText,
+  tokenize,
+  lexicalRelevance,
+  totalBoost,
+  scoreCandidate,
+  rankBy,
+  dedupeBy,
+  mergePeopleByDid,
+  MIN_QUERY_LEN,
+  MAX_TOTAL_BOOST,
+  type RankInput,
+} from "../rank"
+
+describe("normalizeText", () => {
+  it("folds diacritics and lowercases", () => {
+    expect(normalizeText("Bioacústico")).toBe("bioacustico")
+    expect(normalizeText("MONITOREO de Aves")).toBe("monitoreo de aves")
+  })
+  it("collapses whitespace and trims", () => {
+    expect(normalizeText("  the   hearth  ")).toBe("the hearth")
+  })
+})
+
+describe("tokenize", () => {
+  it("splits on punctuation and whitespace", () => {
+    expect(tokenize("Floofy Clarke, PhD")).toEqual(["floofy", "clarke", "phd"])
+  })
+  it("returns a single token for no-whitespace scripts", () => {
+    expect(tokenize("シモクラシー")).toHaveLength(1)
+  })
+  it("returns [] for empty/punctuation-only", () => {
+    expect(tokenize("   ")).toEqual([])
+    expect(tokenize("—")).toEqual([])
+  })
+})
+
+describe("lexicalRelevance", () => {
+  it("scores an exact primary match 1.0", () => {
+    expect(lexicalRelevance("Floofy Clarke", "Floofy Clarke")).toBe(1)
+  })
+  it("is accent-insensitive", () => {
+    expect(lexicalRelevance("bioacustico", "Bioacústico")).toBe(1)
+  })
+  it("scores a contiguous primary prefix at least 0.85", () => {
+    // "edgewood" is a prefix of "Edgewood Labs" but not a multi-token
+    // reorder, so this isolates the prefix signal.
+    expect(lexicalRelevance("edgewood", "Edgewood Labs")).toBeGreaterThanOrEqual(0.85)
+  })
+  it("scores last-name-only and reordered tokens as word-prefix 0.9", () => {
+    expect(lexicalRelevance("clarke", "Floofy Clarke")).toBeCloseTo(0.9)
+    expect(lexicalRelevance("clarke floofy", "Floofy Clarke")).toBeCloseTo(0.9)
+  })
+  it("ranks an exact-name person above a cert that only mentions the term in its description", () => {
+    const person = lexicalRelevance("hearth", "The Hearth")
+    const cert = lexicalRelevance(
+      "hearth",
+      "Traveling Documentary Project",
+      "we gather around the hearth to share stories",
+    )
+    expect(person).toBeGreaterThan(cert)
+  })
+  it("weights secondary-field overlap below primary", () => {
+    const secondaryOnly = lexicalRelevance("governance", "Some Title", "live governance workflows")
+    expect(secondaryOnly).toBeGreaterThan(0)
+    expect(secondaryOnly).toBeLessThanOrEqual(0.3)
+  })
+  it("returns 0 for no match and empty query", () => {
+    expect(lexicalRelevance("zzz", "Floofy Clarke")).toBe(0)
+    expect(lexicalRelevance("", "Floofy Clarke")).toBe(0)
+  })
+})
+
+describe("totalBoost", () => {
+  it("sums and clamps to MAX_TOTAL_BOOST", () => {
+    expect(totalBoost({ owner: 0.05, quality: 0.1 })).toBeCloseTo(0.15)
+    expect(totalBoost({ owner: 0.05, quality: 0.5 })).toBe(MAX_TOTAL_BOOST)
+    expect(totalBoost(undefined)).toBe(0)
+  })
+})
+
+describe("scoreCandidate", () => {
+  it("prefers serverScore over lexical when present", () => {
+    const input: RankInput = { primary: "irrelevant", serverScore: 0.42 }
+    expect(scoreCandidate("anything", input)).toBeCloseTo(0.42)
+  })
+  it("boosts never let a weak lexical match jump a strong one", () => {
+    // substring (0.3) + max boost (0.15) = 0.45 must stay below a clean
+    // word-prefix (0.9) with no boost.
+    const weakBoosted = scoreCandidate("clarke", {
+      primary: "declarke holdings",
+      boosts: { owner: 0.05, quality: 0.1 },
+    })
+    const strong = scoreCandidate("clarke", { primary: "Floofy Clarke" })
+    expect(strong).toBeGreaterThan(weakBoosted)
+  })
+})
+
+describe("rankBy", () => {
+  const items = [
+    { id: "a", title: "Restore Rainforest" },
+    { id: "b", title: "Simocracy at Edge" },
+    { id: "c", title: "Simocracy 3D Print" },
+  ]
+  it("re-orders by relevance, descending", () => {
+    const ranked = rankBy("simocracy", items, (i) => ({ primary: i.title }))
+    expect(ranked.map((i) => i.id).slice(0, 2)).toEqual(["b", "c"])
+    expect(ranked[2].id).toBe("a")
+  })
+  it("preserves server order for queries below MIN_QUERY_LEN", () => {
+    expect("s".length).toBeLessThan(MIN_QUERY_LEN)
+    const ranked = rankBy("s", items, (i) => ({ primary: i.title }))
+    expect(ranked.map((i) => i.id)).toEqual(["a", "b", "c"])
+  })
+  it("is stable for ties (keeps original order)", () => {
+    const tied = [
+      { id: "x", title: "Edge" },
+      { id: "y", title: "Edge" },
+    ]
+    const ranked = rankBy("edge", tied, (i) => ({ primary: i.title }))
+    expect(ranked.map((i) => i.id)).toEqual(["x", "y"])
+  })
+})
+
+describe("dedupeBy", () => {
+  it("keeps the first occurrence per key", () => {
+    const rows = [
+      { uri: "at://1", n: 1 },
+      { uri: "at://2", n: 2 },
+      { uri: "at://1", n: 3 },
+    ]
+    expect(dedupeBy(rows, (r) => r.uri).map((r) => r.n)).toEqual([1, 2])
+  })
+})
+
+describe("mergePeopleByDid", () => {
+  it("unions fields across sources (handle from one, bio from the other)", () => {
+    const certified = [{ did: "did:plc:a", displayName: "Alice", description: "eco" }]
+    const bsky = [{ did: "did:plc:a", displayName: "Alice", handle: "alice.eco" }]
+    const merged = mergePeopleByDid(certified, bsky)
+    expect(merged).toHaveLength(1)
+    expect(merged[0]).toMatchObject({
+      did: "did:plc:a",
+      displayName: "Alice",
+      description: "eco",
+      handle: "alice.eco",
+    })
+  })
+  it("appends DIDs only present in the secondary source, preserving order", () => {
+    const certified = [{ did: "did:plc:a", displayName: "Alice" }]
+    const bsky = [
+      { did: "did:plc:a", displayName: "Alice", handle: "alice.eco" },
+      { did: "did:plc:b", displayName: "Bob", handle: "bob.eco" },
+    ]
+    const merged = mergePeopleByDid(certified, bsky)
+    expect(merged.map((m) => m.did)).toEqual(["did:plc:a", "did:plc:b"])
+  })
+  it("earlier source wins on a non-empty conflict", () => {
+    const certified = [{ did: "did:plc:a", displayName: "Certified Name" }]
+    const bsky = [{ did: "did:plc:a", displayName: "Bsky Name" }]
+    expect(mergePeopleByDid(certified, bsky)[0].displayName).toBe("Certified Name")
+  })
+})

--- a/src/lib/search/__tests__/rank.test.ts
+++ b/src/lib/search/__tests__/rank.test.ts
@@ -135,9 +135,21 @@ describe("dedupeBy", () => {
 })
 
 describe("mergePeopleByDid", () => {
+  // Both sources are normalized to one Actor shape before merge, so the
+  // two arrays share a type (handle/description optional on each).
+  interface Person {
+    did: string
+    displayName: string
+    handle?: string
+    description?: string
+  }
   it("unions fields across sources (handle from one, bio from the other)", () => {
-    const certified = [{ did: "did:plc:a", displayName: "Alice", description: "eco" }]
-    const bsky = [{ did: "did:plc:a", displayName: "Alice", handle: "alice.eco" }]
+    const certified: Person[] = [
+      { did: "did:plc:a", displayName: "Alice", description: "eco" },
+    ]
+    const bsky: Person[] = [
+      { did: "did:plc:a", displayName: "Alice", handle: "alice.eco" },
+    ]
     const merged = mergePeopleByDid(certified, bsky)
     expect(merged).toHaveLength(1)
     expect(merged[0]).toMatchObject({
@@ -148,8 +160,8 @@ describe("mergePeopleByDid", () => {
     })
   })
   it("appends DIDs only present in the secondary source, preserving order", () => {
-    const certified = [{ did: "did:plc:a", displayName: "Alice" }]
-    const bsky = [
+    const certified: Person[] = [{ did: "did:plc:a", displayName: "Alice" }]
+    const bsky: Person[] = [
       { did: "did:plc:a", displayName: "Alice", handle: "alice.eco" },
       { did: "did:plc:b", displayName: "Bob", handle: "bob.eco" },
     ]
@@ -157,8 +169,10 @@ describe("mergePeopleByDid", () => {
     expect(merged.map((m) => m.did)).toEqual(["did:plc:a", "did:plc:b"])
   })
   it("earlier source wins on a non-empty conflict", () => {
-    const certified = [{ did: "did:plc:a", displayName: "Certified Name" }]
-    const bsky = [{ did: "did:plc:a", displayName: "Bsky Name" }]
+    const certified: Person[] = [
+      { did: "did:plc:a", displayName: "Certified Name" },
+    ]
+    const bsky: Person[] = [{ did: "did:plc:a", displayName: "Bsky Name" }]
     expect(mergePeopleByDid(certified, bsky)[0].displayName).toBe("Certified Name")
   })
 })

--- a/src/lib/search/constants.ts
+++ b/src/lib/search/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared search tunables. Previously `SEARCH_DEBOUNCE_MS` was duplicated
+ * verbatim in `global-search.tsx` and `cert-search.tsx`; the unified
+ * search brain (`useUnifiedSearch`) and both surfaces now import one
+ * source so the cadence can't drift.
+ */
+
+/** Keystroke debounce before a search fan-out fires, in ms. */
+export const SEARCH_DEBOUNCE_MS = 250
+
+/**
+ * Fetch-wide / show-narrow: how many candidates to request per source
+ * so client re-ranking has something to reorder. The indexer returns
+ * keyset/recency order, so fetching only the display count would just
+ * re-surface the same recency-buried order. Request this many, rank,
+ * then slice to the display cap.
+ */
+export const CANDIDATE_FETCH_SIZE = 25
+
+/** Default rows shown per section after ranking. */
+export const SECTION_DISPLAY_LIMIT = 6

--- a/src/lib/search/parse-search-intent.ts
+++ b/src/lib/search/parse-search-intent.ts
@@ -1,0 +1,184 @@
+/**
+ * Resilience detector: recognise when the user has pasted a direct
+ * IDENTIFIER (an at-URI, a DID, a handle, or an app/pdsls URL) rather
+ * than a search term, and offer a one-tap "Jump to" that resolves it
+ * WITHOUT the indexer.
+ *
+ * Why: free-text search depends entirely on the magic-indexer, so a
+ * record the indexer hasn't ingested (e.g. on an external PDS — see
+ * magic-indexer#224) is undiscoverable by name. But if the user already
+ * holds its link/handle/DID, we can navigate straight there via the
+ * app's own routing scheme + PDS/`/api/resolve-*`. This is a workaround
+ * for people who have the identifier — NOT a name-discovery fix.
+ *
+ * Pure and synchronous: it only classifies the string and builds the
+ * in-app href. Optional profile enrichment (name/avatar) is left to the
+ * caller, which should only call `/api/resolve-*` when `resolvable` is
+ * true (i.e. the identifier is structurally complete) so we don't fire
+ * a resolve on every keystroke of a half-typed handle.
+ */
+
+import {
+  parseAtUri,
+  parsePastedAtUri,
+  parseActor,
+  isDid,
+  isRecordType,
+  recordUrl,
+  recordUrlFromAtUri,
+  profileUrl,
+  typeForCollection,
+  type ParsedAtUri,
+} from "@/lib/urls"
+
+export type SearchIntent =
+  | {
+      kind: "record"
+      /** In-app href to navigate to. */
+      href: string
+      did: string
+      collection: string
+      rkey: string
+      /** Friendly label, e.g. "Open activity" / "Open project". */
+      label: string
+      /** Whether the caller may enrich via a resolve call. */
+      resolvable: boolean
+    }
+  | {
+      kind: "profile"
+      href: string
+      /** Handle or DID, as pasted. */
+      actor: string
+      label: string
+      resolvable: boolean
+    }
+
+function recordLabel(collection: string): string {
+  const type = typeForCollection(collection)
+  if (type === "activity") return "Open activity"
+  if (type === "project") return "Open project"
+  return "Open record"
+}
+
+/** Build a record-or-profile intent from parsed at-URI parts. Records
+ *  whose collection has no in-app page fall back to the author profile. */
+function intentFromAtUri(parsed: ParsedAtUri): SearchIntent {
+  const href = recordUrlFromAtUri(`at://${parsed.did}/${parsed.collection}/${parsed.rkey}`)
+  if (href) {
+    return {
+      kind: "record",
+      href,
+      did: parsed.did,
+      collection: parsed.collection,
+      rkey: parsed.rkey,
+      label: recordLabel(parsed.collection),
+      resolvable: true,
+    }
+  }
+  return {
+    kind: "profile",
+    href: profileUrl(parsed.did),
+    actor: parsed.did,
+    label: "Go to profile",
+    resolvable: true,
+  }
+}
+
+/** Interpret a URL pathname against the app's routing scheme:
+ *  `/{actor}`, `/{actor}/{type}/{rkey}`, or a pasted `/at/...` form. */
+function intentFromPathname(pathname: string): SearchIntent | null {
+  const pasted = parsePastedAtUri(pathname)
+  if (pasted) return intentFromAtUri(pasted)
+
+  const segments = pathname.replace(/^\/+/, "").split("/").filter(Boolean)
+  if (segments.length === 0) return null
+
+  const actor = parseActor(segments[0])
+  if (actor.kind === "invalid") return null
+
+  if (segments.length >= 3 && isRecordType(segments[1])) {
+    const type = segments[1]
+    const rkey = segments[2]
+    return {
+      kind: "record",
+      href: recordUrl(actor.value, type, rkey),
+      did: actor.kind === "did" ? actor.value : "",
+      collection: type,
+      rkey,
+      label: type === "project" ? "Open project" : "Open activity",
+      resolvable: true,
+    }
+  }
+
+  if (segments.length === 1) {
+    return {
+      kind: "profile",
+      href: profileUrl(actor.value),
+      actor: actor.value,
+      label: actor.kind === "handle" ? `Go to @${actor.value}` : "Go to profile",
+      resolvable: true,
+    }
+  }
+  return null
+}
+
+/**
+ * Classify `query`. Returns a jump intent when the string is a complete
+ * identifier, or null when it's an ordinary search term.
+ */
+export function parseSearchIntent(query: string): SearchIntent | null {
+  const q = query.trim()
+  if (!q) return null
+
+  // 1. Canonical at-URI.
+  if (q.startsWith("at://")) {
+    const parsed = parseAtUri(q)
+    return parsed ? intentFromAtUri(parsed) : null
+  }
+
+  // 2. Other pasted at-uri shapes (at:/…, at/…) without a leading slash.
+  if (/^at[:/]/.test(q)) {
+    const pasted = parsePastedAtUri(q)
+    return pasted ? intentFromAtUri(pasted) : null
+  }
+
+  // 3. A full http(s) URL — interpret its pathname (handles app URLs and
+  //    pdsls-style /at/ paths; foreign hosts simply won't match our
+  //    scheme and return null).
+  if (/^https?:\/\//i.test(q)) {
+    try {
+      const url = new URL(q)
+      return intentFromPathname(url.pathname)
+    } catch {
+      return null
+    }
+  }
+
+  // 4. Bare DID.
+  if (isDid(q) && !/\s/.test(q)) {
+    return {
+      kind: "profile",
+      href: profileUrl(q),
+      actor: q,
+      label: "Go to profile",
+      resolvable: true,
+    }
+  }
+
+  // 5. Handle (optionally @-prefixed). parseActor requires a dot and
+  //    rejects reserved words, so plain product names ("Simocracy")
+  //    return null and fall through to normal search.
+  const handle = q.replace(/^@/, "")
+  const actor = parseActor(handle)
+  if (actor.kind === "handle") {
+    return {
+      kind: "profile",
+      href: profileUrl(actor.value),
+      actor: actor.value,
+      label: `Go to @${actor.value}`,
+      resolvable: true,
+    }
+  }
+
+  return null
+}

--- a/src/lib/search/rank.ts
+++ b/src/lib/search/rank.ts
@@ -1,0 +1,242 @@
+/**
+ * Client-side relevance ranking over an already-fetched candidate set.
+ *
+ * Why this exists: the magic-indexer returns activity/project/actor
+ * matches in keyset (≈ recency) order, NOT relevance order — there is
+ * no server `_score`. So a query whose best match the indexer happens
+ * to place 9th by recency would otherwise be buried. This module
+ * re-ranks the small fetched set (fetch wide, show narrow) by lexical
+ * relevance with a few small, capped boosts.
+ *
+ * Scope & honesty:
+ *   - This re-orders results the indexer ALREADY returned. It cannot
+ *     surface a record the indexer never returned (e.g. records on
+ *     external PDSes that aren't ingested — see magic-indexer#224).
+ *   - Phase 1 has NO typo tolerance ("Simocacy" ≠ "Simocracy"); fuzzy
+ *     matching needs the indexer. The functions here are pure, exact
+ *     (after diacritic folding), and unit-tested.
+ *   - When the indexer eventually returns a relevance score, pass it as
+ *     `serverScore` and it replaces the lexical core verbatim.
+ *
+ * Cross-entity interleaving: `lexicalRelevance` is computed against a
+ * weighted PRIMARY field (name/title) plus a lower-weighted SECONDARY
+ * field (description/workScope). Because the primary field carries the
+ * bulk of the signal regardless of entity kind, scores from people /
+ * certs / projects are comparable enough to interleave by score.
+ */
+
+/** Below this query length we trust the server's order rather than
+ *  re-ranking — single-char queries make prefix/overlap fire on almost
+ *  everything, so boosts would decide the order. */
+export const MIN_QUERY_LEN = 2
+
+/** Hard cap on the SUM of additive boosts. Boosts break ties WITHIN a
+ *  lexical tier; they must never let a weak lexical match jump a strong
+ *  one. The gaps between lexical tiers are ~0.1–0.25, so 0.15 keeps
+ *  boosts sub-tier. */
+export const MAX_TOTAL_BOOST = 0.15
+
+/** Suggested per-signal caps for callers assembling `boosts`. The total
+ *  is clamped to {@link MAX_TOTAL_BOOST} regardless, but keeping each
+ *  input small keeps any single signal from dominating. */
+export const BOOST_CAP = {
+  /** Authored by the viewer ("your" stuff). Tiebreaker only. */
+  owner: 0.05,
+  /** Positive quality-label tier. Certs only (only certs carry
+   *  per-record labels client-side). */
+  quality: 0.1,
+} as const
+
+export interface RankBoosts {
+  owner?: number
+  quality?: number
+}
+
+export interface RankInput {
+  /** Highest-weight matchable text: a person's displayName + handle, or
+   *  a cert/project title. */
+  primary: string
+  /** Lower-weight text: shortDescription + workScope, profile bio, etc. */
+  secondary?: string
+  /** Small additive boosts; the SUM is clamped to MAX_TOTAL_BOOST. */
+  boosts?: RankBoosts
+  /** If the indexer ever returns a 0..1 relevance score, set it here and
+   *  it replaces the client lexical core. */
+  serverScore?: number
+}
+
+/**
+ * Fold diacritics and lowercase so "Bioacústico" matches "bioacustico"
+ * — the indexer's actor search already does unaccent+ILIKE, so the
+ * client must fold too or it would score an accented server hit low.
+ * Also collapses internal whitespace and trims.
+ */
+export function normalizeText(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLocaleLowerCase()
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+/** Split normalized text into word tokens (letters/digits runs). Works
+ *  for space-separated scripts; CJK/no-whitespace text yields a single
+ *  token, so those queries fall back to exact/prefix/substring only. */
+export function tokenize(value: string): string[] {
+  const normalized = normalizeText(value)
+  if (!normalized) return []
+  return normalized.split(/[^\p{L}\p{N}]+/u).filter(Boolean)
+}
+
+/**
+ * Lexical relevance in [0, 1]. `max()` of independent signals — a
+ * deliberate conservative choice (it doesn't double-count corroborating
+ * evidence, but never lets a weaker signal pull a strong one down).
+ */
+export function lexicalRelevance(
+  query: string,
+  primary: string,
+  secondary?: string,
+): number {
+  const nq = normalizeText(query)
+  if (!nq) return 0
+  const nPrimary = normalizeText(primary)
+  if (!nPrimary && !secondary) return 0
+
+  const qTokens = tokenize(nq)
+  const pTokens = tokenize(nPrimary)
+
+  let score = 0
+
+  // Exact / prefix / substring on the primary field.
+  if (nPrimary) {
+    if (nPrimary === nq) return 1
+    if (nPrimary.startsWith(nq)) score = Math.max(score, 0.85)
+    if (nPrimary.includes(nq)) score = Math.max(score, 0.3)
+  }
+
+  // Every query token is a word-prefix of some primary token — covers
+  // reordered and last-name-only people queries ("clarke" → "Floofy
+  // Clarke", "clarke floofy" → "Floofy Clarke"). Strong enough to beat
+  // a mere title prefix on another entity.
+  if (qTokens.length > 0 && pTokens.length > 0) {
+    const allWordPrefix = qTokens.every((qt) =>
+      pTokens.some((pt) => pt.startsWith(qt)),
+    )
+    if (allWordPrefix) score = Math.max(score, 0.9)
+
+    // Token overlap on the primary field (not a long description bag —
+    // that would float verbose records above exact-name matches).
+    const pSet = new Set(pTokens)
+    const overlap = qTokens.filter((qt) => pSet.has(qt)).length / qTokens.length
+    score = Math.max(score, overlap * 0.6)
+  }
+
+  // Token overlap on the secondary field, weighted lower.
+  if (secondary && qTokens.length > 0) {
+    const sTokens = new Set(tokenize(secondary))
+    if (sTokens.size > 0) {
+      const overlap =
+        qTokens.filter((qt) => sTokens.has(qt)).length / qTokens.length
+      score = Math.max(score, overlap * 0.3)
+    }
+  }
+
+  return score
+}
+
+/** Sum the provided boosts and clamp to {@link MAX_TOTAL_BOOST}. */
+export function totalBoost(boosts?: RankBoosts): number {
+  if (!boosts) return 0
+  const sum = (boosts.owner ?? 0) + (boosts.quality ?? 0)
+  return Math.min(Math.max(sum, 0), MAX_TOTAL_BOOST)
+}
+
+/**
+ * Final score for one candidate: lexical (or server) relevance plus the
+ * capped boost. Not clamped at the top — only relative order matters.
+ */
+export function scoreCandidate(query: string, input: RankInput): number {
+  const relevance =
+    typeof input.serverScore === "number"
+      ? input.serverScore
+      : lexicalRelevance(query, input.primary, input.secondary)
+  return relevance + totalBoost(input.boosts)
+}
+
+/**
+ * Stably re-rank `items` by score, descending. For queries shorter than
+ * {@link MIN_QUERY_LEN} the original (server) order is preserved. Ties
+ * keep server order because the sort is stable (decorate-sort-undecorate
+ * on the original index).
+ */
+export function rankBy<T>(
+  query: string,
+  items: readonly T[],
+  toInput: (item: T) => RankInput,
+): T[] {
+  if (normalizeText(query).length < MIN_QUERY_LEN) return [...items]
+  return items
+    .map((item, index) => ({ item, index, score: scoreCandidate(query, toInput(item)) }))
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((d) => d.item)
+}
+
+/**
+ * First-wins de-dupe by a string key. Safe for records keyed on at-URI
+ * (cert and project collections are disjoint, so URIs never collide
+ * across kinds).
+ */
+export function dedupeBy<T>(items: readonly T[], keyFn: (item: T) => string): T[] {
+  const seen = new Set<string>()
+  const out: T[] = []
+  for (const item of items) {
+    const key = keyFn(item)
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(item)
+  }
+  return out
+}
+
+/**
+ * Merge two people sources by DID with FIELD-LEVEL union (not
+ * first-wins): the Bluesky AppView carries `handle` (the certified
+ * `NetworkActor` has none), while the certified source carries richer
+ * profile fields. Keeping both means the handle still contributes to
+ * relevance and the row can render a subtitle.
+ *
+ * `primary` is the source whose non-empty fields win on conflict
+ * (default: pass the certified actors first if you want their display
+ * metadata to win). Order of the returned list follows `primary`, then
+ * any `secondary`-only DIDs appended in their original order.
+ */
+export function mergePeopleByDid<T extends { did: string }>(
+  primary: readonly T[],
+  secondary: readonly T[],
+): T[] {
+  const byDid = new Map<string, T>()
+  const order: string[] = []
+  const add = (actor: T) => {
+    const existing = byDid.get(actor.did)
+    if (!existing) {
+      byDid.set(actor.did, { ...actor })
+      order.push(actor.did)
+      return
+    }
+    // Field-level union: fill any empty field on the existing record
+    // from this one. Existing (earlier source) wins on conflict.
+    const merged = { ...actor, ...existing } as T
+    for (const key of Object.keys(actor) as (keyof T)[]) {
+      const cur = existing[key]
+      if (cur === undefined || cur === null || cur === "") {
+        merged[key] = actor[key]
+      }
+    }
+    byDid.set(actor.did, merged)
+  }
+  for (const a of primary) add(a)
+  for (const a of secondary) add(a)
+  return order.map((did) => byDid.get(did)!)
+}

--- a/src/lib/view-transitions.tsx
+++ b/src/lib/view-transitions.tsx
@@ -68,6 +68,34 @@ export function ViewTransitionProvider({ children }: { children: ReactNode }) {
   const router = useRouter()
   const finishRef = useRef<(() => void) | null>(null)
 
+  // In-app navigation depth, so the default Back action never walks out
+  // of the app. We patch history.pushState (Next's router calls it for
+  // every forward navigation, including query-only tab switches) to
+  // increment, and popstate (back/forward) to decrement, clamped at 0.
+  // router.replace uses replaceState, so URL canonicalization (did→handle)
+  // isn't counted. When the depth is 0 the user entered the app on this
+  // page (direct link, external referrer, or refresh), so `router.back()`
+  // would leave the app — we push "/" instead. Lives here (single,
+  // app-wide mount) rather than per-chrome component so every
+  // `transitionBack()` caller — mobile navbar and desktop top bar — gets
+  // the same guard without double-patching history.
+  const inAppDepthRef = useRef(0)
+  useEffect(() => {
+    const origPushState = history.pushState.bind(history)
+    history.pushState = (...args: Parameters<typeof origPushState>) => {
+      inAppDepthRef.current += 1
+      return origPushState(...args)
+    }
+    const onPop = () => {
+      inAppDepthRef.current = Math.max(0, inAppDepthRef.current - 1)
+    }
+    window.addEventListener("popstate", onPop)
+    return () => {
+      history.pushState = origPushState
+      window.removeEventListener("popstate", onPop)
+    }
+  }, [])
+
   const handleRouteChange = useCallback(() => {
     if (finishRef.current) {
       finishRef.current()
@@ -124,7 +152,20 @@ export function ViewTransitionProvider({ children }: { children: ReactNode }) {
 
   const transitionBack = useCallback(
     (navigate?: () => void) =>
-      run("back", navigate ?? (() => router.back())),
+      run(
+        "back",
+        navigate ??
+          (() => {
+            if (inAppDepthRef.current > 0) {
+              // Real in-app history — safe to pop (popstate decrements).
+              router.back()
+            } else {
+              // Entered the app on this page; router.back() would exit to
+              // an external page. Go home instead.
+              router.push("/")
+            }
+          }),
+      ),
     [run, router],
   )
 


### PR DESCRIPTION
Draft. Bundles four independent areas from one working session; each is in its own commit and could be split into separate PRs if preferred.

## 1. Search — relevance ranking + paste-to-jump resilience
Activity search depends entirely on the magic-indexer, which returns matches in keyset (recency) order with **no relevance score**.
- `src/lib/search/rank.ts` — pure, unit-tested client ranking (NFD diacritic fold, field-weighted primary/secondary via `max()`, total boost capped 0.15, query-length gate, stable ties, de-dupe + people field-merge). Prefers a server `_score` if one ever ships.
- `src/lib/search/parse-search-intent.ts` — pasted at-URI / DID / handle / app-URL → a direct "Jump to" that bypasses the indexer.
- `global-search` fetches wide, re-ranks, slices; adds the pinned jump row + intent-aware Enter.

Does **not** change which records are searchable (indexer-side, see `magic-indexer#224`) — only ordering + an identifier-jump path.

## 2. Groups (CGS) — repo-targeting migration + import/destroy
- **Targeting migration** (the upstream `aud`-overload is deprecated, CGS #27): proxy to the service DID via `certified_group_service`; name the group with an explicit `repo` (querystring for queries/body-less, body for procedures). `updateHandle` stays on the legacy proxy (stock method, no `repo` field).
- **`group.import`** — `POST /api/groups/import` + a focused `/groups/import` page that converts the **signed-in account** into a group (CGS requires the token `iss` to be that account) and a cross-link from `/groups/create`.
- **`group.destroy`** — `POST /api/groups/[groupDid]/destroy` + an owner-only **Danger zone → Remove group** in org settings.
- `putAnyRecord`→admin (CGS #13): verified no UI change needed — all group-record edit affordances already require owner/admin.

## 3. Auth (ePDS)
- Add `favicon_url` to the OAuth client metadata (Certified mark in the auth/consent browser tab).
- Handle ePDS clean-exit (#154): an OAuth `error` redirect now yields a retryable failure with a "Try signing in again" action instead of a dead-end.

## 4. UI fixes
- `AppDialogHeader` opt-in `center` prop; enabled on the funding-receipt and rights modals.
- Back button no longer exits to an external page: in-app depth tracking lifted into `ViewTransitionProvider` so the default `transitionBack()` falls back to `/` (fixes the desktop top-bar Back; removes the navbar's redundant local copy).

## Verification
- `npx tsc --noEmit` clean; `npm run lint` unchanged at 65 warnings / 0 errors; `vitest` 718/718 pass (incl. 34 new search tests).

## Needs live verification before merge
- The CGS `aud`→`repo` migration is mechanical per `docs/aud-migration.md` but can't be runtime-tested here — **verify a real group write/read against staging CGS** (blast radius is all group operations; the legacy form still works upstream, so it can be staged safely).
- `group.import` does not yet enforce `MAX_SELF_CREATED_ORGS` (noted in-code; small abuse surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
