### PR TITLE
feat(visualization): fullscreen covers the stats sidebar too

### DIFF
--- a/src/app/styles/visualization.css
+++ b/src/app/styles/visualization.css
@@ -81,8 +81,25 @@
   inset: 0;
 }
 
-/* Fullscreen mode — the canvas host fills the screen; give it the graph
-   background so there's no black letterboxing around the canvas. */
+/* Fullscreen mode covers the whole `.viz` row — graph AND the stats
+   sidebar — so the rankings and search stay usable. Fill the screen with
+   the page background (not the browser's default black) and let the
+   sidebar scroll within the fixed height. */
+.viz:fullscreen {
+  width: 100vw;
+  height: 100vh;
+  background: var(--bg-canvas);
+  overflow: hidden;
+}
+
+.viz:fullscreen .viz__main,
+.viz:fullscreen .viz__graph,
+.viz:fullscreen .viz__sidebar {
+  min-height: 0;
+}
+
+/* Fallback: if the `.viz` ancestor can't be found we fullscreen the canvas
+   host alone — give it the graph background so there's no letterboxing. */
 .viz__canvas-host:fullscreen {
   background: var(--bg-sunken);
 }

--- a/src/components/visualization/endorsement-graph.tsx
+++ b/src/components/visualization/endorsement-graph.tsx
@@ -376,8 +376,21 @@ export default function EndorsementGraph({ nodes, links, focusReq }: Endorsement
   }, [])
 
   // --- fullscreen --------------------------------------------------------
+  // Fullscreen the whole `.viz` container (graph + stats sidebar), not just
+  // the canvas — the sidebar's rankings and search stay usable. The host
+  // lives a few levels under `.viz`, so walk up to it.
+  const fullscreenTarget = useCallback(
+    () => hostRef.current?.closest(".viz") ?? hostRef.current,
+    [],
+  )
+
   useEffect(() => {
-    const onChange = () => setIsFullscreen(document.fullscreenElement === hostRef.current)
+    const onChange = () =>
+      setIsFullscreen(
+        !!document.fullscreenElement &&
+          !!hostRef.current &&
+          document.fullscreenElement.contains(hostRef.current),
+      )
     document.addEventListener("fullscreenchange", onChange)
     return () => document.removeEventListener("fullscreenchange", onChange)
   }, [])
@@ -386,9 +399,9 @@ export default function EndorsementGraph({ nodes, links, focusReq }: Endorsement
     if (document.fullscreenElement) {
       void document.exitFullscreen?.()
     } else {
-      void hostRef.current?.requestFullscreen?.()
+      void fullscreenTarget()?.requestFullscreen?.()
     }
-  }, [])
+  }, [fullscreenTarget])
 
   return (
     <div ref={hostRef} className="viz__canvas-host">


### PR DESCRIPTION
Follow-up to #199 (which merged before this commit landed). The `/visualization` fullscreen toggle requested fullscreen on the canvas host alone, so the rankings/search sidebar disappeared.

- Request fullscreen on the whole `.viz` container (graph + sidebar) by walking up from the host via `closest(".viz")`.
- Add a `.viz:fullscreen` rule: fill the screen with the page background (not the browser's default black), keep the sidebar scrollable within the fixed height.
- Fullscreen detection now checks containment, so it's correct regardless of which element is the fullscreen root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)