### PR TITLE
staging → main: footer Docs link, Help FAQ build entry

### DIFF
--- a/src/components/help/help-faq.tsx
+++ b/src/components/help/help-faq.tsx
@@ -59,9 +59,9 @@ const HELP_FAQ_ITEMS = [
       "Different apps on AT Protocol are essentially different front-ends over the same underlying data. Certified is the place to explore the whole network — accounts, activities, projects, and endorsements — no matter which app created them. Other apps focus on specific use cases: Ma Earth, for example, is built around funding regenerative land projects.\n\nBecause they share open lexicons, these apps interoperate instead of competing for your data: you maintain one portable record that every compatible app can build on.",
   },
   {
-    question: "How do I build on Certified?",
+    question: "How can we build with Certified?",
     answer:
-      "You can check out the docs, where you'll also find AI skills, and get in contact with us — best in our Telegram group.",
+      "Check out the docs, where you'll also find AI skills, and get in contact with us — best in our Telegram group.",
   },
 ];
 
@@ -107,7 +107,7 @@ export default function HelpFaq() {
         ),
       };
     }
-    if (item.question === "How do I build on Certified?") {
+    if (item.question === "How can we build with Certified?") {
       return { ...item, cta: BUILD_LINKS };
     }
     return item;

--- a/src/components/help/help-faq.tsx
+++ b/src/components/help/help-faq.tsx
@@ -58,30 +58,60 @@ const HELP_FAQ_ITEMS = [
     answer:
       "Different apps on AT Protocol are essentially different front-ends over the same underlying data. Certified is the place to explore the whole network — accounts, activities, projects, and endorsements — no matter which app created them. Other apps focus on specific use cases: Ma Earth, for example, is built around funding regenerative land projects.\n\nBecause they share open lexicons, these apps interoperate instead of competing for your data: you maintain one portable record that every compatible app can build on.",
   },
+  {
+    question: "How do I build on Certified?",
+    answer:
+      "You can check out the docs, where you'll also find AI skills, and get in contact with us — best in our Telegram group.",
+  },
 ];
+
+const BUILD_LINKS = (
+  <div className="flex flex-wrap gap-4">
+    <a
+      href="https://docs.hypercerts.org/"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-[var(--color-accent)] underline hover:text-[var(--color-accent-hover)]"
+    >
+      docs.hypercerts.org
+    </a>
+    <a
+      href="https://t.me/+o4wPsJ7yEZYzNGFk"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-[var(--color-accent)] underline hover:text-[var(--color-accent-hover)]"
+    >
+      Telegram group
+    </a>
+  </div>
+);
 
 export default function HelpFaq() {
   const [graphOpen, setGraphOpen] = useState(false);
 
   // Inject a "see it live" button into the endorsement answer that opens the
   // graph in a large modal (the cta lives here so it can drive modal state).
-  const items = HELP_FAQ_ITEMS.map((item) =>
-    item.question === "What does it mean to endorse someone?"
-      ? {
-          ...item,
-          cta: (
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => setGraphOpen(true)}
-            >
-              <Network size={14} strokeWidth={1.75} aria-hidden />
-              Open the endorsement graph
-            </Button>
-          ),
-        }
-      : item,
-  );
+  const items = HELP_FAQ_ITEMS.map((item) => {
+    if (item.question === "What does it mean to endorse someone?") {
+      return {
+        ...item,
+        cta: (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setGraphOpen(true)}
+          >
+            <Network size={14} strokeWidth={1.75} aria-hidden />
+            Open the endorsement graph
+          </Button>
+        ),
+      };
+    }
+    if (item.question === "How do I build on Certified?") {
+      return { ...item, cta: BUILD_LINKS };
+    }
+    return item;
+  });
 
   return (
     <>

--- a/src/components/layout/site-footer.tsx
+++ b/src/components/layout/site-footer.tsx
@@ -34,6 +34,14 @@ export default function SiteFooter() {
           <Link href="/welcome" className="site-footer__link">
             Welcome
           </Link>
+          <a
+            href="https://docs.hypercerts.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="site-footer__link"
+          >
+            Docs
+          </a>
           <Link href="/terms" className="site-footer__link">
             Terms
           </Link>


### PR DESCRIPTION
## Summary
- Add a "Docs" link to the site footer, linking to docs.hypercerts.org in a new tab
- Add a "How can we build with Certified?" FAQ entry on the Help page, linking to the docs and the Telegram group

## Test plan
- [ ] Verify footer renders Docs link between Welcome and Terms, opens in new tab
- [ ] Verify Help page FAQ shows the new question with working docs/Telegram links
- [ ] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Help FAQ with clearer guidance for getting started.
  * Added quick links to documentation and a Telegram community link from the FAQ.
  * Added a new Docs link in the site footer for easier access to product documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->