### PR TITLE
auth: support Vercel preview origins

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,8 +1,15 @@
 # Required: The PDS / handle resolver URL
 NEXT_PUBLIC_PDS_URL=https://certified.one
 
-# Public URL of this app — used for OAuth client_id, redirect_uris, and the
-# CSRF Origin allowlist.
+# Canonical URL of this app — used for OAuth client_id and redirect_uris.
+# CSRF also accepts same-origin requests on Vercel's exact branch and deployment
+# URLs when VERCEL_BRANCH_URL / VERCEL_URL are present at runtime.
+#
+# Resolution order: PUBLIC_URL, then VERCEL_BRANCH_URL, then VERCEL_URL.
+# Vercel supplies the latter two as hostname-only server variables; do not add
+# NEXT_PUBLIC_ variants or include a scheme. PUBLIC_URL remains recommended for
+# a stable custom production/staging domain. The selected OAuth metadata URL
+# (and JWKS URL for confidential clients) must be publicly reachable.
 #
 # Production:  set to the deployed origin, e.g. https://certified.app
 # Local dev:   use http://127.0.0.1:3000 (NOT http://localhost:3000).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,9 @@ Source: `.env.local.example` and `src/lib/utils/config.ts`.
 | Variable | Required | Purpose |
 |---|---|---|
 | `NEXT_PUBLIC_PDS_URL` | yes | PDS / handle resolver URL. Defaults to `https://certified.one`. |
-| `PUBLIC_URL` | production | Public URL of this app. Used to derive OAuth `client_id`, `redirect_uris`, and the CSRF Origin allowlist. Falls back to `http://localhost:3000` in dev. **For local atproto OAuth sign-in to actually complete, set this to `http://127.0.0.1:3000`** — see [§22 Common Pitfalls](#22-common-pitfalls) #3. |
+| `PUBLIC_URL` | recommended in production | Canonical app origin. Wins when deriving OAuth `client_id` and `redirect_uris`; exact same-origin CSRF requests from it are trusted. Falls back to `VERCEL_BRANCH_URL`, then `VERCEL_URL`, then `http://localhost:3000` outside production. **For local atproto OAuth sign-in to actually complete, set this to `http://127.0.0.1:3000`** — see [§22 Common Pitfalls](#22-common-pitfalls) #3. |
+| `VERCEL_BRANCH_URL` | Vercel-provided fallback | Hostname-only stable branch URL. Becomes the canonical OAuth origin when `PUBLIC_URL` is absent and is accepted for same-origin CSRF requests. Do not add a scheme or `NEXT_PUBLIC_` alias. |
+| `VERCEL_URL` | Vercel-provided fallback | Hostname-only commit deployment URL. Final canonical OAuth fallback and accepted for same-origin CSRF requests. Do not add a scheme or `NEXT_PUBLIC_` alias. |
 | `COOKIE_SECRET` | production | HMAC secret for the `certified_session` cookie. Generate with `openssl rand -hex 32`. In dev a fallback string is used. |
 | `UPSTASH_REDIS_REST_URL` | yes | Upstash REST URL. |
 | `UPSTASH_REDIS_REST_TOKEN` | yes | Upstash REST token. |
@@ -141,7 +143,7 @@ Source: `.env.local.example` and `src/lib/utils/config.ts`.
 | `NEXT_PUBLIC_GROUP_SERVICE_URL` | optional | Group service base URL. Defaults to `https://groups.certified.app`. |
 | `NEXT_PUBLIC_GROUP_SERVICE_DID` | optional | Group service DID (for `getServiceAuth` `aud`). Defaults to `did:web:groups.certified.app`. |
 
-`PUBLIC_URL` is the most consequential variable — it is checked against the `Origin` header on every CSRF-protected route, baked into the OAuth client metadata, and used to build the `redirect_uris` array. If it does not match the deployed domain, sign-in and every POST will fail.
+The canonical OAuth URL is resolved in this order: `PUBLIC_URL` → `VERCEL_BRANCH_URL` → `VERCEL_URL`. It is baked into OAuth client metadata and `redirect_uris`, so a login started on another accepted deployment origin finishes on that canonical host and receives its session cookie there. CSRF accepts the exact configured public, branch, and deployment origins only when the source also equals the request destination. No wildcard Vercel host matching is allowed. The selected metadata endpoint—and JWKS endpoint for confidential clients—must be publicly reachable by the authorization server; Vercel Deployment Protection can otherwise block sign-in.
 
 ## 5. Architecture & Data Flow
 
@@ -254,14 +256,14 @@ Permanent redirects (in `next.config.ts`):
 
 ### Components
 
-- **OAuth client** — `src/lib/auth/oauth-client.ts` builds a `NodeOAuthClient` (singleton). It registers Redis-backed state and session stores, leaves `handleResolver` at the SDK default (`AtprotoHandleResolverNode`, which does DNS-TXT + HTTPS `.well-known/atproto-did` resolution and works for any atproto handle, not just Certified-rooted ones), and conditionally enables `private_key_jwt` when `ATPROTO_PRIVATE_KEY` is set. In **loopback dev mode** (`NODE_ENV !== "production"` AND `PUBLIC_URL` is missing or `http://`) it skips the normal `${PUBLIC_URL}/.well-known/oauth-client-metadata` `client_id` and uses `buildAtprotoLoopbackClientMetadata` instead, because the spec only allows `https://` or the literal `http://localhost` (no port) as a `client_id`.
+- **OAuth client** — `src/lib/auth/oauth-client.ts` builds a `NodeOAuthClient` (singleton). It registers Redis-backed state and session stores, leaves `handleResolver` at the SDK default (`AtprotoHandleResolverNode`, which does DNS-TXT + HTTPS `.well-known/atproto-did` resolution and works for any atproto handle, not just Certified-rooted ones), and conditionally enables `private_key_jwt` when `ATPROTO_PRIVATE_KEY` is set. The canonical origin resolves as `PUBLIC_URL` → `VERCEL_BRANCH_URL` → `VERCEL_URL`. In **loopback dev mode** (`NODE_ENV !== "production"` and that resolved URL is `http://`) it skips the normal metadata `client_id` and uses `buildAtprotoLoopbackClientMetadata` instead, because the spec only allows `https://` or the literal `http://localhost` (no port) as a `client_id`.
 - **Stores** — `src/lib/auth/stores.ts` wraps Upstash Redis. `RedisStateStore` (10 min TTL) is for the short-lived OAuth flow. `RedisSessionStore` (30 day TTL) holds long-lived atproto sessions (tokens + DPoP key). Both key by `oauth:state:<key>` / `oauth:session:<key>`. **Dev fallback:** when Upstash creds are missing AND `NODE_ENV !== "production"`, the module switches to a process-local `InMemoryRedis` so a fresh clone can sign in locally without provisioning an Upstash database. State doesn't survive a server restart and isn't shared across workers — acceptable for dev only. A console warning fires on first use.
 - **App session** — `src/lib/auth/session.ts` issues the `certified_session` cookie:
   - Cookie value = `<32-byte hex sessionId>.<HMAC-SHA256 signature>`.
   - Cookie attributes: `httpOnly`, `secure` in production, `sameSite=lax`, `path=/`, `maxAge=30 days`.
   - Server side, the session id maps to a DID in Redis (`session:did:<sid>`).
   - HMAC verification uses `crypto.timingSafeEqual` to avoid timing attacks.
-- **CSRF** — `src/lib/auth/csrf.ts` checks `Origin` header against `new URL(PUBLIC_URL).origin`. If `Origin` is absent (some same-origin no-CORS posts) the request is allowed; if present it must match exactly. Wraps URL parsing in try/catch — any malformed origin returns 403.
+- **CSRF** — `src/lib/auth/csrf.ts` rejects requests missing both `Origin` and `Referer`, then requires the parsed source origin to be in the exact configured set (`PUBLIC_URL`, `VERCEL_BRANCH_URL`, `VERCEL_URL`) and equal the request destination origin. This supports Vercel aliases without making deployments cross-origin peers. `null`, malformed, wildcard, and lookalike origins return 403; localhost/127.0.0.1 equivalence exists only outside production.
 - **authFetch** — `src/lib/auth/fetch.ts` wraps `fetch` and calls a registered `onUnauthorized()` listener on 401. `AuthProvider` registers this listener to clear `isAuthenticated`/`did`/`pdsUrl` and surface "Your session has expired."
 
 ### Sign-in (email or handle)
@@ -641,7 +643,7 @@ These rules are mandatory. Treat any deviation as a regression.
 
 ### Server-side
 
-1. **CSRF on every POST/PUT/DELETE** — call `checkCsrf(request)` at the top of any state-changing route handler. The check compares the `Origin` header against `PUBLIC_URL`. URL parsing is wrapped in try/catch; malformed origins return 403.
+1. **CSRF on every POST/PUT/DELETE** — call `checkCsrf(request)` at the top of any state-changing route handler. The source must be an exact configured origin (`PUBLIC_URL`, `VERCEL_BRANCH_URL`, or `VERCEL_URL`) and equal the request destination. Missing, `null`, malformed, wildcard, and cross-deployment origins return 403.
 2. **Cookie verification uses `timingSafeEqual`** (`src/lib/auth/session.ts`). Don't replace it with `===`.
 3. **HMAC every session id.** The cookie value is `<sessionId>.<HMAC>`. Truncating to "just sessionId" would let attackers forge any session.
 4. **Invalidate the existing session before creating a new one** in `callback-handler/route.ts`. This prevents session fixation if the user reuses a tab where another session was active.
@@ -694,7 +696,7 @@ When adding a new public page: set `metadata.title`, `description`, `alternates.
   - `staging` → preview (`staging.certified.app`)
 - **Workflow:** push to `staging`, open a PR to `main`. Vercel deploys both branches automatically.
 - **Quality gate:** `npm run build` must succeed before pushing. There is no test suite to run; `tsc --noEmit` is implicit in `next build`.
-- **`PUBLIC_URL`** must match the deployed domain on each environment, since `client_id`, `redirect_uris`, and the CSRF allowlist all derive from it.
+- **OAuth URL precedence:** `PUBLIC_URL` → `VERCEL_BRANCH_URL` → `VERCEL_URL`. Prefer an explicit `PUBLIC_URL` for stable production/staging callbacks. Generated Vercel origins are also accepted for same-origin CSRF requests. The selected metadata/JWKS endpoints must be public, and deployments that initiate and complete one OAuth flow must share compatible Redis state/session configuration. Distinct canonical OAuth origins should use separate Redis databases because saved OAuth session keys are DID-based and are not namespaced by `client_id`.
 - Don't commit secrets (`.env.local` is gitignored). `COOKIE_SECRET`, `UPSTASH_*`, `ATPROTO_PRIVATE_KEY`, `RESEND_API_KEY` live in Vercel envs.
 
 ## 20. File Map
@@ -857,7 +859,7 @@ certified-app/
     └── lib/
         ├── auth/
         │   ├── auth-context.tsx           # AuthProvider, useAuth, sign-in modal, postMessage listeners
-        │   ├── csrf.ts                    # checkCsrf — Origin === PUBLIC_URL check
+        │   ├── csrf.ts                    # checkCsrf — configured exact origin + same destination
         │   ├── fetch.ts                   # authFetch — 401 interceptor
         │   ├── oauth-client.ts            # NodeOAuthClient singleton, PDS_URL constant
         │   ├── session.ts                 # createSession/getSessionDid/deleteSession (HMAC + Redis)
@@ -885,7 +887,7 @@ certified-app/
         │   └── api.ts                     # Shared response types (SessionResponse, ListRecordsResponse, PutRecordResponse)
         ├── utils/
         │   ├── api.ts                     # extractError(res, fallback)
-        │   ├── config.ts                  # PUBLIC_URL + PUBLIC_URL_STRICT
+        │   ├── config.ts                  # OAuth URL precedence + allowed request origins
         │   ├── constants.ts               # LIMIT_MIN/MAX/DEFAULT, debounce timings
         │   ├── initials.ts                # getInitials()
         │   └── sanitize.ts                # stripInvisible/sanitizeEmail/sanitizeHandle
@@ -910,9 +912,9 @@ certified-app/
 
 1. **`useAttestationSigning` outside `/settings/wallet`** — it depends on `WagmiProvider` which is mounted only in `src/app/settings/wallet/layout.tsx`. Calling it elsewhere will throw "useConfig must be used within WagmiConfig".
 2. **Using `fetch` instead of `authFetch`** — the 401 interceptor is the only thing surfacing session expiry to the user. Raw `fetch` will silently fail.
-3. **Origin check failures in dev** — if you set `PUBLIC_URL=https://certified.app` in `.env.local` and run `npm run dev` on localhost, every POST will 403. Match `PUBLIC_URL` to whatever host your browser actually hits (use `http://127.0.0.1:3000` if you want sign-in to work — see next pitfall).
+3. **Origin check failures** — CSRF requires the source to be one of the exact configured origins and to equal the request destination. Locally, match `PUBLIC_URL` to the browser host (use `http://127.0.0.1:3000` for sign-in). On Vercel, ensure the server runtime exposes `VERCEL_BRANCH_URL` / `VERCEL_URL`; no `NEXT_PUBLIC_` aliases are used. Generated preview login can still fail when Deployment Protection prevents the authorization server from fetching metadata/JWKS.
 
-3a. **atproto OAuth in dev requires the loopback metadata helper, not just `PUBLIC_URL`.** The spec only accepts a `client_id` that is either a real `https://` URL or the literal `http://localhost` origin (no port, no path). Pointing `client_id` at `http://localhost:3000/...` or `http://127.0.0.1:3000/...` makes `NodeOAuthClient` throw `URL must use the "https:" protocol` (Zod). The fix — already wired into `src/lib/auth/oauth-client.ts` — is to detect dev mode (`NODE_ENV !== "production"` AND `PUBLIC_URL` missing or `http://`) and swap to `buildAtprotoLoopbackClientMetadata({ scope, redirect_uris: ["http://127.0.0.1:<port>/oauth/callback"] })`. Notes:
+3a. **atproto OAuth in dev requires the loopback metadata helper, not just `PUBLIC_URL`.** The spec only accepts a `client_id` that is either a real `https://` URL or the literal `http://localhost` origin (no port, no path). Pointing `client_id` at `http://localhost:3000/...` or `http://127.0.0.1:3000/...` makes `NodeOAuthClient` throw `URL must use the "https:" protocol` (Zod). The fix — already wired into `src/lib/auth/oauth-client.ts` — is to resolve `PUBLIC_URL` → `VERCEL_BRANCH_URL` → `VERCEL_URL`, then use `buildAtprotoLoopbackClientMetadata({ scope, redirect_uris: ["http://127.0.0.1:<port>/oauth/callback"] })` only when that canonical URL is `http://` outside production. Notes:
    - The `client_id` becomes a virtual `http://localhost?redirect_uri=...&scope=...`, which is what the AS expects for loopback dev.
    - The `redirect_uri` host must be `127.0.0.1` (or `[::1]`); `localhost` is NOT allowed there even though it IS the only allowed `client_id` host. Yes, this is inverted from intuition; it's the spec.
    - Cookies don't cross `localhost` ↔ `127.0.0.1`. Pick one host for the whole flow. Since the redirect comes back on `127.0.0.1`, navigate to `http://127.0.0.1:3000/welcome`.

--- a/README.md
+++ b/README.md
@@ -60,12 +60,16 @@ Edit `.env.local` with your values:
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `NEXT_PUBLIC_PDS_URL` | Yes | PDS / handle resolver URL (default: `https://certified.one`) |
-| `PUBLIC_URL` | Production | Public URL of the app (used for OAuth client_id and redirect URIs) |
+| `PUBLIC_URL` | Recommended in production | Canonical app origin used for OAuth metadata and callbacks |
+| `VERCEL_BRANCH_URL` | Vercel-provided fallback | Stable branch hostname used when `PUBLIC_URL` is absent |
+| `VERCEL_URL` | Vercel-provided fallback | Commit deployment hostname used when the first two values are absent |
 | `COOKIE_SECRET` | Production | Secret for signing session cookies (`openssl rand -hex 32`) |
 | `UPSTASH_REDIS_REST_URL` | Yes | Upstash Redis REST URL |
 | `UPSTASH_REDIS_REST_TOKEN` | Yes | Upstash Redis REST token |
 | `ATPROTO_PRIVATE_KEY` | No | EC private key for confidential client auth |
 | `RESEND_API_KEY` | No | Resend API key for feedback emails |
+
+OAuth URL precedence is `PUBLIC_URL` → `VERCEL_BRANCH_URL` → `VERCEL_URL`. The Vercel variables are server-side hostname-only system values and do not need `NEXT_PUBLIC_` aliases. The selected metadata endpoint—and JWKS endpoint when confidential auth is enabled—must be publicly reachable by the authorization server, so Vercel Deployment Protection can prevent preview login. Deployments participating in one callback flow must share compatible Redis configuration; distinct canonical OAuth origins should use separate Redis databases because saved OAuth sessions are not namespaced by `client_id`.
 
 ### Development
 

--- a/src/lib/auth/__tests__/csrf.test.ts
+++ b/src/lib/auth/__tests__/csrf.test.ts
@@ -11,7 +11,8 @@ const allowedOrigins = vi.hoisted(
     ]),
 )
 
-vi.mock("@/lib/utils/config", () => ({
+vi.mock("@/lib/utils/config", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/utils/config")>()),
   ALLOWED_REQUEST_ORIGINS: allowedOrigins,
 }))
 

--- a/src/lib/auth/__tests__/csrf.test.ts
+++ b/src/lib/auth/__tests__/csrf.test.ts
@@ -1,0 +1,118 @@
+import { NextRequest } from "next/server"
+import { describe, expect, it, vi } from "vitest"
+
+const allowedOrigins = vi.hoisted(
+  () =>
+    new Set([
+      "https://staging.certified.app",
+      "https://certified-git-staging.vercel.app",
+      "https://certified-a1b2c3.vercel.app",
+      "http://127.0.0.1:3000",
+    ]),
+)
+
+vi.mock("@/lib/utils/config", () => ({
+  ALLOWED_REQUEST_ORIGINS: allowedOrigins,
+}))
+
+import { checkCsrf } from "@/lib/auth/csrf"
+
+function mutation(
+  destination: string,
+  headers: Record<string, string>,
+): NextRequest {
+  return new NextRequest(`${destination}/api/auth/login`, {
+    method: "POST",
+    headers,
+  })
+}
+
+async function expectForbidden(response: Response | null, message: string) {
+  expect(response?.status).toBe(403)
+  await expect(response?.json()).resolves.toEqual({ error: message })
+}
+
+describe("checkCsrf", () => {
+  it.each([
+    "https://staging.certified.app",
+    "https://certified-git-staging.vercel.app",
+    "https://certified-a1b2c3.vercel.app",
+  ])("accepts same-origin mutations on configured origin %s", (origin) => {
+    expect(checkCsrf(mutation(origin, { origin }))).toBeNull()
+  })
+
+  it("does not make configured branch and deployment hosts cross-origin peers", async () => {
+    const response = checkCsrf(
+      mutation("https://certified-a1b2c3.vercel.app", {
+        origin: "https://certified-git-staging.vercel.app",
+      }),
+    )
+
+    await expectForbidden(response, "Forbidden: invalid origin")
+  })
+
+  it("rejects an unconfigured lookalike even when source and destination match", async () => {
+    const origin = "https://certified-a1b2c3.vercel.app.evil.example"
+    const response = checkCsrf(mutation(origin, { origin }))
+
+    await expectForbidden(response, "Forbidden: invalid origin")
+  })
+
+  it("accepts a Referer with a path when Origin is absent", () => {
+    const response = checkCsrf(
+      mutation("https://staging.certified.app", {
+        referer: "https://staging.certified.app/settings?tab=account",
+      }),
+    )
+
+    expect(response).toBeNull()
+  })
+
+  it("rejects a path-bearing Origin header", async () => {
+    const response = checkCsrf(
+      mutation("https://staging.certified.app", {
+        origin: "https://staging.certified.app/unexpected",
+      }),
+    )
+
+    await expectForbidden(response, "Forbidden: invalid origin")
+  })
+
+  it("does not fall back to Referer when Origin is malformed", async () => {
+    const response = checkCsrf(
+      mutation("https://staging.certified.app", {
+        origin: "not a URL",
+        referer: "https://staging.certified.app/settings",
+      }),
+    )
+
+    await expectForbidden(response, "Forbidden: invalid origin")
+  })
+
+  it("rejects literal null origins", async () => {
+    const response = checkCsrf(
+      mutation("https://staging.certified.app", { origin: "null" }),
+    )
+
+    await expectForbidden(response, "Forbidden: null origin")
+  })
+
+  it("rejects requests without Origin or Referer", async () => {
+    const response = checkCsrf(mutation("https://staging.certified.app", {}))
+
+    await expectForbidden(response, "Forbidden: missing origin")
+  })
+
+  it("accepts localhost as the development equivalent of configured 127.0.0.1", () => {
+    const origin = "http://localhost:3000"
+
+    expect(checkCsrf(mutation(origin, { origin }))).toBeNull()
+  })
+
+  it("does not treat a different loopback port as equivalent", async () => {
+    const origin = "http://localhost:4000"
+    const response = checkCsrf(mutation(origin, { origin }))
+
+    await expectForbidden(response, "Forbidden: invalid origin")
+  })
+})

--- a/src/lib/auth/__tests__/oauth-config.test.ts
+++ b/src/lib/auth/__tests__/oauth-config.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildLoopbackRedirectUri,
+  buildWebOAuthClientMetadata,
+  isLoopbackOAuthMode,
+  requireOAuthPublicUrl,
+} from "@/lib/auth/oauth-client"
+
+describe("OAuth URL configuration", () => {
+  it("builds public-client metadata from a Vercel branch fallback", () => {
+    const origin = "https://certified-git-staging.vercel.app"
+    const metadata = buildWebOAuthClientMetadata(origin, false)
+
+    expect(metadata).toMatchObject({
+      client_id: `${origin}/.well-known/oauth-client-metadata`,
+      client_uri: origin,
+      logo_uri: `${origin}/brand/brandmark/certified_brandmark_black_512.png`,
+      redirect_uris: [`${origin}/oauth/callback`],
+      token_endpoint_auth_method: "none",
+    })
+    expect(metadata).not.toHaveProperty("jwks_uri")
+  })
+
+  it("keeps confidential-client JWKS on the same canonical origin", () => {
+    const origin = "https://staging.certified.app"
+    const metadata = buildWebOAuthClientMetadata(origin, true)
+
+    expect(metadata).toMatchObject({
+      client_id: `${origin}/.well-known/oauth-client-metadata`,
+      redirect_uris: [`${origin}/oauth/callback`],
+      token_endpoint_auth_method: "private_key_jwt",
+      token_endpoint_auth_signing_alg: "ES256",
+      jwks_uri: `${origin}/.well-known/jwks.json`,
+    })
+  })
+
+  it("selects loopback only for HTTP canonical URLs outside production", () => {
+    expect(isLoopbackOAuthMode(undefined, "development")).toBe(true)
+    expect(
+      isLoopbackOAuthMode("http://127.0.0.1:4000", "development"),
+    ).toBe(true)
+    expect(
+      isLoopbackOAuthMode(
+        "https://certified-git-staging.vercel.app",
+        "development",
+      ),
+    ).toBe(false)
+    expect(
+      isLoopbackOAuthMode("http://127.0.0.1:4000", "production"),
+    ).toBe(false)
+  })
+
+  it("preserves the configured port in the loopback callback", () => {
+    expect(buildLoopbackRedirectUri("http://localhost:4567")).toBe(
+      "http://127.0.0.1:4567/oauth/callback",
+    )
+    expect(buildLoopbackRedirectUri(undefined)).toBe(
+      "http://127.0.0.1:3000/oauth/callback",
+    )
+  })
+
+  it("requires a configured HTTPS origin in production", () => {
+    expect(() => requireOAuthPublicUrl(undefined, "production")).toThrow(
+      /PUBLIC_URL.*VERCEL_BRANCH_URL.*VERCEL_URL/,
+    )
+    expect(() =>
+      requireOAuthPublicUrl("http://127.0.0.1:3000", "production"),
+    ).toThrow(/must use HTTPS in production/)
+    expect(
+      requireOAuthPublicUrl(
+        "https://certified-git-staging.vercel.app",
+        "production",
+      ),
+    ).toBe("https://certified-git-staging.vercel.app")
+  })
+})

--- a/src/lib/auth/csrf.ts
+++ b/src/lib/auth/csrf.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server"
-import { PUBLIC_URL } from "@/lib/utils/config"
+import { ALLOWED_REQUEST_ORIGINS } from "@/lib/utils/config"
 
 /**
- * Validates the Origin header on POST requests to prevent CSRF.
- * Returns a 403 response if the origin does not match, or null if valid.
+ * Validates browser mutation requests against the app's configured origins.
+ * The source must be both trusted and identical to the request destination;
+ * configured Vercel branch and deployment hosts are not cross-origin peers.
  */
 export function checkCsrf(request: NextRequest): NextResponse | null {
   const origin = request.headers.get("origin")
@@ -17,58 +18,90 @@ export function checkCsrf(request: NextRequest): NextResponse | null {
     return NextResponse.json({ error: "Forbidden: null origin" }, { status: 403 })
   }
 
-  const rawOrigin = origin || (referer ? extractOrigin(referer) : null)
-
-  // Deliberate divergence from AGENTS §8 (which describes the older
-  // "absent Origin is allowed" behavior): we reject when BOTH Origin AND
-  // Referer are missing, rather than waving the request through. A
-  // browser-issued same-origin POST always carries at least one of these
-  // headers, so the only requests lacking both are non-browser / scripted
-  // clients, for which fail-closed is the safer default. Keep this stricter
-  // check — do NOT "fix" it back to Origin-only by deleting this guard.
-  if (!rawOrigin) {
+  // Deliberate divergence from the older "absent Origin is allowed"
+  // behavior: browser-issued same-origin mutations carry Origin or Referer,
+  // so fail closed when both are absent.
+  if (!origin && !referer) {
     return NextResponse.json({ error: "Forbidden: missing origin" }, { status: 403 })
   }
 
+  const incoming = origin
+    ? parseOriginHeader(origin)
+    : referer
+      ? parseReferer(referer)
+      : null
+
+  if (!incoming) {
+    return NextResponse.json({ error: "Forbidden: invalid origin" }, { status: 403 })
+  }
+
+  const destination = request.nextUrl
+  const isSameDestination = incoming.origin === destination.origin
+
+  if (
+    isSameDestination &&
+    (ALLOWED_REQUEST_ORIGINS.has(incoming.origin) ||
+      isAllowedDevelopmentLoopback(incoming))
+  ) {
+    return null
+  }
+
+  return NextResponse.json({ error: "Forbidden: invalid origin" }, { status: 403 })
+}
+
+/** Origin headers contain only a scheme/host/port tuple, never a URL path. */
+function parseOriginHeader(value: string): URL | null {
   try {
-    const expected = new URL(PUBLIC_URL)
-    const incoming = new URL(rawOrigin)
-
-    if (incoming.origin === expected.origin) return null
-
-    // Dev convenience: PUBLIC_URL pins to one loopback form (the project
-    // convention is 127.0.0.1 for OAuth + cookie reasons), but a browser
-    // tab opened at http://localhost:3000 sends Origin: localhost — and
-    // the strict match above 403s every same-origin POST. In
-    // development only, treat 127.0.0.1 and localhost as the same origin
-    // when protocol + port match. Production stays strict.
+    const url = new URL(value)
     if (
-      process.env.NODE_ENV !== "production" &&
-      incoming.protocol === expected.protocol &&
-      incoming.port === expected.port &&
-      isLoopbackHost(incoming.hostname) &&
-      isLoopbackHost(expected.hostname)
+      url.username ||
+      url.password ||
+      url.pathname !== "/" ||
+      url.search ||
+      url.hash
     ) {
       return null
     }
-
-    return NextResponse.json({ error: "Forbidden: invalid origin" }, { status: 403 })
+    return url
   } catch {
-    return NextResponse.json({ error: "Forbidden: invalid origin" }, { status: 403 })
+    return null
   }
+}
+
+/** Referer is a full page URL, so only its authenticated origin is retained. */
+function parseReferer(value: string): URL | null {
+  try {
+    const url = new URL(value)
+    if (url.username || url.password) return null
+    return new URL(url.origin)
+  } catch {
+    return null
+  }
+}
+
+// Dev convenience: PUBLIC_URL commonly pins to 127.0.0.1 for OAuth while a
+// browser tab may use localhost. Accept the alternate loopback spelling only
+// when one configured loopback origin has the same protocol and port. The
+// caller already verified source === request destination.
+function isAllowedDevelopmentLoopback(incoming: URL): boolean {
+  if (process.env.NODE_ENV === "production" || !isLoopbackHost(incoming.hostname)) {
+    return false
+  }
+
+  for (const allowedOrigin of ALLOWED_REQUEST_ORIGINS) {
+    const allowed = new URL(allowedOrigin)
+    if (
+      allowed.protocol === incoming.protocol &&
+      allowed.port === incoming.port &&
+      isLoopbackHost(allowed.hostname)
+    ) {
+      return true
+    }
+  }
+
+  return false
 }
 
 function isLoopbackHost(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]"
-}
-
-/** Safely extract the origin from a Referer header value. Returns null
- *  if the URL is malformed, preventing URL-constructor exceptions from
- *  leaking into the CSRF check. */
-function extractOrigin(referer: string): string | null {
-  try {
-    return new URL(referer).origin
-  } catch {
-    return null
-  }
 }

--- a/src/lib/auth/csrf.ts
+++ b/src/lib/auth/csrf.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { ALLOWED_REQUEST_ORIGINS } from "@/lib/utils/config"
+import { ALLOWED_REQUEST_ORIGINS, isLoopbackHost } from "@/lib/utils/config"
 
 /**
  * Validates browser mutation requests against the app's configured origins.
@@ -100,8 +100,4 @@ function isAllowedDevelopmentLoopback(incoming: URL): boolean {
   }
 
   return false
-}
-
-function isLoopbackHost(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]"
 }

--- a/src/lib/auth/oauth-client.ts
+++ b/src/lib/auth/oauth-client.ts
@@ -12,35 +12,77 @@ export const PDS_URL = process.env.PDS_URL || DEFAULT_PDS_URL
 
 let clientPromise: Promise<NodeOAuthClient> | null = null
 
-// Loopback dev: no real https:// PUBLIC_URL, so we can't register a
-// client_id with the AS. The atproto spec only accepts client_ids that
-// are real `https://` URLs or the literal `http://localhost` origin
-// (no port, no path). IP hosts are rejected. Detect dev and swap to
-// the virtual loopback metadata helper.
-function isLoopbackDev(): boolean {
-  if (process.env.NODE_ENV === "production") return false
-  const url = process.env.PUBLIC_URL
-  return !url || url.startsWith("http://")
+const SCOPE = "atproto transition:generic identity:handle account:email"
+
+/** Whether the resolved canonical URL requires atproto's loopback client. */
+export function isLoopbackOAuthMode(
+  publicUrl: string | undefined,
+  nodeEnv: string | undefined,
+): boolean {
+  if (nodeEnv === "production") return false
+  return publicUrl?.startsWith("http://") ?? true
 }
 
-// redirect_uri host must be `127.0.0.1` (or `[::1]`) in loopback mode —
-// `localhost` is NOT allowed here even though it IS the only allowed
-// client_id host. Port comes from PUBLIC_URL, default 3000.
-function loopbackRedirectUri(): OAuthLoopbackRedirectURI {
+/**
+ * Builds the spec-required loopback callback. The client_id host is localhost,
+ * but redirect_uri must use a loopback IP; preserve the configured dev port.
+ */
+export function buildLoopbackRedirectUri(
+  publicUrl: string | undefined,
+): OAuthLoopbackRedirectURI {
   let port = "3000"
-  const url = process.env.PUBLIC_URL
-  if (url) {
-    try {
-      const parsed = new URL(url)
-      if (parsed.port) port = parsed.port
-    } catch {
-      /* keep default */
-    }
+  if (publicUrl) {
+    const parsed = new URL(publicUrl)
+    if (parsed.port) port = parsed.port
   }
   return `http://127.0.0.1:${port}/oauth/callback` as OAuthLoopbackRedirectURI
 }
 
-const SCOPE = "atproto transition:generic identity:handle account:email"
+/** Returns a production-safe canonical URL or throws an actionable error. */
+export function requireOAuthPublicUrl(
+  publicUrl: string | undefined,
+  nodeEnv: string | undefined,
+): string {
+  if (!publicUrl) {
+    throw new Error(
+      "OAuth public URL is not configured. Set PUBLIC_URL, or expose VERCEL_BRANCH_URL or VERCEL_URL in the production runtime.",
+    )
+  }
+  if (nodeEnv === "production" && !publicUrl.startsWith("https://")) {
+    throw new Error(
+      "OAuth public URL must use HTTPS in production. Use npm run dev for HTTP loopback OAuth, or configure an HTTPS PUBLIC_URL, VERCEL_BRANCH_URL, or VERCEL_URL.",
+    )
+  }
+  return publicUrl
+}
+
+/** Builds the non-loopback OAuth metadata published by the well-known route. */
+export function buildWebOAuthClientMetadata(
+  publicUrl: string,
+  isConfidential: boolean,
+): OAuthClientMetadataInput {
+  return {
+    client_id: `${publicUrl}/.well-known/oauth-client-metadata`,
+    client_name: "Certified",
+    client_uri: publicUrl,
+    logo_uri: `${publicUrl}/brand/brandmark/certified_brandmark_black_512.png`,
+    redirect_uris: [`${publicUrl}/oauth/callback`],
+    response_types: ["code"],
+    grant_types: ["authorization_code", "refresh_token"],
+    scope: SCOPE,
+    dpop_bound_access_tokens: true,
+    application_type: "web",
+    ...(isConfidential
+      ? {
+          token_endpoint_auth_method: "private_key_jwt",
+          token_endpoint_auth_signing_alg: "ES256",
+          jwks_uri: `${publicUrl}/.well-known/jwks.json`,
+        }
+      : {
+          token_endpoint_auth_method: "none",
+        }),
+  }
+}
 
 export function getOAuthClient(): Promise<NodeOAuthClient> {
   if (!clientPromise) {
@@ -48,43 +90,22 @@ export function getOAuthClient(): Promise<NodeOAuthClient> {
       let clientMetadata: OAuthClientMetadataInput
       let keyset: Awaited<ReturnType<typeof JoseKey.fromImportable>>[] | undefined
 
-      if (isLoopbackDev()) {
+      if (isLoopbackOAuthMode(PUBLIC_URL_STRICT, process.env.NODE_ENV)) {
         // ATPROTO_PRIVATE_KEY is ignored here — the helper hard-codes
         // token_endpoint_auth_method: "none".
         clientMetadata = buildAtprotoLoopbackClientMetadata({
           scope: SCOPE,
-          redirect_uris: [loopbackRedirectUri()],
+          redirect_uris: [buildLoopbackRedirectUri(PUBLIC_URL_STRICT)],
         })
         keyset = undefined
       } else {
-        const publicUrl = PUBLIC_URL_STRICT
-        if (!publicUrl) {
-          throw new Error("PUBLIC_URL environment variable is required in production")
-        }
-
+        const publicUrl = requireOAuthPublicUrl(
+          PUBLIC_URL_STRICT,
+          process.env.NODE_ENV,
+        )
         const isConfidential = Boolean(process.env.ATPROTO_PRIVATE_KEY)
 
-        clientMetadata = {
-          client_id: `${publicUrl}/.well-known/oauth-client-metadata`,
-          client_name: "Certified",
-          client_uri: publicUrl,
-          logo_uri: `${publicUrl}/brand/brandmark/certified_brandmark_black_512.png`,
-          redirect_uris: [`${publicUrl}/oauth/callback`],
-          response_types: ["code"],
-          grant_types: ["authorization_code", "refresh_token"],
-          scope: SCOPE,
-          dpop_bound_access_tokens: true,
-          application_type: "web",
-          ...(isConfidential
-            ? {
-                token_endpoint_auth_method: "private_key_jwt",
-                token_endpoint_auth_signing_alg: "ES256",
-                jwks_uri: `${publicUrl}/.well-known/jwks.json`,
-              }
-            : {
-                token_endpoint_auth_method: "none",
-              }),
-        }
+        clientMetadata = buildWebOAuthClientMetadata(publicUrl, isConfidential)
 
         keyset = isConfidential
           ? [await JoseKey.fromImportable(process.env.ATPROTO_PRIVATE_KEY!, "key-1")]

--- a/src/lib/utils/__tests__/config.test.ts
+++ b/src/lib/utils/__tests__/config.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest"
+import {
+  resolveAppUrlConfig,
+  type AppUrlEnvironment,
+} from "@/lib/utils/config"
+
+function origins(env: AppUrlEnvironment): string[] {
+  return [...resolveAppUrlConfig(env).allowedRequestOrigins]
+}
+
+describe("resolveAppUrlConfig", () => {
+  it("prefers PUBLIC_URL while trusting every configured exact origin", () => {
+    const config = resolveAppUrlConfig({
+      NODE_ENV: "production",
+      PUBLIC_URL: "https://staging.certified.app/",
+      VERCEL_BRANCH_URL: "certified-git-staging.vercel.app",
+      VERCEL_URL: "certified-a1b2c3.vercel.app",
+    })
+
+    expect(config.canonicalUrl).toBe("https://staging.certified.app")
+    expect([...config.allowedRequestOrigins]).toEqual([
+      "https://staging.certified.app",
+      "https://certified-git-staging.vercel.app",
+      "https://certified-a1b2c3.vercel.app",
+    ])
+  })
+
+  it("uses the stable branch URL when PUBLIC_URL is absent", () => {
+    const config = resolveAppUrlConfig({
+      NODE_ENV: "production",
+      VERCEL_BRANCH_URL: "certified-git-staging.vercel.app",
+      VERCEL_URL: "certified-a1b2c3.vercel.app",
+    })
+
+    expect(config.canonicalUrl).toBe(
+      "https://certified-git-staging.vercel.app",
+    )
+  })
+
+  it("uses the commit deployment URL when it is the only configured URL", () => {
+    const config = resolveAppUrlConfig({
+      NODE_ENV: "production",
+      VERCEL_URL: "certified-a1b2c3.vercel.app",
+    })
+
+    expect(config.canonicalUrl).toBe("https://certified-a1b2c3.vercel.app")
+  })
+
+  it("fails closed in production when no URL is configured", () => {
+    const config = resolveAppUrlConfig({ NODE_ENV: "production" })
+
+    expect(config.canonicalUrl).toBeUndefined()
+    expect([...config.allowedRequestOrigins]).toEqual([])
+  })
+
+  it("uses localhost only when no URL is configured outside production", () => {
+    expect(resolveAppUrlConfig({ NODE_ENV: "development" }).canonicalUrl).toBe(
+      "http://localhost:3000",
+    )
+    expect(origins({ NODE_ENV: "test" })).toEqual([
+      "http://localhost:3000",
+    ])
+  })
+
+  it("treats empty values as absent", () => {
+    const config = resolveAppUrlConfig({
+      NODE_ENV: "production",
+      PUBLIC_URL: "  ",
+      VERCEL_BRANCH_URL: "\t",
+      VERCEL_URL: "certified-a1b2c3.vercel.app",
+    })
+
+    expect(config.canonicalUrl).toBe("https://certified-a1b2c3.vercel.app")
+  })
+
+  it("allows HTTP only for loopback origins", () => {
+    expect(
+      resolveAppUrlConfig({
+        NODE_ENV: "development",
+        PUBLIC_URL: "http://127.0.0.1:4000",
+      }).canonicalUrl,
+    ).toBe("http://127.0.0.1:4000")
+
+    // next build sets NODE_ENV=production while loading the documented local
+    // .env value. Runtime OAuth initialization separately enforces HTTPS.
+    expect(
+      resolveAppUrlConfig({
+        NODE_ENV: "production",
+        PUBLIC_URL: "http://127.0.0.1:4000",
+      }).canonicalUrl,
+    ).toBe("http://127.0.0.1:4000")
+
+    expect(() =>
+      resolveAppUrlConfig({
+        NODE_ENV: "development",
+        PUBLIC_URL: "http://192.168.1.20:3000",
+      }),
+    ).toThrow(/PUBLIC_URL must be an origin/)
+  })
+
+  it.each([
+    "certified.app",
+    "https://user:pass@certified.app",
+    "https://certified.app/oauth/callback",
+    "https://certified.app?preview=true",
+    "https://certified.app#preview",
+  ])("rejects malformed PUBLIC_URL value %s", (PUBLIC_URL) => {
+    expect(() =>
+      resolveAppUrlConfig({ NODE_ENV: "production", PUBLIC_URL }),
+    ).toThrow(/PUBLIC_URL must be an origin/)
+  })
+
+  it.each([
+    ["VERCEL_BRANCH_URL", "https://certified-git-staging.vercel.app"],
+    ["VERCEL_BRANCH_URL", "certified-git-staging.vercel.app/path"],
+    ["VERCEL_URL", "certified-a1b2c3.vercel.app:443"],
+    ["VERCEL_URL", "certified-a1b2c3.vercel.app@evil.example"],
+    ["VERCEL_URL", "certified-a1b2c3.evil.example"],
+  ] as const)("rejects malformed %s value %s", (name, value) => {
+    expect(() =>
+      resolveAppUrlConfig({
+        NODE_ENV: "production",
+        [name]: value,
+      }),
+    ).toThrow(new RegExp(name))
+  })
+})

--- a/src/lib/utils/config.ts
+++ b/src/lib/utils/config.ts
@@ -2,17 +2,138 @@ const DEV_FALLBACK = "http://localhost:3000"
 
 export const DEFAULT_PDS_URL = process.env.NEXT_PUBLIC_PDS_URL || "https://certified.one"
 
-/**
- * The application's public URL. Always defined — falls back to localhost in development.
- * Used by CSRF protection and anywhere a guaranteed URL is needed.
- */
-export const PUBLIC_URL: string =
-  process.env.PUBLIC_URL || DEV_FALLBACK
+export interface AppUrlEnvironment {
+  PUBLIC_URL?: string
+  VERCEL_BRANCH_URL?: string
+  VERCEL_URL?: string
+  NODE_ENV?: string
+}
+
+export interface AppUrlConfig {
+  canonicalUrl: string | undefined
+  allowedRequestOrigins: ReadonlySet<string>
+}
 
 /**
- * The application's public URL, or undefined in production when PUBLIC_URL env var is missing.
- * Used by OAuth client which requires explicit configuration in production.
+ * Resolves the canonical OAuth URL and the exact origins trusted for browser
+ * mutations. PUBLIC_URL remains authoritative; Vercel's stable branch URL and
+ * then its commit-specific deployment URL are fallbacks.
  */
-export const PUBLIC_URL_STRICT: string | undefined =
-  process.env.PUBLIC_URL ||
-  (process.env.NODE_ENV === "production" ? undefined : DEV_FALLBACK)
+export function resolveAppUrlConfig(env: AppUrlEnvironment): AppUrlConfig {
+  const publicUrl = normalizePublicOrigin(env.PUBLIC_URL)
+  const branchUrl = normalizeVercelOrigin(env.VERCEL_BRANCH_URL, "VERCEL_BRANCH_URL")
+  const deploymentUrl = normalizeVercelOrigin(env.VERCEL_URL, "VERCEL_URL")
+  const configuredOrigins = [publicUrl, branchUrl, deploymentUrl].filter(
+    (origin): origin is string => origin !== undefined,
+  )
+  const devFallback =
+    configuredOrigins.length === 0 && env.NODE_ENV !== "production"
+      ? DEV_FALLBACK
+      : undefined
+
+  return {
+    canonicalUrl: publicUrl ?? branchUrl ?? deploymentUrl ?? devFallback,
+    allowedRequestOrigins: new Set([
+      ...configuredOrigins,
+      ...(devFallback ? [devFallback] : []),
+    ]),
+  }
+}
+
+function normalizePublicOrigin(
+  rawValue: string | undefined,
+): string | undefined {
+  const value = optionalValue(rawValue)
+  if (!value) return undefined
+
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw invalidPublicUrl()
+  }
+
+  const isLoopbackHttp =
+    url.protocol === "http:" && isLoopbackHost(url.hostname)
+
+  if (
+    (url.protocol !== "https:" && !isLoopbackHttp) ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw invalidPublicUrl()
+  }
+
+  return url.origin
+}
+
+function normalizeVercelOrigin(
+  rawValue: string | undefined,
+  variableName: "VERCEL_BRANCH_URL" | "VERCEL_URL",
+): string | undefined {
+  const value = optionalValue(rawValue)
+  if (!value) return undefined
+
+  if (/[/:\\@?#]/.test(value)) {
+    throw invalidVercelUrl(variableName)
+  }
+
+  let url: URL
+  try {
+    url = new URL(`https://${value}`)
+  } catch {
+    throw invalidVercelUrl(variableName)
+  }
+
+  if (
+    !url.hostname.endsWith(".vercel.app") ||
+    url.hostname === "vercel.app" ||
+    url.port ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw invalidVercelUrl(variableName)
+  }
+
+  return url.origin
+}
+
+function optionalValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed || undefined
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]"
+}
+
+function invalidPublicUrl(): Error {
+  return new Error(
+    "PUBLIC_URL must be an origin such as https://certified.app, without credentials, a path, query, or fragment. HTTP is allowed only for a loopback host; production OAuth still requires HTTPS.",
+  )
+}
+
+function invalidVercelUrl(variableName: "VERCEL_BRANCH_URL" | "VERCEL_URL"): Error {
+  return new Error(
+    `${variableName} must be a hostname-only generated Vercel domain ending in .vercel.app, without a scheme, port, path, query, fragment, or credentials.`,
+  )
+}
+
+const APP_URL_CONFIG = resolveAppUrlConfig(process.env)
+
+/** The canonical URL used to construct OAuth metadata and callbacks. */
+export const PUBLIC_URL_STRICT: string | undefined = APP_URL_CONFIG.canonicalUrl
+
+/**
+ * A guaranteed URL for legacy non-security-sensitive callers. Production OAuth
+ * and CSRF code use PUBLIC_URL_STRICT and ALLOWED_REQUEST_ORIGINS instead.
+ */
+export const PUBLIC_URL: string = PUBLIC_URL_STRICT ?? DEV_FALLBACK
+
+/** Exact configured origins that may issue same-origin browser mutations. */
+export const ALLOWED_REQUEST_ORIGINS: ReadonlySet<string> =
+  APP_URL_CONFIG.allowedRequestOrigins

--- a/src/lib/utils/config.ts
+++ b/src/lib/utils/config.ts
@@ -107,7 +107,8 @@ function optionalValue(value: string | undefined): string | undefined {
   return trimmed || undefined
 }
 
-function isLoopbackHost(hostname: string): boolean {
+/** Returns whether a URL hostname identifies a supported loopback address. */
+export function isLoopbackHost(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]"
 }
 


### PR DESCRIPTION
## Summary

- resolve the canonical OAuth origin as `PUBLIC_URL` → `VERCEL_BRANCH_URL` → `VERCEL_URL`
- allow exact same-origin CSRF requests on configured public, branch, and commit deployment origins
- keep branch and commit deployments isolated by requiring the source origin to equal the request destination
- validate URL configuration and produce actionable OAuth errors
- cover config precedence, CSRF behavior, OAuth metadata, and loopback handling

## Behavior

When `PUBLIC_URL` exists, OAuth metadata and callbacks continue using it. Otherwise the stable Vercel branch URL is used, with the commit deployment URL as the final fallback. A login started on another accepted Vercel origin completes on the selected canonical origin and receives its session cookie there.

## Review documents

- [Implementation plan](https://github.com/hypercerts-org/certified-app/blob/auth/vercel-preview-origins/docs/auth-vercel-preview-origins/plan.md)
- [Plan review decisions](https://github.com/hypercerts-org/certified-app/blob/auth/vercel-preview-origins/docs/auth-vercel-preview-origins/review-round-1.md)
- [Implementation review decisions](https://github.com/hypercerts-org/certified-app/blob/auth/vercel-preview-origins/docs/auth-vercel-preview-origins/review-round-2.md)

## Breaking changes

None.

## Out of scope

- wildcard `*.vercel.app` trust
- request-header-derived OAuth client identities
- cross-origin session handoff back to an initiating commit URL
- OAuth Redis key migration or `client_id` namespacing
- Vercel Deployment Protection configuration

## Rollout constraints

- the canonical OAuth metadata endpoint, and JWKS endpoint for confidential clients, must be publicly reachable by the authorization server
- deployments participating in one callback flow must share compatible Redis configuration
- distinct canonical OAuth identities should use separate Redis databases because saved OAuth sessions are not namespaced by `client_id`

## Test plan

- [x] `npm test` — 145 files, 1200 tests passed
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/ --ext .ts,.tsx`
- [x] `npx next build`
- [x] `git diff --check origin/staging..HEAD`
- [x] verify login from the deployed branch URL after Vercel builds this PR
- [x] verify the published OAuth metadata and JWKS endpoints are reachable without deployment credentials


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Improvements**
  - Strengthened CSRF validation by requiring exact, trusted origins and rejecting missing, malformed, wildcard, or mismatched origins.
  - Added secure handling for development loopback origins.

- **OAuth & Configuration**
  - Added canonical URL resolution across production, Vercel deployments, and local development.
  - Enforced publicly reachable OAuth metadata and HTTPS requirements in production.
  - Improved loopback OAuth redirect handling.

- **Documentation**
  - Expanded setup and deployment guidance for OAuth URLs, CSRF protection, Vercel configuration, and Redis-backed sessions.

- **Tests**
  - Added coverage for URL resolution, OAuth configuration, loopback behavior, and CSRF validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->