### PR TITLE
fix(layout): keep the page scrollbar reserved so chrome stays flush

### DIFF
--- a/src/app/styles/explore.css
+++ b/src/app/styles/explore.css
@@ -18,10 +18,13 @@
 
 @media (max-width: 799px) {
   /* Clip horizontal overflow so overlong content (degree-pills,
-     monospace DIDs, etc.) can't push the page wider than the viewport. */
+     monospace DIDs, etc.) can't push the page wider than the viewport.
+     Cap at 100% (the containing block, which already excludes the
+     reserved scrollbar gutter) rather than 100vw — 100vw includes the
+     gutter, so it can overhang by the scrollbar width. */
   .explore-page {
     overflow-x: clip;
-    max-width: 100vw;
+    max-width: 100%;
   }
   /* Zero the shell's 16px reading gutter — the page carries its own
      small (8px) gutter above so list rows run nearly edge-to-edge,

--- a/src/app/styles/tokens.css
+++ b/src/app/styles/tokens.css
@@ -370,11 +370,28 @@ button:focus-visible,
   }
 }
 
-/* Reserve scrollbar space in the layout so pages with overflow and
-   pages without don't shift horizontally on Windows/Linux Chromium
-   (where the scrollbar takes ~15-17px). Older Safari (<18) silently
-   falls back to no reservation, which is acceptable. */
+/* Always paint the viewport scrollbar (via `overflow-y: scroll`) so a
+   short / non-overflowing page shows the same inert scrollbar track as a
+   scrolling one — instead of the empty reserved band that
+   `scrollbar-gutter: stable` alone leaves beside the full-bleed top bar
+   and acting-as banner, which reads as a "gap on the right" on classic /
+   always-on scrollbars. Reserving the same width on scrolling AND
+   non-scrolling pages also means no horizontal jump when navigating
+   between them.
+
+   `scrollbar-gutter: stable` is KEPT alongside it, and is load-bearing:
+   the scroll-lock hook (use-body-scroll-lock) toggles THIS element's
+   overflow to `hidden` while a drawer / bottom-sheet is open (html is the
+   viewport scroller once overflow-y is `scroll`, so the lock must live
+   here, not on <body>). The stable gutter keeps the scrollbar's width
+   reserved during that `hidden` lock, so opening an overlay doesn't shift
+   the page.
+
+   Overlay-scrollbar platforms (macOS default, iOS, mobile) reserve zero
+   width either way, so they're unaffected. Older Safari (<18) ignores
+   scrollbar-gutter but honours overflow-y: scroll. */
 html {
+  overflow-y: scroll;
   scrollbar-gutter: stable;
 }
 

--- a/src/hooks/use-body-scroll-lock.ts
+++ b/src/hooks/use-body-scroll-lock.ts
@@ -3,15 +3,27 @@
 import { useEffect } from "react";
 
 /**
- * Lock document body scroll when `isLocked` is true.
- * Restores `overflow` on cleanup or when `isLocked` becomes false.
+ * Lock page scroll while `isLocked` is true; restores the prior value on
+ * cleanup or when `isLocked` becomes false.
+ *
+ * Locks the *documentElement* (`<html>`), not `<body>`. tokens.css sets
+ * `html { overflow-y: scroll }`, which makes `<html>` the viewport scroll
+ * container — and once `<html>` is itself a scroll container, the old
+ * body-based lock (`body { overflow: hidden }`) no longer propagates to
+ * the viewport, so the page would scroll behind an open drawer /
+ * bottom-sheet. Toggling overflow on `<html>` locks the real scroller,
+ * and the `scrollbar-gutter: stable` on that same element keeps the
+ * scrollbar width reserved during the lock so opening an overlay doesn't
+ * shift the page. (Name kept as `useBodyScrollLock` for its callers.)
  */
 export function useBodyScrollLock(isLocked: boolean) {
   useEffect(() => {
     if (isLocked) {
-      document.body.style.overflow = "hidden";
+      const el = document.documentElement;
+      const prev = el.style.overflow;
+      el.style.overflow = "hidden";
       return () => {
-        document.body.style.overflow = "";
+        el.style.overflow = prev;
       };
     }
   }, [isLocked]);


### PR DESCRIPTION
## Problem

On settings (and other) pages, the full-bleed top bar (`.desktop-top-bar`) and the acting-as banner (`.acting-as-bar`) had an empty gap on the right on some pages but not others, and the layout jumped horizontally when navigating between them.

Root cause: `html { scrollbar-gutter: stable }` reserves the scrollbar width but paints **nothing** when a page doesn't overflow. On classic / always-on scrollbars that blank band read as a "gap" beside the edge-to-edge chrome. Pages that *did* overflow drew a real scrollbar in that band, so moving between a scrolling and a non-scrolling page shifted the chrome sideways.

## Fix

- **`tokens.css`** — add `overflow-y: scroll` on `html` so a real (inert) scrollbar is always drawn. Same reserved width on every page → no empty band and no horizontal jump. `scrollbar-gutter: stable` is kept (now load-bearing for the scroll lock, below). Overlay-scrollbar platforms (macOS default, iOS, mobile) reserve zero width either way, so mobile is unaffected.
- **`use-body-scroll-lock.ts`** — lock `document.documentElement` instead of `document.body`. Once `overflow-y: scroll` makes `<html>` the viewport scroll container, a `body { overflow: hidden }` lock no longer propagates to the viewport (that only holds while `<html>` is `overflow: visible`), which would let the page scroll behind an open Drawer / BottomSheet. Locking `<html>` fixes that; the retained stable gutter keeps the width reserved during the lock so opening an overlay doesn't shift the page.
- **`explore.css`** — cap `.explore-page` at `max-width: 100%` instead of `100vw` on mobile; `100vw` includes the reserved gutter and could overhang by the scrollbar width.

## Verification

- `npx tsc --noEmit` — clean
- `eslint` on the changed hook — clean
- off-spec-radii / non-canonical-breakpoint greps — clean
- Scroll-lock behavior (Drawer / BottomSheet stays locked; no shift on open) verified in-browser with forced classic scrollbars.

Consumers of the lock hook (`Drawer`, `BottomSheet`) are unchanged; `AppDialog` uses native `<dialog>`/`showModal()` and doesn't use this hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile layout on the Explore page to prevent horizontal overflow and content overhang.
  * Reduced layout shifts when opening overlays or drawers by keeping scrollbar behavior consistent.
  * Improved scroll locking so pages restore their previous scroll state more reliably after closing overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->