### PR TITLE
feat(indexer): route ProfileCount to Hyperindex

### DIFF
--- a/src/app/api/indexer/__tests__/route.test.ts
+++ b/src/app/api/indexer/__tests__/route.test.ts
@@ -321,6 +321,22 @@ describe("/api/indexer trust boundary", () => {
       expect(mockFetch.mock.calls[0][0]).toBe("https://hyperindex.example/graphql")
     })
 
+    it("routes ProfileCount to Hyperindex with the Hyperindex label-filter query", async () => {
+      const res = await postIndexer({
+        operationName: "ProfileCount",
+        variables: {},
+      })
+      expect(res.headers.get("x-indexer-backend")).toBe("hyperindex")
+      expect(mockFetch.mock.calls[0][0]).toBe("https://hyperindex.example/graphql")
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
+      expect(body.operationName).toBe("ProfileCount")
+      expect(body.query).toContain("query ProfileCount")
+      expect(body.query).toContain("authorLabels")
+      expect(body.query).toContain("none")
+      expect(body.query).toContain("activeOnly")
+      expect(body.query).not.toContain("excludeAuthorLabels")
+    })
+
     it("forwards the server-held query string for the requested operation", async () => {
       await postIndexer({
         operationName: "Followers",

--- a/src/app/api/indexer/route.ts
+++ b/src/app/api/indexer/route.ts
@@ -56,11 +56,13 @@ const MAGIC_INDEXER_URL =
   DEFAULT_MAGIC_INDEXER_URL
 const HYPERINDEX_URL = process.env.HYPERINDEX_URL || DEFAULT_HYPERINDEX_URL
 
-// Stage migration switchboard. Keep this empty until a stage explicitly
-// ports an operation group. Local/staging can also set
-// `HYPERINDEX_OPERATIONS=ProfileCount,ActivityCount` to test routing
+// Stage migration switchboard. Stacked Stage 1 starts with ProfileCount only;
+// all other operations remain Magic-backed until their own PR migrates them.
+// Local/staging can also set `HYPERINDEX_OPERATIONS=...` to test routing
 // without changing production defaults.
-const OPERATION_BACKENDS: Partial<Record<string, IndexerBackend>> = {}
+const OPERATION_BACKENDS: Partial<Record<string, IndexerBackend>> = {
+  ProfileCount: "hyperindex",
+}
 const HYPERINDEX_OPERATION_NAMES = new Set(
   (process.env.HYPERINDEX_OPERATIONS || "")
     .split(",")
@@ -75,6 +77,16 @@ function backendForOperation(operationName: string): IndexerBackend {
 
 function endpointForBackend(backend: IndexerBackend): string {
   return backend === "hyperindex" ? HYPERINDEX_URL : MAGIC_INDEXER_URL
+}
+
+function queryForOperation(
+  operationName: string,
+  backend: IndexerBackend,
+): string | null {
+  if (backend === "hyperindex") {
+    return HYPERINDEX_OPERATION_QUERIES[operationName] ?? OPERATIONS[operationName] ?? null
+  }
+  return OPERATIONS[operationName] ?? null
 }
 
 function logIndexerBackend(
@@ -200,6 +212,32 @@ const ACTIVITY_NODE_SELECTION = `
  * NOTE on adding ops: a new entry MUST come with a `buildVariables`
  * branch below or the request 400s on unknown variables.
  */
+const HYPERINDEX_OPERATION_QUERIES: Partial<Record<string, string>> = {
+  // Hyperindex does not support Magic's connection-level
+  // `excludeAuthorLabels` argument. Use the typed label predicate instead:
+  // hide profiles whose author/account DID has an active likely-test label,
+  // while letting unlabeled profiles pass through.
+  ProfileCount: `
+    query ProfileCount {
+      appCertifiedActorProfile(
+        first: 1
+        where: {
+          authorLabels: {
+            none: {
+              val: { in: ${JSON.stringify([...DEFAULT_HIDDEN_ORG_LABELS])} }
+              activeOnly: true
+            }
+          }
+        }
+      ) {
+        totalCount
+        edges { node { uri } }
+        pageInfo { hasNextPage }
+      }
+    }
+  `,
+}
+
 const OPERATIONS: Record<string, string> = {
   // Global activity feed + per-label / per-author filters.
   Activities: `
@@ -1800,8 +1838,7 @@ export async function POST(request: NextRequest) {
   }
   const operationName = parsed.operationName
 
-  const query = OPERATIONS[operationName]
-  if (!query) {
+  if (!OPERATIONS[operationName]) {
     return NextResponse.json({ error: "Unknown operation" }, { status: 400 })
   }
 
@@ -1819,6 +1856,10 @@ export async function POST(request: NextRequest) {
 
   const backend = backendForOperation(operationName)
   const upstreamUrl = endpointForBackend(backend)
+  const query = queryForOperation(operationName, backend)
+  if (!query) {
+    return NextResponse.json({ error: "Unknown operation" }, { status: 400 })
+  }
   logIndexerBackend(operationName, backend, upstreamUrl)
 
   const timeoutController = new AbortController()


### PR DESCRIPTION
## Summary

Stacked on top of #235.

This PR migrates exactly one operation to Hyperindex:

- `ProfileCount`

Everything else remains Magic-backed.

Implementation details:

- Adds a Hyperindex-specific query for `ProfileCount`.
- Routes `ProfileCount` through the per-operation backend switchboard to `hyperindex`.
- Keeps the public `/api/indexer` operation contract unchanged.
- Translates Magic's `excludeAuthorLabels: ["likely-test"]` into Hyperindex's typed label predicate:

  ```graphql
  where: {
    authorLabels: {
      none: {
        val: { in: ["likely-test"] }
        activeOnly: true
      }
    }
  }
  ```

## Known parity note

At implementation time, the stage-specific sample returned:

- Magic `ProfileCount`: `3388`
- Hyperindex `ProfileCount`: `3236`

This is a visible count difference on the welcome/landing stats. It appears to be due to backend indexing/label semantics rather than a client mapper change. Please manually verify whether this semantic difference is acceptable before merging.

## What did not change

- No other count operations moved.
- `OrganizationCount`, `ActivityCount`, `ProjectCount`, `AwardCount`, `UserActivityCount`, and `ActorWorkspaceCounts` remain Magic-backed.
- No writes changed.
- No client hook/component API changed.

## Checks run

- `npm test -- src/app/api/indexer/__tests__/route.test.ts`
- `npm run typecheck`
- `npx eslint src/app/api/indexer/route.ts src/app/api/indexer/__tests__/route.test.ts`

## Manual test instructions

1. Deploy this stacked branch after #235.
2. Open `/welcome` or the landing surface that renders network stats.
3. Confirm the users/profile count still renders without an error.
4. Confirm `/api/indexer` responses for `ProfileCount` include:

   ```txt
   X-Indexer-Backend: hyperindex
   ```

5. Confirm other count operations still report:

   ```txt
   X-Indexer-Backend: magic
   ```

## Rollback

Revert this PR or remove `ProfileCount: "hyperindex"` from `OPERATION_BACKENDS`. Other operations are unaffected.
