### PR TITLE
feat(settings): "Turn into a group" section (CGS account import)

### DIFF
--- a/src/components/settings/import-as-group-section.tsx
+++ b/src/components/settings/import-as-group-section.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { KeyRound } from "lucide-react"
+import { useOrg } from "@/lib/groups/org-context"
+import { importGroup, putMembership, RegisterGroupError } from "@/lib/groups/api"
+import { authFetch } from "@/lib/auth/fetch"
+import Button from "@/components/ui/button"
+import Input from "@/components/ui/input"
+import ErrorMessage from "@/components/ui/error-message"
+
+/**
+ * Settings section that promotes the signed-in account into a Certified
+ * group via the CGS `app.certified.group.import` procedure (wrapped by
+ * `importGroup`). The account being converted is always the one you're
+ * signed in as — CGS requires the service-auth token's `iss` to equal the
+ * imported account — so the copy names it explicitly and tells you to sign
+ * in as a different account if you meant to convert that one instead.
+ *
+ * Unlike the standalone `/groups/import` page, this stays inline (no
+ * redirect): on success it shows a confirmation and the new group appears
+ * in the account switcher via `refetchOrgs`.
+ */
+export default function ImportAsGroupSection({ did }: { did: string }) {
+  const { refetchOrgs } = useOrg()
+  const [handle, setHandle] = useState<string | null>(null)
+  const [appPassword, setAppPassword] = useState("")
+  const [isImporting, setIsImporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [importedHandle, setImportedHandle] = useState<string | null>(null)
+
+  // Resolve the signed-in account's handle so the copy can name which
+  // account gets converted.
+  useEffect(() => {
+    let cancelled = false
+    authFetch(`/api/resolve-did?did=${encodeURIComponent(did)}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!cancelled && data?.handle) setHandle(data.handle as string)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [did])
+
+  const handleSubmit = useCallback(
+    async (e?: React.FormEvent) => {
+      e?.preventDefault()
+      if (!appPassword.trim() || isImporting) return
+      setIsImporting(true)
+      setError(null)
+      try {
+        const result = await importGroup(appPassword.trim())
+        // Stitch the owner membership marker so the imported group shows up
+        // in the account switcher + group list (mirrors the create flow).
+        try {
+          await putMembership(did, result.groupDid, "owner")
+        } catch (err) {
+          console.error("[settings/import-group] putMembership failed", err)
+        }
+        await refetchOrgs()
+        setImportedHandle(result.handle || handle)
+        setAppPassword("")
+      } catch (err) {
+        if (
+          err instanceof RegisterGroupError &&
+          err.code === "GroupAlreadyRegistered"
+        ) {
+          setError("This account is already registered as a group.")
+        } else if (
+          err instanceof RegisterGroupError &&
+          err.code === "InvalidAppPassword"
+        ) {
+          setError("That app password was not accepted. Check it and try again.")
+        } else {
+          setError(err instanceof Error ? err.message : "Import failed")
+        }
+      } finally {
+        setIsImporting(false)
+      }
+    },
+    [did, appPassword, isImporting, refetchOrgs, handle],
+  )
+
+  if (importedHandle) {
+    return (
+      <p className="settings__note" role="status">
+        ✓ <strong>@{importedHandle}</strong> is now a group, with you as its
+        owner. Switch to it from the account menu to manage members and roles.
+      </p>
+    )
+  }
+
+  const accountLabel = handle ? `@${handle}` : did
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <p className="settings__note">
+        Converts the account you&apos;re signed in as —{" "}
+        <strong>{accountLabel}</strong> — into a group, with you as its owner.
+        The account, its handle, and its records are kept; nothing is deleted.
+        To convert a different account, sign in as that account first.
+      </p>
+
+      <Input
+        type="password"
+        label="App password"
+        size="md"
+        autoComplete="off"
+        leadingIcon={<KeyRound size={16} aria-hidden="true" />}
+        placeholder="xxxx-xxxx-xxxx-xxxx"
+        value={appPassword}
+        onChange={(e) => setAppPassword(e.target.value)}
+      />
+      <p className="settings__note">
+        Create an app password in your account&apos;s settings. It&apos;s stored
+        encrypted so the service can act for the group; you can revoke it
+        anytime.
+      </p>
+
+      {error && <ErrorMessage message={error} />}
+
+      <div className="org-members__add-submit">
+        <Button
+          type="submit"
+          variant="primary"
+          loading={isImporting}
+          disabled={!appPassword.trim() || isImporting}
+        >
+          Import as group
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/settings/settings-panel.tsx
+++ b/src/components/settings/settings-panel.tsx
@@ -71,8 +71,7 @@ const CATEGORIES: CategoryDef[] = [
   {
     key: "group",
     label: "Turn into a group",
-    description:
-      "Promote this account into a Certified group — keep its handle, history, and records, with you as owner.",
+    description: "Promote this account into a Certified group.",
     Icon: Users,
   },
 ]

--- a/src/components/settings/settings-panel.tsx
+++ b/src/components/settings/settings-panel.tsx
@@ -2,12 +2,13 @@
 
 import React, { useCallback, useEffect, useRef, useState } from "react"
 import dynamic from "next/dynamic"
-import { AtSign, KeyRound, Mail, Palette, Share2 } from "lucide-react"
+import { AtSign, KeyRound, Mail, Palette, Share2, Users } from "lucide-react"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useSession } from "@/hooks/use-session"
 import { useOrg } from "@/lib/groups/org-context"
 import OrgSettings from "@/components/groups/org-settings"
 import SyncSocialGraphSection from "@/components/settings/sync-social-graph-section"
+import ImportAsGroupSection from "@/components/settings/import-as-group-section"
 import ThemeToggle from "@/components/ui/theme-toggle"
 
 const UsernameCard = dynamic(
@@ -26,6 +27,7 @@ type CategoryKey =
   | "password"
   | "appearance"
   | "social-graph"
+  | "group"
 
 type CategoryDef = {
   key: CategoryKey
@@ -65,6 +67,13 @@ const CATEGORIES: CategoryDef[] = [
     label: "Password",
     description: "Reset the password used to sign in to this account.",
     Icon: KeyRound,
+  },
+  {
+    key: "group",
+    label: "Turn into a group",
+    description:
+      "Promote this account into a Certified group — keep its handle, history, and records, with you as owner.",
+    Icon: Users,
   },
 ]
 
@@ -239,6 +248,9 @@ export default function SettingsPanel() {
                 {cat.key === "appearance" && <ThemeToggle />}
                 {cat.key === "social-graph" && did ? (
                   <SyncSocialGraphSection did={did} ownDid={did} />
+                ) : null}
+                {cat.key === "group" && did ? (
+                  <ImportAsGroupSection did={did} />
                 ) : null}
               </div>
             </section>


### PR DESCRIPTION
Surfaces the Certified Group Service's `app.certified.group.import` ([certified-group-service](https://github.com/hypercerts-org/certified-group-service)) procedure in the **settings menu**, per the design doc's deferred "client-side upgrade UX".

## What
A new **"Turn into a group"** settings section that promotes the signed-in account into a Certified group:
- Reuses the existing `importGroup()` wrapper → `/api/groups/import` → `app.certified.group.import`.
- The account converted is always the **signed-in one** — CGS requires the service-auth token's `iss` to equal the imported account, so the copy names it and tells you to sign in as a different account if needed.
- Stays **inline** (unlike the standalone `/groups/import` page): asks for an app password, on success confirms and `refetchOrgs` surfaces the new group in the account switcher. Structured errors (`InvalidAppPassword`, `GroupAlreadyRegistered`) get field-level messages.

No backend changes — the route + lib already existed; this is the settings UI for them.

`tsc` clean; lint adds no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)