### PR TITLE
feat(evaluators): drive trusted evaluators from a curated list

### DIFF
--- a/src/components/explore-page/funding-receipt-detail-modal.tsx
+++ b/src/components/explore-page/funding-receipt-detail-modal.tsx
@@ -14,6 +14,7 @@ import ConfirmFundingContent from "@/components/funding/confirm-funding-dialog"
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard"
 import { useAuthorInfo } from "@/hooks/use-author-info"
 import { useAuth } from "@/lib/auth/auth-context"
+import { useTrustedEvaluators } from "@/hooks/use-trusted-evaluators"
 import { useOrg } from "@/lib/groups/org-context"
 import {
   fundingConfirmEligibility,
@@ -60,8 +61,9 @@ function buildPerspective(
   memberByDid: Map<string, FundingReceipt>,
   /** A personal optimistic confirmation this session (bridges indexer lag). */
   bridged: boolean,
+  trustedEvaluatorDids: readonly string[],
 ): Perspective {
-  const elig = fundingConfirmEligibility(receipt, did)
+  const elig = fundingConfirmEligibility(receipt, did, trustedEvaluatorDids)
   return {
     did,
     isGroup,
@@ -101,6 +103,7 @@ export default function FundingReceiptDetailModal({
   const hasForActivity = !!receipt.forUri
 
   const { did: viewerDid } = useAuth()
+  const { evaluatorDids } = useTrustedEvaluators()
   const { groups } = useOrg()
   // A confirmation this session (before the indexer reflects it) keeps the
   // viewer's own affordance hidden so the payment can't be confirmed twice.
@@ -166,16 +169,18 @@ export default function FundingReceiptDetailModal({
   const perspectives = useMemo<Perspective[]>(() => {
     const out: Perspective[] = []
     if (viewerDid) {
-      out.push(buildPerspective(receipt, viewerDid, false, memberByDid, confirmedLocally))
+      out.push(
+        buildPerspective(receipt, viewerDid, false, memberByDid, confirmedLocally, evaluatorDids),
+      )
     }
     for (const g of groups) {
       if (g.role !== "owner" && g.role !== "admin") continue
       if (g.groupDid === viewerDid) continue
       if (!receiptInvolves(receipt, g.groupDid, memberByDid)) continue
-      out.push(buildPerspective(receipt, g.groupDid, true, memberByDid, false))
+      out.push(buildPerspective(receipt, g.groupDid, true, memberByDid, false, evaluatorDids))
     }
     return out
-  }, [receipt, viewerDid, groups, confirmedLocally, memberByDid])
+  }, [receipt, viewerDid, groups, confirmedLocally, memberByDid, evaluatorDids])
 
   const [confirmingAs, setConfirmingAs] = useState<{
     did: string

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -58,7 +58,8 @@ import FundingReceiptRow, {
   FundingReceiptHeader,
 } from "@/components/explore-page/funding-receipt-row"
 import FundingConfirmedByPopover from "@/components/explore-page/funding-confirmed-by-popover"
-import { matchesConfirmedBy, isTrustedEvaluator } from "@/lib/atproto/funding-provenance"
+import { matchesConfirmedBy } from "@/lib/atproto/funding-provenance"
+import { useTrustedEvaluators } from "@/hooks/use-trusted-evaluators"
 import FundingReceiptFormModal from "@/components/funding/funding-receipt-form-modal"
 import FundingIdentityChoiceDialog from "@/components/funding/funding-identity-choice-dialog"
 import RightsDetailModal from "@/components/feed/rights-detail-modal"
@@ -194,6 +195,9 @@ export default function ActivityDetail({
     : null
 
   const [imageFailed, setImageFailed] = useState(false)
+  // Live trusted-evaluator set (curated list) — gates the funding-receipt
+  // "evaluator" provenance treatment.
+  const { evaluatorDids: trustedEvaluatorDids } = useTrustedEvaluators()
   useEffect(() => {
     setImageFailed(false)
   }, [baseImageUrl])
@@ -1638,7 +1642,7 @@ export default function ActivityDetail({
               writerDid={writerDid}
               writerIsGroup={asGroup}
               canRecordAsRecipient={asGroup || sessionDid === did}
-              isEvaluator={isTrustedEvaluator(writerDid)}
+              isEvaluator={trustedEvaluatorDids.includes(writerDid)}
               activityAuthorDid={did}
               forActivity={{
                 uri: `at://${did}/org.hypercerts.claim.activity/${rkey}`,

--- a/src/components/home/home-feed.tsx
+++ b/src/components/home/home-feed.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -48,7 +49,7 @@ import {
   type OrglabelTier,
 } from "@/lib/atproto/labels"
 import { fetchOrgDidsByLabel } from "@/lib/atproto/workspace"
-import { TRUSTED_EVALUATOR_DIDS } from "@/lib/atproto/trusted-evaluators"
+import { useTrustedEvaluators } from "@/hooks/use-trusted-evaluators"
 import type { ActivityRecord } from "@/lib/atproto/activity-types"
 import type { CollectionRecord } from "@/lib/atproto/collection"
 
@@ -138,8 +139,23 @@ export default function HomeFeed({ activeDid }: { activeDid: string }) {
   const [includedTiers, setIncludedTiers] = useState<Set<QualityFilterValue>>(
     () => new Set<QualityFilterValue>([...DEFAULT_INCLUDED_TIERS, UNLABELED_SLUG]),
   )
-  const [selectedEvaluators, setSelectedEvaluators] = useState<Set<string>>(
-    () => new Set(TRUSTED_EVALUATOR_DIDS),
+  // Trusted evaluators are sourced live from the curated list; the
+  // hardcoded set is the fallback used until it resolves.
+  const { evaluatorDids } = useTrustedEvaluators()
+  // Evaluator selection: `null` = default (every current list member
+  // checked), a Set once the viewer customizes. Derived rather than
+  // stored so it tracks the live list as it resolves and is edited —
+  // no state-sync effect needed.
+  const [customEvaluators, setCustomEvaluators] = useState<Set<string> | null>(
+    null,
+  )
+  const selectedEvaluators = useMemo(
+    () => customEvaluators ?? new Set(evaluatorDids),
+    [customEvaluators, evaluatorDids],
+  )
+  const handleEvaluatorsChange = useCallback(
+    (next: Set<string>) => setCustomEvaluators(next),
+    [],
   )
   // Organization-quality filter (Orglabeler tiers) — applied to the
   // event ACTOR rather than the record, by adjusting the author DID
@@ -229,7 +245,7 @@ export default function HomeFeed({ activeDid }: { activeDid: string }) {
   const isDefaultFilters =
     isQualityDefault(includedTiers) &&
     isOrgQualityDefault(includedOrgTiers) &&
-    selectedEvaluators.size === TRUSTED_EVALUATOR_DIDS.length
+    selectedEvaluators.size === evaluatorDids.length
 
   const resetFilters = () => {
     setIncludedTiers(
@@ -238,7 +254,7 @@ export default function HomeFeed({ activeDid }: { activeDid: string }) {
     setIncludedOrgTiers(
       new Set<OrgQualityValue>([...DEFAULT_INCLUDED_ORG_TIERS, UNLABELED_SLUG]),
     )
-    setSelectedEvaluators(new Set(TRUSTED_EVALUATOR_DIDS))
+    setCustomEvaluators(null)
   }
 
   return (
@@ -268,8 +284,9 @@ export default function HomeFeed({ activeDid }: { activeDid: string }) {
         </div>
         {filterOpen ? (
           <FeedFilterPanel
+            evaluatorDids={evaluatorDids}
             selectedEvaluators={selectedEvaluators}
-            onEvaluatorsChange={setSelectedEvaluators}
+            onEvaluatorsChange={handleEvaluatorsChange}
             includedTiers={includedTiers}
             onTiersChange={setIncludedTiers}
             includedOrgTiers={includedOrgTiers}
@@ -488,6 +505,7 @@ function useOrgQualityFilter(included: Set<OrgQualityValue>): {
  * tiers), plus a reset row.
  */
 function FeedFilterPanel({
+  evaluatorDids,
   selectedEvaluators,
   onEvaluatorsChange,
   includedTiers,
@@ -497,6 +515,7 @@ function FeedFilterPanel({
   isDefault,
   onReset,
 }: {
+  evaluatorDids: string[]
   selectedEvaluators: Set<string>
   onEvaluatorsChange: (next: Set<string>) => void
   includedTiers: Set<QualityFilterValue>
@@ -523,7 +542,7 @@ function FeedFilterPanel({
         Show activities from accounts that are endorsed by:
       </p>
       <div className="feed-evaluators__list">
-        {TRUSTED_EVALUATOR_DIDS.map((did) => (
+        {evaluatorDids.map((did) => (
           <EvaluatorRow
             key={did}
             did={did}

--- a/src/hooks/use-trusted-evaluators.ts
+++ b/src/hooks/use-trusted-evaluators.ts
@@ -1,0 +1,56 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { fetchTrustedEvaluatorDids } from "@/lib/atproto/trusted-evaluators"
+
+/**
+ * Live trusted-evaluator DID set, sourced from the curated
+ * `list:accounts` record (`TRUSTED_EVALUATORS_LIST_URI`) — the sole
+ * source of truth. Editing that list in-app changes the evaluators with
+ * no deploy.
+ *
+ * Resolves once per session: a module-level cache + shared in-flight
+ * promise mean repeated mounts (the home-feed popover, the activity
+ * detail funding modal) skip the network read. Until it resolves — and
+ * if the read fails — callers get an empty set (no expansion), never a
+ * stale hardcoded list.
+ */
+
+let cache: string[] | null = null
+let inflight: Promise<string[]> | null = null
+
+export function useTrustedEvaluators(): {
+  evaluatorDids: string[]
+  isLoading: boolean
+} {
+  const [evaluatorDids, setEvaluatorDids] = useState<string[]>(
+    () => cache ?? [],
+  )
+  const [isLoading, setIsLoading] = useState<boolean>(() => cache === null)
+
+  useEffect(() => {
+    let cancelled = false
+    if (!cache && !inflight) {
+      inflight = fetchTrustedEvaluatorDids().then((dids) => {
+        cache = dids
+        return dids
+      })
+      inflight.finally(() => {
+        inflight = null
+      })
+    }
+    // setState only inside the async resolution — never synchronously in
+    // the effect body — so a cache hit and the fetch path share one path.
+    const pending = cache ? Promise.resolve(cache) : inflight
+    pending?.then((dids) => {
+      if (cancelled) return
+      setEvaluatorDids(dids)
+      setIsLoading(false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return { evaluatorDids, isLoading }
+}

--- a/src/lib/atproto/__tests__/funding-provenance.test.ts
+++ b/src/lib/atproto/__tests__/funding-provenance.test.ts
@@ -3,12 +3,10 @@ import {
   thirdPartyDids,
   confirmRoleBucket,
   matchesConfirmedBy,
-  isTrustedEvaluator,
   fundingConfirmEligibility,
   CONFIRM_ROLES,
   type ConfirmRole,
 } from "../funding-provenance"
-import { TRUSTED_EVALUATOR_DIDS } from "../trusted-evaluators"
 import type { FundingAttestation, FundingParty } from "../indexer"
 
 const recipient: FundingAttestation = { role: "recipient", did: "did:plc:rcpt" }
@@ -121,27 +119,15 @@ describe("matchesConfirmedBy", () => {
   })
 })
 
-const EVALUATOR = TRUSTED_EVALUATOR_DIDS[0]
+const EVALUATOR = "did:plc:evaluator0000000000000000"
+const EVALUATORS: readonly string[] = [EVALUATOR]
 const acct = (did: string): FundingParty => ({ kind: "account", did })
 const txt = (value: string): FundingParty => ({ kind: "text", value })
-
-describe("isTrustedEvaluator", () => {
-  it("is true for a DID on the feed-filter evaluator list", () => {
-    expect(isTrustedEvaluator(EVALUATOR)).toBe(true)
-  })
-  it("is false for a random DID", () => {
-    expect(isTrustedEvaluator("did:plc:nobody")).toBe(false)
-  })
-  it("is false for null/undefined", () => {
-    expect(isTrustedEvaluator(null)).toBe(false)
-    expect(isTrustedEvaluator(undefined)).toBe(false)
-  })
-})
 
 describe("fundingConfirmEligibility", () => {
   it("lets the sender (named by DID) confirm as 'sender'", () => {
     const r = { from: acct("did:plc:me"), to: txt("0xRCPT"), attestations: [] }
-    expect(fundingConfirmEligibility(r, "did:plc:me")).toEqual({
+    expect(fundingConfirmEligibility(r, "did:plc:me", EVALUATORS)).toEqual({
       canConfirm: true,
       role: "sender",
       alreadyAttested: false,
@@ -150,21 +136,26 @@ describe("fundingConfirmEligibility", () => {
 
   it("lets the recipient (named by DID) confirm as 'recipient'", () => {
     const r = { from: txt("0xSNDR"), to: acct("did:plc:me"), attestations: [] }
-    expect(fundingConfirmEligibility(r, "did:plc:me").role).toBe("recipient")
+    expect(fundingConfirmEligibility(r, "did:plc:me", EVALUATORS).role).toBe("recipient")
   })
 
   it("lets a trusted evaluator (neither party) confirm as 'third-party'", () => {
     const r = { from: txt("0xS"), to: txt("0xR"), attestations: [] }
-    expect(fundingConfirmEligibility(r, EVALUATOR).role).toBe("third-party")
+    expect(fundingConfirmEligibility(r, EVALUATOR, EVALUATORS).role).toBe("third-party")
   })
 
   it("does not let an unrelated, non-evaluator account confirm", () => {
     const r = { from: txt("0xS"), to: txt("0xR"), attestations: [] }
-    expect(fundingConfirmEligibility(r, "did:plc:nobody")).toEqual({
+    expect(fundingConfirmEligibility(r, "did:plc:nobody", EVALUATORS)).toEqual({
       canConfirm: false,
       role: null,
       alreadyAttested: false,
     })
+  })
+
+  it("does not grant third-party when the evaluator set is empty", () => {
+    const r = { from: txt("0xS"), to: txt("0xR"), attestations: [] }
+    expect(fundingConfirmEligibility(r, EVALUATOR, []).canConfirm).toBe(false)
   })
 
   it("hides confirm once the viewer has already attested", () => {
@@ -173,7 +164,7 @@ describe("fundingConfirmEligibility", () => {
       to: txt("0xRCPT"),
       attestations: [{ role: "sender" as const, did: "did:plc:me" }],
     }
-    const e = fundingConfirmEligibility(r, "did:plc:me")
+    const e = fundingConfirmEligibility(r, "did:plc:me", EVALUATORS)
     expect(e.alreadyAttested).toBe(true)
     expect(e.canConfirm).toBe(false)
   })
@@ -183,11 +174,11 @@ describe("fundingConfirmEligibility", () => {
     // recipient by wallet address, not their DID — so they can't claim the
     // recipient role and are ineligible unless they're an evaluator.
     const r = { from: txt("0xS"), to: txt("0xRCPT"), attestations: [] }
-    expect(fundingConfirmEligibility(r, "did:plc:me").canConfirm).toBe(false)
+    expect(fundingConfirmEligibility(r, "did:plc:me", EVALUATORS).canConfirm).toBe(false)
   })
 
   it("is ineligible for a logged-out viewer", () => {
     const r = { from: acct("did:plc:me"), to: txt("0xR"), attestations: [] }
-    expect(fundingConfirmEligibility(r, null).canConfirm).toBe(false)
+    expect(fundingConfirmEligibility(r, null, EVALUATORS).canConfirm).toBe(false)
   })
 })

--- a/src/lib/atproto/funding-provenance.ts
+++ b/src/lib/atproto/funding-provenance.ts
@@ -1,5 +1,4 @@
 import type { FundingAttestation, FundingReceipt } from "./indexer"
-import { TRUSTED_EVALUATOR_DIDS } from "./trusted-evaluators"
 
 /**
  * Display + filter derivation for funding-receipt provenance. The indexer
@@ -103,19 +102,6 @@ export function matchesConfirmedBy(
 // Write-side permissions: who may record / confirm a funding receipt
 // ---------------------------------------------------------------------------
 
-/**
- * Whether `did` is one of the trusted evaluators — the exact list the
- * home-feed filter "Show activities from accounts that are endorsed by:"
- * renders ({@link TRUSTED_EVALUATOR_DIDS}, the single source of truth).
- * These accounts are the only ones allowed to record or confirm a payment
- * as a *third party* (i.e. when they are neither the sender nor the
- * recipient).
- */
-export function isTrustedEvaluator(did: string | null | undefined): boolean {
-  if (!did) return false
-  return (TRUSTED_EVALUATOR_DIDS as readonly string[]).includes(did)
-}
-
 /** The attestation role a viewer's receipt would carry for a payment. */
 export type FundingRole = "sender" | "recipient" | "third-party"
 
@@ -140,10 +126,16 @@ export interface FundingConfirmEligibility {
  * trusted evaluator — and have not already attested it. Copying the
  * payment's coordinates into a fresh receipt authored by the viewer then
  * yields exactly this role from the indexer.
+ *
+ * `trustedEvaluatorDids` is the live evaluator set (sourced from the
+ * curated list via `useTrustedEvaluators`); only those accounts may
+ * confirm as a *third party* when they are neither the sender nor the
+ * recipient.
  */
 export function fundingConfirmEligibility(
   receipt: Pick<FundingReceipt, "from" | "to" | "attestations">,
   viewerDid: string | null | undefined,
+  trustedEvaluatorDids: readonly string[],
 ): FundingConfirmEligibility {
   if (!viewerDid) return { canConfirm: false, role: null, alreadyAttested: false }
 
@@ -154,7 +146,7 @@ export function fundingConfirmEligibility(
     role = "sender"
   } else if (receipt.to?.kind === "account" && receipt.to.did === viewerDid) {
     role = "recipient"
-  } else if (isTrustedEvaluator(viewerDid)) {
+  } else if (trustedEvaluatorDids.includes(viewerDid)) {
     role = "third-party"
   }
 

--- a/src/lib/atproto/trusted-evaluators.ts
+++ b/src/lib/atproto/trusted-evaluators.ts
@@ -9,22 +9,60 @@
  * activity from the people their trusted evaluators have vouched
  * for, without having to follow each one directly.
  *
- * The default-selected list is hard-coded for now (curated by hand);
- * a future iteration can let the viewer add their own evaluators.
+ * The evaluator set is driven entirely by a curated `list:accounts`
+ * record (`TRUSTED_EVALUATORS_LIST_URI`), read live via
+ * `fetchTrustedEvaluatorDids` so editing the list (profile → Lists)
+ * propagates without a code change. There is no hardcoded evaluator
+ * list: an unreadable list yields an empty set (no expansion) rather
+ * than a stale baked-in one.
  */
 import { INDEXER_PROXY_URL } from "./indexer"
+import { authFetch } from "@/lib/auth/fetch"
 
 /**
- * Default-selected trusted evaluators. All four are checked by
- * default in the popover; the viewer can uncheck any to drop that
- * evaluator's expansion from the feed.
+ * Curated `list:accounts` collection whose members ARE the trusted
+ * evaluators. The list is editable in-app (profile → Lists), so adding
+ * or removing an account there changes the evaluator set with no deploy.
  */
-export const TRUSTED_EVALUATOR_DIDS = [
-  "did:plc:s4puetfspot742ai7y4otuel",
-  "did:plc:xqrmqd4h7f3fpe7ue7qdhp7h",
-  "did:plc:qoti4acfmc5wg6zzmtix6hse",
-  "did:plc:ghilmzxkfzrg6zr4bglxvlio",
-] as const
+export const TRUSTED_EVALUATORS_LIST_URI =
+  "at://did:plc:apun3uo5jqm34pxzqq6on754/org.hypercerts.collection/3moknbntllx2s"
+
+/**
+ * Read the trusted-evaluator DIDs from the curated list. Each item's
+ * strongRef URI is `at://<did>/<profile-nsid>/self`, so the member DID is
+ * the second path segment regardless of which profile lexicon backs it.
+ * Returns an empty array on any failure (missing list, network error,
+ * empty membership) — the sole source of truth is the list.
+ */
+export async function fetchTrustedEvaluatorDids(
+  signal?: AbortSignal,
+): Promise<string[]> {
+  try {
+    const [, , repo, collection, rkey] = TRUSTED_EVALUATORS_LIST_URI.split("/")
+    if (!repo || !collection || !rkey) return []
+    const params = new URLSearchParams({ repo, collection, rkey })
+    const res = await authFetch(
+      `/api/xrpc/com/atproto/repo/getRecord?${params.toString()}`,
+      signal ? { signal } : {},
+    )
+    if (!res.ok) return []
+    const data = (await res.json()) as {
+      value?: { items?: { itemIdentifier?: { uri?: string } }[] }
+    }
+    const seen = new Set<string>()
+    const dids: string[] = []
+    for (const item of data.value?.items ?? []) {
+      const did = item.itemIdentifier?.uri?.split("/")[2]
+      if (did && did.startsWith("did:") && !seen.has(did)) {
+        seen.add(did)
+        dids.push(did)
+      }
+    }
+    return dids
+  } catch {
+    return []
+  }
+}
 
 /** Per-page size for the EvaluatorEndorsements indexer query. The
  *  proxy clamps `first` to 100; the upstream silently caps higher
@@ -116,9 +154,9 @@ interface RawResponse {
 
 /**
  * Module-level cache for the resolved DID set, keyed by the sorted
- * evaluator list. Sized small because the popover only exposes
- * `TRUSTED_EVALUATOR_DIDS` (4 evaluators); the practical key set is
- * the power-set of those 4 — at most 15 non-empty subsets.
+ * evaluator list. Sized small because the popover only exposes the
+ * curated evaluator list (a handful of accounts); the practical key set
+ * is the power-set of those — a few dozen non-empty subsets at most.
  *
  * Each entry stores the result Set itself, NOT a Promise — by the
  * time we hand a cached entry back the inflight resolution has


### PR DESCRIPTION
The trusted-evaluator set is now sourced **live** from a curated `list:accounts` record (`TRUSTED_EVALUATORS_LIST_URI` → `at://did:plc:apun3uo5…/org.hypercerts.collection/3moknbntllx2s`) via a new `useTrustedEvaluators` hook. Editing that list in-app (profile → Lists) changes the evaluators with **no deploy**.

## Removes the old hardcoded list
Per request, the hardcoded `TRUSTED_EVALUATOR_DIDS` array is deleted entirely — it's no longer the source of truth. An unreadable/empty list now yields an empty evaluator set (no expansion) rather than a stale baked-in one.

- **home-feed**: the evaluator checkboxes + default selection come from the live list; selection is *derived* (no state-sync effect).
- **funding-provenance**: `isTrustedEvaluator` is gone. `fundingConfirmEligibility(receipt, viewerDid, trustedEvaluatorDids)` now takes the set as a param, threaded from the hook in the funding-receipt detail modal.
- **activity-detail**: the funding "evaluator" provenance treatment uses the live set.

## Notes
- The list members ARE the evaluators (DID extracted from each item's `at://<did>/<profile-nsid>/self`, works for both Certified and bsky-profile-backed entries).
- Resolves once per session (module cache + shared in-flight); cold load / failure → empty set.
- `tsc` clean; lint clean (no new warnings); funding-provenance tests updated to pass the evaluator set explicitly (28 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)