### PR TITLE
feat(settings): rename group section + main-pane Advanced toggle

### DIFF
--- a/src/app/styles/settings-page.css
+++ b/src/app/styles/settings-page.css
@@ -209,6 +209,52 @@
   transform: rotate(180deg);
 }
 
+/* Advanced disclosure — main-pane control. The sidebar nav is hidden on
+   mobile, so this full-width divider is the only reveal there. Leading
+   icon + label, trailing chevron that flips when expanded. */
+.sx-advanced-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 12px 0;
+  border: 0;
+  border-top: 1px solid var(--border-subtle);
+  background: none;
+  color: var(--fg-muted);
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.95rem;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.sx-advanced-divider:hover,
+.sx-advanced-divider:focus-visible {
+  color: var(--fg-primary);
+  outline: none;
+}
+
+.sx-advanced-divider:focus-visible {
+  border-radius: var(--radius);
+  box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+.sx-advanced-divider__label {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.sx-advanced-divider__chevron {
+  flex-shrink: 0;
+  transition: transform var(--transition-fast);
+}
+
+.sx-advanced-divider__chevron--open {
+  transform: rotate(180deg);
+}
+
 /* ---------- App passwords section ---------- */
 .app-passwords {
   display: flex;

--- a/src/components/settings/settings-panel.tsx
+++ b/src/components/settings/settings-panel.tsx
@@ -235,7 +235,42 @@ export default function SettingsPanel() {
     )
   }
 
-  const panelCategories = advancedOpen ? CATEGORIES : REGULAR_CATEGORIES
+  const renderSection = (cat: CategoryDef) => (
+    <section
+      key={cat.key}
+      id={cat.key}
+      ref={setSectionRef(cat.key)}
+      className="sx-section"
+      aria-labelledby={`sx-section-${cat.key}-title`}
+    >
+      <header className="sx-panel__header">
+        <h2 id={`sx-section-${cat.key}-title`} className="sx-panel__title">
+          {cat.label}
+        </h2>
+        {cat.description ? (
+          <p className="sx-panel__desc">{cat.description}</p>
+        ) : null}
+      </header>
+
+      <div className="sx-panel__body">
+        {cat.key === "username" && (
+          <UsernameCard
+            handle={handle}
+            pdsUrl={pdsUrl || undefined}
+            did={did || undefined}
+          />
+        )}
+        {cat.key === "email" && <EmailSection email={email || ""} />}
+        {cat.key === "password" && <PasswordSection email={email || ""} />}
+        {cat.key === "appearance" && <ThemeToggle />}
+        {cat.key === "social-graph" && did ? (
+          <SyncSocialGraphSection did={did} ownDid={did} />
+        ) : null}
+        {cat.key === "app-passwords" && <AppPasswordsSection />}
+        {cat.key === "group" && did ? <ImportAsGroupSection did={did} /> : null}
+      </div>
+    </section>
+  )
 
   return (
     <div className="sx">
@@ -270,51 +305,26 @@ export default function SettingsPanel() {
         </aside>
 
         <div className="page-layout__main sx__panel">
-          {panelCategories.map((cat) => (
-            <section
-              key={cat.key}
-              id={cat.key}
-              ref={setSectionRef(cat.key)}
-              className="sx-section"
-              aria-labelledby={`sx-section-${cat.key}-title`}
-            >
-              <header className="sx-panel__header">
-                <h2
-                  id={`sx-section-${cat.key}-title`}
-                  className="sx-panel__title"
-                >
-                  {cat.label}
-                </h2>
-                {cat.description ? (
-                  <p className="sx-panel__desc">{cat.description}</p>
-                ) : null}
-              </header>
+          {REGULAR_CATEGORIES.map(renderSection)}
 
-              <div className="sx-panel__body">
-                {cat.key === "username" && (
-                  <UsernameCard
-                    handle={handle}
-                    pdsUrl={pdsUrl || undefined}
-                    did={did || undefined}
-                  />
-                )}
-                {cat.key === "email" && (
-                  <EmailSection email={email || ""} />
-                )}
-                {cat.key === "password" && (
-                  <PasswordSection email={email || ""} />
-                )}
-                {cat.key === "appearance" && <ThemeToggle />}
-                {cat.key === "social-graph" && did ? (
-                  <SyncSocialGraphSection did={did} ownDid={did} />
-                ) : null}
-                {cat.key === "app-passwords" && <AppPasswordsSection />}
-                {cat.key === "group" && did ? (
-                  <ImportAsGroupSection did={did} />
-                ) : null}
-              </div>
-            </section>
-          ))}
+          {/* Advanced disclosure in the main pane too — the sidebar nav is
+              hidden on mobile, so this is the only reveal control there. */}
+          <button
+            type="button"
+            className="sx-advanced-divider"
+            aria-expanded={advancedOpen}
+            onClick={() => setAdvancedOpen((open) => !open)}
+          >
+            <SlidersHorizontal size={16} strokeWidth={1.75} aria-hidden />
+            <span className="sx-advanced-divider__label">Advanced</span>
+            <ChevronDown
+              size={16}
+              aria-hidden
+              className={`sx-advanced-divider__chevron${advancedOpen ? " sx-advanced-divider__chevron--open" : ""}`}
+            />
+          </button>
+
+          {advancedOpen ? ADVANCED_CATEGORIES.map(renderSection) : null}
         </div>
       </div>
     </div>

--- a/src/components/settings/settings-panel.tsx
+++ b/src/components/settings/settings-panel.tsx
@@ -92,8 +92,8 @@ const CATEGORIES: CategoryDef[] = [
   },
   {
     key: "group",
-    label: "Turn into a group",
-    description: "Promote this account into a Certified group.",
+    label: "Promote this account to a group account",
+    description: "",
     Icon: Users,
     advanced: true,
   },
@@ -285,7 +285,9 @@ export default function SettingsPanel() {
                 >
                   {cat.label}
                 </h2>
-                <p className="sx-panel__desc">{cat.description}</p>
+                {cat.description ? (
+                  <p className="sx-panel__desc">{cat.description}</p>
+                ) : null}
               </header>
 
               <div className="sx-panel__body">


### PR DESCRIPTION
Renames the advanced settings section to **"Promote this account to a group account"** and removes its description (the description `<p>` is skipped when empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)