### PR TITLE
feat(auth): skip ePDS consent screen on first-time sign-up

### DIFF
--- a/src/app/.well-known/oauth-client-metadata/route.ts
+++ b/src/app/.well-known/oauth-client-metadata/route.ts
@@ -17,6 +17,11 @@ export async function GET() {
     policy_uri: `${origin}/privacy`,
     email_template_uri: `${origin}/email/otp-email-template.html`,
     email_subject_template: "{{code}} — Your Certified sign-in code",
+    // ePDS extension: skip the "Authorize your account" consent screen on a
+    // user's first-time sign-up so new accounts land straight in the app.
+    // Only honoured when the PDS runs with PDS_SIGNUP_ALLOW_CONSENT_SKIP=true
+    // and this client_id is on its PDS_OAUTH_TRUSTED_CLIENTS allowlist.
+    epds_skip_consent_on_signup: true,
     // Opt in to ePDS's "Or sign in with ATProto/Bluesky" button. ePDS
     // redirects here with ?handle=<value>; the GET handler in
     // src/app/api/auth/login/route.ts resolves the handle to its PDS


### PR DESCRIPTION
Advertise the ePDS `epds_skip_consent_on_signup` client-metadata extension so brand-new accounts skip the "Authorize your account" consent screen and land straight in the app.

This is the only client-side change required. It takes effect once the certified.one PDS runs with PDS_SIGNUP_ALLOW_CONSENT_SKIP=true and this client_id is on its PDS_OAUTH_TRUSTED_CLIENTS allowlist (operator-side config, not part of this repo).