### PR TITLE
feat(visualization): use full 1300px grid width

### DIFF
--- a/src/app/styles/visualization.css
+++ b/src/app/styles/visualization.css
@@ -3,6 +3,16 @@
  * --radius; shadows via --shadow tokens; z-index via --z tokens.
  * Breakpoints 800/1100/1300. */
 
+/* Opt the page out of the shell's 720px reading column so the graph uses
+   the full grid width (capped at 1300px by .app-shell__grid). The shell's
+   horizontal padding is dropped here — `.viz`'s own padding is the gutter —
+   while its navbar-offset top/bottom padding is kept. */
+.app-shell:has(.viz) .app-shell__content {
+  max-width: none;
+  padding-left: 0;
+  padding-right: 0;
+}
+
 .viz {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
## What

Follow-up to #194. The `/visualization` page was constrained to the app shell's 720px reading column (`.app-shell__content`), leaving the endorsement graph and stats squeezed into the centre of the page.

This opts the page out of that cap — using the same `:has()` mechanism the home and explore pages use — so the graph and stats fill the full app-shell grid (capped at 1300px by `.app-shell__grid`). The shell's horizontal padding is dropped on this page so `.viz`'s own padding is the gutter; the navbar-offset top/bottom padding is kept.

## Change

CSS only — 10 lines added to `src/app/styles/visualization.css`:

```css
.app-shell:has(.viz) .app-shell__content {
  max-width: none;
  padding-left: 0;
  padding-right: 0;
}
```

## Verification

- Full `next build` passes; `/visualization` renders edge-to-edge within the 1300px grid.
- Tokens only, no off-spec values (CLAUDE.md guardrails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)