### PR TITLE
feat(activity): full-width Contributors tab

### DIFF
--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -81,15 +81,17 @@
 
   /* Full-bleed tabs: drop the supplementary aside so the content spans the
      full width of both panes. The Contributor Board tab adds the
-     contributors list beneath the board; Description / Funding / Updates
-     just want the room. (Overview + Contributors keep the aside.) */
+     contributors list beneath the board; Contributors / Description /
+     Funding / Updates just want the room. (Overview keeps the aside.) */
   .cert-detail--wide.cert-detail--tab-contributor-board.page-layout,
+  .cert-detail--wide.cert-detail--tab-contributors.page-layout,
   .cert-detail--wide.cert-detail--tab-description.page-layout,
   .cert-detail--wide.cert-detail--tab-funding.page-layout,
   .cert-detail--wide.cert-detail--tab-updates.page-layout {
     grid-template-columns: minmax(0, 1fr);
   }
   .cert-detail--wide.cert-detail--tab-contributor-board.page-layout > .cert-detail__aside,
+  .cert-detail--wide.cert-detail--tab-contributors.page-layout > .cert-detail__aside,
   .cert-detail--wide.cert-detail--tab-description.page-layout > .cert-detail__aside,
   .cert-detail--wide.cert-detail--tab-funding.page-layout > .cert-detail__aside,
   .cert-detail--wide.cert-detail--tab-updates.page-layout > .cert-detail__aside {


### PR DESCRIPTION
Removes the small side pane (the `cert-detail__aside`) from the **Contributors** tab on an activity claim, so the contributor list spans the full width of both panes — matching the Contributor Board / Description / Funding / Updates tabs. Only the Overview tab keeps the aside.

One-line CSS change: add `cert-detail--tab-contributors` to the existing full-bleed rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)