### PR TITLE
fix(feed): align card content with the author name/handle

### DIFF
--- a/src/app/styles/feed.css
+++ b/src/app/styles/feed.css
@@ -406,6 +406,9 @@
   display: block;
   color: inherit;
   text-decoration: none;
+  /* Align the content with the author's name/handle, not the avatar:
+     indent by the byline avatar (sm = 32px) + its 10px gap. */
+  padding-left: 42px;
 }
 
 .feed-card__body:hover .feed-card__title {

--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -397,6 +397,13 @@
   color: var(--fg-primary);
 }
 
+/* Align everything under the byline (the preview card / endorsement
+   expansion) with the actor's name column rather than the avatar: indent
+   by the head's avatar column (32px) + its 10px gap. */
+.home-feed__card > :not(.home-feed__card-head) {
+  padding-left: 42px;
+}
+
 /* ---- Head: avatar + byline + verb sentence ---- */
 
 .home-feed__card-head {


### PR DESCRIPTION
On the feed, the card body (image, title, description, meta) was left-aligned with the **avatar**. Indent `.feed-card__body` by the byline avatar (sm = 32px) + its 10px gap = **42px** so the content lines up under the **display name / handle** instead — the standard social-feed (Twitter/Bluesky) thread layout.

CSS-only; radii/tokens/breakpoint rules clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)