### PR TITLE
feat(auth): skip ePDS consent screen on first-time sign-up

### DIFF
--- a/src/app/.well-known/oauth-client-metadata/route.ts
+++ b/src/app/.well-known/oauth-client-metadata/route.ts
@@ -17,6 +17,11 @@ export async function GET() {
     policy_uri: `${origin}/privacy`,
     email_template_uri: `${origin}/email/otp-email-template.html`,
     email_subject_template: "{{code}} — Your Certified sign-in code",
+    // ePDS extension: skip the "Authorize your account" consent screen on a
+    // user's first-time sign-up so new accounts land straight in the app.
+    // Only honoured when the PDS runs with PDS_SIGNUP_ALLOW_CONSENT_SKIP=true
+    // and this client_id is on its PDS_OAUTH_TRUSTED_CLIENTS allowlist.
+    epds_skip_consent_on_signup: true,
     // Opt in to ePDS's "Or sign in with ATProto/Bluesky" button. ePDS
     // redirects here with ?handle=<value>; the GET handler in
     // src/app/api/auth/login/route.ts resolves the handle to its PDS


### PR DESCRIPTION
## What

Adds the ePDS `epds_skip_consent_on_signup: true` extension to Certified's OAuth client metadata (`/.well-known/oauth-client-metadata`).

This removes the **"Authorize your account"** consent screen that first-time users currently hit during sign-up, so new accounts land straight in the app.

## Why

Apps that delegate sign-in to the `certs` provider (e.g. the GainForest frontend) bounce users through certified.one's OAuth flow, and the ePDS shows its stock consent screen on a user's first sign-up. The ePDS exposes a client-metadata opt-out for exactly this case.

## Changes

- `src/app/.well-known/oauth-client-metadata/route.ts` — advertise `epds_skip_consent_on_signup: true` alongside the existing ePDS extension fields.

This is the only change required **in this repo**.

## Operator-side prerequisite (not in this repo, for reference)

The flag is only honoured when the certified.one PDS is configured with:

- `PDS_SIGNUP_ALLOW_CONSENT_SKIP=true`
- this `client_id` present on `PDS_OAUTH_TRUSTED_CLIENTS`

(certified-app is already a trusted client — its `brand_color` / `email_template_uri` only work for trusted clients — so realistically only `PDS_SIGNUP_ALLOW_CONSENT_SKIP=true` needs flipping.)

## Scope

Skips consent on **initial sign-up (new accounts)** only, matching "first time someone signs in". An existing account's very first authorization to this client still shows consent once, then it's remembered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth client metadata now advertises support for skipping consent during signup for eligible trusted clients.
  * This capability is only available when the service is configured to allow consent skipping and the client is approved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->