### PR TITLE
fix(profile): retry profile save once on InvalidSwap

### DIFF
--- a/src/hooks/use-profile-inline-edit.ts
+++ b/src/hooks/use-profile-inline-edit.ts
@@ -2,12 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
+  getProfileWithCid,
   putProfile,
   uploadAvatar,
   uploadBanner,
   uploadBlob,
   type UploadedBlob,
 } from "@/lib/atproto/profile"
+import { InvalidSwapError } from "@/lib/atproto/repo-write"
 import { putOrgMarker } from "@/lib/groups/org-marker"
 import {
   putLocationRecord,
@@ -736,10 +738,26 @@ export function useProfileInlineEdit(
       // banner carrier, i.e. the data-loss surface) is guarded here.
       // (judgment-006 / #71)
       const profileSwapCid = profileSwapCidRef.current
-      await putProfile(sessionDid, next, {
-        ...(editTargetDid ? { targetDid: editTargetDid } : {}),
-        ...(profileSwapCid ? { swapRecord: profileSwapCid } : {}),
-      })
+      try {
+        await putProfile(sessionDid, next, {
+          ...(editTargetDid ? { targetDid: editTargetDid } : {}),
+          ...(profileSwapCid ? { swapRecord: profileSwapCid } : {}),
+        })
+      } catch (err) {
+        // The snapshot CID went stale since edit-start (a concurrent
+        // write from another tab/device, or a prior failed attempt).
+        // Re-read the live record's CID, refresh the swap precondition,
+        // and retry the write ONCE. A second failure bubbles to the
+        // outer catch (which surfaces `saveError`). (judgment-006 / #71)
+        if (!(err instanceof InvalidSwapError)) throw err
+        const fresh = await getProfileWithCid(sessionDid)
+        const freshSwapCid = fresh?.cid ?? null
+        profileSwapCidRef.current = freshSwapCid
+        await putProfile(sessionDid, next, {
+          ...(editTargetDid ? { targetDid: editTargetDid } : {}),
+          ...(freshSwapCid ? { swapRecord: freshSwapCid } : {}),
+        })
+      }
 
       let nextMarker: GroupMetadata | null = null
       if (sidebarIsOrg) {


### PR DESCRIPTION
## Problem

Editing a personal profile (display name / about) and clicking **Save** could fail with `InvalidSwapError: Record was at bafyrei…`, and repeat identically on every retry.

## Root cause

In `src/hooks/use-profile-inline-edit.ts`, the profile record's swap CID is captured **once** at edit-start (`profileSwapCidRef.current = profileCid ?? null` in `handleEditClick`) and never refreshed — only cleared on cancel / successful save. The save handler threads it into `putProfile(sessionDid, next, { swapRecord })`. If the record's CID changed since edit-start (a concurrent write from another tab/device, or a prior failed attempt), the PDS rejects the write with `InvalidSwap`, and the old catch block just surfaced `err.message`. Every retry re-sent the same stale CID and failed the same way.

## Fix (Option A — single retry on InvalidSwap)

Wrap the `putProfile` call so that on `InvalidSwapError` it:

1. Re-reads the live record via `getProfileWithCid(sessionDid)`,
2. Refreshes `profileSwapCidRef.current` to the fresh `cid ?? null`,
3. Retries `putProfile` **once** with that fresh swap CID.

A second failure bubbles to the existing outer catch (which shows `saveError`). The location / org-marker writes and the success path (which still clears `profileSwapCidRef`) are unchanged. `InvalidSwapError` is imported from `@/lib/atproto/repo-write`, matching `project-detail.tsx` and `activity-detail.tsx`.

## Verification

- `npx tsc --noEmit` — clean (only the pre-existing, unrelated `react-force-graph-2d` "Cannot find module" error).
- `npx eslint src/hooks/use-profile-inline-edit.ts` — clean, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)