### PR TITLE
feat(visualization): sidebar stats follow the filters; scope switch

### DIFF
--- a/src/app/styles/visualization.css
+++ b/src/app/styles/visualization.css
@@ -127,9 +127,10 @@
   min-width: 200px;
 }
 
-/* Layout switcher fills the control panel so its three segments read as one
-   clear toggle rather than floating short. */
-.viz__layout-toggle {
+/* Layout + scope switchers fill the control panel so their segments read
+   as one clear toggle rather than floating short. */
+.viz__layout-toggle,
+.viz__scope-toggle {
   width: 100%;
 }
 

--- a/src/components/visualization/endorsement-graph.tsx
+++ b/src/components/visualization/endorsement-graph.tsx
@@ -24,7 +24,11 @@ import SegmentedControl from "@/components/ui/segmented-control"
 import { getInitials } from "@/lib/utils/initials"
 import { profileUrl } from "@/lib/urls"
 import { useTrustedEvaluators } from "@/hooks/use-trusted-evaluators"
-import type { GraphNode, GraphLink } from "@/hooks/use-endorsement-graph"
+import type {
+  GraphNode,
+  GraphLink,
+  EndorsementGraph as EndorsementGraphData,
+} from "@/hooks/use-endorsement-graph"
 
 type FGNode = NodeObject<GraphNode>
 type FGLink = LinkObject<GraphNode, GraphLink>
@@ -39,6 +43,52 @@ interface EndorsementGraphProps {
   nodes: GraphNode[]
   links: GraphLink[]
   focusReq: FocusRequest
+  /** Whether the source dataset was capped — forwarded into the stats
+   *  the sidebar shows for the filtered view. */
+  truncated?: boolean
+  /** Emits the stats of the CURRENTLY-VISIBLE (filtered) graph so the
+   *  sidebar can mirror the active scope/mutual filters. */
+  onStats?: (stats: EndorsementGraphData) => void
+}
+
+/**
+ * Recompute sidebar stats over the visible (filtered) graph: per-node
+ * given/received/mutual within the shown edges, total shown edges, and
+ * mutual pairs. New node objects (not the canvas's) so the force
+ * simulation isn't disturbed.
+ */
+function computeFilteredStats(
+  nodes: GraphNode[],
+  links: GraphLink[],
+  truncated: boolean,
+): EndorsementGraphData {
+  const given = new Map<string, Set<string>>()
+  const received = new Map<string, Set<string>>()
+  const mutualCount = new Map<string, number>()
+  let mutualLinks = 0
+  for (const l of links) {
+    const s = linkEndId(l.source)
+    const t = linkEndId(l.target)
+    if (!s || !t) continue
+    ;(given.get(s) ?? given.set(s, new Set()).get(s)!).add(t)
+    ;(received.get(t) ?? received.set(t, new Set()).get(t)!).add(s)
+    if (l.mutual) {
+      mutualLinks++
+      mutualCount.set(s, (mutualCount.get(s) ?? 0) + 1)
+    }
+  }
+  return {
+    nodes: nodes.map((n) => ({
+      ...n,
+      given: given.get(n.id)?.size ?? 0,
+      received: received.get(n.id)?.size ?? 0,
+      mutual: mutualCount.get(n.id) ?? 0,
+    })),
+    links,
+    totalEndorsements: links.length,
+    mutualPairs: Math.round(mutualLinks / 2),
+    truncated,
+  }
 }
 
 interface ThemeColors {
@@ -171,7 +221,7 @@ function linkEndId(end: string | NodeObject<GraphNode> | undefined): string | nu
   return typeof end.id === "string" ? end.id : null
 }
 
-export default function EndorsementGraph({ nodes, links, focusReq }: EndorsementGraphProps) {
+export default function EndorsementGraph({ nodes, links, focusReq, truncated = false, onStats }: EndorsementGraphProps) {
   const hostRef = useRef<HTMLDivElement | null>(null)
   const fgRef = useRef<ForceGraphMethods<FGNode, FGLink> | undefined>(undefined)
   const colorsRef = useRef<ThemeColors | null>(null)
@@ -310,6 +360,16 @@ export default function EndorsementGraph({ nodes, links, focusReq }: Endorsement
 
     return { nodes: nds, links: lks }
   }, [nodes, links, onlyMutual, evaluatorConnectedOnly, evaluatorDids])
+
+  // Mirror the visible (filtered) graph's stats up to the sidebar so its
+  // counts + rankings track the active scope / mutual filters.
+  const filteredStats = useMemo(
+    () => computeFilteredStats(data.nodes, data.links, truncated),
+    [data, truncated],
+  )
+  useEffect(() => {
+    onStats?.(filteredStats)
+  }, [filteredStats, onStats])
 
   // --- layout forces -----------------------------------------------------
   // Configure the simulation per layout mode. Re-runs when the mode or the
@@ -690,14 +750,19 @@ export default function EndorsementGraph({ nodes, links, focusReq }: Endorsement
           />
         </div>
         <div className="viz__control-row">
-          <Button
-            variant={evaluatorConnectedOnly ? "primary" : "secondary"}
+          <SegmentedControl
+            className="viz__scope-toggle"
+            aria-label="Network scope"
+            value={evaluatorConnectedOnly ? "evaluator" : "everything"}
+            onValueChange={(v) => setEvaluatorConnectedOnly(v === "evaluator")}
             size="sm"
-            pressed={evaluatorConnectedOnly}
-            onClick={() => setEvaluatorConnectedOnly((v) => !v)}
-          >
-            Evaluator network
-          </Button>
+            options={[
+              { value: "evaluator", label: "Evaluator network" },
+              { value: "everything", label: "Everything" },
+            ]}
+          />
+        </div>
+        <div className="viz__control-row">
           <Button
             variant={onlyMutual ? "primary" : "secondary"}
             size="sm"

--- a/src/components/visualization/endorsement-graph.tsx
+++ b/src/components/visualization/endorsement-graph.tsx
@@ -215,6 +215,27 @@ function makeRadialForce(
   return force
 }
 
+/**
+ * Gentle gravity toward the origin (0,0). Disconnected components have no
+ * links pulling them together, so the charge force alone flings them far
+ * apart; a small inward pull keeps separate clusters near the centre and
+ * close to each other.
+ */
+function makeGravityForce(strength: number) {
+  let ns: SimNode[] = []
+  const force = (alpha: number) => {
+    for (const n of ns) {
+      if (n.x == null || n.y == null) continue
+      n.vx = (n.vx ?? 0) - n.x * strength * alpha
+      n.vy = (n.vy ?? 0) - n.y * strength * alpha
+    }
+  }
+  force.initialize = (nodes: SimNode[]) => {
+    ns = nodes
+  }
+  return force
+}
+
 function linkEndId(end: string | NodeObject<GraphNode> | undefined): string | null {
   if (end == null) return null
   if (typeof end === "string") return end
@@ -399,16 +420,22 @@ export default function EndorsementGraph({ nodes, links, focusReq, truncated = f
       charge?.strength?.(-200)
       link?.distance?.(100)
       fg.d3Force("radial", null)
+      // Pull disconnected clusters back toward the centre so they don't
+      // drift into empty space (no links bind separate components).
+      fg.d3Force("gravity", makeGravityForce(0.05))
     } else if (layout === "radial") {
       charge?.strength?.(-45)
       link?.distance?.(60)
       const outerR = Math.max(180, Math.sqrt(count) * 40)
       fg.d3Force("radial", makeRadialForce(maxDegree, 30, outerR, 0.6))
+      // Radial already pulls toward rings around the origin — no gravity.
+      fg.d3Force("gravity", null)
     } else {
       // network (compact, the default)
       charge?.strength?.(-70)
       link?.distance?.(48)
       fg.d3Force("radial", null)
+      fg.d3Force("gravity", makeGravityForce(0.09))
     }
     fg.d3ReheatSimulation?.()
   }, [layout, data, size.w])

--- a/src/components/visualization/visualization.tsx
+++ b/src/components/visualization/visualization.tsx
@@ -5,7 +5,10 @@ import dynamic from "next/dynamic"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import EmptyState from "@/components/ui/empty-state"
 import EndorsementStats from "@/components/visualization/endorsement-stats"
-import { useEndorsementGraph } from "@/hooks/use-endorsement-graph"
+import {
+  useEndorsementGraph,
+  type EndorsementGraph as EndorsementGraphData,
+} from "@/hooks/use-endorsement-graph"
 import { usePageTitle } from "@/lib/navbar-context"
 import type { FocusRequest } from "@/components/visualization/endorsement-graph"
 
@@ -25,6 +28,10 @@ const EndorsementGraph = dynamic(
 export default function Visualization() {
   const { graph, isLoading, error } = useEndorsementGraph()
   const [focusReq, setFocusReq] = useState<FocusRequest>({ did: null, nonce: 0 })
+  // Stats of the currently-visible (filtered) graph, emitted by the graph
+  // component so the sidebar mirrors the active scope / mutual filters.
+  // Falls back to the full graph until the first emit.
+  const [statsGraph, setStatsGraph] = useState<EndorsementGraphData | null>(null)
 
   // Shows "Endorsement network" in the top bar next to the brandmark (which
   // replaces the wordmark whenever a page title is set).
@@ -69,13 +76,15 @@ export default function Visualization() {
               nodes={graph.nodes}
               links={graph.links}
               focusReq={focusReq}
+              truncated={graph.truncated}
+              onStats={setStatsGraph}
             />
           )}
         </div>
       </div>
 
       {!isLoading && !error && graph && graph.nodes.length > 0 && (
-        <EndorsementStats graph={graph} onFocus={handleFocus} />
+        <EndorsementStats graph={statsGraph ?? graph} onFocus={handleFocus} />
       )}
     </div>
   )


### PR DESCRIPTION
Follow-up to #206 (merged).

## Sidebar stats now follow the filters
The stats panel (Endorsements / People / Mutual pairs / Reciprocity, plus the **Top endorsers** / **Most endorsed** rankings) reflected the *full* graph even when the Evaluator-network / Mutual-only filters were active. Now the graph component recomputes per-node given/received/mutual + totals over the **currently-visible edges** and emits them up via an `onStats` callback, which the parent feeds to the sidebar. Counts are over shown (deduped) edges, so they match what's drawn.

## "Evaluator network" is now a switch
The toggle became a two-option `SegmentedControl`: **Evaluator network** | **Everything**.

`tsc` clean (only the pre-existing react-force-graph module error); lint + CSS rules clean.

Note: I can't render the graph in this checkout (react-force-graph-2d isn't installed here) — visual check is on the dev worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)