### PR TITLE
fix(endorsements): view toggle matches the toolbar buttons (smaller)

### DIFF
--- a/src/app/styles/profile-endorsements.css
+++ b/src/app/styles/profile-endorsements.css
@@ -32,7 +32,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 30px;
+  height: 28px;
   padding: 0 12px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
@@ -70,8 +70,8 @@
 
 @media (max-width: 799px) {
   /* Controls take their own full-width row; the search stretches to fill
-     it beside the buttons, and every control matches the plus button's
-     30px height. */
+     it beside the buttons, and every control matches the compact 28px
+     toolbar height (same as the gallery/list view toggle beside them). */
   .profile-endorsements-v2__controls {
     flex: 1 1 100%;
     min-width: 0;
@@ -79,7 +79,7 @@
   .profile-endorsements-v2__search {
     flex: 1 1 auto;
     min-width: 0;
-    height: 30px;
+    height: 28px;
   }
   .profile-endorsements-v2__search-input {
     width: auto;
@@ -88,11 +88,11 @@
   }
   /* Scoped under their containers so they beat the base `…__sort-btn`
      / `…__endorse-add` rules declared LATER in this file (equal
-     specificity would otherwise let the taller 36px base win). */
+     specificity would otherwise let the taller base win). */
   .profile-endorsements-v2__controls .profile-endorsements-v2__sort-btn,
   .profile-endorsements-v2__controls .profile-endorsements-v2__endorse-add {
-    width: 30px;
-    height: 30px;
+    width: 28px;
+    height: 28px;
   }
   .endorsement-lists .endorsement-lists__sort-btn {
     width: 30px;
@@ -109,8 +109,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
   border-radius: var(--radius);
@@ -138,8 +138,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
   border-radius: var(--radius);

--- a/src/components/profile/profile-endorsements.tsx
+++ b/src/components/profile/profile-endorsements.tsx
@@ -475,7 +475,7 @@ export default function ProfileEndorsements({ did }: ProfileEndorsementsProps) {
             aria-label="Endorsements view"
             value={view}
             onValueChange={(v) => setViewParam(v === "list" ? "list" : "gallery")}
-            size="md"
+            size="sm"
             joined
             shape="square"
             iconOnly


### PR DESCRIPTION
The gallery/list view switcher on the Endorsements tab rendered at `SegmentedControl size="md"` (32px), 2px taller than the 30px toolbar buttons next to it.

- Switch the toggle to `size="sm"` (the smaller variant).
- Bring the endorsements toolbar controls (search, sort/filter, endorse-add) to **28px** so the whole row is one uniform, smaller height — matching the toggle.
- No change to the shared `SegmentedControl` primitive (so other usages, e.g. explore's switcher, are untouched).

Per the "use the smaller button everywhere" request, the toolbar standardizes on the compact 28px height. (If you'd rather keep the buttons at 30px and only bring the toggle down to match, that's a one-line flip.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)