### PR TITLE
fix(lists): add accounts that only have a Bluesky profile

### DIFF
--- a/src/components/lists/add-to-list-menu.tsx
+++ b/src/components/lists/add-to-list-menu.tsx
@@ -18,6 +18,8 @@ import { useTypedLists } from "@/hooks/use-typed-lists"
 import {
   itemUriMatchesType,
   resolveRecordCid,
+  resolveAccountProfileRef,
+  LIST_ACCOUNTS_TYPE,
   type TypedListType,
 } from "@/lib/atproto/typed-lists"
 
@@ -221,15 +223,33 @@ function AddToListModal({
     if (creating) newInputRef.current?.focus()
   }, [creating])
 
+  // Resolve the strongRef to add. For accounts we accept either profile
+  // lexicon: try the Certified profile, then fall back to the Bluesky
+  // profile — callers always hand us the Certified URI, but a member who
+  // only has a bsky profile must still be addable. Other types resolve
+  // their single record directly.
+  const resolveTargetRef = useCallback(async (): Promise<{
+    uri: string
+    cid: string
+  } | null> => {
+    if (targetCid) return { uri: targetUri, cid: targetCid }
+    if (targetType === LIST_ACCOUNTS_TYPE) {
+      const did = targetUri.split("/")[2]
+      return did ? resolveAccountProfileRef(did) : null
+    }
+    const cid = await resolveRecordCid(targetUri)
+    return cid ? { uri: targetUri, cid } : null
+  }, [targetCid, targetUri, targetType])
+
   const handleAdd = useCallback(
     async (rkey: string) => {
       if (busyRkey) return
       setBusyRkey(rkey)
       setError(null)
       try {
-        const cid = targetCid || (await resolveRecordCid(targetUri))
-        if (!cid) throw new Error("Couldn't resolve record CID")
-        await addItem(rkey, targetType, { uri: targetUri, cid })
+        const targetRef = await resolveTargetRef()
+        if (!targetRef) throw new Error("Couldn't resolve record CID")
+        await addItem(rkey, targetType, targetRef)
         // Reflect "Added" immediately — the hook's refetch follows
         // but may lag by a tick.
         setJustAdded((prev) => {
@@ -244,7 +264,7 @@ function AddToListModal({
         setBusyRkey(null)
       }
     },
-    [addItem, busyRkey, targetCid, targetType, targetUri],
+    [addItem, busyRkey, resolveTargetRef, targetType],
   )
 
   const handleCreateAndAdd = useCallback(
@@ -255,12 +275,12 @@ function AddToListModal({
       setBusyRkey("__new__")
       setError(null)
       try {
-        const cid = targetCid || (await resolveRecordCid(targetUri))
-        if (!cid) throw new Error("Couldn't resolve record CID")
+        const targetRef = await resolveTargetRef()
+        if (!targetRef) throw new Error("Couldn't resolve record CID")
         const ref = await createList(targetType, title)
         const rkey = ref.uri.split("/").pop()
         if (!rkey) throw new Error("New list missing rkey")
-        await addItem(rkey, targetType, { uri: targetUri, cid })
+        await addItem(rkey, targetType, targetRef)
         // Optimistic state: preview the new list immediately so it
         // renders in the candidates section, and mark its rkey as
         // already-added so the row shows "Added" right away. Both
@@ -283,7 +303,7 @@ function AddToListModal({
         setBusyRkey(null)
       }
     },
-    [addItem, busyRkey, createList, newTitle, targetCid, targetType, targetUri],
+    [addItem, busyRkey, createList, newTitle, resolveTargetRef, targetType],
   )
 
   return (

--- a/src/components/profile/profile-lists.tsx
+++ b/src/components/profile/profile-lists.tsx
@@ -34,6 +34,7 @@ import { loadResolvedProfile } from "@/lib/atproto/resolve-did-batch"
 import ProjectListRow from "@/components/explore-page/project-list-row"
 import {
   ITEM_NSID,
+  BSKY_ACTOR_PROFILE_NSID,
   LIST_ACCOUNTS_TYPE,
   LIST_CERTS_TYPE,
   LIST_PROJECTS_TYPE,
@@ -1348,50 +1349,113 @@ async function runSearch(
   return searchProjects(query, signal)
 }
 
+interface MergedActor {
+  did: string
+  displayName: string | null
+  handle: string | null
+  avatarUrl: string | null
+  /** Profile lexicon to strong-ref. Certified for indexer (onboarded)
+   *  accounts; Bluesky for bsky-only ones. Each points at a record that
+   *  actually exists, so the add-time `resolveRecordCid` always resolves. */
+  profileNsid: string
+}
+
+/** Bluesky AppView actor search — finds bsky-native accounts (which may
+ *  have no Certified profile). Returns [] on any failure so a merge
+ *  partner's results still surface. */
+async function searchBskyActors(
+  query: string,
+  signal: AbortSignal,
+): Promise<{ did: string; handle?: string; displayName?: string; avatar?: string }[]> {
+  try {
+    const res = await fetch(
+      `/api/search-actors?q=${encodeURIComponent(query)}&limit=10`,
+      { signal },
+    )
+    if (!res.ok) return []
+    const data = (await res.json()) as {
+      actors?: { did?: string; handle?: string; displayName?: string; avatar?: string }[]
+    }
+    return (data.actors ?? []).filter((a): a is { did: string } & typeof a => !!a.did)
+  } catch {
+    return []
+  }
+}
+
 async function searchAccounts(query: string, signal: AbortSignal): Promise<SearchResult[]> {
-  // Search the magic-indexer's Certified actor index (not Bluesky's
-  // AppView). Account-list items strong-ref an `app.certified.actor
-  // .profile` record, so the only addable accounts are the ones that
-  // HAVE such a record — exactly what this connection returns. Bluesky's
-  // searchActors did the opposite: it surfaced bsky-native accounts that
-  // often have no Certified profile (the add then failed with "Couldn't
-  // resolve record CID") while missing Certified-only orgs like
-  // biofi-project that have no bsky profile at all. The indexer `search`
-  // matches handle + displayName + description server-side.
-  const page = await fetchNetworkActors({ first: 10, search: query, signal })
+  // Account-list items strong-ref a profile record, but membership in an
+  // accounts list must NOT require a Certified profile. So we search BOTH
+  // sources and merge by DID:
+  //   - the magic-indexer's Certified actor index — finds onboarded
+  //     accounts AND Certified-only orgs (e.g. biofi-project) that have
+  //     no Bluesky profile and so never appear in bsky search;
+  //   - Bluesky's AppView — finds bsky-native accounts (e.g. maearth.com)
+  //     that have no Certified profile.
+  // The source fixes which profile lexicon we point the strongRef at, so
+  // the URI always targets a record that exists and `resolveRecordCid`
+  // succeeds on add — no more "Couldn't resolve record CID".
+  const [indexerPage, bsky] = await Promise.all([
+    fetchNetworkActors({ first: 10, search: query, signal }).catch(() => ({ actors: [] })),
+    searchBskyActors(query, signal),
+  ])
   if (signal.aborted) return []
 
-  // The profile connection doesn't denormalise handle, so resolve it for
-  // the small result set — batched into a single /api/resolve-dids call —
-  // to keep the @handle subtitle. Failures fall back to no subtitle.
-  const handles = await Promise.all(
-    page.actors.map((a) =>
-      loadResolvedProfile(a.did)
+  const byDid = new Map<string, MergedActor>()
+  // Indexer (Certified) accounts first — these win on overlap and carry
+  // the Certified profile NSID.
+  for (const a of indexerPage.actors) {
+    byDid.set(a.did, {
+      did: a.did,
+      displayName: a.displayName,
+      handle: null,
+      avatarUrl: a.avatarUrl,
+      profileNsid: ITEM_NSID["list:accounts"],
+    })
+  }
+  // Bluesky accounts: fill the handle/display gaps on a Certified match,
+  // or add a bsky-only entry (Bluesky profile NSID) when unseen.
+  for (const a of bsky) {
+    const existing = byDid.get(a.did)
+    if (existing) {
+      existing.handle ??= a.handle ?? null
+      existing.displayName ??= a.displayName ?? null
+      existing.avatarUrl ??= a.avatar ?? null
+      continue
+    }
+    byDid.set(a.did, {
+      did: a.did,
+      displayName: a.displayName ?? null,
+      handle: a.handle ?? null,
+      avatarUrl: a.avatar ?? null,
+      profileNsid: BSKY_ACTOR_PROFILE_NSID,
+    })
+  }
+
+  // Resolve handles for entries still missing one (indexer-only accounts —
+  // the profile connection doesn't denormalise handle). Batched into a
+  // single /api/resolve-dids round-trip; failures just drop the subtitle.
+  const merged = [...byDid.values()]
+  await Promise.all(
+    merged.map(async (a) => {
+      if (a.handle) return
+      a.handle = await loadResolvedProfile(a.did)
         .then((r) => r?.handle ?? null)
-        .catch(() => null),
-    ),
+        .catch(() => null)
+    }),
   )
   if (signal.aborted) return []
 
-  const out: SearchResult[] = []
-  page.actors.forEach((a, i) => {
-    const handle = handles[i]
-    // app.certified.actor.profile records use the literal rkey "self" —
-    // the at:// for an account-list item is
-    // at://<did>/app.certified.actor.profile/self. We emit an empty CID
-    // placeholder and let `handleAdd` resolve the real CID on click via
-    // `resolveRecordCid` before the strongRef is written — keeps the
-    // typeahead fast and writes never use an unsigned CID.
-    out.push({
-      uri: `at://${a.did}/${ITEM_NSID["list:accounts"]}/self`,
-      cid: "",
-      title: a.displayName || (handle ? `@${handle}` : a.did),
-      subtitle: handle ? `@${handle}` : null,
-      avatarUrl: a.avatarUrl,
-      initials: getInitials(a.displayName, a.did),
-    })
-  })
-  return out
+  return merged.map((a) => ({
+    // Strong-ref the profile record this account actually has; rkey is the
+    // literal "self". The empty CID placeholder is resolved on click by
+    // `resolveRecordCid` before the strongRef is written.
+    uri: `at://${a.did}/${a.profileNsid}/self`,
+    cid: "",
+    title: a.displayName || (a.handle ? `@${a.handle}` : a.did),
+    subtitle: a.handle ? `@${a.handle}` : null,
+    avatarUrl: a.avatarUrl,
+    initials: getInitials(a.displayName, a.did),
+  }))
 }
 
 async function searchCerts(query: string, signal: AbortSignal): Promise<SearchResult[]> {

--- a/src/lib/atproto/__tests__/typed-lists.test.ts
+++ b/src/lib/atproto/__tests__/typed-lists.test.ts
@@ -69,6 +69,28 @@ describe("typed-lists / itemUriMatchesType", () => {
     ).toBe(true)
   })
 
+  it("accepts a Bluesky-profile URI for list:accounts (bsky-only account)", async () => {
+    const { itemUriMatchesType, LIST_ACCOUNTS_TYPE } = await loadModule()
+    // Accounts with no Certified profile strong-ref their app.bsky.actor
+    // .profile record, so list:accounts must accept that NSID too.
+    expect(
+      itemUriMatchesType(
+        "at://did:plc:abc/app.bsky.actor.profile/self",
+        LIST_ACCOUNTS_TYPE,
+      ),
+    ).toBe(true)
+  })
+
+  it("rejects a Bluesky-profile URI for list:projects (wrong NSID)", async () => {
+    const { itemUriMatchesType, LIST_PROJECTS_TYPE } = await loadModule()
+    expect(
+      itemUriMatchesType(
+        "at://did:plc:abc/app.bsky.actor.profile/self",
+        LIST_PROJECTS_TYPE,
+      ),
+    ).toBe(false)
+  })
+
   it("rejects a malformed URI (too few segments)", async () => {
     const { itemUriMatchesType, LIST_CERTS_TYPE } = await loadModule()
     expect(itemUriMatchesType("at://did:plc:abc", LIST_CERTS_TYPE)).toBe(false)

--- a/src/lib/atproto/typed-lists.ts
+++ b/src/lib/atproto/typed-lists.ts
@@ -39,14 +39,34 @@ export const TYPED_LIST_TYPES = [
 ] as const
 export type TypedListType = (typeof TYPED_LIST_TYPES)[number]
 
-/** AT-URI collection name expected on `items[i].itemIdentifier.uri`
- *  for each list type. The cert / project / account distinction is
- *  enforced purely at the at:// path-prefix level — we don't need
- *  to resolve the referenced record to know it's of the wrong shape. */
+/** AT-URI collection name written on `items[i].itemIdentifier.uri` for a
+ *  freshly-added item of each list type. The cert / project / account
+ *  distinction is enforced purely at the at:// path-prefix level — we
+ *  don't need to resolve the referenced record to know it's of the wrong
+ *  shape. For accounts this is the PREFERRED (Certified) profile NSID;
+ *  see `ACCEPTED_ITEM_NSIDS` for the full set a stored item may carry. */
 export const ITEM_NSID: Record<TypedListType, string> = {
   [LIST_CERTS_TYPE]: "org.hypercerts.claim.activity",
   [LIST_PROJECTS_TYPE]: "org.hypercerts.collection",
   [LIST_ACCOUNTS_TYPE]: "app.certified.actor.profile",
+}
+
+/** Bluesky profile NSID. Accounts that exist only on Bluesky (never
+ *  onboarded to Certified) have no `app.certified.actor.profile` record,
+ *  so a list:accounts item for them strong-refs their `app.bsky.actor
+ *  .profile/self` instead. The read side renders an account row from the
+ *  item's DID regardless of which profile NSID backs the strongRef (see
+ *  AccountItemRow), so both are interchangeable as the record to point at. */
+export const BSKY_ACTOR_PROFILE_NSID = "app.bsky.actor.profile"
+
+/** The NSID(s) a stored item's strongRef may legitimately target, per
+ *  list type. Accounts accept either profile lexicon — Certified for
+ *  onboarded accounts, Bluesky for bsky-only ones — so a member with no
+ *  Certified profile can still be added. */
+const ACCEPTED_ITEM_NSIDS: Record<TypedListType, readonly string[]> = {
+  [LIST_CERTS_TYPE]: [ITEM_NSID[LIST_CERTS_TYPE]],
+  [LIST_PROJECTS_TYPE]: [ITEM_NSID[LIST_PROJECTS_TYPE]],
+  [LIST_ACCOUNTS_TYPE]: [ITEM_NSID[LIST_ACCOUNTS_TYPE], BSKY_ACTOR_PROFILE_NSID],
 }
 
 export interface TypedListValue extends CollectionValue {
@@ -73,12 +93,13 @@ export function rkeyFromUri(uri: string): string {
   return uri.split("/").pop() ?? ""
 }
 
-/** Check that an at:// URI targets the lexicon expected by the list type. */
+/** Check that an at:// URI targets a lexicon accepted for the list type.
+ *  Accounts accept either profile NSID (Certified or Bluesky); cert /
+ *  project lists accept their single lexicon. */
 export function itemUriMatchesType(uri: string, listType: TypedListType): boolean {
-  const nsid = ITEM_NSID[listType]
   // `at://<did>/<nsid>/<rkey>` — split on "/" gives ["at:", "", did, nsid, rkey].
   const parts = uri.split("/")
-  return parts.length >= 5 && parts[3] === nsid
+  return parts.length >= 5 && ACCEPTED_ITEM_NSIDS[listType].includes(parts[3])
 }
 
 interface RawCollectionsResponse {
@@ -451,4 +472,25 @@ export async function resolveRecordCid(uri: string): Promise<string | null> {
   if (!res.ok) return null
   const data = (await res.json()) as { cid?: string }
   return data.cid ?? null
+}
+
+/**
+ * Resolve a strongRef ({uri, cid}) to an account's profile record for a
+ * list:accounts item. Prefers the Certified profile and falls back to the
+ * Bluesky profile, so an account that never onboarded to Certified (has
+ * only an `app.bsky.actor.profile`) can still be added. Returns null only
+ * when the DID has neither record (genuinely unresolvable). Used by the
+ * per-profile "Add to list" menu, whose callers always hand it the
+ * Certified URI; the search-modal flow already targets the correct NSID
+ * per result, so it resolves directly via `resolveRecordCid`.
+ */
+export async function resolveAccountProfileRef(
+  did: string,
+): Promise<{ uri: string; cid: string } | null> {
+  for (const nsid of [ITEM_NSID[LIST_ACCOUNTS_TYPE], BSKY_ACTOR_PROFILE_NSID]) {
+    const uri = `at://${did}/${nsid}/self`
+    const cid = await resolveRecordCid(uri)
+    if (cid) return { uri, cid }
+  }
+  return null
 }


### PR DESCRIPTION
Membership in an accounts list must not require a Certified profile. This fixes both halves of the account-picker mismatch reported on staging.

## Problem
The picker searched only one source and assumed one profile lexicon:
- **biofi-project.certified.one** (Certified-only org, no bsky profile) never appeared in Bluesky-backed search.
- **maearth.com** (bsky-native, no Certified profile) appeared but failed on add with **"Couldn't resolve record CID"**, because the item hardcoded a strongRef to `app.certified.actor.profile/self`, which that account doesn't have.

## Fix
- **Search both sources, merged by DID**: the magic-indexer's `appCertifiedActorProfile.search` (Certified accounts incl. Certified-only orgs) **and** Bluesky's AppView (bsky-native accounts).
- **Source fixes the strongRef NSID**: indexer hits ref the Certified profile; bsky-only hits ref `app.bsky.actor.profile/self`. Each targets a record that actually exists, so add-time CID resolution always succeeds.
- `typed-lists`: list:accounts items accept either profile NSID (`ACCEPTED_ITEM_NSIDS`); added `resolveAccountProfileRef` (Certified → Bluesky fallback) for callers that only hold the Certified URI.
- `add-to-list-menu`: the per-profile "Add to list" menu uses the fallback resolver, so a bsky-only profile is addable from the sidebar too.
- Read side is unchanged — account rows render from the item's DID regardless of which profile backs the strongRef.

## Verification
- Indexer search confirmed to return BioFi Project for "biofi"/"biofi-project"/"BioFi".
- maearth.com (`did:plc:xqrmqd4h7…`) has `app.bsky.actor.profile` → now resolves and adds.
- `tsc` clean; new unit tests for `itemUriMatchesType` accepting the bsky NSID (12 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)