### PR TITLE
feat(settings): app passwords + Advanced disclosure

### DIFF
--- a/src/app/api/xrpc/[...method]/route.ts
+++ b/src/app/api/xrpc/[...method]/route.ts
@@ -8,6 +8,8 @@ import type {
   ComAtprotoServerRequestPasswordReset,
   ComAtprotoServerResetPassword,
   ComAtprotoServerUpdateEmail,
+  ComAtprotoServerCreateAppPassword,
+  ComAtprotoServerRevokeAppPassword,
 } from "@atproto/api"
 import { getOAuthClient } from "@/lib/auth/oauth-client"
 import { getSessionDid, deleteSession } from "@/lib/auth/session"
@@ -449,6 +451,13 @@ export async function GET(
         const result = await agent.com.atproto.server.getSession()
         return NextResponse.json(result.data, { headers: SAME_SESSION_NO_STORE_HEADERS })
       }
+      case "com.atproto.server.listAppPasswords": {
+        if (!agent) {
+          return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+        }
+        const result = await agent.com.atproto.server.listAppPasswords()
+        return NextResponse.json(result.data, { headers: SAME_SESSION_NO_STORE_HEADERS })
+      }
       case "com.atproto.sync.getBlob": {
         const { did: blobDid, cid } = queryParams
         if (!blobDid || !cid) {
@@ -670,6 +679,20 @@ export async function POST(
       case "com.atproto.server.updateEmail": {
         await agent.com.atproto.server.updateEmail(
           body as ComAtprotoServerUpdateEmail.InputSchema
+        )
+        return NextResponse.json({})
+      }
+      case "com.atproto.server.createAppPassword": {
+        // Returns the generated password ONCE (the PDS never reveals it
+        // again). The caller shows it for copy then drops it.
+        const result = await agent.com.atproto.server.createAppPassword(
+          body as ComAtprotoServerCreateAppPassword.InputSchema
+        )
+        return NextResponse.json(result.data)
+      }
+      case "com.atproto.server.revokeAppPassword": {
+        await agent.com.atproto.server.revokeAppPassword(
+          body as ComAtprotoServerRevokeAppPassword.InputSchema
         )
         return NextResponse.json({})
       }

--- a/src/app/styles/settings-page.css
+++ b/src/app/styles/settings-page.css
@@ -197,6 +197,87 @@
   min-width: 0;
 }
 
+/* "Advanced" disclosure toggle — reuses .sx-menu__item; the chevron sits at
+   the trailing edge (the label is flex:1) and flips when expanded. */
+.sx-menu__chevron {
+  flex-shrink: 0;
+  color: var(--fg-muted);
+  transition: transform var(--transition-fast);
+}
+
+.sx-menu__chevron--open {
+  transform: rotate(180deg);
+}
+
+/* ---------- App passwords section ---------- */
+.app-passwords {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.app-passwords__create,
+.app-passwords__created {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.app-passwords__secret {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.app-passwords__secret-value {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--fg-primary);
+  overflow-wrap: anywhere;
+}
+
+.app-passwords__loading {
+  display: flex;
+  justify-content: center;
+  padding: 12px 0;
+}
+
+.app-passwords__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.app-passwords__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.app-passwords__row:first-child {
+  border-top: 0;
+}
+
+.app-passwords__row-name {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: 0.9rem;
+  color: var(--fg-primary);
+}
+
 /* ------------------------------------------------------------------------
    Right pane — wrapper for ALL stacked sections.
    The wrapper itself is a flex column; the `gap` defines breathing

--- a/src/components/settings/app-passwords-section.tsx
+++ b/src/components/settings/app-passwords-section.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { Check, Copy, KeyRound, Plus, Trash2 } from "lucide-react"
+import {
+  createAppPassword,
+  listAppPasswords,
+  revokeAppPassword,
+  type AppPasswordInfo,
+  type CreatedAppPassword,
+} from "@/lib/atproto/app-passwords"
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard"
+import Button from "@/components/ui/button"
+import Input from "@/components/ui/input"
+import ErrorMessage from "@/components/ui/error-message"
+import LoadingSpinner from "@/components/ui/loading-spinner"
+
+/**
+ * Create / list / revoke atproto app passwords (`com.atproto.server.*`).
+ *
+ * An app password lets another client — or the Certified Group Service's
+ * group import — act for this account without the main password. The
+ * generated secret is shown exactly once on creation (the PDS never returns
+ * it again), so we surface it for copy and then drop it from state.
+ */
+export default function AppPasswordsSection() {
+  const [items, setItems] = useState<AppPasswordInfo[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const [name, setName] = useState("")
+  const [isCreating, setIsCreating] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
+  const [created, setCreated] = useState<CreatedAppPassword | null>(null)
+
+  const [revoking, setRevoking] = useState<string | null>(null)
+  const { copied, copy } = useCopyToClipboard()
+
+  const refresh = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const list = await listAppPasswords(signal)
+      if (!signal?.aborted) {
+        setItems(list)
+        setLoadError(null)
+      }
+    } catch {
+      if (!signal?.aborted) setLoadError("Couldn't load app passwords.")
+    } finally {
+      if (!signal?.aborted) setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void refresh(controller.signal)
+    return () => controller.abort()
+  }, [refresh])
+
+  const handleCreate = useCallback(
+    async (e?: React.FormEvent) => {
+      e?.preventDefault()
+      const trimmed = name.trim()
+      if (!trimmed || isCreating) return
+      setIsCreating(true)
+      setCreateError(null)
+      try {
+        const result = await createAppPassword(trimmed)
+        setCreated(result)
+        setName("")
+        await refresh()
+      } catch (err) {
+        setCreateError(
+          err instanceof Error ? err.message : "Failed to create app password",
+        )
+      } finally {
+        setIsCreating(false)
+      }
+    },
+    [name, isCreating, refresh],
+  )
+
+  const handleRevoke = useCallback(
+    async (pwName: string) => {
+      setRevoking(pwName)
+      try {
+        await revokeAppPassword(pwName)
+        await refresh()
+      } catch {
+        setLoadError("Couldn't revoke that app password.")
+      } finally {
+        setRevoking(null)
+      }
+    },
+    [refresh],
+  )
+
+  return (
+    <div className="app-passwords">
+      {/* One-time reveal of a freshly created password. */}
+      {created ? (
+        <div className="app-passwords__created">
+          <p className="settings__note">
+            Copy <strong>{created.name}</strong> now — this password won&apos;t
+            be shown again.
+          </p>
+          <div className="app-passwords__secret">
+            <code className="app-passwords__secret-value">
+              {created.password}
+            </code>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => copy(created.password)}
+            >
+              {copied ? <Check size={14} /> : <Copy size={14} />}
+              {copied ? "Copied" : "Copy"}
+            </Button>
+          </div>
+          <div className="org-members__add-submit">
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={() => setCreated(null)}
+            >
+              Done
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={handleCreate} className="app-passwords__create">
+          <Input
+            label="Name"
+            size="md"
+            autoComplete="off"
+            leadingIcon={<KeyRound size={16} aria-hidden="true" />}
+            placeholder="e.g. my-other-client"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          {createError && <ErrorMessage message={createError} />}
+          <div className="org-members__add-submit">
+            <Button
+              type="submit"
+              variant="primary"
+              size="sm"
+              loading={isCreating}
+              disabled={!name.trim() || isCreating}
+            >
+              <Plus size={14} /> Create app password
+            </Button>
+          </div>
+        </form>
+      )}
+
+      {/* Existing app passwords. */}
+      {isLoading ? (
+        <div className="app-passwords__loading">
+          <LoadingSpinner size="sm" />
+        </div>
+      ) : loadError ? (
+        <ErrorMessage message={loadError} />
+      ) : items.length === 0 ? (
+        <p className="settings__note">No app passwords yet.</p>
+      ) : (
+        <ul className="app-passwords__list">
+          {items.map((p) => (
+            <li key={p.name} className="app-passwords__row">
+              <span className="app-passwords__row-name">{p.name}</span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                loading={revoking === p.name}
+                disabled={revoking === p.name}
+                onClick={() => handleRevoke(p.name)}
+              >
+                <Trash2 size={14} /> Revoke
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/settings/settings-panel.tsx
+++ b/src/components/settings/settings-panel.tsx
@@ -2,13 +2,24 @@
 
 import React, { useCallback, useEffect, useRef, useState } from "react"
 import dynamic from "next/dynamic"
-import { AtSign, KeyRound, Mail, Palette, Share2, Users } from "lucide-react"
+import {
+  AtSign,
+  ChevronDown,
+  Key,
+  KeyRound,
+  Mail,
+  Palette,
+  Share2,
+  SlidersHorizontal,
+  Users,
+} from "lucide-react"
 import { useAuth } from "@/lib/auth/auth-context"
 import { useSession } from "@/hooks/use-session"
 import { useOrg } from "@/lib/groups/org-context"
 import OrgSettings from "@/components/groups/org-settings"
 import SyncSocialGraphSection from "@/components/settings/sync-social-graph-section"
 import ImportAsGroupSection from "@/components/settings/import-as-group-section"
+import AppPasswordsSection from "@/components/settings/app-passwords-section"
 import ThemeToggle from "@/components/ui/theme-toggle"
 
 const UsernameCard = dynamic(
@@ -27,6 +38,7 @@ type CategoryKey =
   | "password"
   | "appearance"
   | "social-graph"
+  | "app-passwords"
   | "group"
 
 type CategoryDef = {
@@ -34,6 +46,8 @@ type CategoryDef = {
   label: string
   description: string
   Icon: typeof AtSign
+  /** Tucked behind the "Advanced" disclosure — hidden until expanded. */
+  advanced?: boolean
 }
 
 const CATEGORIES: CategoryDef[] = [
@@ -69,12 +83,24 @@ const CATEGORIES: CategoryDef[] = [
     Icon: KeyRound,
   },
   {
+    key: "app-passwords",
+    label: "App passwords",
+    description:
+      "Create passwords for other apps (and the group import). Shown once — revoke anytime.",
+    Icon: Key,
+    advanced: true,
+  },
+  {
     key: "group",
     label: "Turn into a group",
     description: "Promote this account into a Certified group.",
     Icon: Users,
+    advanced: true,
   },
 ]
+
+const REGULAR_CATEGORIES = CATEGORIES.filter((c) => !c.advanced)
+const ADVANCED_CATEGORIES = CATEGORIES.filter((c) => c.advanced)
 
 const DEFAULT_CATEGORY: CategoryKey = CATEGORIES[0].key
 
@@ -89,6 +115,9 @@ function readHashCategory(): CategoryKey | null {
  * Shared settings two-pane layout. Renders on both `/settings` and the
  * profile-page `?tab=settings` panel. Scroll-spy + deep-link behavior
  * is identical in both contexts.
+ *
+ * Advanced sections (App passwords, Turn into a group) live behind an
+ * "Advanced" disclosure in the menu — hidden until the user expands it.
  */
 export default function SettingsPanel() {
   const { did, pdsUrl } = useAuth()
@@ -96,11 +125,16 @@ export default function SettingsPanel() {
   const { activeOrg } = useOrg()
 
   const [active, setActive] = useState<CategoryKey>(DEFAULT_CATEGORY)
+  const [advancedOpen, setAdvancedOpen] = useState(false)
   const sectionRefs = useRef<Map<CategoryKey, HTMLElement>>(new Map())
 
   useEffect(() => {
     const initial = readHashCategory()
     if (initial) {
+      // Deep-link straight to an advanced section: reveal the group first.
+      if (CATEGORIES.find((c) => c.key === initial)?.advanced) {
+        setAdvancedOpen(true)
+      }
       setActive(initial)
       requestAnimationFrame(() => {
         const el = sectionRefs.current.get(initial)
@@ -135,7 +169,8 @@ export default function SettingsPanel() {
 
     for (const [, el] of els) observer.observe(el)
     return () => observer.disconnect()
-  }, [])
+    // Re-observe when the advanced sections mount/unmount.
+  }, [advancedOpen])
 
   const onMenuClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>, key: CategoryKey) => {
@@ -180,6 +215,28 @@ export default function SettingsPanel() {
     return <OrgSettings groupDid={activeOrg.groupDid} org={activeOrg} />
   }
 
+  const renderNavItem = (cat: CategoryDef) => {
+    const isActive = cat.key === active
+    const Icon = cat.Icon
+    return (
+      <li key={cat.key}>
+        <a
+          href={`#${cat.key}`}
+          aria-current={isActive ? "true" : undefined}
+          className={`sx-menu__item${isActive ? " sx-menu__item--active" : ""}`}
+          onClick={(e) => onMenuClick(e, cat.key)}
+        >
+          <span className="sx-menu__icon" aria-hidden>
+            <Icon size={16} strokeWidth={1.75} />
+          </span>
+          <span className="sx-menu__label">{cat.label}</span>
+        </a>
+      </li>
+    )
+  }
+
+  const panelCategories = advancedOpen ? CATEGORIES : REGULAR_CATEGORIES
+
   return (
     <div className="sx">
       <h1 className="sx__heading sr-only">Settings</h1>
@@ -188,31 +245,32 @@ export default function SettingsPanel() {
         <aside className="sx__menu">
           <nav aria-label="Settings sections">
             <ul className="sx-menu">
-              {CATEGORIES.map((cat) => {
-                const isActive = cat.key === active
-                const Icon = cat.Icon
-                return (
-                  <li key={cat.key}>
-                    <a
-                      href={`#${cat.key}`}
-                      aria-current={isActive ? "true" : undefined}
-                      className={`sx-menu__item${isActive ? " sx-menu__item--active" : ""}`}
-                      onClick={(e) => onMenuClick(e, cat.key)}
-                    >
-                      <span className="sx-menu__icon" aria-hidden>
-                        <Icon size={16} strokeWidth={1.75} />
-                      </span>
-                      <span className="sx-menu__label">{cat.label}</span>
-                    </a>
-                  </li>
-                )
-              })}
+              {REGULAR_CATEGORIES.map(renderNavItem)}
+              <li>
+                <button
+                  type="button"
+                  className="sx-menu__item sx-menu__item--toggle"
+                  aria-expanded={advancedOpen}
+                  onClick={() => setAdvancedOpen((open) => !open)}
+                >
+                  <span className="sx-menu__icon" aria-hidden>
+                    <SlidersHorizontal size={16} strokeWidth={1.75} />
+                  </span>
+                  <span className="sx-menu__label">Advanced</span>
+                  <ChevronDown
+                    size={15}
+                    aria-hidden
+                    className={`sx-menu__chevron${advancedOpen ? " sx-menu__chevron--open" : ""}`}
+                  />
+                </button>
+              </li>
+              {advancedOpen ? ADVANCED_CATEGORIES.map(renderNavItem) : null}
             </ul>
           </nav>
         </aside>
 
         <div className="page-layout__main sx__panel">
-          {CATEGORIES.map((cat) => (
+          {panelCategories.map((cat) => (
             <section
               key={cat.key}
               id={cat.key}
@@ -248,6 +306,7 @@ export default function SettingsPanel() {
                 {cat.key === "social-graph" && did ? (
                   <SyncSocialGraphSection did={did} ownDid={did} />
                 ) : null}
+                {cat.key === "app-passwords" && <AppPasswordsSection />}
                 {cat.key === "group" && did ? (
                   <ImportAsGroupSection did={did} />
                 ) : null}

--- a/src/lib/atproto/app-passwords.ts
+++ b/src/lib/atproto/app-passwords.ts
@@ -1,0 +1,71 @@
+import { authFetch } from "@/lib/auth/fetch"
+
+/**
+ * App-password management via the XRPC proxy (`com.atproto.server.*`).
+ *
+ * App passwords let the account authenticate to third-party clients (and
+ * the Certified Group Service's `import` flow) without handing over the
+ * main password. `createAppPassword` returns the generated secret EXACTLY
+ * ONCE — the PDS never reveals it again — so the caller must surface it for
+ * copy immediately and then drop it.
+ */
+
+export interface AppPasswordInfo {
+  name: string
+  createdAt: string
+}
+
+export interface CreatedAppPassword {
+  name: string
+  password: string
+  createdAt: string
+}
+
+export async function listAppPasswords(
+  signal?: AbortSignal,
+): Promise<AppPasswordInfo[]> {
+  const res = await authFetch(
+    "/api/xrpc/com/atproto/server/listAppPasswords",
+    { signal },
+  )
+  if (!res.ok) throw new Error("Failed to load app passwords")
+  const data = (await res.json()) as { passwords?: AppPasswordInfo[] }
+  return data.passwords ?? []
+}
+
+export async function createAppPassword(
+  name: string,
+): Promise<CreatedAppPassword> {
+  const res = await authFetch(
+    "/api/xrpc/com/atproto/server/createAppPassword",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    },
+  )
+  if (!res.ok) {
+    let message = "Failed to create app password"
+    try {
+      const data = (await res.json()) as { error?: string; message?: string }
+      if (typeof data.message === "string") message = data.message
+      else if (typeof data.error === "string") message = data.error
+    } catch {
+      // keep the default message
+    }
+    throw new Error(message)
+  }
+  return (await res.json()) as CreatedAppPassword
+}
+
+export async function revokeAppPassword(name: string): Promise<void> {
+  const res = await authFetch(
+    "/api/xrpc/com/atproto/server/revokeAppPassword",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    },
+  )
+  if (!res.ok) throw new Error("Failed to revoke app password")
+}


### PR DESCRIPTION
Builds on the merged "Turn into a group" section (#211).

## App passwords
A new **App passwords** settings section: create / list / revoke via `com.atproto.server.createAppPassword` / `listAppPasswords` / `revokeAppPassword` — newly allowlisted in the XRPC proxy (`/api/xrpc/[...method]/route.ts`). The generated secret is shown **once** with a copy affordance, then dropped from state (the PDS never returns it again). Structured create errors surface inline; existing passwords list with a Revoke action.

This pairs with the group-import flow, which asks the user to "create an app password in your account's settings."

## Advanced disclosure
Both **App passwords** and **Turn into a group** now live behind an **Advanced** toggle in the settings menu — hidden until the user expands it. Deep-linking to `#group` / `#app-passwords` auto-expands the group.

`tsc` clean; lint adds no new warnings (the one set-state-in-effect warning is pre-existing in the mount/deep-link effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)