### PR TITLE
fix(welcome): drop the double-counted top gap above the mobile hero

### DIFF
--- a/src/app/styles/landing.css
+++ b/src/app/styles/landing.css
@@ -517,7 +517,11 @@
   .lp-hero {
     display: block;
     min-height: auto;
-    padding: calc(var(--navbar-height) + 8px) 20px 48px;
+    /* No top padding: on /welcome the topbar (.lp-topbar) is in normal
+       flow, so its 64px already sits above the hero (the wordmark is
+       vertically centered, leaving ~21px of intrinsic space below it).
+       Any extra padding-top double-counted the gap. */
+    padding: 0 20px 48px;
   }
   /* Cropped seal band above the stacked copy. */
   .lp-hero__art {


### PR DESCRIPTION
## Problem

On `/welcome`, mobile viewports (`< 800px`) showed a large empty band between the topbar and the hero guilloche animation.

Root cause: the landing topbar (`.lp-topbar`) renders in **normal document flow**, so its 64px height already sits above the hero. But the mobile hero *also* reserved `--navbar-height` in its top padding — `calc(var(--navbar-height) + 8px)` = 72px — double-counting the gap. (It was masked on desktop, where `--navbar-height` is zeroed at `>=800px`.)

## Fix

Zero the mobile hero's `padding-top` so the animation sits directly beneath the topbar. The wordmark's vertical centering already leaves ~21px of intrinsic space below it, so the result reads as a tight, intentional gap rather than a collision.

```css
/* @media (max-width: 799px) */
.lp-hero { padding: 0 20px 48px; }  /* was: calc(var(--navbar-height) + 8px) 20px 48px */
```

Desktop is untouched (change is scoped to the `max-width: 799px` block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted mobile landing-page spacing so the hero section no longer has extra top padding on smaller screens.
  * Improved layout alignment on the welcome page by preventing unnecessary vertical gap above the hero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->