### PR TITLE
staging → main: skip the ePDS consent screen on first-time sign-up

### DIFF
--- a/src/app/.well-known/oauth-client-metadata/route.ts
+++ b/src/app/.well-known/oauth-client-metadata/route.ts
@@ -17,6 +17,11 @@ export async function GET() {
     policy_uri: `${origin}/privacy`,
     email_template_uri: `${origin}/email/otp-email-template.html`,
     email_subject_template: "{{code}} — Your Certified sign-in code",
+    // ePDS extension: skip the "Authorize your account" consent screen on a
+    // user's first-time sign-up so new accounts land straight in the app.
+    // Only honoured when the PDS runs with PDS_SIGNUP_ALLOW_CONSENT_SKIP=true
+    // and this client_id is on its PDS_OAUTH_TRUSTED_CLIENTS allowlist.
+    epds_skip_consent_on_signup: true,
     // Opt in to ePDS's "Or sign in with ATProto/Bluesky" button. ePDS
     // redirects here with ?handle=<value>; the GET handler in
     // src/app/api/auth/login/route.ts resolves the handle to its PDS


### PR DESCRIPTION
Single change on top of #241: adds the ePDS `epds_skip_consent_on_signup: true` extension to Certified's OAuth client metadata at `/.well-known/oauth-client-metadata`.

This removes the "Authorize your account" consent screen first-time users hit during sign-up, so new accounts land straight in the app. It matters for apps that delegate sign-in to the `certs` provider (e.g. the GainForest frontend), which currently bounce users through certified.one's OAuth flow into the ePDS stock consent screen.

Originally opened as #227 and closed unmerged; revived via #242 onto `staging`.

## Risk

Inert until the PDS side is configured. The flag is only honoured when the ePDS runs with `PDS_SIGNUP_ALLOW_CONSENT_SKIP=true` **and** this `client_id` is on its `PDS_OAUTH_TRUSTED_CLIENTS` allowlist. Until both hold, the consent screen behaves exactly as it does today.

## Changes

- `src/app/.well-known/oauth-client-metadata/route.ts` — 5 lines added, no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
