### PR TITLE
feat(activity): redesign the Contributors tab + slim tab headlines

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,7 @@
 @import "./styles/pages.css";
 @import "./styles/cert-detail.css";
 @import "./styles/contributor-board.css";
+@import "./styles/fancy-contributor-board.css";
 @import "./styles/profile-endorsements.css";
 @import "./styles/profile-lists.css";
 @import "./styles/profile-edit.css";

--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -84,12 +84,14 @@
      contributors list beneath the board; Description / Funding / Updates
      just want the room. (Overview + Contributors keep the aside.) */
   .cert-detail--wide.cert-detail--tab-contributor-board.page-layout,
+  .cert-detail--wide.cert-detail--tab-contributor-board-fancy.page-layout,
   .cert-detail--wide.cert-detail--tab-description.page-layout,
   .cert-detail--wide.cert-detail--tab-funding.page-layout,
   .cert-detail--wide.cert-detail--tab-updates.page-layout {
     grid-template-columns: minmax(0, 1fr);
   }
   .cert-detail--wide.cert-detail--tab-contributor-board.page-layout > .cert-detail__aside,
+  .cert-detail--wide.cert-detail--tab-contributor-board-fancy.page-layout > .cert-detail__aside,
   .cert-detail--wide.cert-detail--tab-description.page-layout > .cert-detail__aside,
   .cert-detail--wide.cert-detail--tab-funding.page-layout > .cert-detail__aside,
   .cert-detail--wide.cert-detail--tab-updates.page-layout > .cert-detail__aside {

--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -80,18 +80,18 @@
   }
 
   /* Full-bleed tabs: drop the supplementary aside so the content spans the
-     full width of both panes. The Contributor Board tab adds the
-     contributors list beneath the board; Description / Funding / Updates
-     just want the room. (Overview + Contributors keep the aside.) */
+     full width of both panes. The Contributor Board + Contributors tabs add
+     the deluxe board above the list; Description / Funding / Updates just
+     want the room. (Only Overview keeps the aside.) */
   .cert-detail--wide.cert-detail--tab-contributor-board.page-layout,
-  .cert-detail--wide.cert-detail--tab-contributor-board-fancy.page-layout,
+  .cert-detail--wide.cert-detail--tab-contributors.page-layout,
   .cert-detail--wide.cert-detail--tab-description.page-layout,
   .cert-detail--wide.cert-detail--tab-funding.page-layout,
   .cert-detail--wide.cert-detail--tab-updates.page-layout {
     grid-template-columns: minmax(0, 1fr);
   }
   .cert-detail--wide.cert-detail--tab-contributor-board.page-layout > .cert-detail__aside,
-  .cert-detail--wide.cert-detail--tab-contributor-board-fancy.page-layout > .cert-detail__aside,
+  .cert-detail--wide.cert-detail--tab-contributors.page-layout > .cert-detail__aside,
   .cert-detail--wide.cert-detail--tab-description.page-layout > .cert-detail__aside,
   .cert-detail--wide.cert-detail--tab-funding.page-layout > .cert-detail__aside,
   .cert-detail--wide.cert-detail--tab-updates.page-layout > .cert-detail__aside {
@@ -936,6 +936,26 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* ---- Contributors-tab headline -----------------------------------------
+   A slim variant: the title row carries the author (right-aligned) and a
+   trailing three-dot actions menu. No date / project byline. (Hidden on
+   mobile by the reorder block above, like the other tab headlines.) */
+.cert-detail__headline--contributors .cert-detail__title-row {
+  flex-wrap: nowrap;
+}
+
+/* Push the author + menu to the right; the title (flex:1) takes the slack. */
+.cert-contrib-headline__author {
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+/* Avatar now trails the name, so the two-line meta reads right-aligned. */
+.cert-contrib-headline__author .cert-detail__headline-author-meta {
+  align-items: flex-end;
+  text-align: right;
 }
 
 /* Skeletons */

--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -946,16 +946,29 @@
   flex-wrap: nowrap;
 }
 
-/* Push the author + menu to the right; the title (flex:1) takes the slack. */
-.cert-contrib-headline__author {
-  flex-shrink: 0;
+/* Author + actions hug the right edge (the title, flex:1, takes the slack).
+   `stretch` makes the menu button match the author block's height. */
+.cert-contrib-headline__trailing {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
   margin-left: auto;
+  flex-shrink: 0;
 }
 
-/* Avatar now trails the name, so the two-line meta reads right-aligned. */
-.cert-contrib-headline__author .cert-detail__headline-author-meta {
-  align-items: flex-end;
-  text-align: right;
+/* The author's own content stays left-aligned (avatar then name/handle). */
+.cert-contrib-headline__author {
+  flex-shrink: 0;
+}
+
+/* Drop the icon button's fixed 40px square so it stretches to the author's
+   height inside the trailing row; aspect-ratio keeps it square. The
+   two-class selector outranks the Tailwind h-/w- utilities. */
+.cert-detail__headline--contributors .cert-contrib-headline__menu {
+  height: auto;
+  width: auto;
+  min-height: 0;
+  aspect-ratio: 1 / 1;
 }
 
 /* Skeletons */

--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -936,17 +936,18 @@
   text-overflow: ellipsis;
 }
 
-/* ---- Contributors-tab headline -----------------------------------------
-   A slim variant: the title row carries the author (right-aligned) and a
-   trailing three-dot actions menu. No date / project byline. (Hidden on
-   mobile by the reorder block above, like the other tab headlines.) */
-.cert-detail__headline--contributors .cert-detail__title-row {
+/* ---- Slim tab headline --------------------------------------------------
+   Used by every tab except Overview (Description / Contributors / Funding /
+   Updates): the title row carries the author (right-aligned) and a trailing
+   three-dot actions menu. No date / project byline. (Mostly hidden on mobile
+   by the reorder block above, like the other tab headlines.) */
+.cert-detail__headline--slim .cert-detail__title-row {
   flex-wrap: nowrap;
 }
 
 /* Author + actions hug the right edge (the title, flex:1, takes the slack).
    `stretch` makes the menu button match the author block's height. */
-.cert-contrib-headline__trailing {
+.cert-slim-headline__trailing {
   display: flex;
   align-items: stretch;
   gap: 6px;
@@ -955,14 +956,14 @@
 }
 
 /* The author's own content stays left-aligned (avatar then name/handle). */
-.cert-contrib-headline__author {
+.cert-slim-headline__author {
   flex-shrink: 0;
 }
 
 /* Drop the icon button's fixed 40px square so it stretches to the author's
    height inside the trailing row; aspect-ratio keeps it square. The
    two-class selector outranks the Tailwind h-/w- utilities. */
-.cert-detail__headline--contributors .cert-contrib-headline__menu {
+.cert-detail__headline--slim .cert-slim-headline__menu {
   height: auto;
   width: auto;
   min-height: 0;

--- a/src/app/styles/cert-detail.css
+++ b/src/app/styles/cert-detail.css
@@ -80,17 +80,15 @@
   }
 
   /* Full-bleed tabs: drop the supplementary aside so the content spans the
-     full width of both panes. The Contributor Board + Contributors tabs add
-     the deluxe board above the list; Description / Funding / Updates just
-     want the room. (Only Overview keeps the aside.) */
-  .cert-detail--wide.cert-detail--tab-contributor-board.page-layout,
+     full width of both panes. The Contributors tab carries the deluxe board
+     above the list; Description / Funding / Updates just want the room.
+     (Only Overview keeps the aside.) */
   .cert-detail--wide.cert-detail--tab-contributors.page-layout,
   .cert-detail--wide.cert-detail--tab-description.page-layout,
   .cert-detail--wide.cert-detail--tab-funding.page-layout,
   .cert-detail--wide.cert-detail--tab-updates.page-layout {
     grid-template-columns: minmax(0, 1fr);
   }
-  .cert-detail--wide.cert-detail--tab-contributor-board.page-layout > .cert-detail__aside,
   .cert-detail--wide.cert-detail--tab-contributors.page-layout > .cert-detail__aside,
   .cert-detail--wide.cert-detail--tab-description.page-layout > .cert-detail__aside,
   .cert-detail--wide.cert-detail--tab-funding.page-layout > .cert-detail__aside,

--- a/src/app/styles/fancy-contributor-board.css
+++ b/src/app/styles/fancy-contributor-board.css
@@ -125,8 +125,8 @@
   cursor: pointer;
 }
 
-/* Hover lights the tile up in gold — border, glow, and avatar ring all
-   pick up the accent. */
+/* Hover lights the tile up: the gold accent is carried by the BORDER only;
+   the interior glow + lift stay neutral. */
 .fancy-tile:hover {
   border-color: var(--accent-gold);
   box-shadow: var(--shadow-lg);
@@ -161,13 +161,14 @@
   transform: translateX(60%);
 }
 
-/* Radial gold glow that blooms from the tile centre on hover. */
+/* Radial glow that blooms from the tile centre on hover — neutral, so the
+   gold accent stays on the border only. */
 .fancy-tile__glow {
   position: absolute;
   inset: 0;
   background: radial-gradient(
     circle at 50% 38%,
-    var(--accent-gold-soft) 0%,
+    var(--color-surface-container-high) 0%,
     transparent 65%
   );
   opacity: 0;
@@ -217,7 +218,7 @@
 .fancy-tile:hover .fancy-tile__media {
   box-shadow:
     var(--shadow-md),
-    inset 0 0 0 1px var(--accent-gold);
+    inset 0 0 0 1px var(--border-hover);
 }
 
 .fancy-tile__img {

--- a/src/app/styles/fancy-contributor-board.css
+++ b/src/app/styles/fancy-contributor-board.css
@@ -1,10 +1,10 @@
-/* Fancy Contributor Board — the deluxe "Board ✦" tab. Same weighted treemap
- * geometry as the standard board (positions/sizes set inline by the layout),
- * skinned with an ambient gradient stage, glassy gradient tiles with depth +
- * glow, rank medals for the top three, and a staggered entrance.
+/* Fancy Contributor Board — the deluxe board shown on the Contributors tab.
+ * Same weighted treemap geometry as the standard board (positions/sizes set
+ * inline by the layout), skinned with an ambient gradient stage, glassy
+ * gradient tiles with depth, a gold hover highlight, and a staggered entrance.
  *
  * All colours/radii/shadows come from tokens. The only colour in the system
- * is the rank-medal set (--medal-*), used exclusively here. No z-index
+ * is the gold accent (--accent-gold*), used here on hover. No z-index
  * literals: layering relies on DOM order + positioning (design rule #5). */
 
 .fancy-board {
@@ -125,8 +125,10 @@
   cursor: pointer;
 }
 
+/* Hover lights the tile up in gold — border, glow, and avatar ring all
+   pick up the accent. */
 .fancy-tile:hover {
-  border-color: var(--border-hover);
+  border-color: var(--accent-gold);
   box-shadow: var(--shadow-lg);
   transform: translate3d(0, -3px, 0) scale(1.025);
 }
@@ -159,13 +161,13 @@
   transform: translateX(60%);
 }
 
-/* Radial glow that blooms from the tile centre on hover. */
+/* Radial gold glow that blooms from the tile centre on hover. */
 .fancy-tile__glow {
   position: absolute;
   inset: 0;
   background: radial-gradient(
     circle at 50% 38%,
-    var(--color-surface-container-high) 0%,
+    var(--accent-gold-soft) 0%,
     transparent 65%
   );
   opacity: 0;
@@ -174,7 +176,7 @@
 }
 
 .fancy-tile:hover .fancy-tile__glow {
-  opacity: 0.9;
+  opacity: 0.85;
 }
 
 /* Content wrapper is positioned, so it paints above the sheen/glow layers
@@ -215,7 +217,7 @@
 .fancy-tile:hover .fancy-tile__media {
   box-shadow:
     var(--shadow-md),
-    inset 0 0 0 1px var(--border-hover);
+    inset 0 0 0 1px var(--accent-gold);
 }
 
 .fancy-tile__img {
@@ -270,53 +272,6 @@
 .fancy-tile:hover .fancy-tile__weight {
   opacity: 1;
   transform: translateY(0);
-}
-
-/* ---- Rank medals (top three) ------------------------------------------- */
-
-.fancy-tile__medal {
-  position: absolute;
-  top: 6px;
-  left: 6px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 20px;
-  height: 20px;
-  padding: 0 5px;
-  border-radius: 999px;
-  font-size: 0.72rem;
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-  color: var(--medal-fg);
-  box-shadow: var(--shadow-sm);
-}
-
-.fancy-tile__medal--1 {
-  background: linear-gradient(140deg, var(--medal-gold) 0%, var(--medal-gold-soft) 100%);
-}
-
-.fancy-tile__medal--2 {
-  background: linear-gradient(140deg, var(--medal-silver) 0%, var(--medal-silver-soft) 100%);
-}
-
-.fancy-tile__medal--3 {
-  background: linear-gradient(140deg, var(--medal-bronze) 0%, var(--medal-bronze-soft) 100%);
-}
-
-/* The top-ranked tile gets a richer border + a steady ambient lift so it
-   reads as the centrepiece even before hover. */
-.fancy-tile--rank-1 {
-  border-color: var(--medal-gold);
-  box-shadow:
-    var(--shadow-md),
-    inset 0 0 0 1px var(--medal-gold-soft);
-}
-
-.fancy-tile--rank-1 .fancy-tile__media {
-  box-shadow:
-    var(--shadow-md),
-    inset 0 0 0 1px var(--medal-gold);
 }
 
 /* Respect reduced-motion: no drift, no sheen glide, instant tile reveal. */

--- a/src/app/styles/fancy-contributor-board.css
+++ b/src/app/styles/fancy-contributor-board.css
@@ -1,0 +1,334 @@
+/* Fancy Contributor Board — the deluxe "Board ✦" tab. Same weighted treemap
+ * geometry as the standard board (positions/sizes set inline by the layout),
+ * skinned with an ambient gradient stage, glassy gradient tiles with depth +
+ * glow, rank medals for the top three, and a staggered entrance.
+ *
+ * All colours/radii/shadows come from tokens. The only colour in the system
+ * is the rank-medal set (--medal-*), used exclusively here. No z-index
+ * literals: layering relies on DOM order + positioning (design rule #5). */
+
+.fancy-board {
+  position: relative;
+  width: 100%;
+}
+
+.fancy-board__stage {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  /* Layered gradient base: a soft diagonal between the raised + sunken
+     surfaces reads as depth under the translucent tiles. */
+  background:
+    linear-gradient(135deg, var(--bg-raised) 0%, var(--bg-sunken) 100%);
+  box-shadow: var(--shadow-lg);
+}
+
+/* Drifting ambient light — two large radial blooms that slowly orbit behind
+   the tiles, giving the stage a living, premium feel. Painted first (behind). */
+.fancy-board__ambient {
+  position: absolute;
+  inset: -20%;
+  background:
+    radial-gradient(40% 40% at 20% 25%, var(--color-surface-container-high) 0%, transparent 70%),
+    radial-gradient(45% 45% at 80% 75%, var(--color-surface-container-high) 0%, transparent 70%);
+  opacity: 0.6;
+  filter: blur(8px);
+  animation: fancy-board-drift 22s ease-in-out infinite alternate;
+  pointer-events: none;
+}
+
+/* Faint engraved grid for texture. */
+.fancy-board__grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--border-subtle) 1px, transparent 1px),
+    linear-gradient(90deg, var(--border-subtle) 1px, transparent 1px);
+  background-size: 44px 44px;
+  -webkit-mask-image: radial-gradient(120% 120% at 50% 0%, black 35%, transparent 80%);
+  mask-image: radial-gradient(120% 120% at 50% 0%, black 35%, transparent 80%);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.fancy-board__canvas {
+  position: absolute;
+  inset: 0;
+}
+
+.fancy-board__empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  text-align: center;
+  color: var(--fg-muted);
+  font-size: 0.875rem;
+}
+
+@keyframes fancy-board-drift {
+  0% {
+    transform: translate3d(-4%, -2%, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(4%, 3%, 0) scale(1.12);
+  }
+}
+
+/* ---- Tile --------------------------------------------------------------- */
+
+.fancy-tile {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  overflow: hidden;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  /* Glassy gradient surface — top-lit, so tiles read as raised glass. */
+  background:
+    linear-gradient(
+      160deg,
+      var(--color-surface-container-low) 0%,
+      var(--color-surface-container-high) 100%
+    );
+  color: var(--fg-primary);
+  text-decoration: none;
+  box-shadow: var(--shadow-sm);
+  transform: translateZ(0);
+  transition:
+    transform var(--transition-base),
+    box-shadow var(--transition-base),
+    border-color var(--transition-base);
+  /* Staggered entrance (delay set inline per tile). */
+  opacity: 0;
+  animation: fancy-tile-in 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes fancy-tile-in {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 10px, 0) scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+.fancy-tile--link {
+  cursor: pointer;
+}
+
+.fancy-tile:hover {
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-lg);
+  transform: translate3d(0, -3px, 0) scale(1.025);
+}
+
+.fancy-tile:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+/* Diagonal sheen sweep — a soft highlight that glides across on hover. */
+.fancy-tile__sheen {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    115deg,
+    transparent 30%,
+    var(--color-surface-container-high) 48%,
+    transparent 66%
+  );
+  opacity: 0;
+  transform: translateX(-60%);
+  transition:
+    opacity var(--transition-base),
+    transform 0.7s ease;
+  pointer-events: none;
+}
+
+.fancy-tile:hover .fancy-tile__sheen {
+  opacity: 0.7;
+  transform: translateX(60%);
+}
+
+/* Radial glow that blooms from the tile centre on hover. */
+.fancy-tile__glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at 50% 38%,
+    var(--color-surface-container-high) 0%,
+    transparent 65%
+  );
+  opacity: 0;
+  transition: opacity var(--transition-base);
+  pointer-events: none;
+}
+
+.fancy-tile:hover .fancy-tile__glow {
+  opacity: 0.9;
+}
+
+/* Content wrapper is positioned, so it paints above the sheen/glow layers
+   (which come earlier in the DOM) without needing a z-index. */
+.fancy-tile__content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  width: 100%;
+  height: 100%;
+}
+
+.fancy-tile__media {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+  background: var(--bg-sunken);
+  box-shadow:
+    var(--shadow-sm),
+    inset 0 0 0 1px var(--border-subtle);
+  transition: box-shadow var(--transition-base);
+}
+
+.fancy-tile__media--circle {
+  border-radius: 50%;
+}
+
+.fancy-tile__media--square {
+  border-radius: var(--radius);
+}
+
+.fancy-tile:hover .fancy-tile__media {
+  box-shadow:
+    var(--shadow-md),
+    inset 0 0 0 1px var(--border-hover);
+}
+
+.fancy-tile__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.fancy-tile__initials {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-weight: 600;
+  font-size: 0.9em;
+  color: var(--fg-muted);
+  letter-spacing: 0.02em;
+}
+
+.fancy-tile__name {
+  max-width: 96%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 550;
+  line-height: 1.2;
+  text-align: center;
+  color: var(--fg-primary);
+}
+
+/* Weight badge — sits at the bottom, fades up into view on hover. */
+.fancy-tile__weight {
+  position: absolute;
+  bottom: 0;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-subtle);
+  font-size: 0.7rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-muted);
+  opacity: 0;
+  transform: translateY(6px);
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base);
+  pointer-events: none;
+}
+
+.fancy-tile:hover .fancy-tile__weight {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ---- Rank medals (top three) ------------------------------------------- */
+
+.fancy-tile__medal {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 5px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--medal-fg);
+  box-shadow: var(--shadow-sm);
+}
+
+.fancy-tile__medal--1 {
+  background: linear-gradient(140deg, var(--medal-gold) 0%, var(--medal-gold-soft) 100%);
+}
+
+.fancy-tile__medal--2 {
+  background: linear-gradient(140deg, var(--medal-silver) 0%, var(--medal-silver-soft) 100%);
+}
+
+.fancy-tile__medal--3 {
+  background: linear-gradient(140deg, var(--medal-bronze) 0%, var(--medal-bronze-soft) 100%);
+}
+
+/* The top-ranked tile gets a richer border + a steady ambient lift so it
+   reads as the centrepiece even before hover. */
+.fancy-tile--rank-1 {
+  border-color: var(--medal-gold);
+  box-shadow:
+    var(--shadow-md),
+    inset 0 0 0 1px var(--medal-gold-soft);
+}
+
+.fancy-tile--rank-1 .fancy-tile__media {
+  box-shadow:
+    var(--shadow-md),
+    inset 0 0 0 1px var(--medal-gold);
+}
+
+/* Respect reduced-motion: no drift, no sheen glide, instant tile reveal. */
+@media (prefers-reduced-motion: reduce) {
+  .fancy-board__ambient {
+    animation: none;
+  }
+  .fancy-tile {
+    animation: none;
+    opacity: 1;
+  }
+  .fancy-tile__sheen {
+    transition: opacity var(--transition-base);
+  }
+}

--- a/src/app/styles/tokens.css
+++ b/src/app/styles/tokens.css
@@ -148,16 +148,11 @@
   --badge-accent-fg: #454747;
   --badge-accent-border: #dcdcdc;
 
-  /* Rank medals — the one splash of colour in the otherwise grayscale
-     system, used only by the deluxe "Board ✦" contributor view for the
-     top-three ranks. Light + dark variants below. */
-  --medal-gold: #d4a32b;
-  --medal-gold-soft: #f6e6b8;
-  --medal-silver: #9aa1a9;
-  --medal-silver-soft: #e3e7ec;
-  --medal-bronze: #b07248;
-  --medal-bronze-soft: #efd9c6;
-  --medal-fg: #2a2a2a;
+  /* Gold accent — the one splash of colour in the otherwise grayscale
+     system, used only by the deluxe contributor board to highlight a tile
+     on hover. Light + dark variants below. */
+  --accent-gold: #c9962a;
+  --accent-gold-soft: #f3e2b0;
 
   /* Primary button (inverts in dark mode) */
   --btn-primary-bg: var(--color-primary);
@@ -319,14 +314,9 @@
   --badge-accent-fg: #c7c7cc;
   --badge-accent-border: rgba(255, 255, 255, 0.14);
 
-  /* Rank medals — dark variants (richer so they glow on the dark stage). */
-  --medal-gold: #e8b73e;
-  --medal-gold-soft: #6b551d;
-  --medal-silver: #b9c0c9;
-  --medal-silver-soft: #4a5159;
-  --medal-bronze: #cd8a5a;
-  --medal-bronze-soft: #5e4030;
-  --medal-fg: #14140f;
+  /* Gold accent — dark variant (richer so it glows on the dark stage). */
+  --accent-gold: #e8b73e;
+  --accent-gold-soft: #6b551d;
 
   /* Primary button inverts so it pops off the dark canvas */
   --btn-primary-bg: #f5f5f7;

--- a/src/app/styles/tokens.css
+++ b/src/app/styles/tokens.css
@@ -148,6 +148,17 @@
   --badge-accent-fg: #454747;
   --badge-accent-border: #dcdcdc;
 
+  /* Rank medals — the one splash of colour in the otherwise grayscale
+     system, used only by the deluxe "Board ✦" contributor view for the
+     top-three ranks. Light + dark variants below. */
+  --medal-gold: #d4a32b;
+  --medal-gold-soft: #f6e6b8;
+  --medal-silver: #9aa1a9;
+  --medal-silver-soft: #e3e7ec;
+  --medal-bronze: #b07248;
+  --medal-bronze-soft: #efd9c6;
+  --medal-fg: #2a2a2a;
+
   /* Primary button (inverts in dark mode) */
   --btn-primary-bg: var(--color-primary);
   --btn-primary-fg: var(--color-white);
@@ -307,6 +318,15 @@
   --badge-accent-bg: rgba(255, 255, 255, 0.08);
   --badge-accent-fg: #c7c7cc;
   --badge-accent-border: rgba(255, 255, 255, 0.14);
+
+  /* Rank medals — dark variants (richer so they glow on the dark stage). */
+  --medal-gold: #e8b73e;
+  --medal-gold-soft: #6b551d;
+  --medal-silver: #b9c0c9;
+  --medal-silver-soft: #4a5159;
+  --medal-bronze: #cd8a5a;
+  --medal-bronze-soft: #5e4030;
+  --medal-fg: #14140f;
 
   /* Primary button inverts so it pops off the dark canvas */
   --btn-primary-bg: #f5f5f7;

--- a/src/components/contributor-board/activity-fancy-board.tsx
+++ b/src/components/contributor-board/activity-fancy-board.tsx
@@ -14,11 +14,11 @@ interface ActivityFancyBoardProps {
 }
 
 /**
- * The "Board ✦" tab: a deluxe, read-only rendering of the same contributor
- * board record that the standard Contributor Board tab edits. It reuses the
- * weighted treemap geometry but skins it with depth, glow, rank medals, and
- * motion. Edits still happen on the plain Contributor Board tab — this is a
- * showcase view, so there's no edit affordance here.
+ * The deluxe contributor board shown at the top of the Contributors tab: a
+ * read-only rendering of the same board record the standard Contributor
+ * Board tab edits. It reuses the weighted treemap geometry but skins it with
+ * depth, a gold hover highlight, and motion. Edits still happen on the plain
+ * Contributor Board tab — this is a showcase view, no edit affordance here.
  */
 export function ActivityFancyBoard({
   did,

--- a/src/components/contributor-board/activity-fancy-board.tsx
+++ b/src/components/contributor-board/activity-fancy-board.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useHyperboard } from "@/hooks/use-hyperboard"
+import LoadingSpinner from "@/components/ui/loading-spinner"
+import { FancyContributorBoard } from "./fancy-contributor-board"
+import type { ActivityContributor } from "@/lib/atproto/activity-types"
+
+interface ActivityFancyBoardProps {
+  /** the activity author / repo DID */
+  did: string
+  /** the activity record key */
+  rkey: string | null
+  contributors: ActivityContributor[]
+}
+
+/**
+ * The "Board ✦" tab: a deluxe, read-only rendering of the same contributor
+ * board record that the standard Contributor Board tab edits. It reuses the
+ * weighted treemap geometry but skins it with depth, glow, rank medals, and
+ * motion. Edits still happen on the plain Contributor Board tab — this is a
+ * showcase view, so there's no edit affordance here.
+ */
+export function ActivityFancyBoard({
+  did,
+  rkey,
+  contributors,
+}: ActivityFancyBoardProps) {
+  const { config, entries, isLoading } = useHyperboard(did, rkey, contributors)
+
+  return (
+    <section className="cert-detail__section">
+      <div className="cert-detail__section-header">
+        <h2 className="cert-detail__section-title">Contributor Board</h2>
+        <span className="cert-detail__section-count">{entries.length}</span>
+      </div>
+
+      {isLoading && entries.length === 0 ? (
+        <div className="cert-detail__funding-loading">
+          <LoadingSpinner size="sm" />
+        </div>
+      ) : (
+        <FancyContributorBoard
+          entries={entries}
+          config={config}
+          boardDid={did}
+        />
+      )}
+    </section>
+  )
+}
+
+export default ActivityFancyBoard

--- a/src/components/contributor-board/fancy-contributor-board.tsx
+++ b/src/components/contributor-board/fancy-contributor-board.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useRef, useState } from "react"
 import Image from "next/image"
-import { Crown } from "lucide-react"
 import { getInitials } from "@/lib/utils/initials"
 import { layoutTreemap, tileSizing, type TreemapTile } from "@/lib/contributor-board/treemap"
 import type { BoardConfig, BoardEntry } from "@/lib/atproto/hyperboard-types"
@@ -45,14 +44,13 @@ function useElementSize() {
 
 interface FancyTileProps {
   tile: TreemapTile
-  rank: number
   /** share of total weight, 0–100 */
   percent: number
   /** staggered entrance delay (ms) */
   delay: number
 }
 
-function FancyTile({ tile, rank, percent, delay }: FancyTileProps) {
+function FancyTile({ tile, percent, delay }: FancyTileProps) {
   const { x, y, width, height, entry } = tile
   const { avatarSize, fontSize, showAvatar, showLabel } = tileSizing(width, height)
   const [imgError, setImgError] = useState(false)
@@ -60,8 +58,6 @@ function FancyTile({ tile, rank, percent, delay }: FancyTileProps) {
   const shapeClass = entry.circular
     ? "fancy-tile__media--circle"
     : "fancy-tile__media--square"
-  const rankClass =
-    rank <= 3 ? ` fancy-tile--rank fancy-tile--rank-${rank}` : ""
 
   const content = (
     <>
@@ -104,17 +100,6 @@ function FancyTile({ tile, rank, percent, delay }: FancyTileProps) {
           <span className="fancy-tile__weight">{Math.round(percent)}%</span>
         ) : null}
       </span>
-
-      {/* Medal sits last so it paints on top of everything. */}
-      {rank <= 3 ? (
-        <span className={`fancy-tile__medal fancy-tile__medal--${rank}`}>
-          {rank === 1 ? (
-            <Crown size={Math.max(10, Math.min(16, avatarSize * 0.26))} />
-          ) : (
-            rank
-          )}
-        </span>
-      ) : null}
     </>
   )
 
@@ -130,19 +115,19 @@ function FancyTile({ tile, rank, percent, delay }: FancyTileProps) {
   if (linkUrl) {
     return (
       <a
-        className={`fancy-tile fancy-tile--link${rankClass}`}
+        className="fancy-tile fancy-tile--link"
         style={style}
         href={linkUrl}
         target="_blank"
         rel="noopener noreferrer"
-        aria-label={`${entry.name} — rank ${rank}`}
+        aria-label={entry.name}
       >
         {content}
       </a>
     )
   }
   return (
-    <div className={`fancy-tile${rankClass}`} style={style}>
+    <div className="fancy-tile" style={style}>
       {content}
     </div>
   )
@@ -151,9 +136,9 @@ function FancyTile({ tile, rank, percent, delay }: FancyTileProps) {
 /**
  * A deluxe rendering of the contributor board: same weighted treemap geometry
  * as {@link ContributorBoard}, skinned with an ambient gradient stage, glassy
- * gradient tiles with depth + glow, a crown / rank medals for the top three
- * contributors, weight badges, and a staggered entrance. Read-only showcase —
- * editing lives on the standard Contributor Board tab.
+ * gradient tiles with depth, a gold hover highlight, weight badges, and a
+ * staggered entrance. Read-only showcase — editing lives on the standard
+ * Contributor Board tab.
  */
 export function FancyContributorBoard({
   entries,
@@ -167,20 +152,14 @@ export function FancyContributorBoard({
     [entries, width, height],
   )
 
-  // Rank + weight share are derived from the entry weights (the treemap is
-  // already weight-sorted, but rank by value is independent of layout order).
-  const { rankByKey, percentByKey } = useMemo(() => {
+  // Each tile's share of the total contribution weight, for the hover badge.
+  const percentByKey = useMemo(() => {
     const total = entries.reduce((sum, e) => sum + Math.max(0, e.value), 0)
-    const sorted = [...entries]
-      .filter((e) => e.value > 0)
-      .sort((a, b) => b.value - a.value)
-    const rankByKey = new Map<string, number>()
-    const percentByKey = new Map<string, number>()
-    sorted.forEach((e, i) => {
-      rankByKey.set(e.key, i + 1)
-      percentByKey.set(e.key, total > 0 ? (e.value / total) * 100 : 0)
-    })
-    return { rankByKey, percentByKey }
+    const map = new Map<string, number>()
+    for (const e of entries) {
+      map.set(e.key, total > 0 ? (Math.max(0, e.value) / total) * 100 : 0)
+    }
+    return map
   }, [entries])
 
   const aspectRatio = ASPECT[config.aspectRatio ?? "16:9"] ?? "16 / 9"
@@ -197,7 +176,6 @@ export function FancyContributorBoard({
             <FancyTile
               key={tile.entry.key}
               tile={tile}
-              rank={rankByKey.get(tile.entry.key) ?? entries.length}
               percent={percentByKey.get(tile.entry.key) ?? 0}
               delay={Math.min(i * 45, 600)}
             />

--- a/src/components/contributor-board/fancy-contributor-board.tsx
+++ b/src/components/contributor-board/fancy-contributor-board.tsx
@@ -1,0 +1,215 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import Image from "next/image"
+import { Crown } from "lucide-react"
+import { getInitials } from "@/lib/utils/initials"
+import { layoutTreemap, tileSizing, type TreemapTile } from "@/lib/contributor-board/treemap"
+import type { BoardConfig, BoardEntry } from "@/lib/atproto/hyperboard-types"
+
+interface FancyContributorBoardProps {
+  entries: BoardEntry[]
+  config: BoardConfig
+  /** repo that owns the board (reserved for future blob backgrounds) */
+  boardDid: string | null
+  emptyMessage?: string
+}
+
+const ASPECT: Record<string, string> = {
+  "16:9": "16 / 9",
+  "4:3": "4 / 3",
+  "1:1": "1 / 1",
+}
+
+/** Only http(s) links are followed — a board owner could type a javascript: URL. */
+function safeHttpUrl(url: string | null): string | null {
+  return url && /^https?:\/\//i.test(url) ? url : null
+}
+
+/** Track an element's content-box size with a ResizeObserver. */
+function useElementSize() {
+  const ref = useRef<HTMLDivElement>(null)
+  const [size, setSize] = useState({ width: 0, height: 0 })
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const ro = new ResizeObserver((entries) => {
+      const box = entries[0]?.contentRect
+      if (box) setSize({ width: box.width, height: box.height })
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+  return { ref, ...size }
+}
+
+interface FancyTileProps {
+  tile: TreemapTile
+  rank: number
+  /** share of total weight, 0–100 */
+  percent: number
+  /** staggered entrance delay (ms) */
+  delay: number
+}
+
+function FancyTile({ tile, rank, percent, delay }: FancyTileProps) {
+  const { x, y, width, height, entry } = tile
+  const { avatarSize, fontSize, showAvatar, showLabel } = tileSizing(width, height)
+  const [imgError, setImgError] = useState(false)
+
+  const shapeClass = entry.circular
+    ? "fancy-tile__media--circle"
+    : "fancy-tile__media--square"
+  const rankClass =
+    rank <= 3 ? ` fancy-tile--rank fancy-tile--rank-${rank}` : ""
+
+  const content = (
+    <>
+      {/* Decorative layers paint behind the content span (earlier in DOM,
+          both positioned, so content wins paint order without a z-index). */}
+      <span className="fancy-tile__sheen" aria-hidden="true" />
+      <span className="fancy-tile__glow" aria-hidden="true" />
+
+      <span className="fancy-tile__content">
+        {showAvatar ? (
+          <span
+            className={`fancy-tile__media ${shapeClass}`}
+            style={{ width: avatarSize, height: avatarSize }}
+          >
+            {entry.imageUrl && !imgError ? (
+              <Image
+                src={entry.imageUrl}
+                alt={entry.name}
+                width={avatarSize}
+                height={avatarSize}
+                className="fancy-tile__img"
+                onError={() => setImgError(true)}
+                unoptimized
+              />
+            ) : (
+              <span className="fancy-tile__initials" aria-hidden="true">
+                {getInitials(entry.name, entry.did)}
+              </span>
+            )}
+          </span>
+        ) : null}
+
+        {showLabel ? (
+          <span className="fancy-tile__name" style={{ fontSize }}>
+            {entry.name}
+          </span>
+        ) : null}
+
+        {showLabel && percent >= 1 ? (
+          <span className="fancy-tile__weight">{Math.round(percent)}%</span>
+        ) : null}
+      </span>
+
+      {/* Medal sits last so it paints on top of everything. */}
+      {rank <= 3 ? (
+        <span className={`fancy-tile__medal fancy-tile__medal--${rank}`}>
+          {rank === 1 ? (
+            <Crown size={Math.max(10, Math.min(16, avatarSize * 0.26))} />
+          ) : (
+            rank
+          )}
+        </span>
+      ) : null}
+    </>
+  )
+
+  const style = {
+    left: x,
+    top: y,
+    width,
+    height,
+    animationDelay: `${delay}ms`,
+  } as const
+
+  const linkUrl = safeHttpUrl(entry.url)
+  if (linkUrl) {
+    return (
+      <a
+        className={`fancy-tile fancy-tile--link${rankClass}`}
+        style={style}
+        href={linkUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`${entry.name} — rank ${rank}`}
+      >
+        {content}
+      </a>
+    )
+  }
+  return (
+    <div className={`fancy-tile${rankClass}`} style={style}>
+      {content}
+    </div>
+  )
+}
+
+/**
+ * A deluxe rendering of the contributor board: same weighted treemap geometry
+ * as {@link ContributorBoard}, skinned with an ambient gradient stage, glassy
+ * gradient tiles with depth + glow, a crown / rank medals for the top three
+ * contributors, weight badges, and a staggered entrance. Read-only showcase —
+ * editing lives on the standard Contributor Board tab.
+ */
+export function FancyContributorBoard({
+  entries,
+  config,
+  emptyMessage = "No contributors on this board yet.",
+}: FancyContributorBoardProps) {
+  const { ref, width, height } = useElementSize()
+
+  const tiles = useMemo(
+    () => layoutTreemap(entries, width, height),
+    [entries, width, height],
+  )
+
+  // Rank + weight share are derived from the entry weights (the treemap is
+  // already weight-sorted, but rank by value is independent of layout order).
+  const { rankByKey, percentByKey } = useMemo(() => {
+    const total = entries.reduce((sum, e) => sum + Math.max(0, e.value), 0)
+    const sorted = [...entries]
+      .filter((e) => e.value > 0)
+      .sort((a, b) => b.value - a.value)
+    const rankByKey = new Map<string, number>()
+    const percentByKey = new Map<string, number>()
+    sorted.forEach((e, i) => {
+      rankByKey.set(e.key, i + 1)
+      percentByKey.set(e.key, total > 0 ? (e.value / total) * 100 : 0)
+    })
+    return { rankByKey, percentByKey }
+  }, [entries])
+
+  const aspectRatio = ASPECT[config.aspectRatio ?? "16:9"] ?? "16 / 9"
+
+  return (
+    <div className="fancy-board">
+      <div ref={ref} className="fancy-board__stage" style={{ aspectRatio }}>
+        {/* Ambient drifting light, behind the tiles. */}
+        <span className="fancy-board__ambient" aria-hidden="true" />
+        <span className="fancy-board__grid" aria-hidden="true" />
+
+        <div className="fancy-board__canvas">
+          {tiles.map((tile, i) => (
+            <FancyTile
+              key={tile.entry.key}
+              tile={tile}
+              rank={rankByKey.get(tile.entry.key) ?? entries.length}
+              percent={percentByKey.get(tile.entry.key) ?? 0}
+              delay={Math.min(i * 45, 600)}
+            />
+          ))}
+        </div>
+
+        {entries.length === 0 ? (
+          <div className="fancy-board__empty">{emptyMessage}</div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export default FancyContributorBoard

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -1033,12 +1033,12 @@ export default function ActivityDetail({
     </header>
   )
 
-  // Contributors-tab headline — a slimmer variant: the activity title with
-  // the author pulled up onto the same row (right-aligned, no "Author"
+  // Slim headline — used by every tab except Overview: the activity title
+  // with the author pulled up onto the same row (right-aligned, no "Author"
   // label) and the edit/delete actions tucked into a three-dot menu. No
   // date-created / project byline (those live on the Overview tab).
-  const contributorsHeadline = (
-    <ContributorsTabHeadline
+  const slimHeadline = (
+    <SlimTabHeadline
       did={did}
       title={effectiveValue.title}
       isCreator={isCreator}
@@ -1406,10 +1406,11 @@ export default function ActivityDetail({
 
       <div className="page-layout__main cert-detail__main">
         {/* Title stays put across tabs (the active tab shows in the top
-            bar's second row); only the per-tab content below slides. The
-            Contributors tab uses a slimmer headline (author on the title
-            row, actions in a three-dot menu). */}
-        {activeTab === "contributors" ? contributorsHeadline : headline}
+            bar's second row); only the per-tab content below slides. Every
+            tab except Overview uses the slim headline (author on the title
+            row, actions in a three-dot menu, no date/project byline);
+            Overview keeps the full headline with the byline columns. */}
+        {activeTab === "overview" ? headline : slimHeadline}
 
         <TabPanelTransition
           className="cert-detail__content"
@@ -1884,12 +1885,13 @@ function ContributorRow({ contributor, role, weight }: ContributorRowProps) {
 }
 
 /**
- * Slim headline for the Contributors tab: the activity title with the
- * author pulled onto the same row (right-aligned, no "Author" label) and
- * the owner actions (Edit / Delete) collapsed into a three-dot menu. No
- * date-created / project byline — that detail lives on the Overview tab.
+ * Slim headline used by every tab except Overview (Description /
+ * Contributors / Funding / Updates): the activity title with the author
+ * pulled onto the same row (right-aligned, no "Author" label) and the owner
+ * actions (Edit / Delete) collapsed into a three-dot menu. No date-created /
+ * project byline — that detail lives on the Overview tab's full headline.
  */
-function ContributorsTabHeadline({
+function SlimTabHeadline({
   did,
   title,
   isCreator,
@@ -1915,7 +1917,7 @@ function ContributorsTabHeadline({
   const profileHref = profileUrl(info?.handle || did)
 
   return (
-    <header className="cert-detail__headline cert-detail__headline--contributors">
+    <header className="cert-detail__headline cert-detail__headline--slim">
       <div className="cert-detail__title-row">
         <h1 className="cert-detail__title">{title}</h1>
 
@@ -1923,11 +1925,11 @@ function ContributorsTabHeadline({
             own content stays left-aligned (avatar then name/handle). The
             trailing row stretches so the menu button matches the author's
             height. */}
-        <div className="cert-contrib-headline__trailing">
+        <div className="cert-slim-headline__trailing">
           {!authorLoading && info ? (
             <Link
               href={profileHref}
-              className="cert-detail__headline-author cert-contrib-headline__author"
+              className="cert-detail__headline-author cert-slim-headline__author"
               aria-label={`View ${displayName}'s profile`}
             >
               <Avatar
@@ -1955,7 +1957,7 @@ function ContributorsTabHeadline({
                 <Button
                   size="icon"
                   variant="ghost"
-                  className="cert-contrib-headline__menu"
+                  className="cert-slim-headline__menu"
                   aria-label="Activity actions"
                 >
                   <MoreVertical size={16} strokeWidth={1.75} aria-hidden />

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -47,6 +47,7 @@ import Avatar from "@/components/ui/avatar"
 import Input from "@/components/ui/input"
 import LoadingSpinner from "@/components/ui/loading-spinner"
 import { ActivityContributorBoard } from "@/components/contributor-board/activity-contributor-board"
+import { ActivityFancyBoard } from "@/components/contributor-board/activity-fancy-board"
 import EditBanner from "@/components/ui/edit-banner"
 import Tooltip from "@/components/ui/tooltip"
 import { TabPanelTransition } from "@/components/ui/tab-panel-transition"
@@ -326,11 +327,13 @@ export default function ActivityDetail({
     | "description"
     | "contributors"
     | "contributor-board"
+    | "contributor-board-fancy"
     | "funding"
     | "updates" =
     tabParam === "description" ||
     tabParam === "contributors" ||
     tabParam === "contributor-board" ||
+    tabParam === "contributor-board-fancy" ||
     tabParam === "funding" ||
     tabParam === "updates"
       ? tabParam
@@ -353,6 +356,8 @@ export default function ActivityDetail({
           : "Contributors"
         : activeTab === "contributor-board"
         ? "Contributor Board"
+        : activeTab === "contributor-board-fancy"
+        ? "Board ✦"
         : activeTab === "funding"
           ? shownFundingCount > 0
             ? `Funding (${shownFundingCount})`
@@ -1532,6 +1537,15 @@ export default function ActivityDetail({
               cid={cid}
               contributors={contributors}
               canEdit={isCreator && sessionDid === did}
+            />
+            {contributorsSection}
+          </>
+        ) : activeTab === "contributor-board-fancy" ? (
+          <>
+            <ActivityFancyBoard
+              did={did}
+              rkey={rkey}
+              contributors={contributors}
             />
             {contributorsSection}
           </>

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -19,6 +19,7 @@ import {
   Calendar,
   FileText,
   MapPin,
+  MoreVertical,
   Pencil,
   Plus,
   RefreshCw,
@@ -65,6 +66,12 @@ import FundingReceiptFormModal from "@/components/funding/funding-receipt-form-m
 import FundingIdentityChoiceDialog from "@/components/funding/funding-identity-choice-dialog"
 import RightsDetailModal from "@/components/feed/rights-detail-modal"
 import Button from "@/components/ui/button"
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverItem,
+} from "@/components/ui/popover"
 import { useFundingConfirmedBy } from "@/hooks/use-funding-confirmed-by"
 import { useAuthorInfo } from "@/hooks/use-author-info"
 import { TransitionLink } from "@/lib/view-transitions"
@@ -327,13 +334,11 @@ export default function ActivityDetail({
     | "description"
     | "contributors"
     | "contributor-board"
-    | "contributor-board-fancy"
     | "funding"
     | "updates" =
     tabParam === "description" ||
     tabParam === "contributors" ||
     tabParam === "contributor-board" ||
-    tabParam === "contributor-board-fancy" ||
     tabParam === "funding" ||
     tabParam === "updates"
       ? tabParam
@@ -356,8 +361,6 @@ export default function ActivityDetail({
           : "Contributors"
         : activeTab === "contributor-board"
         ? "Contributor Board"
-        : activeTab === "contributor-board-fancy"
-        ? "Board ✦"
         : activeTab === "funding"
           ? shownFundingCount > 0
             ? `Funding (${shownFundingCount})`
@@ -1035,6 +1038,27 @@ export default function ActivityDetail({
     </header>
   )
 
+  // Contributors-tab headline — a slimmer variant: the activity title with
+  // the author pulled up onto the same row (right-aligned, no "Author"
+  // label) and the edit/delete actions tucked into a three-dot menu. No
+  // date-created / project byline (those live on the Overview tab).
+  const contributorsHeadline = (
+    <ContributorsTabHeadline
+      did={did}
+      title={effectiveValue.title}
+      isCreator={isCreator}
+      editHref={editHref}
+      editAsGroupLabel={
+        editAsGroup ? editAsGroup.displayName || editAsGroup.handle : null
+      }
+      onEditAsGroup={() => setGroupEditOpen(true)}
+      onDelete={() => {
+        setDeleteError(null)
+        setDeleteOpen(true)
+      }}
+    />
+  )
+
   // Overview-only shortDescription section. Lives BELOW the headline
   // (with `cert-detail__main`'s 24px gap) so its top edge aligns
   // with the first content row on the Description / Contributors
@@ -1387,8 +1411,10 @@ export default function ActivityDetail({
 
       <div className="page-layout__main cert-detail__main">
         {/* Title stays put across tabs (the active tab shows in the top
-            bar's second row); only the per-tab content below slides. */}
-        {headline}
+            bar's second row); only the per-tab content below slides. The
+            Contributors tab uses a slimmer headline (author on the title
+            row, actions in a three-dot menu). */}
+        {activeTab === "contributors" ? contributorsHeadline : headline}
 
         <TabPanelTransition
           className="cert-detail__content"
@@ -1527,7 +1553,16 @@ export default function ActivityDetail({
             )}
           </section>
         ) : activeTab === "contributors" ? (
-          contributorsSection
+          <>
+            {contributorCount > 0 ? (
+              <ActivityFancyBoard
+                did={did}
+                rkey={rkey}
+                contributors={contributors}
+              />
+            ) : null}
+            {contributorsSection}
+          </>
         ) : activeTab === "contributor-board" ? (
           <>
             <ActivityContributorBoard
@@ -1537,15 +1572,6 @@ export default function ActivityDetail({
               cid={cid}
               contributors={contributors}
               canEdit={isCreator && sessionDid === did}
-            />
-            {contributorsSection}
-          </>
-        ) : activeTab === "contributor-board-fancy" ? (
-          <>
-            <ActivityFancyBoard
-              did={did}
-              rkey={rkey}
-              contributors={contributors}
             />
             {contributorsSection}
           </>
@@ -1871,6 +1897,96 @@ function ContributorRow({ contributor, role, weight }: ContributorRowProps) {
         <span className="cert-detail__contributor-weight">{weight}</span>
       ) : null}
     </li>
+  )
+}
+
+/**
+ * Slim headline for the Contributors tab: the activity title with the
+ * author pulled onto the same row (right-aligned, no "Author" label) and
+ * the owner actions (Edit / Delete) collapsed into a three-dot menu. No
+ * date-created / project byline — that detail lives on the Overview tab.
+ */
+function ContributorsTabHeadline({
+  did,
+  title,
+  isCreator,
+  editHref,
+  editAsGroupLabel,
+  onEditAsGroup,
+  onDelete,
+}: {
+  did: string
+  title: string
+  isCreator: boolean
+  editHref: string
+  /** Display label of the group the viewer may edit as, or null. */
+  editAsGroupLabel: string | null
+  onEditAsGroup: () => void
+  onDelete: () => void
+}) {
+  const router = useRouter()
+  const { info, isLoading: authorLoading } = useAuthorInfo(did)
+  const showMenu = isCreator || !!editAsGroupLabel
+
+  const displayName = info?.displayName || info?.handle || "Anonymous"
+  const profileHref = profileUrl(info?.handle || did)
+
+  return (
+    <header className="cert-detail__headline cert-detail__headline--contributors">
+      <div className="cert-detail__title-row">
+        <h1 className="cert-detail__title">{title}</h1>
+
+        {!authorLoading && info ? (
+          <Link
+            href={profileHref}
+            className="cert-detail__headline-author cert-contrib-headline__author"
+            aria-label={`View ${displayName}'s profile`}
+          >
+            <span className="cert-detail__headline-author-meta">
+              <span className="cert-detail__headline-name">{displayName}</span>
+              {info.handle ? (
+                <span className="cert-detail__headline-handle">
+                  @{info.handle}
+                </span>
+              ) : null}
+            </span>
+            <Avatar
+              size="sm"
+              src={info.avatarUrl || undefined}
+              alt=""
+              fallbackInitials={getInitials(info.displayName, did)}
+            />
+          </Link>
+        ) : null}
+
+        {showMenu ? (
+          <Popover>
+            <PopoverTrigger>
+              <Button size="icon" variant="ghost" aria-label="Activity actions">
+                <MoreVertical size={16} strokeWidth={1.75} aria-hidden />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end">
+              {isCreator ? (
+                <PopoverItem onClick={() => router.push(editHref)}>
+                  <Pencil size={14} strokeWidth={1.75} aria-hidden /> Edit
+                </PopoverItem>
+              ) : (
+                <PopoverItem onClick={onEditAsGroup}>
+                  <Pencil size={14} strokeWidth={1.75} aria-hidden /> Edit as{" "}
+                  {editAsGroupLabel}
+                </PopoverItem>
+              )}
+              {isCreator ? (
+                <PopoverItem onClick={onDelete}>
+                  <Trash2 size={14} strokeWidth={1.75} aria-hidden /> Delete
+                </PopoverItem>
+              ) : null}
+            </PopoverContent>
+          </Popover>
+        ) : null}
+      </div>
+    </header>
   )
 }
 

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -47,7 +47,6 @@ import { formatShortDate } from "@/lib/utils/format-date"
 import Avatar from "@/components/ui/avatar"
 import Input from "@/components/ui/input"
 import LoadingSpinner from "@/components/ui/loading-spinner"
-import { ActivityContributorBoard } from "@/components/contributor-board/activity-contributor-board"
 import { ActivityFancyBoard } from "@/components/contributor-board/activity-fancy-board"
 import EditBanner from "@/components/ui/edit-banner"
 import Tooltip from "@/components/ui/tooltip"
@@ -333,12 +332,10 @@ export default function ActivityDetail({
     | "overview"
     | "description"
     | "contributors"
-    | "contributor-board"
     | "funding"
     | "updates" =
     tabParam === "description" ||
     tabParam === "contributors" ||
-    tabParam === "contributor-board" ||
     tabParam === "funding" ||
     tabParam === "updates"
       ? tabParam
@@ -359,8 +356,6 @@ export default function ActivityDetail({
         ? contributorCount > 0
           ? `Contributors (${contributorCount})`
           : "Contributors"
-        : activeTab === "contributor-board"
-        ? "Contributor Board"
         : activeTab === "funding"
           ? shownFundingCount > 0
             ? `Funding (${shownFundingCount})`
@@ -1119,8 +1114,8 @@ export default function ActivityDetail({
       </section>
     ) : null
 
-  // The Contributors list — shown on its own tab AND beneath the board on
-  // the Contributor Board tab.
+  // The Contributors list — shown on the Contributors tab beneath the
+  // deluxe board.
   const contributorsSection = (
     <section className="cert-detail__section">
       <div className="cert-detail__section-header">
@@ -1561,18 +1556,6 @@ export default function ActivityDetail({
                 contributors={contributors}
               />
             ) : null}
-            {contributorsSection}
-          </>
-        ) : activeTab === "contributor-board" ? (
-          <>
-            <ActivityContributorBoard
-              did={did}
-              rkey={rkey}
-              value={value}
-              cid={cid}
-              contributors={contributors}
-              canEdit={isCreator && sessionDid === did}
-            />
             {contributorsSection}
           </>
         ) : activeTab === "funding" ? (

--- a/src/components/feed/activity-detail.tsx
+++ b/src/components/feed/activity-detail.tsx
@@ -1936,55 +1936,68 @@ function ContributorsTabHeadline({
       <div className="cert-detail__title-row">
         <h1 className="cert-detail__title">{title}</h1>
 
-        {!authorLoading && info ? (
-          <Link
-            href={profileHref}
-            className="cert-detail__headline-author cert-contrib-headline__author"
-            aria-label={`View ${displayName}'s profile`}
-          >
-            <span className="cert-detail__headline-author-meta">
-              <span className="cert-detail__headline-name">{displayName}</span>
-              {info.handle ? (
-                <span className="cert-detail__headline-handle">
-                  @{info.handle}
+        {/* Author + actions sit together at the right edge; the author's
+            own content stays left-aligned (avatar then name/handle). The
+            trailing row stretches so the menu button matches the author's
+            height. */}
+        <div className="cert-contrib-headline__trailing">
+          {!authorLoading && info ? (
+            <Link
+              href={profileHref}
+              className="cert-detail__headline-author cert-contrib-headline__author"
+              aria-label={`View ${displayName}'s profile`}
+            >
+              <Avatar
+                size="sm"
+                src={info.avatarUrl || undefined}
+                alt=""
+                fallbackInitials={getInitials(info.displayName, did)}
+              />
+              <span className="cert-detail__headline-author-meta">
+                <span className="cert-detail__headline-name">
+                  {displayName}
                 </span>
-              ) : null}
-            </span>
-            <Avatar
-              size="sm"
-              src={info.avatarUrl || undefined}
-              alt=""
-              fallbackInitials={getInitials(info.displayName, did)}
-            />
-          </Link>
-        ) : null}
+                {info.handle ? (
+                  <span className="cert-detail__headline-handle">
+                    @{info.handle}
+                  </span>
+                ) : null}
+              </span>
+            </Link>
+          ) : null}
 
-        {showMenu ? (
-          <Popover>
-            <PopoverTrigger>
-              <Button size="icon" variant="ghost" aria-label="Activity actions">
-                <MoreVertical size={16} strokeWidth={1.75} aria-hidden />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent align="end">
-              {isCreator ? (
-                <PopoverItem onClick={() => router.push(editHref)}>
-                  <Pencil size={14} strokeWidth={1.75} aria-hidden /> Edit
-                </PopoverItem>
-              ) : (
-                <PopoverItem onClick={onEditAsGroup}>
-                  <Pencil size={14} strokeWidth={1.75} aria-hidden /> Edit as{" "}
-                  {editAsGroupLabel}
-                </PopoverItem>
-              )}
-              {isCreator ? (
-                <PopoverItem onClick={onDelete}>
-                  <Trash2 size={14} strokeWidth={1.75} aria-hidden /> Delete
-                </PopoverItem>
-              ) : null}
-            </PopoverContent>
-          </Popover>
-        ) : null}
+          {showMenu ? (
+            <Popover>
+              <PopoverTrigger>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="cert-contrib-headline__menu"
+                  aria-label="Activity actions"
+                >
+                  <MoreVertical size={16} strokeWidth={1.75} aria-hidden />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="end">
+                {isCreator ? (
+                  <PopoverItem onClick={() => router.push(editHref)}>
+                    <Pencil size={14} strokeWidth={1.75} aria-hidden /> Edit
+                  </PopoverItem>
+                ) : (
+                  <PopoverItem onClick={onEditAsGroup}>
+                    <Pencil size={14} strokeWidth={1.75} aria-hidden /> Edit as{" "}
+                    {editAsGroupLabel}
+                  </PopoverItem>
+                )}
+                {isCreator ? (
+                  <PopoverItem onClick={onDelete}>
+                    <Trash2 size={14} strokeWidth={1.75} aria-hidden /> Delete
+                  </PopoverItem>
+                ) : null}
+              </PopoverContent>
+            </Popover>
+          ) : null}
+        </div>
       </div>
     </header>
   )

--- a/src/lib/detail-tabs.ts
+++ b/src/lib/detail-tabs.ts
@@ -16,7 +16,6 @@ export const CERT_DETAIL_TABS: DetailTab[] = [
   { key: "overview", label: "Overview" },
   { key: "description", label: "Description" },
   { key: "contributors", label: "Contributors" },
-  { key: "contributor-board", label: "Contributor Board" },
   { key: "funding", label: "Funding" },
   { key: "updates", label: "Updates" },
 ]

--- a/src/lib/detail-tabs.ts
+++ b/src/lib/detail-tabs.ts
@@ -17,6 +17,7 @@ export const CERT_DETAIL_TABS: DetailTab[] = [
   { key: "description", label: "Description" },
   { key: "contributors", label: "Contributors" },
   { key: "contributor-board", label: "Contributor Board" },
+  { key: "contributor-board-fancy", label: "Board ✦" },
   { key: "funding", label: "Funding" },
   { key: "updates", label: "Updates" },
 ]

--- a/src/lib/detail-tabs.ts
+++ b/src/lib/detail-tabs.ts
@@ -17,7 +17,6 @@ export const CERT_DETAIL_TABS: DetailTab[] = [
   { key: "description", label: "Description" },
   { key: "contributors", label: "Contributors" },
   { key: "contributor-board", label: "Contributor Board" },
-  { key: "contributor-board-fancy", label: "Board ✦" },
   { key: "funding", label: "Funding" },
   { key: "updates", label: "Updates" },
 ]


### PR DESCRIPTION
Reworks the activity-claim detail page around the contributor board.

## Contributors tab
- A **deluxe contributor board** now sits at the top of the Contributors tab, above the contributor list. Same weighted treemap geometry as the old board, skinned with an ambient gradient stage, glassy depth tiles, a staggered entrance, and per-tile weight badges. On hover a tile gets a **gold border** (interior glow + avatar ring stay neutral). Reduced-motion friendly.
- The standalone **Contributor Board tab is removed** (the board lives on the Contributors tab now). Note: that tab was the only board-EDIT UI, so board editing is currently unreachable — the editable-board components are left in the tree, unwired, in case it's re-surfaced.

## Slim tab headline (every tab except Overview)
Description, Contributors, Funding, and Updates now share a **slim headline**: the activity title with the author pulled onto the same row (author content left-aligned, the block right-aligned) and the Edit/Delete actions collapsed into a **three-dot menu**. No date/project byline. The three-dot button stretches to match the author block's height. Overview keeps the full headline with the date/author/project byline columns.

## Tabs / layout
- Tab order: Overview · Description · Contributors · Funding · Updates.
- Contributors / Description / Funding / Updates are full-bleed (the supplementary aside is dropped); only Overview keeps the aside.

## Design-system compliance
- Added a scoped `--accent-gold*` token set (light + dark) — the only colour in the otherwise-grayscale system, used here on the hover border.
- No raw hex/rgb, no z-index literals (layering via DOM order), radii are `var(--radius)`/`999px`/`50%`, shadows are `--shadow-*`. Dark mode flips via the surface/accent tokens.

`tsc` clean; lint adds no new warnings (the one set-state-in-effect warning is pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)