### PR TITLE
fix(contributor-board): visual parity with hyperboards.org

### DIFF
--- a/docs/contributor-board/parity-fixes.md
+++ b/docs/contributor-board/parity-fixes.md
@@ -1,0 +1,34 @@
+# Contributor Board — visual parity fixes
+
+After the first PR merged, a side-by-side of the live boards (e.g. holke.xyz's
+"Hypercerts Documentation" and "atproto" boards) against hyperboards.org showed
+the render was **not** at parity: no background image, opaque white card tiles,
+and a long tail of empty boxes. Root-caused against the real on-chain board data
+(captured with a headless browser) and fixed.
+
+## Root causes (from the actual board records)
+
+- **`backgroundImage` is stored as a bare URL string** in hyperboards-v2 (e.g.
+  `"https://…/photo.jpg"`), not a `uri`/`smallImage` union. `boardImageUrl` only
+  handled the union → the background never rendered. Now returns a bare string
+  as-is. Types widened to `BoardImage | string`.
+- **`backgroundOpacity` is a `0–1` value, often a string** (`"0.55"`). The code
+  only accepted a number in `0–100` → it fell back to `0.15`. Now normalises any
+  of number/string × 0–1/0–100 to a 0–1 fraction (background layer + settings).
+
+## Visual parity changes
+
+- **Tiles are transparent** over the board background (translucent mosaic, like
+  hyperboards), not opaque `--bg-elevated` cards; subtle theme-aware hover tint.
+- **Avatars get an explicit wrapper size and scale with the tile**, so a heavy
+  contributor gets a big medallion and the long tail still shows small faces
+  (down to ~14px) instead of empty cells. Fixes the prior `img{width:100%}` /
+  unsized-wrapper bug that let large-tile images balloon.
+
+## Verified
+
+Built locally and screenshotted the same two boards (4-contributor and
+98-contributor) — both now render the background photo with translucent
+weighted tiles and consistent circular avatars, matching hyperboards.org.
+tsc/lint/build clean; 703 unit tests pass (added `boardImageUrl` bare-string
+coverage; updated `tileSizing` thresholds).

--- a/src/app/styles/contributor-board.css
+++ b/src/app/styles/contributor-board.css
@@ -60,15 +60,18 @@
   align-items: center;
   justify-content: center;
   gap: 0.25rem;
-  padding: 0.375rem;
+  padding: 0.25rem;
   overflow: hidden;
+  /* Transparent so the board background shows through (like hyperboards) —
+     tiles read as a translucent mosaic over the backdrop, not opaque cards. */
+  background: transparent;
   border: 1px solid var(--border-default);
   border-radius: var(--radius);
-  background: var(--bg-elevated);
   color: var(--fg-primary);
   text-decoration: none;
   transition:
     border-color var(--transition-base),
+    background var(--transition-base),
     box-shadow var(--transition-base);
 }
 
@@ -84,6 +87,9 @@
 
 .contributor-tile:hover {
   border-color: var(--border-hover);
+  /* Faint theme-aware tint on hover (token alpha), matching hyperboards'
+     translucent hover overlay without an opaque fill. */
+  background: var(--border-subtle);
   box-shadow: var(--shadow-md);
 }
 .contributor-tile:focus-visible {

--- a/src/components/contributor-board/board-settings-dialog.tsx
+++ b/src/components/contributor-board/board-settings-dialog.tsx
@@ -20,6 +20,13 @@ type BgKind = "none" | "image" | "iframe"
 // not a design-system colour. The chosen value is stored as record data.
 const COLOR_SEED = "#888888"
 
+/** Normalise a stored opacity (0–1 or 0–100, number or string) to a 0–1 fraction. */
+function normalizeOpacity(v: number | string | undefined): number {
+  const n = typeof v === "number" ? v : typeof v === "string" ? parseFloat(v) : NaN
+  if (!Number.isFinite(n)) return 0.15
+  return Math.max(0, Math.min(1, n > 1 ? n / 100 : n))
+}
+
 /**
  * Edit a board's cosmetics: aspect ratio, image shape, grayscale, background
  * (image/iframe/none), opacity, and border/background colours. Returns the
@@ -30,7 +37,12 @@ export function BoardSettingsDialog({
   onClose,
   onSave,
 }: BoardSettingsDialogProps) {
-  const [draft, setDraft] = useState<BoardConfig>({ ...config })
+  // Normalise opacity to a 0–1 fraction on load so the edit round-trips
+  // cleanly regardless of how the loaded record stored it.
+  const [draft, setDraft] = useState<BoardConfig>({
+    ...config,
+    backgroundOpacity: normalizeOpacity(config.backgroundOpacity),
+  })
   const [bgKind, setBgKind] = useState<BgKind>(
     config.backgroundType === "iframe"
       ? "iframe"
@@ -172,10 +184,12 @@ export function BoardSettingsDialog({
             type="number"
             min={0}
             max={100}
-            value={String(draft.backgroundOpacity ?? 15)}
-            onChange={(e) =>
-              set({ backgroundOpacity: Math.max(0, Math.min(100, parseInt(e.target.value || "0", 10))) })
-            }
+            value={String(Math.round(normalizeOpacity(draft.backgroundOpacity) * 100))}
+            onChange={(e) => {
+              const pct = Math.max(0, Math.min(100, parseInt(e.target.value || "0", 10)))
+              // Store as a 0–1 fraction (matches the de-facto hyperboards data).
+              set({ backgroundOpacity: pct / 100 })
+            }}
           />
           <label className="mt-2 flex items-center gap-2 text-body-sm text-[var(--fg-primary)]">
             <input

--- a/src/components/contributor-board/contributor-board.tsx
+++ b/src/components/contributor-board/contributor-board.tsx
@@ -59,10 +59,17 @@ function BackgroundLayer({
   boardDid: string | null
 }) {
   const grayscale = config.backgroundGrayscale !== false
-  const opacity =
+  // Opacity may arrive as a 0–1 fraction or a 0–100 percent, number or string
+  // (hyperboards-v2 stores e.g. "0.55"). Normalise to a 0–1 fraction.
+  const rawOpacity =
     typeof config.backgroundOpacity === "number"
-      ? Math.max(0, Math.min(100, config.backgroundOpacity)) / 100
-      : 0.15
+      ? config.backgroundOpacity
+      : typeof config.backgroundOpacity === "string"
+        ? parseFloat(config.backgroundOpacity)
+        : NaN
+  const opacity = Number.isFinite(rawOpacity)
+    ? Math.max(0, Math.min(1, rawOpacity > 1 ? rawOpacity / 100 : rawOpacity))
+    : 0.15
   const layerStyle = {
     opacity,
     filter: grayscale ? "grayscale(1)" : undefined,

--- a/src/components/contributor-board/contributor-tile.tsx
+++ b/src/components/contributor-board/contributor-tile.tsx
@@ -53,7 +53,10 @@ export function ContributorTile({
   const content = (
     <>
       {showAvatar ? (
-        <span className={`contributor-tile__avatar ${shapeClass}`}>
+        <span
+          className={`contributor-tile__avatar ${shapeClass}`}
+          style={{ width: avatarSize, height: avatarSize }}
+        >
           {entry.imageUrl && !imgError ? (
             <Image
               src={entry.imageUrl}

--- a/src/lib/atproto/__tests__/hyperboard.test.ts
+++ b/src/lib/atproto/__tests__/hyperboard.test.ts
@@ -11,6 +11,7 @@ import {
   parseBoardRecord,
   fetchBoardForActivity,
   invalidateBoardForActivity,
+  boardImageUrl,
   type ResolvedContributorProfile,
   type BuildEntriesInput,
 } from "@/lib/atproto/hyperboard"
@@ -122,6 +123,21 @@ describe("buildBoardEntries precedence", () => {
     expect(e.name).toBe("plainname")
     expect(e.imageUrl).toBeNull()
     expect(e.value).toBe(1)
+  })
+})
+
+describe("boardImageUrl", () => {
+  it("returns a bare string URL as-is (hyperboards-v2 stores backgroundImage as a string)", () => {
+    expect(boardImageUrl("https://example.com/bg.jpg", "did:plc:x")).toBe(
+      "https://example.com/bg.jpg",
+    )
+  })
+  it("returns the uri from a uri union", () => {
+    expect(boardImageUrl(uri("https://a/b.png"), "did:plc:x")).toBe("https://a/b.png")
+  })
+  it("returns null for nullish input", () => {
+    expect(boardImageUrl(undefined, "did:plc:x")).toBeNull()
+    expect(boardImageUrl(null, "did:plc:x")).toBeNull()
   })
 })
 

--- a/src/lib/atproto/hyperboard-types.ts
+++ b/src/lib/atproto/hyperboard-types.ts
@@ -44,12 +44,13 @@ export type BackgroundType = "image" | "iframe"
 /** org.hyperboards.board#boardConfig — board-level visual settings. */
 export interface BoardConfig {
   backgroundType?: BackgroundType
-  backgroundImage?: BoardImage
+  /** a uri/blob union OR a bare URL string (hyperboards-v2 stores a string) */
+  backgroundImage?: BoardImage | string
   backgroundIframeUrl?: string
   /** default true */
   backgroundGrayscale?: boolean
-  /** 0–100 */
-  backgroundOpacity?: number
+  /** opacity as a 0–1 fraction or a 0–100 percent, number or string */
+  backgroundOpacity?: number | string
   /** hex string */
   backgroundColor?: string
   /** hex string */

--- a/src/lib/atproto/hyperboard.ts
+++ b/src/lib/atproto/hyperboard.ts
@@ -57,10 +57,12 @@ interface RawUnion {
  * that holds them (`ownerDid`). Tolerant of records missing `$type`.
  */
 export function boardImageUrl(
-  image: BoardImage | undefined | null,
+  image: BoardImage | string | undefined | null,
   ownerDid: string | null,
 ): string | null {
   if (!image) return null
+  // hyperboards-v2 stores backgroundImage as a bare URL string.
+  if (typeof image === "string") return image
   const u = image as RawUnion
   if (typeof u.uri === "string") return u.uri
   if (u.image && "ref" in u.image) {

--- a/src/lib/contributor-board/__tests__/treemap.test.ts
+++ b/src/lib/contributor-board/__tests__/treemap.test.ts
@@ -55,12 +55,16 @@ describe("layoutTreemap", () => {
 })
 
 describe("tileSizing", () => {
-  it("scales avatar + font with tile size and hides chrome on tiny tiles", () => {
+  it("scales avatar + font with tile size, keeps small tiles as avatars, hides the label", () => {
     const big = tileSizing(400, 300)
     expect(big.showAvatar).toBe(true)
     expect(big.showLabel).toBe(true)
-    const tiny = tileSizing(20, 20)
+    // Small tiles still show an avatar (mosaic of faces) but drop the name.
+    const small = tileSizing(20, 20)
+    expect(small.showAvatar).toBe(true)
+    expect(small.showLabel).toBe(false)
+    // Only the truly tiny long-tail cells render no avatar.
+    const tiny = tileSizing(10, 10)
     expect(tiny.showAvatar).toBe(false)
-    expect(tiny.showLabel).toBe(false)
   })
 })

--- a/src/lib/contributor-board/treemap.ts
+++ b/src/lib/contributor-board/treemap.ts
@@ -76,12 +76,16 @@ export function tileSizing(
   height: number,
 ): { avatarSize: number; fontSize: number; showAvatar: boolean; showLabel: boolean } {
   const min = Math.min(width, height)
-  const avatarSize = Math.max(20, Math.min(96, Math.round(min * 0.4)))
-  const fontSize = Math.max(9, Math.min(14, Math.round(min * 0.12)))
+  // Avatar scales with the tile (so a heavy contributor gets a big medallion,
+  // like hyperboards) and stays visible down to tiny tiles. Shrink a little
+  // when a name label will sit beneath it so both fit.
+  const factor = width > 64 && height > 46 ? 0.62 : 0.78
+  const avatarSize = Math.max(14, Math.min(440, Math.round(min * factor)))
+  const fontSize = Math.max(9, Math.min(14, Math.round(min * 0.11)))
   return {
     avatarSize,
     fontSize,
-    showAvatar: min >= 36,
-    showLabel: width > 56 && height > 36,
+    showAvatar: min >= 14,
+    showLabel: width > 64 && height > 46,
   }
 }


### PR DESCRIPTION
## Contributor Board — visual parity with hyperboards.org

Follow-up to #191 (merged). After it landed, the live boards didn't match hyperboards.org — so I compared them directly (headless-browser screenshots of the same boards on staging vs hyperboards.org) and fixed the render against the **actual** on-chain board data.

### Root causes (found in the real board records, not the lexicon)
- **`backgroundImage` is a bare URL string** in hyperboards-v2 (`"https://…/photo.jpg"`), not a `uri`/`smallImage` union — so the background never rendered. `boardImageUrl` now returns a bare string as-is; types widened.
- **`backgroundOpacity` is a `0–1` value, usually a string** (`"0.55"`) — the code only accepted a `0–100` number and fell back to `0.15`. Now normalises number/string × 0–1/0–100 → a 0–1 fraction (render + settings).

### Visual parity
- **Transparent tiles** over the board background (translucent weighted mosaic, like hyperboards) instead of opaque white cards; subtle theme-aware hover tint.
- **Avatars scale with the tile** (explicit wrapper size) — heavy contributors get a big medallion, the long tail still shows small faces down to ~14px instead of empty boxes (fixes the prior unsized-wrapper bug).

### Before / after
Verified locally by rebuilding and screenshotting the same two boards (4-contributor "Hypercerts Documentation" and 98-contributor "atproto"): both now render the background photo with translucent weighted tiles and consistent circular avatars, matching hyperboards.org.

### Test plan
- [x] `npx tsc --noEmit` — 0 new errors (over the `.next` baseline)
- [x] `npm run lint` — 0 errors, 65 warnings (= baseline)
- [x] `npm run build` — green
- [x] `npm run test` — 703 passing (added `boardImageUrl` bare-string coverage; updated `tileSizing`)
- [x] Visual: local screenshots of both boards vs hyperboards.org

Details: `docs/contributor-board/parity-fixes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
