### PR TITLE
fix(endorse): merged Certified+Bluesky search in the Endorse-people modal

### DIFF
--- a/src/components/profile/endorse-people-modal.tsx
+++ b/src/components/profile/endorse-people-modal.tsx
@@ -14,6 +14,7 @@ import LoadingSpinner from "@/components/ui/loading-spinner"
 import AppDialog, { AppDialogHeader, AppDialogBody } from "@/components/ui/app-dialog"
 import Tooltip from "@/components/ui/tooltip"
 import { getInitials } from "@/lib/utils/initials"
+import { searchMergedActors } from "@/lib/atproto/actor-search"
 
 interface Actor {
   did: string
@@ -124,9 +125,10 @@ export default function EndorsePeopleModal({
     inputRef.current?.focus()
   }, [])
 
-  // Debounced fetch against `/api/search-actors`. Same endpoint as the
-  // global PeopleSearch. We bail early when the query is empty so the
-  // results list collapses back to selected-only.
+  // Debounced merged search (Certified + Bluesky, deduped by DID — see
+  // `searchMergedActors`) so Certified-only orgs (e.g. biofi-project) and
+  // bsky-only accounts both surface. We bail early when the query is empty
+  // so the results list collapses back to selected-only.
   const runSearch = useCallback(async (q: string, seq: number) => {
     const trimmed = q.trim()
     if (!trimmed) {
@@ -136,18 +138,18 @@ export default function EndorsePeopleModal({
     }
     setIsSearching(true)
     try {
-      const res = await fetch(
-        `/api/search-actors?q=${encodeURIComponent(trimmed)}&limit=8`,
-        { headers: { Accept: "application/json" } },
-      )
+      const merged = await searchMergedActors(trimmed)
       if (seq !== requestSeq.current) return
-      if (res.ok) {
-        const data = (await res.json()) as { actors?: Actor[] }
-        setResults(data.actors ?? [])
-      } else {
-        setResults([])
-      }
+      setResults(
+        merged.map((a) => ({
+          did: a.did,
+          handle: a.handle ?? "",
+          displayName: a.displayName ?? "",
+          avatar: a.avatarUrl,
+        })),
+      )
     } catch (err) {
+      if (seq === requestSeq.current) setResults([])
       if (process.env.NODE_ENV !== "production") {
         console.warn("[endorse-people] search failed:", err)
       }

--- a/src/components/profile/profile-lists.tsx
+++ b/src/components/profile/profile-lists.tsx
@@ -29,12 +29,10 @@ import { useActivity } from "@/hooks/use-activity"
 import { useProject } from "@/hooks/use-project"
 import { useTypedLists } from "@/hooks/use-typed-lists"
 import { fetchIndexerActivities, INDEXER_PROXY_URL } from "@/lib/atproto/indexer"
-import { fetchNetworkActors } from "@/lib/atproto/workspace"
-import { loadResolvedProfile } from "@/lib/atproto/resolve-did-batch"
+import { searchMergedActors } from "@/lib/atproto/actor-search"
 import ProjectListRow from "@/components/explore-page/project-list-row"
 import {
   ITEM_NSID,
-  BSKY_ACTOR_PROFILE_NSID,
   LIST_ACCOUNTS_TYPE,
   LIST_CERTS_TYPE,
   LIST_PROJECTS_TYPE,
@@ -1349,106 +1347,14 @@ async function runSearch(
   return searchProjects(query, signal)
 }
 
-interface MergedActor {
-  did: string
-  displayName: string | null
-  handle: string | null
-  avatarUrl: string | null
-  /** Profile lexicon to strong-ref. Certified for indexer (onboarded)
-   *  accounts; Bluesky for bsky-only ones. Each points at a record that
-   *  actually exists, so the add-time `resolveRecordCid` always resolves. */
-  profileNsid: string
-}
-
-/** Bluesky AppView actor search — finds bsky-native accounts (which may
- *  have no Certified profile). Returns [] on any failure so a merge
- *  partner's results still surface. */
-async function searchBskyActors(
-  query: string,
-  signal: AbortSignal,
-): Promise<{ did: string; handle?: string; displayName?: string; avatar?: string }[]> {
-  try {
-    const res = await fetch(
-      `/api/search-actors?q=${encodeURIComponent(query)}&limit=10`,
-      { signal },
-    )
-    if (!res.ok) return []
-    const data = (await res.json()) as {
-      actors?: { did?: string; handle?: string; displayName?: string; avatar?: string }[]
-    }
-    return (data.actors ?? []).filter((a): a is { did: string } & typeof a => !!a.did)
-  } catch {
-    return []
-  }
-}
-
 async function searchAccounts(query: string, signal: AbortSignal): Promise<SearchResult[]> {
-  // Account-list items strong-ref a profile record, but membership in an
-  // accounts list must NOT require a Certified profile. So we search BOTH
-  // sources and merge by DID:
-  //   - the magic-indexer's Certified actor index — finds onboarded
-  //     accounts AND Certified-only orgs (e.g. biofi-project) that have
-  //     no Bluesky profile and so never appear in bsky search;
-  //   - Bluesky's AppView — finds bsky-native accounts (e.g. maearth.com)
-  //     that have no Certified profile.
-  // The source fixes which profile lexicon we point the strongRef at, so
-  // the URI always targets a record that exists and `resolveRecordCid`
-  // succeeds on add — no more "Couldn't resolve record CID".
-  const [indexerPage, bsky] = await Promise.all([
-    fetchNetworkActors({ first: 10, search: query, signal }).catch(() => ({ actors: [] })),
-    searchBskyActors(query, signal),
-  ])
-  if (signal.aborted) return []
-
-  const byDid = new Map<string, MergedActor>()
-  // Indexer (Certified) accounts first — these win on overlap and carry
-  // the Certified profile NSID.
-  for (const a of indexerPage.actors) {
-    byDid.set(a.did, {
-      did: a.did,
-      displayName: a.displayName,
-      handle: null,
-      avatarUrl: a.avatarUrl,
-      profileNsid: ITEM_NSID["list:accounts"],
-    })
-  }
-  // Bluesky accounts: fill the handle/display gaps on a Certified match,
-  // or add a bsky-only entry (Bluesky profile NSID) when unseen.
-  for (const a of bsky) {
-    const existing = byDid.get(a.did)
-    if (existing) {
-      existing.handle ??= a.handle ?? null
-      existing.displayName ??= a.displayName ?? null
-      existing.avatarUrl ??= a.avatar ?? null
-      continue
-    }
-    byDid.set(a.did, {
-      did: a.did,
-      displayName: a.displayName ?? null,
-      handle: a.handle ?? null,
-      avatarUrl: a.avatar ?? null,
-      profileNsid: BSKY_ACTOR_PROFILE_NSID,
-    })
-  }
-
-  // Resolve handles for entries still missing one (indexer-only accounts —
-  // the profile connection doesn't denormalise handle). Batched into a
-  // single /api/resolve-dids round-trip; failures just drop the subtitle.
-  const merged = [...byDid.values()]
-  await Promise.all(
-    merged.map(async (a) => {
-      if (a.handle) return
-      a.handle = await loadResolvedProfile(a.did)
-        .then((r) => r?.handle ?? null)
-        .catch(() => null)
-    }),
-  )
-  if (signal.aborted) return []
-
+  // Account-list membership must NOT require a Certified profile, so search
+  // Certified + Bluesky merged (see `searchMergedActors`). Each result
+  // strong-refs the profile record it actually has (`profileNsid`) — rkey
+  // is the literal "self" — so the URI always targets an existing record
+  // and `resolveRecordCid` succeeds on add.
+  const merged = await searchMergedActors(query, signal)
   return merged.map((a) => ({
-    // Strong-ref the profile record this account actually has; rkey is the
-    // literal "self". The empty CID placeholder is resolved on click by
-    // `resolveRecordCid` before the strongRef is written.
     uri: `at://${a.did}/${a.profileNsid}/self`,
     cid: "",
     title: a.displayName || (a.handle ? `@${a.handle}` : a.did),

--- a/src/lib/atproto/actor-search.ts
+++ b/src/lib/atproto/actor-search.ts
@@ -1,0 +1,119 @@
+/**
+ * Account typeahead that finds BOTH Certified accounts and Bluesky-native
+ * accounts, merged by DID. Shared by the list account-picker and the
+ * "Endorse people" modal so both surfaces behave the same.
+ *
+ * Why two sources:
+ *   - the magic-indexer's Certified actor index finds onboarded accounts
+ *     AND Certified-only orgs (e.g. biofi-project) that have no Bluesky
+ *     profile and so never appear in Bluesky's search;
+ *   - Bluesky's AppView finds bsky-native accounts (e.g. maearth.com)
+ *     that have no Certified profile.
+ *
+ * The source also records which profile lexicon backs the account
+ * (`profileNsid`) — the list picker strong-refs that record; the endorse
+ * modal only needs the DID and ignores it.
+ */
+
+import { fetchNetworkActors } from "@/lib/atproto/workspace"
+import { loadResolvedProfile } from "@/lib/atproto/resolve-did-batch"
+import { BSKY_ACTOR_PROFILE_NSID } from "@/lib/atproto/typed-lists"
+
+const CERTIFIED_ACTOR_PROFILE_NSID = "app.certified.actor.profile"
+
+export interface MergedActor {
+  did: string
+  displayName: string | null
+  handle: string | null
+  avatarUrl: string | null
+  /** Profile lexicon backing the account — Certified for indexer
+   *  (onboarded) accounts, Bluesky for bsky-only ones. */
+  profileNsid: string
+}
+
+/** Bluesky AppView actor search — finds bsky-native accounts (which may
+ *  have no Certified profile). Returns [] on any failure so the indexer
+ *  results still surface. */
+async function searchBskyActors(
+  query: string,
+  signal?: AbortSignal,
+): Promise<{ did: string; handle?: string; displayName?: string; avatar?: string }[]> {
+  try {
+    const res = await fetch(
+      `/api/search-actors?q=${encodeURIComponent(query)}&limit=10`,
+      signal ? { signal } : undefined,
+    )
+    if (!res.ok) return []
+    const data = (await res.json()) as {
+      actors?: { did?: string; handle?: string; displayName?: string; avatar?: string }[]
+    }
+    return (data.actors ?? []).filter((a): a is { did: string } & typeof a => !!a.did)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Search Certified + Bluesky accounts, merged and deduped by DID.
+ * Indexer (Certified) hits win on overlap and carry the Certified profile
+ * NSID; bsky-only hits carry the Bluesky profile NSID. Handles missing
+ * from the indexer rows are backfilled in one batched `/api/resolve-dids`
+ * call. Returns [] for an empty query or once the signal aborts.
+ */
+export async function searchMergedActors(
+  query: string,
+  signal?: AbortSignal,
+): Promise<MergedActor[]> {
+  if (!query.trim()) return []
+
+  const [indexerPage, bsky] = await Promise.all([
+    fetchNetworkActors({ first: 10, search: query, signal }).catch(() => ({ actors: [] })),
+    searchBskyActors(query, signal),
+  ])
+  if (signal?.aborted) return []
+
+  const byDid = new Map<string, MergedActor>()
+  // Certified (indexer) accounts first — preferred on overlap.
+  for (const a of indexerPage.actors) {
+    byDid.set(a.did, {
+      did: a.did,
+      displayName: a.displayName,
+      handle: null,
+      avatarUrl: a.avatarUrl,
+      profileNsid: CERTIFIED_ACTOR_PROFILE_NSID,
+    })
+  }
+  // Bluesky accounts: fill gaps on a Certified match, else add a bsky-only
+  // entry carrying the Bluesky profile NSID.
+  for (const a of bsky) {
+    const existing = byDid.get(a.did)
+    if (existing) {
+      existing.handle ??= a.handle ?? null
+      existing.displayName ??= a.displayName ?? null
+      existing.avatarUrl ??= a.avatar ?? null
+      continue
+    }
+    byDid.set(a.did, {
+      did: a.did,
+      displayName: a.displayName ?? null,
+      handle: a.handle ?? null,
+      avatarUrl: a.avatar ?? null,
+      profileNsid: BSKY_ACTOR_PROFILE_NSID,
+    })
+  }
+
+  // Backfill handles for indexer-only accounts (the profile connection
+  // doesn't denormalise handle), batched into one /api/resolve-dids call.
+  const merged = [...byDid.values()]
+  await Promise.all(
+    merged.map(async (a) => {
+      if (a.handle) return
+      a.handle = await loadResolvedProfile(a.did)
+        .then((r) => r?.handle ?? null)
+        .catch(() => null)
+    }),
+  )
+  if (signal?.aborted) return []
+
+  return merged
+}


### PR DESCRIPTION
The **Endorse people** modal (Endorsements tab) searched Bluesky's AppView only, so Certified-only orgs (e.g. **biofi-project**) never appeared — the same gap already fixed for the list account-picker (#200). This applies the same fix.

## Change
- New shared helper **`src/lib/atproto/actor-search.ts`** → `searchMergedActors(query, signal)`: searches the magic-indexer's Certified actor index **and** Bluesky's AppView, merges/dedupes by DID, backfills missing handles in one batched `/api/resolve-dids` call. Returns each account's `profileNsid` (Certified vs Bluesky).
- **profile-lists** account-picker: its inline merge logic is replaced by the shared helper (behavior identical).
- **endorse-people-modal**: searches via the helper instead of hitting `/api/search-actors` directly.

## Why endorsing bsky-only accounts is fine
Endorsing writes a `badge.award` whose subject is just the **DID** — no profile-record CID needed — so bsky-only accounts (e.g. maearth.com) endorse cleanly. (The list picker still strong-refs the right profile record via `profileNsid`.)

`tsc` clean (no new errors); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)