### PR TITLE
fix(profile): truncate sidebar display name instead of overflowing

### DIFF
--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -2102,6 +2102,9 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   flex-direction: column;
   gap: 2px;
   margin-top: 4px;
+  /* Let the name shrink within the sidebar so an unbreakable display name
+     truncates instead of overflowing into the main column. */
+  min-width: 0;
 }
 
 .profile-sidebar__name {
@@ -2112,6 +2115,11 @@ a.mobile-sidebar__profile:hover .mobile-sidebar__name {
   color: var(--fg-primary);
   margin: 0;
   line-height: 1.2;
+  /* A display name with no spaces (e.g. a handle used as the name) can't
+     wrap — cut it off with an ellipsis rather than overflow. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .profile-sidebar__handle {


### PR DESCRIPTION
A display name with no spaces (e.g. a handle used as the display name, like `holkebrammer001.certified.one`) can't wrap, so it overflowed the sidebar into the main column.

- `.profile-sidebar__name-block`: `min-width: 0` so it can shrink within the sidebar.
- `.profile-sidebar__name`: `white-space: nowrap; overflow: hidden; text-overflow: ellipsis` — cut it off with an ellipsis.

(Short multi-word names still show in full; only an overflowing name is truncated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)