### PR TITLE
copy(funding): clearer Confirmed-by filter labels

### DIFF
--- a/src/components/explore-page/funding-confirmed-by-popover.tsx
+++ b/src/components/explore-page/funding-confirmed-by-popover.tsx
@@ -19,9 +19,9 @@ import {
 import type { FundingReceipt } from "@/lib/atproto/indexer"
 
 const ROLE_LABEL: Record<ConfirmRole, string> = {
-  both: "Both",
-  sender: "Funder",
-  recipient: "Recipient",
+  both: "Funders & Recipient",
+  sender: "Only funder",
+  recipient: "Only recipient",
 }
 
 /**


### PR DESCRIPTION
Rename the funding-receipt **Confirmed by** filter options (the shared popover used on `/explore` Funding and the activity-claim Funding tab):

- Both → **Funders & Recipient**
- Funder → **Only funder**
- Recipient → **Only recipient**

One-line copy change in `funding-confirmed-by-popover.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)