### PR TITLE
ci: run production build in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
         run: npm test
 
       - name: Build
-        run: npm run build
+        run: COOKIE_SECRET="$(openssl rand -hex 32)" npm run build


### PR DESCRIPTION
## Summary

Add `npm run build` to the existing pull-request verification job after tests. This makes Next.js production compilation and page generation part of CI for PRs targeting `staging` or `main`.

## Breaking changes

None.

## Test plan

- [x] `npm run build`
- [x] workflow YAML parsed successfully
- [x] `git diff --check origin/staging..HEAD`
